### PR TITLE
refactor(settings): move the api keys table onto SettingsTable

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1835,6 +1835,7 @@ checksums:
     workspace/api_keys/unable_to_copy_api_key: 148506832e31d033fa3569ce292d2120
     workspace/api_keys/unable_to_delete_api_key: 1fd76d9a22c5f5f8c241c4891fca8295
     workspace/api_keys/unknown_workspace: 4b0df2d07ebc9ab084158b1b9525ae5e
+    workspace/api_keys/view_permissions_for: 5f9583d5753fc9c95aa1a9eb7856dbed
     workspace/api_keys/workspace_access: b38cb73197ef5f5fa6653b88c68aa0bd
     workspace/api_keys/workspace_access_description: ac787b9e4c81dd8b3a7caf6cc1eecf3c
     workspace/api_keys/workspace_access_empty: bf73cc7b68bea2f7bfa6550762a28d35

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "API-Schlüssel konnte nicht kopiert werden",
       "unable_to_delete_api_key": "API-Schlüssel konnte nicht gelöscht werden",
       "unknown_workspace": "Unbekannter Arbeitsbereich",
+      "view_permissions_for": "Berechtigungen anzeigen für {{label}}",
       "workspace_access": "Workspace-Zugriff",
       "workspace_access_description": "Umfrage- und Antwortdaten. Gewähre Zugriff jeweils für einen Workspace.",
       "workspace_access_empty": "Noch keine Workspaces hinzugefügt."

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "Unable to copy API key",
       "unable_to_delete_api_key": "Unable to delete API Key",
       "unknown_workspace": "Unknown workspace",
+      "view_permissions_for": "View permissions for {{label}}",
       "workspace_access": "Workspace Access",
       "workspace_access_description": "Survey and response data. Grant access one workspace at a time.",
       "workspace_access_empty": "No workspaces added yet."

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "No se puede copiar la clave de API",
       "unable_to_delete_api_key": "No se puede eliminar la clave API",
       "unknown_workspace": "Espacio de trabajo desconocido",
+      "view_permissions_for": "Ver permisos de {{label}}",
       "workspace_access": "Acceso al espacio de trabajo",
       "workspace_access_description": "Datos de encuestas y respuestas. Concede acceso a un espacio de trabajo a la vez.",
       "workspace_access_empty": "Aún no se ha añadido ningún espacio de trabajo."

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "Impossible de copier la clé API",
       "unable_to_delete_api_key": "Impossible de supprimer la clé API",
       "unknown_workspace": "Espace de travail inconnu",
+      "view_permissions_for": "Voir les autorisations pour {{label}}",
       "workspace_access": "Accès à l'espace de travail",
       "workspace_access_description": "Données d'enquête et de réponse. Accorde l'accès un espace de travail à la fois.",
       "workspace_access_empty": "Aucun espace de travail ajouté pour le moment."

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "Nem lehet másolni az API-kulcsot",
       "unable_to_delete_api_key": "Nem lehet törölni az API-kulcsot",
       "unknown_workspace": "Ismeretlen munkaterület",
+      "view_permissions_for": "Engedélyek megtekintése a következőhöz: {{label}}",
       "workspace_access": "Munkaterület-hozzáférés",
       "workspace_access_description": "Felmérési és válaszadatok. Hozzáférés biztosítása munkaterületenként.",
       "workspace_access_empty": "Még nem lett hozzáadva munkaterület."

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "APIキーをコピーできません",
       "unable_to_delete_api_key": "APIキーを削除できません",
       "unknown_workspace": "不明なワークスペース",
+      "view_permissions_for": "{{label}}の権限を表示",
       "workspace_access": "ワークスペースアクセス",
       "workspace_access_description": "アンケートと回答データ。ワークスペースごとにアクセス権を付与します。",
       "workspace_access_empty": "まだワークスペースが追加されていません。"

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "Kan API-sleutel niet kopiëren",
       "unable_to_delete_api_key": "Kan API-sleutel niet verwijderen",
       "unknown_workspace": "Onbekende workspace",
+      "view_permissions_for": "Bekijk rechten voor {{label}}",
       "workspace_access": "Workspace-toegang",
       "workspace_access_description": "Enquête- en antwoordgegevens. Verleen toegang per werkruimte.",
       "workspace_access_empty": "Nog geen werkruimtes toegevoegd."

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "Não foi possível copiar a chave de API",
       "unable_to_delete_api_key": "Não foi possível excluir a chave de API",
       "unknown_workspace": "Workspace desconhecido",
+      "view_permissions_for": "Ver permissões para {{label}}",
       "workspace_access": "Acesso ao workspace",
       "workspace_access_description": "Dados de pesquisas e respostas. Conceda acesso a um workspace por vez.",
       "workspace_access_empty": "Nenhum workspace adicionado ainda."

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "Não foi possível copiar a chave API",
       "unable_to_delete_api_key": "Não foi possível eliminar a chave de API",
       "unknown_workspace": "Área de trabalho desconhecida",
