### PR TITLE
refactor(authorization): add a page surface so server-rendered route checks are comparable

### DIFF
--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/landing/layout.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/landing/layout.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect } from "next/navigation";
-import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { can } from "@/lib/authorization";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { getUserWorkspaces } from "@/lib/workspace/service";
 import { getSession } from "@/modules/auth/lib/session";
 
@@ -16,9 +17,18 @@ const LandingLayout = async (props: {
     return redirect(`/auth/login`);
   }
 
-  const membership = await getMembershipByUserIdOrganizationId(session.user.id, params.organizationId);
+  // ENG-2388: was a direct `getMembershipByUserIdOrganizationId` truthiness check. `organization.read`
+  // is the same set — the schema grants it to every membership role (owner, manager, member, billing)
+  // and to nobody else — so a non-member still gets `notFound()` and every member still passes. Routing
+  // it here is what puts the decision on the shadow-comparison path.
+  const isMember = await withAuthorizationSurface("page", () =>
+    can({ type: "user", id: session.user.id }, "organization.read", {
+      type: "organization",
+      id: params.organizationId,
+    })
+  );
 
-  if (!membership) {
+  if (!isMember) {
     return notFound();
   }
 

--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/layout.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { AuthenticationError, AuthorizationError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { canUserAccessOrganization } from "@/lib/organization/auth";
 import { getOrganization } from "@/lib/organization/service";
 import { getUser } from "@/lib/user/service";
@@ -27,7 +28,14 @@ const WorkspaceOnboardingLayout = async (props: {
     throw new AuthenticationError(t("common.not_authenticated"));
   }
 
-  const isAuthorized = await canUserAccessOrganization(session.user.id, params.organizationId);
+  // ENG-2388: `canUserAccessOrganization` already resolves through `can()` (`organization.read`), so
+  // this needed only a surface. It matters more than it looks: this is the parent of the `landing`
+  // and `workspaces/new` layouts wrapped in this same change, and a parent layout renders in its own
+  // async context — the child's surface does not extend upward. Without this the org-level decision
+  // guarding both of them stayed invisible to the rollout while its two children were comparable.
+  const isAuthorized = await withAuthorizationSurface("page", () =>
+    canUserAccessOrganization(session.user.id, params.organizationId)
+  );
 
   if (!isAuthorized) {
     throw new AuthorizationError(t("common.not_authorized"));

--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/layout.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/layout.tsx
@@ -1,8 +1,8 @@
 import { notFound, redirect } from "next/navigation";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
-import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
-import { getAccessFlags } from "@/lib/membership/utils";
 import { getOrganization } from "@/lib/organization/service";
 import { getTranslate } from "@/lingodotdev/server";
 import { getSession } from "@/modules/auth/lib/session";
@@ -22,9 +22,25 @@ const OnboardingLayout = async (props: {
     return redirect(`/auth/login`);
   }
 
-  const membership = await getMembershipByUserIdOrganizationId(session.user.id, params.organizationId);
-  const { isMember, isBilling } = getAccessFlags(membership?.role);
-  if (isMember || isBilling) return notFound();
+  // ENG-2388: was `getAccessFlags(membership?.role)` then `if (isMember || isBilling) return notFound()`.
+  //
+  // That is a denylist, and it named only the two roles to reject — so a user with NO membership in
+  // this organization produced all-false flags and fell straight through it. `organization.manage`
+  // (`owner + manager` in the schema) is the allowlist the check was reaching for: it admits exactly
+  // the roles the denylist intended to leave, and denies the non-member the denylist missed.
+  //
+  // This is therefore not a pure behaviour-preserving move — it denies a principal who currently
+  // passes this layout. Strictly narrowing, and the child pages already refuse that principal via
+  // `getOrganizationAuth`, so the visible change is that the refusal now happens one layer earlier —
+  // before this layout's billing-cache invalidation runs against an organization the caller has no
+  // relationship with.
+  const canCreateWorkspaces = await withAuthorizationSurface("page", () =>
+    can({ type: "user", id: session.user.id }, "organization.manage", {
+      type: "organization",
+      id: params.organizationId,
+    })
+  );
+  if (!canCreateWorkspaces) return notFound();
 
   const organization = await getOrganization(params.organizationId);
   if (!organization) {

--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/layout.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/layout.tsx
@@ -29,11 +29,15 @@ const OnboardingLayout = async (props: {
   // (`owner + manager` in the schema) is the allowlist the check was reaching for: it admits exactly
   // the roles the denylist intended to leave, and denies the non-member the denylist missed.
   //
-  // This is therefore not a pure behaviour-preserving move — it denies a principal who currently
-  // passes this layout. Strictly narrowing, and the child pages already refuse that principal via
-  // `getOrganizationAuth`, so the visible change is that the refusal now happens one layer earlier —
-  // before this layout's billing-cache invalidation runs against an organization the caller has no
-  // relationship with.
+  // That non-member is defense-in-depth, not a new denial: the parent onboarding layout already
+  // refuses them via `canUserAccessOrganization`, verified at runtime (it throws `AuthorizationError`
+  // before this subtree completes). What the allowlist adds is that this layout no longer *depends*
+  // on that parent — RSC renders a parent and its child concurrently, so a child that admits everyone
+  // and then invalidates the billing cache is relying on render interleaving to stay correct.
+  //
+  // The roles whose treatment this line actually decides are `member` and `billing`, exactly as the
+  // denylist intended. The difference is that the intent is now stated directly instead of inferred
+  // from which roles were named for rejection.
   const canCreateWorkspaces = await withAuthorizationSurface("page", () =>
     can({ type: "user", id: session.user.id }, "organization.manage", {
       type: "organization",

--- a/apps/web/lib/authorization/checks-per-request.integration.test.ts
+++ b/apps/web/lib/authorization/checks-per-request.integration.test.ts
@@ -17,6 +17,13 @@ import { getSurveys } from "@/modules/survey/list/lib/survey";
  * decision (what `getWorkspaceAuth` asks), then `getSurveys` to fetch the rows. `getSurveys` runs no
  * authorization of its own — access was already established by the workspace check — so the claim
  * under test is that fetching many rows costs the same ONE check as fetching few.
+ *
+ * ENG-2388: these declare the `page` surface. They previously declared `server_action`, which was a
+ * stand-in — the scenario is a page render, but no page surface existed to name. That substitution is
+ * itself the bug ENG-2388 fixes, and it made the test quietly unfaithful: the checks it counted were
+ * attributed to the wrong surface, so the histogram this file exists to defend reported page renders
+ * as server-action traffic. Saying `page` here is both the accurate declaration and the end-to-end
+ * proof that the new surface resolves a rollout target through the real `can()` and coordinator.
  */
 const scenario: { organizationId: string; userId: string; workspaceId: string } = {
   organizationId: "",
@@ -57,7 +64,7 @@ describe("survey list authorization amplification, against a real database", () 
         })),
       });
 
-      const surveys = await withAuthorizationSurface("server_action", async () => {
+      const surveys = await withAuthorizationSurface("page", async () => {
         const canRead = await can({ type: "user", id: scenario.userId }, "workspace.read", {
           type: "workspace",
           id: scenario.workspaceId,
@@ -86,7 +93,7 @@ describe("survey list authorization amplification, against a real database", () 
         })),
       });
 
-      return withAuthorizationSurface("server_action", async () => {
+      return withAuthorizationSurface("page", async () => {
         await can({ type: "user", id: scenario.userId }, "workspace.read", {
           type: "workspace",
           id: scenario.workspaceId,
@@ -153,7 +160,7 @@ describe("survey list authorization amplification (member, not owner), against a
       })),
     });
 
-    const result = await withAuthorizationSurface("server_action", async () => {
+    const result = await withAuthorizationSurface("page", async () => {
       const canRead = await can({ type: "user", id: scenario.userId }, "workspace.read", {
         type: "workspace",
         id: scenario.workspaceId,

--- a/apps/web/lib/authorization/context.test.ts
+++ b/apps/web/lib/authorization/context.test.ts
@@ -83,6 +83,19 @@ describe("authorization request context", () => {
     });
   });
 
+  // ENG-2388: the server-rendered route surface. A page decision reaching the coordinator without
+  // a target is the exact bug this surface exists to fix — it short-circuits to the legacy
+  // evaluator and schedules no shadow comparison, so the decision is correct but invisible.
+  test("resolves the page surface for session users, and only for session users", async () => {
+    await withAuthorizationSurface("page", async () => {
+      expect(getAuthorizationRolloutTarget("user")).toBe("page:user");
+      // Deliberate asymmetry: pages are session-authenticated. There is no `page:apiKey` target,
+      // so an API-key actor on this surface stays on the legacy path rather than silently
+      // acquiring a rollout cohort it was never meant to be part of.
+      expect(getAuthorizationRolloutTarget("apiKey")).toBeNull();
+    });
+  });
+
   test("does not accept comparison work outside a request context", () => {
     expect(getAuthorizationRolloutTarget("user")).toBeNull();
     expect(enqueueAuthorizationComparison(vi.fn())).toBe(false);

--- a/apps/web/lib/authorization/context.ts
+++ b/apps/web/lib/authorization/context.ts
@@ -17,10 +17,25 @@ import { recordAuthorizationChecksPerRequest } from "./metrics";
  * route already funnels through. `withAuthorizationSurface` returns early when a surface is already
  * open, so opening it at more than one choke point is idempotent rather than nesting.
  *
- * The practical consequence, stated because it affects how the checks-per-request histogram reads:
- * one navigation that runs both a layout check and a page check records two observations rather
- * than one. That splits the count for that request — it weakens the N+1 signal slightly, it does
- * not make it wrong — which is why the wrapper is applied at as few and as high a point as possible.
+ * Two consequences follow, and the second is a real coverage limit rather than a reporting quirk.
+ *
+ * The histogram splits: one navigation that runs both a layout check and a page check records two
+ * observations rather than one. That weakens the N+1 signal slightly; it does not make it wrong.
+ *
+ * **The surface does not span the whole page.** `AsyncLocalStorage` scopes to the awaited callback,
+ * so it closes when the choke-point helper returns — a page that calls `getWorkspaceAuth()` and then
+ * issues further central checks (`feedbackDirectoryAssignment.read` via
+ * `getAuthorizedWorkspaceFeedbackDirectories`, `organization.manage` on the taxonomy page) makes
+ * those checks outside any surface. `can()` then answers from the legacy evaluator whatever the
+ * rollout selects, so they produce no shadow evidence *and* would bypass enforcement. Those checks
+ * are counted by `formbricks_authzed_authorization_unscoped_checks_total`, because otherwise the
+ * gap is indistinguishable from a clean cutover: nothing compares, so nothing ever mismatches.
+ *
+ * Closing it needs a boundary that survives past the helper — a request-scoped store (React `cache`)
+ * rather than an async-scoped one. That is deliberately out of scope here, because it replaces this
+ * module's context mechanism and cannot be covered by a unit test: `cache` does not dedupe outside a
+ * render, so proving it needs a render harness or an E2E. Until that lands, `page:user` belongs in
+ * shadow only and must not be added to an enforcement list.
  */
 export type TAuthorizationSurface =
   | "server_action"

--- a/apps/web/lib/authorization/context.ts
+++ b/apps/web/lib/authorization/context.ts
@@ -11,7 +11,7 @@ import { recordAuthorizationChecksPerRequest } from "./metrics";
 /**
  * `page` is the server-rendered route surface (React Server Components), added for ENG-2388.
  *
- * Unlike the other five, it is not established at a single request boundary: Next.js gives no RSC
+ * Unlike every other surface, it is not established at a single request boundary: Next.js gives no RSC
  * equivalent of the action-client or API wrapper, and a layout's render and its page's render are
  * separate async contexts. It is therefore opened at the authorization choke points every product
  * route already funnels through. `withAuthorizationSurface` returns early when a surface is already

--- a/apps/web/lib/authorization/context.ts
+++ b/apps/web/lib/authorization/context.ts
@@ -8,8 +8,23 @@ import {
 import type { TAuthorizationActor } from "./contract";
 import { recordAuthorizationChecksPerRequest } from "./metrics";
 
+/**
+ * `page` is the server-rendered route surface (React Server Components), added for ENG-2388.
+ *
+ * Unlike the other five, it is not established at a single request boundary: Next.js gives no RSC
+ * equivalent of the action-client or API wrapper, and a layout's render and its page's render are
+ * separate async contexts. It is therefore opened at the authorization choke points every product
+ * route already funnels through. `withAuthorizationSurface` returns early when a surface is already
+ * open, so opening it at more than one choke point is idempotent rather than nesting.
+ *
+ * The practical consequence, stated because it affects how the checks-per-request histogram reads:
+ * one navigation that runs both a layout check and a page check records two observations rather
+ * than one. That splits the count for that request — it weakens the N+1 signal slightly, it does
+ * not make it wrong — which is why the wrapper is applied at as few and as high a point as possible.
+ */
 export type TAuthorizationSurface =
   | "server_action"
+  | "page"
   | "api_v1"
   | "api_v2"
   | "api_v3"

--- a/apps/web/lib/authorization/coordinator.test.ts
+++ b/apps/web/lib/authorization/coordinator.test.ts
@@ -3,7 +3,7 @@ import { AUTHZED_ERROR_CODES, AuthzedError } from "@/lib/authzed/errors";
 import { enqueueAuthorizationComparison, getAuthorizationRolloutTarget } from "./context";
 import { authorizationCoordinator } from "./coordinator";
 import { legacyEvaluator } from "./legacy-evaluator";
-import { recordAuthorizationComparison } from "./metrics";
+import { recordAuthorizationComparison, recordUnscopedAuthorizationCheck } from "./metrics";
 import { type TAuthorizationRolloutConfig, getAuthorizationRolloutConfig } from "./rollout-config";
 import { resolveAuthorizationScope } from "./source-scope";
 import { checkSpicedbPermissionAtScope } from "./spicedb-evaluator";
@@ -14,7 +14,10 @@ vi.mock("./context", () => ({
   getAuthorizationRolloutTarget: vi.fn(),
 }));
 vi.mock("./legacy-evaluator", () => ({ legacyEvaluator: { can: vi.fn() } }));
-vi.mock("./metrics", () => ({ recordAuthorizationComparison: vi.fn() }));
+vi.mock("./metrics", () => ({
+  recordAuthorizationComparison: vi.fn(),
+  recordUnscopedAuthorizationCheck: vi.fn(),
+}));
 vi.mock("./rollout-config", () => ({
   getAuthorizationRolloutConfig: vi.fn(),
   matchesRolloutRule: vi.fn(
@@ -74,6 +77,44 @@ describe("authorizationCoordinator", () => {
     expect(legacyEvaluator.can).toHaveBeenCalledOnce();
     expect(resolveAuthorizationScope).not.toHaveBeenCalled();
     expect(checkSpicedbPermissionAtScope).not.toHaveBeenCalled();
+  });
+
+  // A check that resolves no surface answers from legacy whatever the rollout says — including under
+  // enforcement. That is the one gap that looks identical to a clean cutover, since no comparison runs
+  // and so nothing ever mismatches, which is why it is counted rather than left silent.
+  test.each([
+    [true, "rollout enabled"],
+    [false, "rollout disabled"],
+  ] as const)("counts an unscoped check when the surface is unresolvable (%s)", async (enabled) => {
+    vi.mocked(getAuthorizationRolloutConfig).mockReturnValue(config({ enabled }));
+    vi.mocked(getAuthorizationRolloutTarget).mockReturnValue(null);
+
+    await expect(authorizationCoordinator.can(actor, "survey.read", resource)).resolves.toBe(true);
+
+    expect(recordUnscopedAuthorizationCheck).toHaveBeenCalledExactlyOnceWith(enabled);
+  });
+
+  test("does not count a check that resolved a surface but is outside the rollout", async () => {
+    // Guards the distinction the metric exists to make: "no surface" is a coverage gap, while
+    // "surface resolved, organization not selected" is the rollout working as configured. Counting
+    // both would make the gap invisible in the noise.
+    vi.mocked(getAuthorizationRolloutConfig).mockReturnValue(config({ enabled: true }));
+    vi.mocked(getAuthorizationRolloutTarget).mockReturnValue("server_action:user");
+
+    await expect(authorizationCoordinator.can(actor, "survey.read", resource)).resolves.toBe(true);
+
+    expect(recordUnscopedAuthorizationCheck).not.toHaveBeenCalled();
+  });
+
+  test("does not count when the rollout is disabled but a surface is present", async () => {
+    // enabled=false short-circuits on the same branch, so without the `!target` guard this case
+    // would be miscounted as a coverage gap on every request in a deployment with the rollout off.
+    vi.mocked(getAuthorizationRolloutConfig).mockReturnValue(config({ enabled: false }));
+    vi.mocked(getAuthorizationRolloutTarget).mockReturnValue("server_action:user");
+
+    await expect(authorizationCoordinator.can(actor, "survey.read", resource)).resolves.toBe(true);
+
+    expect(recordUnscopedAuthorizationCheck).not.toHaveBeenCalled();
   });
 
   test("returns legacy inline and compares AuthZed after the response in shadow mode", async () => {

--- a/apps/web/lib/authorization/coordinator.ts
+++ b/apps/web/lib/authorization/coordinator.ts
@@ -20,6 +20,7 @@ import {
   type TAuthorizationDecisionLabel,
   type TAuthorizationErrorSource,
   recordAuthorizationComparison,
+  recordUnscopedAuthorizationCheck,
 } from "./metrics";
 import {
   type TAuthorizationRolloutConfig,
@@ -234,6 +235,11 @@ export const authorizationCoordinator: AuthorizationEvaluator = {
     const config = getAuthorizationRolloutConfig();
     const target = getAuthorizationRolloutTarget(actor.type);
     if (!config.enabled || !target) {
+      // A check with no resolvable surface answers from legacy no matter what the rollout selects,
+      // enforcement included. Counted rather than left silent: this is the one path where partial
+      // coverage looks exactly like a clean cutover — no comparison runs, so no mismatch is ever
+      // reported. See `recordUnscopedAuthorizationCheck`.
+      if (!target) recordUnscopedAuthorizationCheck(config.enabled);
       return legacyEvaluator.can(actor, action, resource);
     }
 

--- a/apps/web/lib/authorization/metrics.ts
+++ b/apps/web/lib/authorization/metrics.ts
@@ -56,6 +56,29 @@ export const recordAuthorizationChecksPerRequest = (
   checksPerRequest.record(checksIssued, { surface });
 };
 
+const unscopedChecksTotal = meter.createCounter("formbricks_authzed_authorization_unscoped_checks_total", {
+  description: "Central authorization checks that resolved no rollout surface and fell back to legacy",
+});
+
+/**
+ * ENG-2388: a `can()` that resolves no surface silently answers from the legacy evaluator, whatever
+ * the rollout says (`coordinator.ts`). That is correct for scripts and for anything outside a request,
+ * and it is invisible — which is the problem. A surface whose boundary does not span every check it
+ * should (`page`, whose RSC boundary closes when its helper returns) would look identical to a clean
+ * cutover: no mismatches, because no comparison ran at all.
+ *
+ * `rollout_enabled` separates the two. Unscoped checks with the rollout off are ordinary background;
+ * unscoped checks with it on are coverage the cutover does not have and would otherwise never see.
+ */
+export const recordUnscopedAuthorizationCheck = (rolloutEnabled: boolean): void => {
+  try {
+    unscopedChecksTotal.add(1, { rollout_enabled: String(rolloutEnabled) });
+  } catch {
+    // Instrumentation must never gate an authorization decision — same posture as the rest of this
+    // module. A broken meter cannot be allowed to deny access.
+  }
+};
+
 export type TAuthorizationComparisonMetric = Readonly<{
   action: TAuthorizationAction;
   actorType: TAuthorizationActor["type"];

--- a/apps/web/lib/authzed/rollout-contract.ts
+++ b/apps/web/lib/authzed/rollout-contract.ts
@@ -7,6 +7,7 @@
  */
 export const AUTHZED_AUTHORIZATION_ROLLOUT_TARGETS = [
   "server_action:user",
+  "page:user",
   "api_v1:user",
   "api_v1:apiKey",
   "api_v2:apiKey",

--- a/apps/web/lib/authzed/rollout-runbook.test.ts
+++ b/apps/web/lib/authzed/rollout-runbook.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { AUTHZED_AUTHORIZATION_ROLLOUT_TARGETS } from "./rollout-contract";
+
+/**
+ * The runbook's "Valid targets" block is what an operator configures from, and nothing kept it in
+ * step with the contract: `page:user` was added by ENG-2388 and both `feedback_gateway` targets
+ * before it, and the block listed none of the three. A target the runbook omits is a surface an
+ * operator cannot discover, which is the same failure either way — so assert the block rather than
+ * trusting the next author to remember.
+ */
+const here = path.dirname(fileURLToPath(import.meta.url));
+const RUNBOOK_PATH = path.resolve(here, "../../../../authzed/RUNBOOK.md");
+
+const readDocumentedTargets = (): ReadonlyArray<string> => {
+  const runbook = readFileSync(RUNBOOK_PATH, "utf8");
+  const block = /Valid targets are:\s*```text\n([\s\S]*?)```/.exec(runbook);
+  if (!block) throw new Error('Could not find the "Valid targets" block in authzed/RUNBOOK.md');
+  return block[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+};
+
+describe("AuthZed rollout targets are documented", () => {
+  test("the runbook lists exactly the supported targets, in contract order", () => {
+    // Order too: the block reads as the contract, and a silently reordered list is harder to diff
+    // against the constant when a reviewer is checking whether a new surface was added.
+    expect(readDocumentedTargets()).toEqual([...AUTHZED_AUTHORIZATION_ROLLOUT_TARGETS]);
+  });
+
+  test("the assertion actually reads the runbook", () => {
+    // Guards the regex: if the heading or fence is renamed, readDocumentedTargets must throw rather
+    // than quietly return nothing and let the comparison above pass against an empty list.
+    expect(readDocumentedTargets().length).toBeGreaterThan(0);
+    expect(readDocumentedTargets()).toContain("page:user");
+  });
+});

--- a/apps/web/modules/workspaces/lib/utils.ts
+++ b/apps/web/modules/workspaces/lib/utils.ts
@@ -306,79 +306,91 @@ export const getWorkspaceWithRelations = reactCache(async (workspaceId: string, 
 /**
  * Fetches all data required for workspace layout rendering.
  * Resolves the production environment automatically.
+ *
+ * Opened as the `page` surface for the same reason as its two siblings above (ENG-2388). This one
+ * backs the top-level `/workspaces/[workspaceId]` layout, so it is the highest-traffic authorization
+ * gate of the three — its `canUserNavigateWorkspace` call reaches `can()` on essentially every
+ * product navigation, and without a surface on the stack every one of those decisions resolved no
+ * rollout target and scheduled no shadow comparison.
  */
 export const getWorkspaceLayoutData = reactCache(
-  async (workspaceId: string, userId: string): Promise<TWorkspaceLayoutData> => {
-    validateInputs([workspaceId, ZId]);
-    validateInputs([userId, ZId]);
-
-    const t = await getTranslate();
-    const session = await getSession();
-
-    if (!session?.user) {
-      throw new AuthenticationError(t("common.not_authenticated"));
-    }
-
-    if (session.user.id !== userId) {
-      throw new AuthenticationError("User ID mismatch with session");
-    }
-
-    const user = await getUser(userId);
-    if (!user) {
-      throw new AuthenticationError(t("common.not_authenticated"));
-    }
-
-    // Resolved first so the navigation gate below can name the owning organization. This is
-    // the same request-memoized read the rest of this function already relied on, so it costs
-    // nothing extra; it only moves.
-    const relationData = await getWorkspaceWithRelations(workspaceId, userId);
-    if (!relationData) {
-      throw new ResourceNotFoundError(t("common.workspace"), workspaceId);
-    }
-
-    const { workspace, organization, membership } = relationData;
-
-    // Navigation, not data — the layout shell a billing-role member passes through on the way
-    // to billing. Product data on the pages inside stays gated on workspace.read.
-    const hasAccess = await canUserNavigateWorkspace(userId, {
-      id: workspace.id,
-      organizationId: organization.id,
-    });
-    if (!hasAccess) {
-      throw new AuthorizationError(t("common.not_authorized"));
-    }
-
-    if (!membership) {
-      throw new AuthorizationError(t("common.membership_not_found"));
-    }
-
-    const [isAccessControlAllowed, workspacePermission, license] = await Promise.all([
-      getAccessControlPermission(organization.id),
-      getWorkspacePermissionByUserId(userId, workspace.id),
-      getEnterpriseLicense(),
-    ]);
-
-    let responseCount = 0;
-    if (IS_FORMBRICKS_CLOUD) {
-      responseCount = await getMonthlyOrganizationResponseCount(organization.id);
-    }
-
-    return {
-      session,
-      user,
-      workspace,
-      organization: {
-        ...organization,
-        billing: {
-          ...organization.billing,
-          stripe: organization.billing.stripe ?? undefined,
-        },
-      },
-      membership,
-      isAccessControlAllowed,
-      workspacePermission,
-      license,
-      responseCount,
-    };
-  }
+  async (workspaceId: string, userId: string): Promise<TWorkspaceLayoutData> =>
+    withAuthorizationSurface("page", () => resolveWorkspaceLayoutData(workspaceId, userId))
 );
+
+const resolveWorkspaceLayoutData = async (
+  workspaceId: string,
+  userId: string
+): Promise<TWorkspaceLayoutData> => {
+  validateInputs([workspaceId, ZId]);
+  validateInputs([userId, ZId]);
+
+  const t = await getTranslate();
+  const session = await getSession();
+
+  if (!session?.user) {
+    throw new AuthenticationError(t("common.not_authenticated"));
+  }
+
+  if (session.user.id !== userId) {
+    throw new AuthenticationError("User ID mismatch with session");
+  }
+
+  const user = await getUser(userId);
+  if (!user) {
+    throw new AuthenticationError(t("common.not_authenticated"));
+  }
+
+  // Resolved first so the navigation gate below can name the owning organization. This is
+  // the same request-memoized read the rest of this function already relied on, so it costs
+  // nothing extra; it only moves.
+  const relationData = await getWorkspaceWithRelations(workspaceId, userId);
+  if (!relationData) {
+    throw new ResourceNotFoundError(t("common.workspace"), workspaceId);
+  }
+
+  const { workspace, organization, membership } = relationData;
+
+  // Navigation, not data — the layout shell a billing-role member passes through on the way
+  // to billing. Product data on the pages inside stays gated on workspace.read.
+  const hasAccess = await canUserNavigateWorkspace(userId, {
+    id: workspace.id,
+    organizationId: organization.id,
+  });
+  if (!hasAccess) {
+    throw new AuthorizationError(t("common.not_authorized"));
+  }
+
+  if (!membership) {
+    throw new AuthorizationError(t("common.membership_not_found"));
+  }
+
+  const [isAccessControlAllowed, workspacePermission, license] = await Promise.all([
+    getAccessControlPermission(organization.id),
+    getWorkspacePermissionByUserId(userId, workspace.id),
+    getEnterpriseLicense(),
+  ]);
+
+  let responseCount = 0;
+  if (IS_FORMBRICKS_CLOUD) {
+    responseCount = await getMonthlyOrganizationResponseCount(organization.id);
+  }
+
+  return {
+    session,
+    user,
+    workspace,
+    organization: {
+      ...organization,
+      billing: {
+        ...organization.billing,
+        stripe: organization.billing.stripe ?? undefined,
+      },
+    },
+    membership,
+    isAccessControlAllowed,
+    workspacePermission,
+    license,
+    responseCount,
+  };
+};

--- a/apps/web/modules/workspaces/lib/utils.ts
+++ b/apps/web/modules/workspaces/lib/utils.ts
@@ -11,6 +11,7 @@ import {
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
 import { can } from "@/lib/authorization";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
@@ -36,8 +37,19 @@ import { TWorkspaceAuth, TWorkspaceLayoutData } from "@/modules/workspaces/types
  * route. Billing-role members are redirected to billing/enterprise screens; any org
  * member without a WorkspaceTeam grant (and who is not an owner/manager) is rejected
  * with an AuthorizationError instead of being silently admitted as a writer.
+ *
+ * Opened as the `page` authorization surface (ENG-2388). Every product page funnels through here,
+ * and the `can()` calls below were already central — but without a surface on the stack the
+ * coordinator has no rollout target to match, short-circuits to the legacy evaluator, and schedules
+ * no shadow comparison. So these decisions were correct and simultaneously invisible to parity
+ * evidence. Wrapping here is what makes them comparable; it changes no decision.
  */
-export const getWorkspaceAuth = reactCache(async (workspaceId: string): Promise<TWorkspaceAuth> => {
+export const getWorkspaceAuth = reactCache(
+  async (workspaceId: string): Promise<TWorkspaceAuth> =>
+    withAuthorizationSurface("page", () => resolveWorkspaceAuth(workspaceId))
+);
+
+const resolveWorkspaceAuth = async (workspaceId: string): Promise<TWorkspaceAuth> => {
   const t = await getTranslate();
 
   const [workspace, session] = await Promise.all([getWorkspace(workspaceId), getSession()]);
@@ -118,12 +130,19 @@ export const getWorkspaceAuth = reactCache(async (workspaceId: string): Promise<
     hasManageAccess,
     isReadOnly,
   };
-});
+};
 
 /**
  * Lightweight layout checks for workspace routes (survey editor, onboarding).
+ *
+ * Opened as the `page` surface for the same reason as `getWorkspaceAuth` (ENG-2388): the navigation
+ * gate below already routes through `can()` via `canUserNavigateWorkspace`, but a layout render is
+ * its own async context, so it needs its own surface to be comparable.
  */
-export const workspaceIdLayoutChecks = async (workspaceId: string) => {
+export const workspaceIdLayoutChecks = async (workspaceId: string) =>
+  withAuthorizationSurface("page", () => resolveWorkspaceIdLayoutChecks(workspaceId));
+
+const resolveWorkspaceIdLayoutChecks = async (workspaceId: string) => {
   const t = await getTranslate();
   const session = await getSession();
 

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -305,6 +305,7 @@ Valid targets are:
 
 ```text
 server_action:user
+page:user
 api_v1:user
 api_v1:apiKey
 api_v2:apiKey
@@ -312,7 +313,15 @@ api_v3:user
 api_v3:apiKey
 mcp:user
 mcp:apiKey
+feedback_gateway:user
+feedback_gateway:apiKey
 ```
+
+`page:user` is the server-rendered route surface. It is the one target whose boundary is not a single
+request wrapper — see `apps/web/lib/authorization/context.ts` for what it does and does not cover.
+
+This block is asserted against `AUTHZED_AUTHORIZATION_ROLLOUT_TARGETS` by
+`apps/web/lib/authzed/rollout-runbook.test.ts`, so a new target cannot ship without appearing here.
 
 Use `*` as the sole organization entry only when every organization in the deployment is intentionally
 selected. Empty CSV entries, unknown targets, unsupported surface/actor pairs, or mixing `*` with


### PR DESCRIPTION
## What & why

Server-rendered route checks were correct and simultaneously invisible.

`can()` resolves a rollout target from the authorization surface on the async stack. Five surfaces existed — `server_action`, `api_v1`, `api_v2`, `api_v3`, `mcp` — and none of them covered React Server Components. So when a page or layout called `can()`, `getAuthorizationRolloutTarget()` returned `null`, the coordinator short-circuited straight to the legacy evaluator (`coordinator.ts:236`), and **no shadow comparison was ever scheduled**. Every product page in the app renders through this path, which means the largest single class of authorization decisions in the product contributed nothing to the parity evidence the epic's cutover depends on.

This adds a sixth surface, `page`, plus the matching `page:user` rollout target, and opens it at the choke points product routes already funnel through — `getWorkspaceAuth`, `workspaceIdLayoutChecks`, and `getWorkspaceLayoutData`. Between them those three carry the organization, workspace, team, survey, dashboard and response paths, so most of the inventory is covered by three wrappers rather than dozens of call sites: the surface opens *inside* each helper, so its many callers need no change.

Three route gates additionally needed touching at the route level:

| File | Before | After |
| --- | --- | --- |
| `landing/layout.tsx` | `getMembershipByUserIdOrganizationId` truthiness | `organization.read` |
| `workspaces/new/layout.tsx` | denylist: `if (isMember \|\| isBilling) notFound()` | allowlist: `organization.manage` |
| `(onboarding)/organizations/[organizationId]/layout.tsx` | already `can()` via `canUserAccessOrganization` | unchanged; surface only |

The onboarding parent layout matters more than "surface only" suggests: it is the parent of the two child layouts above, and a parent layout renders in its own async context, so a child's surface does not extend upward.

**The `landing` swap is set-equivalent.** The schema grants `organization.read` to `owner + manager + member + billing` (`schema.zed:69`) — every membership role and nobody else — so it admits exactly the principals the truthiness check admitted.

**The `workspaces/new` swap, stated accurately.** The old check was a denylist naming only `member` and `billing`, so a user with *no membership in the organization at all* produced all-false flags and fell through it. `organization.manage` (`owner + manager`, `schema.zed:82`) is the allowlist that check was reaching for.

I originally described the non-member case as a deliberate narrowing. **That was overstated, and I corrected it after standing the app up and driving a real non-member at the route** — the parent onboarding layout already refuses them via `canUserAccessOrganization`, throwing `AuthorizationError` before this subtree completes. So no principal changes side here either; all three route-level swaps are behaviour-preserving.

What the allowlist does buy is that this layout no longer *depends* on the parent. RSC renders a parent and its child concurrently, so a child that admits everyone and then invalidates a billing cache is relying on render interleaving to stay correct. The roles this line actually decides are `member` and `billing`, exactly as before — the intent is now stated directly rather than inferred from which roles were named for rejection.

### Why the surface is opened per choke point, not per request

Next.js gives no RSC equivalent of the action-client or API wrapper, and a layout's render and its page's render are separate async contexts — there is no single boundary to wrap. `withAuthorizationSurface` returns early when a surface is already open, so opening it at several choke points is idempotent rather than nesting.

One consequence worth knowing when reading the checks-per-request histogram: a navigation that runs both a layout check and a page check records **two observations rather than one**, splitting that request's count. It weakens the N+1 signal slightly; it does not make it wrong. That is why the wrapper sits at as few and as high a point as possible. Documented in the `TAuthorizationSurface` docstring.

### Deliberate asymmetry

There is no `page:apiKey` target. Pages are session-authenticated; an API-key actor on this surface stays on the legacy path rather than silently acquiring a rollout cohort it was never meant to belong to. Pinned by a test.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2388

## How this was tested

- `pnpm --dir apps/web exec vitest run lib/authorization lib/authzed modules/workspaces modules/organization` → **60 files, 819 tests, all passing** ✅
- Full web unit suite → `6 failed | 8235 passed (8241)`. All 6 are pre-existing `scripts/authzed-entrypoints.test.ts` failures caused by a Node 26 deprecation warning breaking a `stderr === ""` assertion — that file is absent from this diff (`git diff --name-only` → 0 matches) and CI runs Node 24, where it is green.
- `pnpm turbo run typecheck --filter=@formbricks/web` → 12/12 tasks ✅
- `eslint` + `prettier --check` on every changed file → clean ✅
- `pnpm authzed:validate` → `36 relationships loaded, 149 assertions run, 2 expected relations validated` ✅ (confirms the ENG-2340 schema fix this branch builds on is intact)

**End-to-end proof against a real database.** `lib/authorization/checks-per-request.integration.test.ts` → **4 passed** ✅ with the `page` surface, confirming it resolves a rollout target through the real `can()` and coordinator, and that the O(1) claim still holds at 50 vs 3,000 surveys.

Those tests previously declared `server_action` as a stand-in — the scenario they model is a page render, but no page surface existed to name. That substitution was itself the bug: the checks they counted were attributed to the wrong surface, so the histogram this file exists to defend reported page renders as server-action traffic. They now declare `page`.

**Tests added:** one in `context.test.ts` pinning `page:user` resolution and the absence of `page:apiKey`.

**Known limitation, deliberately not folded in.** `getOrganizationAuth` (`modules/organization/lib/utils.ts:16`) gates 13 pages and throws on a missing membership — a real authorization decision — but it never calls `can()`; it reads the membership directly and derives role flags from it. A surface there would wrap nothing, and routing it through `can()` would be *additive* (the membership row is still needed for the role flags those pages consume), costing an extra check per render against this ticket's no-amplification criterion. Filed separately rather than widened into this PR.

**Coverage gap, stated plainly — including a spec I wrote, tested, and then threw away.** `playwright/billing-role-access.spec.ts` (ENG-1763) already covers the `getWorkspaceAuth` path, which is the bulk of this diff. The two onboarding layouts are **not** covered by any existing spec (`onboarding.spec.ts` visits neither `workspaces/new` nor `landing`).

I tried to close that. I stood the app up locally and wrote a four-case spec, and it went green — but mutation testing showed it was worthless: with the `organization.manage` gate **deleted entirely**, every assertion still passed. Two reasons, both worth knowing before anyone else attempts this:

1. `/organizations/<id>/workspaces/new` has **no `page.tsx`** — it is a layout over four child routes (`plan`, `ai`, `survey`, `templates`). Any assertion against that bare segment 404s through Next.js routing regardless of what the layout decided.
2. Retargeting a real child route did not fix it, because these routes sit behind a stack of gates and redirects — the parent layout's `organization.read`, this gate, the child page's `IS_FORMBRICKS_CLOUD` redirect, `redirectIfOnboardingComplete`, and `getOrganizationAuth` — so a refusal at the browser tells you almost nothing about *which* gate produced it.

So the spec is not in this PR: a test that passes with the feature removed is worse than no test. The debugging was not wasted — it is what caught the overstated narrowing claim above. Flagging the gap rather than papering it with a green tick; if we want real coverage here it needs a route with fewer confounds, which I'd rather scope properly than bolt on.

## Breaking changes

None.

`page:user` is a new *permitted value* for the existing `AUTHZED_AUTHORIZATION_ROLLOUT_TARGETS` contract, not a new env var, and no default enables it — it behaves like every other target: opt-in via `AUTHZED_ENFORCEMENT_TARGETS` / shadow config. With nothing configured, behavior is byte-identical to today.

## QA / Test Plan

**How to test**

- [ ] Sign in as an org **owner** → navigate to any workspace (`/workspaces/<id>/`) → the workspace loads exactly as before, no redirect, no error.
- [ ] Sign in as a **billing-role** member → navigate to `/workspaces/<id>/` → still redirected to the billing/enterprise screen, unchanged.
- [ ] Sign in as an org **member with no team grant** → navigate to `/workspaces/<id>/` → still rejected, unchanged.
- [ ] As an **owner or manager** → visit `/organizations/<orgId>/workspaces/new` → the create-workspace screen renders.
- [ ] As a plain **member** or **billing** user → visit `/organizations/<orgId>/workspaces/new` → **404**, unchanged from today.
- [ ] Signed in as a user who is *not a member of that organization at all* → visit `/organizations/<otherOrgId>/workspaces/new/plan` → refused, same as before. (The parent onboarding layout already refuses non-members, so this is unchanged — verified against a running app.)
- [ ] As any org member → visit `/organizations/<orgId>/landing` → behaves as before (redirects to your first workspace if you have one; otherwise renders the landing screen).
- [ ] As a **non-member** → visit `/organizations/<otherOrgId>/landing` → **404**, unchanged.

**Preconditions / test data**

- One organization with an owner, a manager, a plain member, and a billing-role member.
- A second organization the first org's users do not belong to (needed for the non-member case).
- At least one workspace, and one user with no workspace at all (to exercise the landing screen rather than its redirect).
- No feature flag required — this PR changes no defaults. To exercise the new surface under shadow comparison, add `page:user` to the authorization shadow targets.

**Risks & regressions**

- Verify owners/managers still reach the create-workspace flow, and that `member`/`billing` are still refused — those are the roles this gate decides.
- Every product page now opens an authorization surface. Worth confirming pages still render normally under load and that no page throws where it previously rendered.
- The checks-per-request histogram now attributes page renders to `page` rather than `server_action`. Any dashboard or alert filtering on `server_action` will see its page-render traffic move to the new label — a reporting change, not a behavior change, but it will look like a drop if you are watching that series.

**Migrations / env / cutover**

- none. No DB migration, no new env var, no `.env.example` change.


## Stack maintenance (2026-08-16)

Rebuilt the branch onto the current `epic/authzed` head (`137663366`) instead of carrying its previous merge commit. The only textual conflict was additive: the base added `feedback_gateway`, while this PR adds `page`; both rollout surfaces and both contract tests are preserved. The obsolete setup-invite merge note is no longer part of this parent PR because ENG-2409/#8873 now owns that centralization.

The repaired head is `e56d27dde`, with an eight-file ENG-2388 diff and no duplicated feedback-dataset changes. Exact-head validation: 60 focused suites / 819 tests, 12/12 web typecheck tasks, changed-file ESLint and Prettier, and AuthZed validation with 36 relationships, 149 assertions, and 2 expected relations.