+      "view_permissions_for": "Ver permissões de {{label}}",
       "workspace_access": "Acesso ao workspace",
       "workspace_access_description": "Dados de inquéritos e respostas. Concede acesso uma área de trabalho de cada vez.",
       "workspace_access_empty": "Ainda não foram adicionadas áreas de trabalho."

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "Nu se poate copia cheia API",
       "unable_to_delete_api_key": "Nu se poate șterge cheia API",
       "unknown_workspace": "Spațiu de lucru necunoscut",
+      "view_permissions_for": "Vizualizează permisiunile pentru {{label}}",
       "workspace_access": "Acces spațiu de lucru",
       "workspace_access_description": "Date de sondaj și răspunsuri. Acordă acces câte un workspace odată.",
       "workspace_access_empty": "Niciun workspace adăugat încă."

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "Не удалось скопировать API-ключ",
       "unable_to_delete_api_key": "Не удалось удалить API-ключ",
       "unknown_workspace": "Неизвестное рабочее пространство",
+      "view_permissions_for": "Просмотреть права доступа для {{label}}",
       "workspace_access": "Доступ к рабочему пространству",
       "workspace_access_description": "Данные опросов и ответов. Предоставляй доступ по одному рабочему пространству за раз.",
       "workspace_access_empty": "Рабочие пространства еще не добавлены."

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "Kunde inte kopiera API-nyckel",
       "unable_to_delete_api_key": "Det gick inte att radera API-nyckeln",
       "unknown_workspace": "Okänd arbetsyta",
+      "view_permissions_for": "Visa behörigheter för {{label}}",
       "workspace_access": "Arbetsyteåtkomst",
       "workspace_access_description": "Enkät- och svarsdata. Ge åtkomst en arbetsyta i taget.",
       "workspace_access_empty": "Inga arbetsytor tillagda ännu."

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "API anahtarı kopyalanamıyor",
       "unable_to_delete_api_key": "API anahtarı silinemiyor",
       "unknown_workspace": "Bilinmeyen çalışma alanı",
+      "view_permissions_for": "{{label}} için izinleri görüntüle",
       "workspace_access": "Çalışma Alanı Erişimi",
       "workspace_access_description": "Anket ve yanıt verileri. Erişimi her seferinde bir çalışma alanı için ver.",
       "workspace_access_empty": "Henüz çalışma alanı eklenmedi."

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "无法复制 API 密钥",
       "unable_to_delete_api_key": "无法删除 API 密钥",
       "unknown_workspace": "未知工作区",
+      "view_permissions_for": "查看 {{label}} 的权限",
       "workspace_access": "工作区访问权限",
       "workspace_access_description": "问卷和回复数据。每次授予一个工作区的访问权限。",
       "workspace_access_empty": "尚未添加任何工作区。"

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1903,6 +1903,7 @@
       "unable_to_copy_api_key": "無法複製 API 金鑰",
       "unable_to_delete_api_key": "無法刪除 API 金鑰",
       "unknown_workspace": "未知工作區",
+      "view_permissions_for": "查看 {{label}} 的權限",
       "workspace_access": "工作區存取",
       "workspace_access_description": "問卷和回覆資料。每次授予一個工作區的存取權限。",
       "workspace_access_empty": "尚未新增任何工作區。"

--- a/apps/web/modules/organization/settings/api-keys/components/api-key-list.tsx
+++ b/apps/web/modules/organization/settings/api-keys/components/api-key-list.tsx
@@ -6,7 +6,6 @@ import { EditAPIKeys } from "./edit-api-keys";
 interface ApiKeyListProps {
   organizationId: string;
   locale: TUserLocale;
-  isReadOnly: boolean;
   workspaces: TOrganizationWorkspace[];
   isFormbricksCloud: boolean;
 }
@@ -14,7 +13,6 @@ interface ApiKeyListProps {
 export const ApiKeyList = async ({
   organizationId,
   locale,
-  isReadOnly,
   workspaces,
   isFormbricksCloud,
 }: ApiKeyListProps) => {
@@ -25,7 +23,6 @@ export const ApiKeyList = async ({
       organizationId={organizationId}
       apiKeys={apiKeys}
       locale={locale}
-      isReadOnly={isReadOnly}
       workspaces={workspaces}
       isFormbricksCloud={isFormbricksCloud}
     />

--- a/apps/web/modules/organization/settings/api-keys/components/edit-api-keys.tsx
+++ b/apps/web/modules/organization/settings/api-keys/components/edit-api-keys.tsx
@@ -73,69 +73,67 @@ const ApiKeyDisplay = ({ apiKey }: Readonly<{ apiKey: string }>) => {
 export const getApiKeyColumns = ({
   t,
   locale,
-  isReadOnly,
   onDelete,
 }: Readonly<{
   t: TFunction;
   locale: TUserLocale;
-  isReadOnly: boolean;
   onDelete: (event: React.MouseEvent, apiKey: TApiKeyRow) => void;
-}>): TSettingsTableColumn<TApiKeyRow>[] => {
-  const columns: TSettingsTableColumn<TApiKeyRow>[] = [
-    {
-      id: "label",
-      header: t("common.label"),
-      headerClassName: "w-[25%]",
-      cellClassName: "font-semibold",
-      skeletonWidth: "w-32",
-      cell: (apiKey) => apiKey.label,
-    },
-    {
-      id: "apiKey",
-      header: t("workspace.api_keys.api_key"),
-      headerClassName: "w-[45%]",
-      // Replaces `hidden sm:block`, which would have restored a `<td>` to `display: block` and dropped it
-      // out of the table's column layout. `hideBelow` uses `table-cell` for exactly that reason.
-      hideBelow: "sm",
-      skeletonWidth: "w-64",
-      cell: (apiKey) => <ApiKeyDisplay apiKey={apiKey.actualKey ?? ""} />,
-    },
-    {
-      id: "createdAt",
-      header: t("common.created_at"),
-      headerClassName: "w-[20%]",
-      skeletonWidth: "w-20",
-      cell: (apiKey) => timeSince(apiKey.createdAt.toString(), locale),
-    },
-  ];
-
-  if (!isReadOnly) {
-    columns.push({
-      id: "actions",
-      header: null,
-      srLabel: t("common.actions"),
-      headerClassName: "w-[10%]",
-      // The flex aligns the button; `align` would be inert here, since the button is block-level and the
-      // header has no visible text.
-      cellClassName: "flex justify-end",
-      stopRowClick: true,
-      skeletonWidth: "w-8",
-      cell: (apiKey) => (
-        <Button size="icon" variant="ghost" onClick={(event) => onDelete(event, apiKey)}>
+}>): TSettingsTableColumn<TApiKeyRow>[] => [
+  {
+    id: "label",
+    header: t("common.label"),
+    headerClassName: "w-[25%]",
+    cellClassName: "font-semibold",
+    skeletonWidth: "w-32",
+    cell: (apiKey) => apiKey.label,
+  },
+  {
+    id: "apiKey",
+    header: t("workspace.api_keys.api_key"),
+    headerClassName: "w-[45%]",
+    // Replaces `hidden sm:block`, which would have restored a `<td>` to `display: block` and dropped it
+    // out of the table's column layout. `hideBelow` uses `table-cell` for exactly that reason.
+    hideBelow: "sm",
+    skeletonWidth: "w-64",
+    cell: (apiKey) => <ApiKeyDisplay apiKey={apiKey.actualKey ?? ""} />,
+  },
+  {
+    id: "createdAt",
+    header: t("common.created_at"),
+    headerClassName: "w-[20%]",
+    skeletonWidth: "w-20",
+    cell: (apiKey) => timeSince(apiKey.createdAt.toString(), locale),
+  },
+  {
+    id: "actions",
+    header: null,
+    srLabel: t("common.actions"),
+    headerClassName: "w-[10%]",
+    stopRowClick: true,
+    skeletonWidth: "w-8",
+    // The flex goes on a wrapper inside the cell, never on `cellClassName`: that class lands on the `<td>`
+    // itself, and `display: flex` there stops it being a table-cell — which silently kills the shared
+    // `align-middle` (`vertical-align` applies only to inline-level and table-cell boxes) and makes the
+    // browser wrap the cell in an anonymous table-cell that defaults to baseline alignment. The button
+    // would sit high in the row instead of centred. Same reasoning as `hideBelow` above.
+    cell: (apiKey) => (
+      <div className="flex justify-end">
+        <Button
+          size="icon"
+          variant="ghost"
+          aria-label={t("common.delete")}
+          onClick={(event) => onDelete(event, apiKey)}>
           <TrashIcon />
         </Button>
-      ),
-    });
-  }
-
-  return columns;
-};
+      </div>
+    ),
+  },
+];
 
 interface EditAPIKeysProps {
   organizationId: string;
   apiKeys: TApiKeyWithEnvironmentPermission[];
   locale: TUserLocale;
-  isReadOnly: boolean;
   workspaces: TOrganizationWorkspace[];
   isFormbricksCloud: boolean;
 }
@@ -144,7 +142,6 @@ export const EditAPIKeys = ({
   organizationId,
   apiKeys,
   locale,
-  isReadOnly,
   workspaces,
   isFormbricksCloud,
 }: Readonly<EditAPIKeysProps>) => {
@@ -245,23 +242,21 @@ export const EditAPIKeys = ({
 
   return (
     <>
-      {!isReadOnly && (
-        // Moved above the table, matching every other settings table in this series — and required, since
-        // a flush card body means the table has to be the last thing in it. The control carries the card's
-        // gutter itself.
-        <div className="mb-4 flex justify-end px-4 pt-4">
-          <Button
-            size="sm"
-            onClick={() => {
-              setIsAddAPIKeyModalOpen(true);
-            }}>
-            {t("workspace.settings.api_keys.add_api_key")}
-          </Button>
-        </div>
-      )}
+      {/* Moved above the table, matching every other settings table in this series — and required, since
+          a flush card body means the table has to be the last thing in it. The control carries the card's
+          gutter itself. */}
+      <div className="mb-4 flex justify-end px-4 pt-4">
+        <Button
+          size="sm"
+          onClick={() => {
+            setIsAddAPIKeyModalOpen(true);
+          }}>
+          {t("workspace.settings.api_keys.add_api_key")}
+        </Button>
+      </div>
 
       <SettingsTable
-        columns={getApiKeyColumns({ t, locale, isReadOnly, onDelete: handleOpenDeleteKeyModal })}
+        columns={getApiKeyColumns({ t, locale, onDelete: handleOpenDeleteKeyModal })}
         rows={apiKeysLocal}
         getRowId={(apiKey) => apiKey.id}
         emptyMessage={t("workspace.api_keys.no_api_keys_yet")}

--- a/apps/web/modules/organization/settings/api-keys/components/edit-api-keys.tsx
+++ b/apps/web/modules/organization/settings/api-keys/components/edit-api-keys.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { TFunction } from "i18next";
 import { FilesIcon, TrashIcon } from "lucide-react";
 import { useState } from "react";
 import toast from "react-hot-toast";
@@ -17,8 +18,12 @@ import {
 } from "@/modules/organization/settings/api-keys/types/api-keys";
 import { Button } from "@/modules/ui/components/button";
 import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
+import { SettingsTable, type TSettingsTableColumn } from "@/modules/ui/components/settings-table";
 import { createApiKeyAction, deleteApiKeyAction, updateApiKeyAction } from "../actions";
 import { AddApiKeyModal } from "./add-api-key-modal";
+
+/** A stored key, plus the plaintext value the create response returns once and only once. */
+type TApiKeyRow = TApiKeyWithEnvironmentPermission & { actualKey?: string };
 
 const ApiKeyDisplay = ({ apiKey }: Readonly<{ apiKey: string }>) => {
   const { t } = useTranslation();
@@ -38,10 +43,15 @@ const ApiKeyDisplay = ({ apiKey }: Readonly<{ apiKey: string }>) => {
   return (
     <div className="flex items-center justify-between gap-2">
       <span className="break-all whitespace-pre-line">{apiKey}</span>
+      {/* `copyApiKeyIcon` is load-bearing: `playwright/lib/utils.ts` waits for and clicks it to read a
+          freshly created key, which eight API specs depend on for their bearer token. */}
       <div className="copyApiKeyIcon shrink-0">
         <FilesIcon
           className="size-4 cursor-pointer"
           onClick={(e) => {
+            // Stops the click reaching the row, which would open the permissions modal. The column is
+            // deliberately not `stopRowClick`: clicking the key *text* has always opened the modal, and
+            // only the copy affordance is an exception.
             e.stopPropagation();
             void copyToClipboard();
           }}
@@ -50,6 +60,75 @@ const ApiKeyDisplay = ({ apiKey }: Readonly<{ apiKey: string }>) => {
       </div>
     </div>
   );
+};
+
+/**
+ * Exported so `loading.tsx` renders its skeleton from the same column array. That is the whole point of
+ * the factory: the old skeleton hand-rolled the header and had drifted to **three** columns against the
+ * table's four, which no test could catch.
+ *
+ * Defined at module level rather than inside the component: an inline `cell` that returns JSX reads as a
+ * nested component definition to Sonar (typescript:S6478).
+ */
+export const getApiKeyColumns = ({
+  t,
+  locale,
+  isReadOnly,
+  onDelete,
+}: Readonly<{
+  t: TFunction;
+  locale: TUserLocale;
+  isReadOnly: boolean;
+  onDelete: (event: React.MouseEvent, apiKey: TApiKeyRow) => void;
+}>): TSettingsTableColumn<TApiKeyRow>[] => {
+  const columns: TSettingsTableColumn<TApiKeyRow>[] = [
+    {
+      id: "label",
+      header: t("common.label"),
+      headerClassName: "w-[25%]",
+      cellClassName: "font-semibold",
+      skeletonWidth: "w-32",
+      cell: (apiKey) => apiKey.label,
+    },
+    {
+      id: "apiKey",
+      header: t("workspace.api_keys.api_key"),
+      headerClassName: "w-[45%]",
+      // Replaces `hidden sm:block`, which would have restored a `<td>` to `display: block` and dropped it
+      // out of the table's column layout. `hideBelow` uses `table-cell` for exactly that reason.
+      hideBelow: "sm",
+      skeletonWidth: "w-64",
+      cell: (apiKey) => <ApiKeyDisplay apiKey={apiKey.actualKey ?? ""} />,
+    },
+    {
+      id: "createdAt",
+      header: t("common.created_at"),
+      headerClassName: "w-[20%]",
+      skeletonWidth: "w-20",
+      cell: (apiKey) => timeSince(apiKey.createdAt.toString(), locale),
+    },
+  ];
+
+  if (!isReadOnly) {
+    columns.push({
+      id: "actions",
+      header: null,
+      srLabel: t("common.actions"),
+      headerClassName: "w-[10%]",
+      // The flex aligns the button; `align` would be inert here, since the button is block-level and the
+      // header has no visible text.
+      cellClassName: "flex justify-end",
+      stopRowClick: true,
+      skeletonWidth: "w-8",
+      cell: (apiKey) => (
+        <Button size="icon" variant="ghost" onClick={(event) => onDelete(event, apiKey)}>
+          <TrashIcon />
+        </Button>
+      ),
+    });
+  }
+
+  return columns;
 };
 
 interface EditAPIKeysProps {
@@ -68,12 +147,11 @@ export const EditAPIKeys = ({
   isReadOnly,
   workspaces,
   isFormbricksCloud,
-}: EditAPIKeysProps) => {
+}: Readonly<EditAPIKeysProps>) => {
   const { t } = useTranslation();
   const [isAddAPIKeyModalOpen, setIsAddAPIKeyModalOpen] = useState(false);
   const [isDeleteKeyModalOpen, setIsDeleteKeyModalOpen] = useState(false);
-  const [apiKeysLocal, setApiKeysLocal] =
-    useState<(TApiKeyWithEnvironmentPermission & { actualKey?: string })[]>(apiKeys);
+  const [apiKeysLocal, setApiKeysLocal] = useState<TApiKeyRow[]>(apiKeys);
   const [activeKey, setActiveKey] = useState<TApiKeyWithEnvironmentPermission | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [viewPermissionsOpen, setViewPermissionsOpen] = useState(false);
@@ -166,66 +244,12 @@ export const EditAPIKeys = ({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="rounded-lg border border-slate-200">
-        <div className="grid h-12 grid-cols-10 content-center rounded-t-lg bg-slate-100 px-6 text-left text-sm font-semibold text-slate-900">
-          <div className="col-span-4 sm:col-span-2">{t("common.label")}</div>
-          <div className="col-span-4 hidden sm:col-span-5 sm:block">{t("workspace.api_keys.api_key")}</div>
-          <div className="col-span-4 sm:col-span-2">{t("common.created_at")}</div>
-          <div></div>
-        </div>
-        <div className="grid-cols-9">
-          {apiKeysLocal?.length === 0 ? (
-            <div className="flex h-12 items-center justify-center px-6 text-sm font-medium whitespace-nowrap text-slate-400">
-              {t("workspace.api_keys.no_api_keys_yet")}
-            </div>
-          ) : (
-            apiKeysLocal?.map((apiKey) => (
-              <div
-                role="button"
-                className="grid h-12 w-full grid-cols-10 content-center items-center rounded-lg px-6 text-left text-sm text-slate-900 hover:bg-slate-50 focus:bg-slate-50 focus:outline-hidden"
-                onClick={() => {
-                  setActiveKey(apiKey);
-                  setViewPermissionsOpen(true);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setActiveKey(apiKey);
-                    setViewPermissionsOpen(true);
-                  }
-                }}
-                tabIndex={0}
-                data-testid="api-key-row"
-                key={apiKey.id}>
-                <div className="col-span-4 font-semibold sm:col-span-2">{apiKey.label}</div>
-                <div className="col-span-4 hidden pr-4 sm:col-span-5 sm:block">
-                  <ApiKeyDisplay apiKey={apiKey.actualKey ?? ""} />
-                </div>
-                <div className="col-span-4 sm:col-span-2">
-                  {timeSince(apiKey.createdAt.toString(), locale)}
-                </div>
-                {!isReadOnly && (
-                  <div className="col-span-1 text-center">
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      onClick={(e) => {
-                        handleOpenDeleteKeyModal(e, apiKey);
-                        e.stopPropagation();
-                      }}>
-                      <TrashIcon />
-                    </Button>
-                  </div>
-                )}
-              </div>
-            ))
-          )}
-        </div>
-      </div>
-
+    <>
       {!isReadOnly && (
-        <div>
+        // Moved above the table, matching every other settings table in this series — and required, since
+        // a flush card body means the table has to be the last thing in it. The control carries the card's
+        // gutter itself.
+        <div className="mb-4 flex justify-end px-4 pt-4">
           <Button
             size="sm"
             onClick={() => {
@@ -235,6 +259,21 @@ export const EditAPIKeys = ({
           </Button>
         </div>
       )}
+
+      <SettingsTable
+        columns={getApiKeyColumns({ t, locale, isReadOnly, onDelete: handleOpenDeleteKeyModal })}
+        rows={apiKeysLocal}
+        getRowId={(apiKey) => apiKey.id}
+        emptyMessage={t("workspace.api_keys.no_api_keys_yet")}
+        getRowProps={() => ({ "data-testid": "api-key-row" })}
+        aria-label={t("common.api_keys")}
+        onRowClick={(apiKey) => {
+          setActiveKey(apiKey);
+          setViewPermissionsOpen(true);
+        }}
+        getRowLabel={(apiKey) => t("workspace.api_keys.view_permissions_for", { label: apiKey.label })}
+      />
+
       <AddApiKeyModal
         open={isAddAPIKeyModalOpen}
         setOpen={setIsAddAPIKeyModalOpen}
@@ -261,6 +300,6 @@ export const EditAPIKeys = ({
         isDeleting={isLoading}
         text={t("workspace.api_keys.delete_api_key_confirmation")}
       />
-    </div>
+    </>
   );
 };

--- a/apps/web/modules/organization/settings/api-keys/loading.tsx
+++ b/apps/web/modules/organization/settings/api-keys/loading.tsx
@@ -38,7 +38,6 @@ const LoadingCard = () => {
           columns={getApiKeyColumns({
             t,
             locale: "en-US",
-            isReadOnly: false,
             onDelete: () => undefined,
           })}
         />

--- a/apps/web/modules/organization/settings/api-keys/loading.tsx
+++ b/apps/web/modules/organization/settings/api-keys/loading.tsx
@@ -3,11 +3,13 @@
 import { useTranslation } from "react-i18next";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
+import { SettingsTableSkeleton } from "@/modules/ui/components/settings-table";
+import { getApiKeyColumns } from "./components/edit-api-keys";
 
 const LoadingCard = () => {
   const { t } = useTranslation();
   return (
-    <div className="w-full max-w-4xl rounded-xl border border-slate-200 bg-white py-4 shadow-xs">
+    <div className="w-full max-w-4xl overflow-hidden rounded-xl border border-slate-200 bg-white py-4 shadow-xs">
       <div className="grid content-center border-b border-slate-200 px-4 pb-4 text-left text-slate-900">
         <h3 className="h-6 w-full max-w-56 animate-pulse rounded-lg bg-slate-100 text-lg leading-6 font-medium">
           <span className="sr-only">{t("common.loading")}</span>
@@ -16,28 +18,30 @@ const LoadingCard = () => {
           <span className="sr-only">{t("common.loading")}</span>
         </p>
       </div>
-      <div className="w-full">
-        <div className="rounded-lg px-4 pt-4">
-          <div className="rounded-lg border border-slate-200">
-            <div className="grid h-12 grid-cols-10 content-center rounded-t-lg bg-slate-100 px-6 text-left text-sm font-semibold text-slate-900">
-              <div className="col-span-4 sm:col-span-2">{t("common.label")}</div>
-              <div className="col-span-4 hidden sm:col-span-5 sm:block">
-                {t("workspace.api_keys.api_key")}
-              </div>
-              <div className="col-span-4 sm:col-span-2">{t("common.created_at")}</div>
-            </div>
-            <div className="px-6">
-              <div className="my-4 h-5 w-full animate-pulse rounded-full bg-slate-200">
-                <span className="sr-only">{t("common.loading")}</span>
-              </div>
-            </div>
-          </div>
-          <div className="flex justify-start">
-            <div className="mt-4 flex h-8 w-44 animate-pulse flex-col items-center justify-center rounded-md bg-black text-sm text-white">
-              {t("common.loading")}
-            </div>
+      {/* `-mb-4` mirrors `SettingsCard`'s `bodyVariant="flush"`, so the skeleton table meets the card's
+          bottom edge the way the real one does. */}
+      <div className="-mb-4">
+        <div className="mb-4 flex justify-end px-4 pt-4">
+          <div className="flex h-8 w-32 animate-pulse items-center justify-center rounded-md bg-slate-200">
+            <span className="sr-only">{t("common.loading")}</span>
           </div>
         </div>
+        {/*
+          The columns come from the table's own factory rather than being hand-rolled here. This skeleton
+          previously duplicated the header markup and had drifted to three columns against the table's
+          four — the exact failure the shared factory makes unrepresentable.
+
+          `locale` and `onDelete` are never reached: the skeleton renders each column's header and a
+          placeholder bar, and never calls `cell`.
+        */}
+        <SettingsTableSkeleton
+          columns={getApiKeyColumns({
+            t,
+            locale: "en-US",
+            isReadOnly: false,
+            onDelete: () => undefined,
+          })}
+        />
       </div>
     </div>
   );

--- a/apps/web/modules/organization/settings/api-keys/page.tsx
+++ b/apps/web/modules/organization/settings/api-keys/page.tsx
@@ -31,7 +31,8 @@ export const APIKeysPage = async (props: Readonly<{ params: Promise<{ organizati
       <PageHeader pageTitle={t("common.api_keys")} />
       <SettingsCard
         title={t("common.api_keys")}
-        description={t("workspace.settings.api_keys.api_keys_description")}>
+        description={t("workspace.settings.api_keys.api_keys_description")}
+        bodyVariant="flush">
         <ApiKeyList
           organizationId={organization.id}
           locale={locale ?? DEFAULT_LOCALE}

--- a/apps/web/modules/organization/settings/api-keys/page.tsx
+++ b/apps/web/modules/organization/settings/api-keys/page.tsx
@@ -36,7 +36,6 @@ export const APIKeysPage = async (props: Readonly<{ params: Promise<{ organizati
         <ApiKeyList
           organizationId={organization.id}
           locale={locale ?? DEFAULT_LOCALE}
-          isReadOnly={!canAccessApiKeys}
           workspaces={workspaces}
           isFormbricksCloud={IS_FORMBRICKS_CLOUD}
         />


### PR DESCRIPTION
## What & why

Seventh of the ENG-762 series, and the **first CSS-grid conversion** — so this is the proof case for that
half of the work, the way #8839 was for the semantic-table half. `hideBelow`, `stopRowClick` and the row
activator all get their first real use here.

**Branches off `main` directly.** #8837–#8840 have merged, so PRs 7–12 no longer stack: each converts one
independent table and can land in any order.

### What the grid was hiding

- **A real header/row misalignment.** The header declared `grid-cols-10` with **four** cells; the rows
  declared `grid-cols-10` with **three or four** depending on `isReadOnly`. The trailing empty header cell
  was unconditional while the actions cell was not, so in the read-only case the header had a column the
  rows didn't. Both are now one column object, so they cannot disagree.
- **Dead code the grid made invisible:** a `grid-cols-9` wrapper around the row list (a *third* column
  count, different from both the header and the rows), a `rounded-t-lg` on a header whose top corners have
  never been visible because the card's header block owns them, and a `rounded-lg` on every row.
- **A row that claimed to be a button.** `role="button"` plus `tabIndex={0}` plus a hand-rolled
  `onKeyDown` on a `<div>`. A `row` cannot also be a `button` — the role override drops the row out of the
  table's accessibility tree entirely, and the six cell divs inside had no column association. The
  primitive wraps the first cell's content in a real `<button>` instead, so the row keeps its `row` role,
  the button gets a proper accessible name, and there is still exactly one tab stop.

### The skeleton is the payoff

`loading.tsx` hand-rolled the header markup and **had already drifted: three columns against the table's
four.** Nothing could catch that — it's two files agreeing by convention. It now renders
`SettingsTableSkeleton` from the table's own exported `getApiKeyColumns`, so the two cannot diverge.

This is the first table in the series where the factory-export pattern earns its keep rather than just
being available — which is why I un-exported the equivalent factories on #8839 and #8841 when a reviewer
pointed out they had no consumer.

## Changes from code review

Three findings, all valid, all fixed in `e9b5c0d`:

- **The actions cell is a real table cell again.** `cellClassName: "flex justify-end"` lands on the `<td>`
  itself, and overriding its display away from `table-cell` makes the shared `align-middle` a no-op
  (`vertical-align` applies only to inline-level and table-cell boxes) and forces the browser to wrap the
  cell in an anonymous table-cell defaulting to baseline — so the delete button would sit high in the row
  on every row. The flex moved to a wrapper inside `cell`. **This is the same reasoning the `hideBelow`
  comment two columns above already spells out, and I failed to apply it here.** Fixed in the three
  sibling tables too (#8841, #8842) and documented on the `cellClassName` prop, since three call sites
  making the same mistake is an API problem rather than three coding slips.
- **The icon-only delete button gained `aria-label={t("common.delete")}`.** It had no accessible name at
  all, before this PR or after it — only a `TrashIcon` inside.
- **`isReadOnly` is removed rather than worked around.** It was dead through three files: `page.tsx`
  computes `canAccessApiKeys`, **throws** `not_authorized` when false, and *then* passes
  `isReadOnly={!canAccessApiKeys}`. My first version kept the prop and hardcoded `isReadOnly: false` in
  the skeleton — which left a skeleton/table column contract with no compiler signal, since the four
  widths only sum to 100% with all four columns present. Removing the prop makes that failure mode
  unrepresentable instead of merely unreachable, and made the diff smaller.

## Preserved deliberately (E2E-critical)

**`.copyApiKeyIcon` must not move.** `playwright/lib/utils.ts:141,147` waits for it and clicks it to read a
freshly created key, and **eight API specs take their bearer token from that helper** — webhook, contacts,
response, survey, role, user, workspace-team, team. Breaking it breaks all eight, in a way that looks like
an auth failure rather than a selector failure.

| Kept | Where |
| --- | --- |
| `.copyApiKeyIcon` class | on the copy affordance, with a comment saying why it can't be renamed |
| `data-testid="copy-button"` | on the icon |
| `data-testid="api-key-row"` | via `getRowProps` |

`hideBelow: "sm"` reproduces the old `hidden sm:block` breakpoint exactly, so the copy icon is visible at
the same viewports as before — which matters, because that helper waits on its *visibility*.

One subtlety worth stating: **the api key column is deliberately not `stopRowClick`.** Clicking the key
*text* has always opened the permissions modal; only the copy icon is an exception, so it keeps its own
`stopPropagation` rather than the whole column opting out. Marking the column would have silently removed
a click target.

## Behaviour and visual deltas

| Change | Why |
| --- | --- |
| **"Add API key" moves from below-left to above-right** | Matches every other converted settings table, and is required: a flush card body means the table must be the last thing in the card. This is the one deliberate UX change — say so in review if you'd rather it stayed below. |
| Header type goes **bold slate-900 → medium slate-500** | The shared settings-table treatment. |
| Actions button goes **centred → right-aligned** | Consistency with the other actions columns. In a 10%-wide column it's a few pixels. |
| Empty state row gets taller (`h-12` → `h-24`) | The primitive's empty cell. Same copy. |

`hidden sm:block` → `hideBelow: "sm"` is not cosmetic: `display: block` on a `<td>` drops it out of the
table's column layout and misaligns the whole row, so the primitive uses `table-cell`.

## Linear ticket

Ref ENG-762

## How this was tested

- `npx turbo run typecheck --filter=@formbricks/web` → **12/12 tasks successful, 0 errors.**
- `npx vitest run modules/ui/components/settings-table` → **25/25 pass.**
- `npx eslint` over the whole `api-keys` module and `npx prettier --check` → clean.
- **`pnpm scan-translations` → all validations pass.** This needed care: the row activator's accessible
  name is a new key, and the scanner fails on a key present in `en-US` but missing from the other 14
  locales *and* on a stale `i18n.lock`. Hand-adding to the other locales is forbidden by AGENTS.md, so I
  added it to `en-US.json` only and ran `pnpm i18n:web:generate`, which regenerated all 14 locales and
  rebuilt the lockfile. Diff is exactly **one key per locale plus the lockfile line** — no incidental
  reformatting.
- **Traced every consumer of the E2E selectors before touching them**, rather than assuming
  `data-testid="api-key-row"` was the only coupling. `.copyApiKeyIcon` is a bare CSS class with no testid,
  which is exactly what a refactor deletes by accident.
- **Swept the whole app for the `cellClassName` display bug** after review, not just this file:
  `grep 'cellClassName: "[^"]*\(flex\|grid\|block\)'` now returns nothing across `modules/` and `app/`.

**Still owed before merge:** I can't run Playwright here — no Docker, so no database and no app. Nothing in
this PR edits a spec, so the whole suite should pass **unchanged**; the risk concentrates on
`.copyApiKeyIcon` still being clickable, which `pnpm test:e2e -- playwright/api/` covers. The vertical
centring of the delete button is also reasoned from CSS box semantics rather than observed, so it needs a
real look.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Open Organization settings → API Keys → the table fills the card edge to edge, header band flush
      against the card's title divider, last row meeting the card's bottom border
- [ ] On that page, find the "Add API key" button → it is now **above** the table, right-aligned, and inset
      from the card edges → a button touching the card edge is the regression
- [ ] On that page, read across a row → label (semibold), the key, created-at, and a trash button
- [ ] On that page, look down the trash-button column → each button is **vertically centred** in its row,
      level with the label text beside it → a button sitting high or on the text baseline is the bug the
      review round fixed, and it shows up most on rows where the key text wraps to two lines
- [ ] Click "Add API key", fill the form and submit → the new row appears with the plaintext key visible
- [ ] Click the copy icon on that new row → toast confirms, and pasting gives the key → **highest-risk
      check: eight API specs read their bearer token through this exact icon**
- [ ] Click the copy icon again and confirm the permissions modal does **not** open → the icon stops the
      click from reaching the row
- [ ] Click anywhere else on a row — the label, the key text, the created-at cell → the permissions modal
      opens for that key
- [ ] Tab to a row → focus lands on one visible ring around the label cell, not the whole row; press Enter
      → the permissions modal opens
- [ ] With a screen reader, move onto a row's activator → it announces "View permissions for &lt;label&gt;";
      move onto the trash button → it announces "Delete"
- [ ] Click the trash button → the delete dialog opens and the permissions modal does **not**
- [ ] Confirm the delete → the row disappears and a toast confirms
- [ ] In the permissions modal, rename the key and click Update → the row's label updates in place
- [ ] Narrow the browser below 640px, then reload → the API-key column disappears and the remaining three
      columns rescale with no empty gap and no sideways page scroll
- [ ] Widen back above 640px → the API-key column returns
- [ ] Throttle the network and reload → the loading skeleton shows **four** column headers matching the
      real table, plus a placeholder button above it → three headers is the drift this PR fixes
- [ ] Open an organization with no API keys → "You do not have any API keys yet" centred in a full-width
      row, headers still visible above it

**Preconditions / test data**

- An org owner or manager account — the page throws for anyone else
- At least three API keys, one created during the session so its plaintext value is on screen
- A key whose label is long, and one row where the key text wraps, to make the vertical-centring check
  meaningful
- A browser where clipboard read is permitted, for the copy check
- A throttled connection or cold cache to see the loading skeleton at all

**Risks & regressions**

- **`.copyApiKeyIcon` is the single highest risk in this PR.** A bare CSS class, referenced only from
  `playwright/lib/utils.ts`, with eight API specs depending on the helper that clicks it. If those specs
  fail with auth errors rather than selector errors, this is why.
- The row activator replaces a hand-rolled `role="button"`/`onKeyDown` div. Keyboard activation is the
  thing to check — mouse clicking will work regardless.
- `hideBelow: "sm"` must hide and show at the same width as the old `hidden sm:block`, since the copy-icon
  helper waits on visibility.
- The "Add API key" reposition is deliberate but is a real UX change; anyone used to the old position will
  notice.
- Vertical alignment of the delete button changed twice in this PR (broken, then fixed). It is reasoned
  from CSS box semantics, not screenshotted, so it deserves an actual look.

**Migrations / env / cutover**

- One new i18n key (`workspace.api_keys.view_permissions_for`) with all 14 locales generated. No env, no
  migration.

## Follow-ups this PR deliberately does not do

- **The page throws instead of rendering read-only.** `page.tsx` throws `not_authorized` for a
  non-owner/manager, which is what made `isReadOnly` dead. Fixing that is a behaviour change well outside a
  restyle; whoever does it should reintroduce the flag deliberately and reconsider the column widths at the
  same time.
- **`MemberActions`' icon-only share-invite and resend-invite buttons** have the same missing accessible
  name this PR fixed for the trash button. Different module, so not touched here.
- **The skeleton's actions bar is left-aligned** while the real button is right-aligned. It can't be
  addressed through column config — the skeleton renders a block-level bar, so neither `align` nor a `cell`
  wrapper reaches it. A few pixels of grey rectangle in a 10% column; not worth new primitive API.
