### PR TITLE
refactor(authorization): route the organization page gates through can()

### DIFF
--- a/apps/web/app/(app)/organizations/[organizationId]/settings/enterprise/page.tsx
+++ b/apps/web/app/(app)/organizations/[organizationId]/settings/enterprise/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { EnterpriseLicenseFeaturesTable } from "@/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable";
 import { EnterpriseLicenseStatus } from "@/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseStatus";
+import { can } from "@/lib/authorization";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { GRACE_PERIOD_MS, getEnterpriseLicense } from "@/modules/ee/license-check/lib/license";
@@ -16,8 +18,12 @@ import { PageHeader } from "@/modules/ui/components/page-header";
 const Page = async (props: Readonly<{ params: Promise<{ organizationId: string }> }>) => {
   const params = await props.params;
   const t = await getTranslate();
-  const { session, isBilling, isMember } = await getOrganizationAuth(params.organizationId);
+  const { session, isBilling } = await getOrganizationAuth(params.organizationId);
 
+  // Not routed through can(), deliberately: this line does not decide access. On Cloud the next
+  // block refuses everyone anyway, so all it chooses is whether a billing-role user gets a 302 to
+  // their billing home or a 404. Expressing it centrally would need a "billing role only"
+  // capability, and inventing one would encode a role name as a permission.
   if (isBilling && IS_FORMBRICKS_CLOUD) {
     redirect(getOrganizationBillingPath(params.organizationId, IS_FORMBRICKS_CLOUD));
   }
@@ -26,7 +32,23 @@ const Page = async (props: Readonly<{ params: Promise<{ organizationId: string }
     return notFound();
   }
 
-  if (isMember) {
+  // ENG-2409: was `isMember -> notFound()`.
+  //
+  // `organization.manage_billing` (owner + manager + billing) is exactly `!isMember` — the caller
+  // has a membership by now, since getOrganizationAuth throws otherwise, so the four roles partition
+  // cleanly. It is NOT `organization.manage`, which is the mapping this gate invites: on self-hosted
+  // `getOrganizationBillingPath(orgId, false)` resolves to this very page, so this is where the
+  // billing role gets redirected TO. Gating on owner + manager would 404 that role on its own
+  // landing page, and billing-role-access.spec.ts would not catch it — it asserts on URL, and a 404
+  // keeps the URL.
+  const hasBillingAccess = await withAuthorizationSurface("page", () =>
+    can({ type: "user", id: session.user.id }, "organization.manage_billing", {
+      type: "organization",
+      id: params.organizationId,
+    })
+  );
+
+  if (!hasBillingAccess) {
     return notFound();
   }
 

--- a/apps/web/lib/authorization/README.md
+++ b/apps/web/lib/authorization/README.md
@@ -152,6 +152,41 @@ migration; resource-level relationships belong to the later sharing phase.
   `member` role by name, which admitted `billing`; `organization.manage` is what
   its own message always claimed.
 
+### Migrated by ENG-2388 and ENG-2409
+
+ENG-2388 added the `page` surface for server-rendered routes. Until then a `can`
+call from a page or layout resolved no rollout target, so the coordinator
+short-circuited to the legacy evaluator and scheduled no comparison — those
+decisions were correct and invisible at the same time. The surface is opened at
+the choke points routes already funnel through (`getWorkspaceAuth`,
+`workspaceIdLayoutChecks`, `getWorkspaceLayoutData`) rather than at one boundary,
+because Next gives no RSC equivalent of the action-client wrapper.
+
+ENG-2409 then routed the organization-side gates, which a surface alone could not
+help because they never called `can` at all:
+
+| Gate | Was | Now |
+| --- | --- | --- |
+| `getOrganizationAuth` tenancy check | `if (!membership) throw` | `organization.read` |
+| `redirectBillingRoleFromRestrictedOrgSettings` (5 pages) | `isBilling` | `organization.read_access` |
+| Enterprise settings page | `isMember` | `organization.manage_billing` |
+| Feedback directories page | `isOwner \|\| isManager` | `organization.manage` |
+| API keys page | `role === "owner" \|\| "manager"` | `organization.manage_api_keys` |
+
+Two of those deserve their reasoning recorded, because the obvious mapping is
+wrong in both cases:
+
+- **`read_access`, not `read`,** for the billing redirect. `read_access` is the
+  only permission whose expansion is "holds a product-eligible membership role",
+  which is what "not the billing role" means here. `product_member` has the same
+  expansion but is deliberately absent from the permission map — it exists to
+  intersect into `team#member`, and giving it a second job would mean a future
+  edit to it silently changed team-derived workspace access.
+- **`manage_billing`, not `manage`,** for the enterprise page. On self-hosted,
+  `getOrganizationBillingPath` resolves to that very page, so it is where the
+  `billing` role is redirected _to_. Gating it on owner+manager would 404 that
+  role on its own landing page.
+
 #### Retained by design
 
 These read a role but do not decide access, so they stay as they are:
@@ -161,6 +196,12 @@ These read a role but do not decide access, so they stay as they are:
   on the action or page behind it.
 - **Context output.** `getWorkspaceAuth` and `getOrganizationAuth` _return_ the
   flags for those consumers. Their own gates are `can` calls.
+- **`getOrganizationAuth` gates on membership only.** Unlike `getWorkspaceAuth`,
+  which redirects `billing` away from product data, the organization helper asks
+  only `organization.read`. The asymmetry is required: the billing settings page
+  is the `billing` role's own page, so a billing exclusion there would lock that
+  role out of the one surface it exists to reach. Callers that need to exclude
+  it do so themselves, via `redirectBillingRoleFromRestrictedOrgSettings`.
 - **Invariants and finer rules.** An owner may not leave their organization; a
   manager may only assign the `member` role; `billing` is Cloud-only. The
   schema comments already name these as application rules — they constrain a

--- a/apps/web/lib/authorization/README.md
+++ b/apps/web/lib/authorization/README.md
@@ -165,13 +165,13 @@ because Next gives no RSC equivalent of the action-client wrapper.
 ENG-2409 then routed the organization-side gates, which a surface alone could not
 help because they never called `can` at all:
 
-| Gate | Was | Now |
-| --- | --- | --- |
-| `getOrganizationAuth` tenancy check | `if (!membership) throw` | `organization.read` |
-| `redirectBillingRoleFromRestrictedOrgSettings` (5 pages) | `isBilling` | `organization.read_access` |
-| Enterprise settings page | `isMember` | `organization.manage_billing` |
-| Feedback directories page | `isOwner \|\| isManager` | `organization.manage` |
-| API keys page | `role === "owner" \|\| "manager"` | `organization.manage_api_keys` |
+| Gate                                                     | Was                               | Now                            |
+| -------------------------------------------------------- | --------------------------------- | ------------------------------ |
+| `getOrganizationAuth` tenancy check                      | `if (!membership) throw`          | `organization.read`            |
+| `redirectBillingRoleFromRestrictedOrgSettings` (5 pages) | `isBilling`                       | `organization.read_access`     |
+| Enterprise settings page                                 | `isMember`                        | `organization.manage_billing`  |
+| Feedback directories page                                | `isOwner \|\| isManager`          | `organization.manage`          |
+| API keys page                                            | `role === "owner" \|\| "manager"` | `organization.manage_api_keys` |
 
 Two of those deserve their reasoning recorded, because the obvious mapping is
 wrong in both cases:

--- a/apps/web/lib/authorization/org-page-gates.integration.test.ts
+++ b/apps/web/lib/authorization/org-page-gates.integration.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import type { TOrganizationRole } from "@formbricks/types/memberships";
+import { resetDb } from "@/integration/reset-db";
+import { can } from "@/lib/authorization";
+import { getIssuedAuthorizationCheckCount, withAuthorizationSurface } from "@/lib/authorization/context";
+
+/**
+ * ENG-2409 — the equivalence claims behind the organization page gates, decided against real rows.
+ *
+ * Every gate this ticket moved is an assertion that some `organization.*` permission selects exactly
+ * the roles a flag test used to select. Those claims are proven three ways, and this is the one that
+ * exercises the real evaluator end to end rather than a mock or the schema in isolation:
+ *
+ *   - `authzed/schema-validation.yaml` proves the SpiceDB side (and now proves the billing exclusion
+ *     of `read_access`, which had no assertFalse at all before this ticket).
+ *   - the unit tests prove each call site asks the right question.
+ *   - this file proves the legacy evaluator — the side that is authoritative today, and the side
+ *     shadow mode compares against — answers the same way for real membership rows.
+ *
+ * The mapping under test, all for a session user:
+ *   organization.read           = owner + manager + member + billing   (the getOrganizationAuth gate)
+ *   organization.read_access    = owner + manager + member             (the billing-role redirect)
+ *   organization.manage_billing = owner + manager + billing            (the enterprise page)
+ *   organization.manage         = owner + manager                      (feedback directories)
+ *   organization.manage_api_keys= owner + manager                      (API keys)
+ */
+const scenario: { organizationId: string; userIdByRole: Map<TOrganizationRole, string>; outsiderId: string } =
+  { organizationId: "", userIdByRole: new Map(), outsiderId: "" };
+
+const ORGANIZATION_ROLES: ReadonlyArray<TOrganizationRole> = ["owner", "manager", "member", "billing"];
+
+beforeAll(async () => {
+  await resetDb();
+
+  const organization = await prisma.organization.create({ data: { name: "Org Page Gates" } });
+
+  for (const role of ORGANIZATION_ROLES) {
+    const user = await prisma.user.create({ data: { name: role, email: `${role}@org-gates.test` } });
+    await prisma.membership.create({
+      data: { userId: user.id, organizationId: organization.id, role, accepted: true },
+    });
+    scenario.userIdByRole.set(role, user.id);
+  }
+
+  const outsider = await prisma.user.create({
+    data: { name: "outsider", email: "outsider@org-gates.test" },
+  });
+
+  scenario.organizationId = organization.id;
+  scenario.outsiderId = outsider.id;
+}, 120_000);
+
+const check = async (userId: string, action: Parameters<typeof can>[1]) =>
+  withAuthorizationSurface("page", () =>
+    can({ type: "user", id: userId }, action, { type: "organization", id: scenario.organizationId })
+  );
+
+describe("organization page gates, against a real database", () => {
+  // Each row is "this permission admits exactly these roles". Stated as the full four-role partition
+  // rather than only the allowed set, so a widening fails here and not only in the schema suite.
+  const GATES = [
+    { action: "organization.read", allowed: ["owner", "manager", "member", "billing"] },
+    { action: "organization.read_access", allowed: ["owner", "manager", "member"] },
+    { action: "organization.manage_billing", allowed: ["owner", "manager", "billing"] },
+    { action: "organization.manage", allowed: ["owner", "manager"] },
+    { action: "organization.manage_api_keys", allowed: ["owner", "manager"] },
+  ] as const;
+
+  test.each(GATES)("$action admits exactly $allowed", async ({ action, allowed }) => {
+    const decisions = await Promise.all(
+      ORGANIZATION_ROLES.map(async (role) => [role, await check(scenario.userIdByRole.get(role)!, action)])
+    );
+
+    expect(Object.fromEntries(decisions)).toEqual(
+      Object.fromEntries(ORGANIZATION_ROLES.map((role) => [role, allowed.includes(role as never)]))
+    );
+  });
+
+  test.each(GATES)("$action refuses a user with no membership in the organization", async ({ action }) => {
+    expect(await check(scenario.outsiderId, action)).toBe(false);
+  });
+
+  test("a page's gates cost one check each, and do not scale with anything", async () => {
+    // The api-keys page is the worst case in this ticket: the shared billing redirect runs one check
+    // and the page's own gate runs another. Pinned so a later change that moves a check inside a loop
+    // over workspaces or API keys shows up here rather than in production latency.
+    const issued = await withAuthorizationSurface("page", async () => {
+      const actor = { type: "user", id: scenario.userIdByRole.get("owner")! } as const;
+      const organization = { type: "organization", id: scenario.organizationId } as const;
+
+      await can(actor, "organization.read_access", organization);
+      await can(actor, "organization.manage_api_keys", organization);
+
+      return getIssuedAuthorizationCheckCount();
+    });
+
+    expect(issued).toBe(2);
+  });
+});

--- a/apps/web/modules/ee/feedback-directory/page.tsx
+++ b/apps/web/modules/ee/feedback-directory/page.tsx
@@ -23,14 +23,22 @@ export const FeedbackDirectoriesPage = async (props: { params: Promise<{ organiz
   // ENG-2409: was a second `getAccessFlags(currentUserMembership.role)` on a role this page had
   // already been handed, then `!isOwner && !isManager`. `organization.manage` is the same set.
   // `membershipRole` below still comes from the row — that is a rendering prop, retained by design.
-  const canManageOrganization = await withAuthorizationSurface("page", () =>
-    can({ type: "user", id: session.user.id }, "organization.manage", {
-      type: "organization",
-      id: organization.id,
-    })
-  );
+  //
+  // Run alongside the license lookup rather than before it: the two are independent (one asks about
+  // the caller's role, the other about the organization's plan), and the flag test this replaced was
+  // synchronous, so awaiting them in series would have made every load of this page pay for both
+  // round trips end to end. The *branches* below keep their original order — an unlicensed
+  // organization must still see the upgrade prompt rather than a no-access message.
+  const [canManageOrganization, isFeedbackDirectoriesAllowed] = await Promise.all([
+    withAuthorizationSurface("page", () =>
+      can({ type: "user", id: session.user.id }, "organization.manage", {
+        type: "organization",
+        id: organization.id,
+      })
+    ),
+    getIsFeedbackDirectoriesEnabled(organization.id),
+  ]);
 
-  const isFeedbackDirectoriesAllowed = await getIsFeedbackDirectoriesEnabled(organization.id);
   const pageTitle = t("workspace.settings.feedback_directories.title");
 
   if (!isFeedbackDirectoriesAllowed) {

--- a/apps/web/modules/ee/feedback-directory/page.tsx
+++ b/apps/web/modules/ee/feedback-directory/page.tsx
@@ -1,5 +1,6 @@
 import { SettingsCard } from "@/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard";
 import { can } from "@/lib/authorization";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { FeedbackDirectoryView } from "@/modules/ee/feedback-directory/components/feedback-directory-view";
@@ -18,6 +19,16 @@ export const FeedbackDirectoriesPage = async (props: { params: Promise<{ organiz
   await redirectBillingRoleFromRestrictedOrgSettings(params.organizationId);
 
   const { currentUserMembership, organization, session } = await getOrganizationAuth(params.organizationId);
+
+  // ENG-2409: was a second `getAccessFlags(currentUserMembership.role)` on a role this page had
+  // already been handed, then `!isOwner && !isManager`. `organization.manage` is the same set.
+  // `membershipRole` below still comes from the row — that is a rendering prop, retained by design.
+  const canManageOrganization = await withAuthorizationSurface("page", () =>
+    can({ type: "user", id: session.user.id }, "organization.manage", {
+      type: "organization",
+      id: organization.id,
+    })
+  );
 
   const isFeedbackDirectoriesAllowed = await getIsFeedbackDirectoriesEnabled(organization.id);
   const pageTitle = t("workspace.settings.feedback_directories.title");
@@ -53,12 +64,7 @@ export const FeedbackDirectoriesPage = async (props: { params: Promise<{ organiz
     );
   }
 
-  const canManageFeedbackDirectories = await can(
-    { type: "user", id: session.user.id },
-    "organization.manage",
-    { type: "organization", id: organization.id }
-  );
-  if (!canManageFeedbackDirectories) {
+  if (!canManageOrganization) {
     return (
       <PageContentWrapper>
         <PageHeader pageTitle={pageTitle} />

--- a/apps/web/modules/organization/lib/utils.test.ts
+++ b/apps/web/modules/organization/lib/utils.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthenticationError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TMembership } from "@formbricks/types/memberships";
 import { TOrganization } from "@formbricks/types/organizations";
+import { can } from "@/lib/authorization";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getOrganization } from "@/lib/organization/service";
 import { getSession } from "@/modules/auth/lib/session";
@@ -28,8 +29,20 @@ vi.mock("@/modules/auth/lib/session", () => ({
   getSession: vi.fn(),
 }));
 vi.mock("react", () => ({ cache: (fn: Function) => fn }));
+// ENG-2409: the tenancy gate now asks `can(organization.read)`. Mocked rather than left real so the
+// two arms of the throw can be driven independently — under the legacy evaluator they are the same
+// condition (`read` is granted to exactly the roles that have a membership row), so with the real
+// evaluator a deleted `can()` call would still throw via the membership arm and no test would fail.
+vi.mock("@/lib/authorization", () => ({ can: vi.fn() }));
+vi.mock("@/lib/authorization/context", () => ({
+  withAuthorizationSurface: (_surface: string, callback: () => unknown) => callback(),
+}));
 
 describe("getOrganizationAuth", () => {
+  beforeEach(() => {
+    vi.mocked(can).mockResolvedValue(true);
+  });
+
   const mockSession = { user: { id: "user-1" }, expires: new Date().toISOString() };
   const mockOrg = { id: "org-1" } as TOrganization;
   const mockMembership: TMembership = {
@@ -71,5 +84,31 @@ describe("getOrganizationAuth", () => {
     vi.mocked(getOrganization).mockResolvedValue(mockOrg);
     vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(null);
     await expect(getOrganizationAuth("org-1")).rejects.toThrow(ResourceNotFoundError);
+  });
+
+  // ENG-2409: the gate half of that throw, isolated. Unreachable under the legacy evaluator, where
+  // `organization.read` and "has a membership row" are the same condition — but reachable under
+  // SpiceDB enforcement if projection drifts, and this is what proves the decision now actually
+  // depends on `can()` rather than on the row.
+  test("throws when authorization denies even though a membership row exists", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    vi.mocked(getOrganization).mockResolvedValue(mockOrg);
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(mockMembership);
+    vi.mocked(can).mockResolvedValue(false);
+
+    await expect(getOrganizationAuth("org-1")).rejects.toThrow(ResourceNotFoundError);
+  });
+
+  test("asks the central interface for organization.read on the acting user", async () => {
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    vi.mocked(getOrganization).mockResolvedValue(mockOrg);
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(mockMembership);
+
+    await getOrganizationAuth("org-1");
+
+    expect(can).toHaveBeenCalledExactlyOnceWith({ type: "user", id: "user-1" }, "organization.read", {
+      type: "organization",
+      id: "org-1",
+    });
   });
 });

--- a/apps/web/modules/organization/lib/utils.ts
+++ b/apps/web/modules/organization/lib/utils.ts
@@ -52,7 +52,7 @@ export const getOrganizationAuth = reactCache(async (organizationId: string): Pr
   // resolves organization actions through `getMembershipByUserIdOrganizationId`, the same
   // reactCache-memoized function called here, so the pair costs one query rather than two. Under
   // enforcement `can()` takes the scope-resolver path and issues no membership query at all.
-  const [hasOrganizationAccess, currentUserMembership] = await Promise.all([
+  const [hasOrganizationRead, currentUserMembership] = await Promise.all([
     withAuthorizationSurface("page", () =>
       can({ type: "user", id: session.user.id }, "organization.read", {
         type: "organization",
@@ -66,7 +66,7 @@ export const getOrganizationAuth = reactCache(async (organizationId: string): Pr
   // could allow while the row is absent (projection drift), and `TOrganizationAuth` promises a
   // non-null membership to every caller. Keeping both conditions on one throw preserves the exact
   // error this has always raised while making the authorization half of it comparable.
-  if (!hasOrganizationAccess || !currentUserMembership) {
+  if (!hasOrganizationRead || !currentUserMembership) {
     throw new ResourceNotFoundError(t("common.membership"), null);
   }
 

--- a/apps/web/modules/organization/lib/utils.ts
+++ b/apps/web/modules/organization/lib/utils.ts
@@ -1,5 +1,7 @@
 import { cache as reactCache } from "react";
 import { AuthenticationError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getAccessFlags } from "@/lib/membership/utils";
 import { getOrganization } from "@/lib/organization/service";
@@ -12,6 +14,16 @@ import { TOrganizationAuth } from "../types/organization-auth";
  *
  * Usage:
  *   const { session, organization, ... } = await getOrganizationAuth(params.organizationId);
+ *
+ * Deliberately gates on membership only (`organization.read`), never on a product permission —
+ * unlike `getWorkspaceAuth`, which redirects the billing role away from product data. The
+ * asymmetry is required, not an oversight: `modules/ee/billing/page.tsx` is the billing role's
+ * own page, so a billing exclusion here would lock that role out of the one surface it exists to
+ * reach. Callers that need to exclude billing do so themselves, via
+ * `redirectBillingRoleFromRestrictedOrgSettings`.
+ *
+ * The role flags below stay for rendering (isReadOnly, isDeleteDisabled, membershipRole) — retained
+ * by design, see lib/authorization/README.md. What ENG-2409 moved is the *gate*, not the flags.
  */
 export const getOrganizationAuth = reactCache(async (organizationId: string): Promise<TOrganizationAuth> => {
   const t = await getTranslate();
@@ -27,12 +39,38 @@ export const getOrganizationAuth = reactCache(async (organizationId: string): Pr
     throw new ResourceNotFoundError(t("common.organization"), organizationId);
   }
 
-  const currentUserMembership = await getMembershipByUserIdOrganizationId(session?.user.id, organization.id);
-  if (!currentUserMembership) {
+  // ENG-2409: the tenancy gate. This was `if (!currentUserMembership) throw`, a decision made by
+  // reading a row rather than by asking the central interface — so it was correct and invisible:
+  // with no `can()` call there is nothing for shadow comparison to compare, and this one gate sits
+  // behind all 13 organization-scoped pages.
+  //
+  // `organization.read` is the same set. The schema grants it to owner + manager + member + billing
+  // (schema.zed:69) — every membership role and nobody else — so "holds this permission" and "has a
+  // membership row" describe the same principals.
+  //
+  // Run alongside the membership read rather than after it: under the legacy evaluator `can()`
+  // resolves organization actions through `getMembershipByUserIdOrganizationId`, the same
+  // reactCache-memoized function called here, so the pair costs one query rather than two. Under
+  // enforcement `can()` takes the scope-resolver path and issues no membership query at all.
+  const [hasOrganizationAccess, currentUserMembership] = await Promise.all([
+    withAuthorizationSurface("page", () =>
+      can({ type: "user", id: session.user.id }, "organization.read", {
+        type: "organization",
+        id: organization.id,
+      })
+    ),
+    getMembershipByUserIdOrganizationId(session.user.id, organization.id),
+  ]);
+
+  // The membership is still required, and not only for the flags below: under enforcement SpiceDB
+  // could allow while the row is absent (projection drift), and `TOrganizationAuth` promises a
+  // non-null membership to every caller. Keeping both conditions on one throw preserves the exact
+  // error this has always raised while making the authorization half of it comparable.
+  if (!hasOrganizationAccess || !currentUserMembership) {
     throw new ResourceNotFoundError(t("common.membership"), null);
   }
 
-  const { isMember, isOwner, isManager, isBilling } = getAccessFlags(currentUserMembership?.role);
+  const { isMember, isOwner, isManager, isBilling } = getAccessFlags(currentUserMembership.role);
 
   return {
     organization,

--- a/apps/web/modules/organization/settings/api-keys/page.tsx
+++ b/apps/web/modules/organization/settings/api-keys/page.tsx
@@ -1,4 +1,6 @@
 import { SettingsCard } from "@/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard";
+import { assertCan } from "@/lib/authorization";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { DEFAULT_LOCALE, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getUserLocale } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
@@ -15,16 +17,31 @@ export const APIKeysPage = async (props: Readonly<{ params: Promise<{ organizati
 
   await redirectBillingRoleFromRestrictedOrgSettings(params.organizationId);
 
-  const { currentUserMembership, organization, session } = await getOrganizationAuth(params.organizationId);
+  const { organization, session } = await getOrganizationAuth(params.organizationId);
+
+  // ENG-2409: was `currentUserMembership.role === "owner" || "manager"` followed by a bare
+  // `throw new Error(...)`. `organization.manage_api_keys` is the same set, and it is the exact
+  // question `createApiKeyAction` already asks — so the page and the mutation behind it cannot drift
+  // if that permission is ever split from `organization.manage`.
+  //
+  // Two deliberate changes beyond the routing:
+  //   - `assertCan` throws `AuthorizationError`, which is in EXPECTED_ERROR_NAMES. The bare `Error`
+  //     was not, so every unauthorized load of this page was being reported to Sentry as an
+  //     unexpected exception. `app/error.tsx` renders both identically, so nothing user-visible moves.
+  //   - The gate now runs BEFORE the workspace/locale fetch below rather than after it. Authorizing
+  //     after reading the data it protects was harmless here (nothing was rendered) but is the wrong
+  //     order to leave in place.
+  await withAuthorizationSurface("page", () =>
+    assertCan({ type: "user", id: session.user.id }, "organization.manage_api_keys", {
+      type: "organization",
+      id: organization.id,
+    })
+  );
 
   const [workspaces, locale] = await Promise.all([
     getWorkspacesByOrganizationId(organization.id),
     getUserLocale(session.user.id),
   ]);
-
-  const canAccessApiKeys = currentUserMembership.role === "owner" || currentUserMembership.role === "manager";
-
-  if (!canAccessApiKeys) throw new Error(t("common.not_authorized"));
 
   return (
     <PageContentWrapper>
@@ -35,7 +52,9 @@ export const APIKeysPage = async (props: Readonly<{ params: Promise<{ organizati
         <ApiKeyList
           organizationId={organization.id}
           locale={locale ?? DEFAULT_LOCALE}
-          isReadOnly={!canAccessApiKeys}
+          // Always false by construction: assertCan above throws for anyone who is not
+          // owner/manager, so nobody reaches this render read-only.
+          isReadOnly={false}
           workspaces={workspaces}
           isFormbricksCloud={IS_FORMBRICKS_CLOUD}
         />

--- a/apps/web/modules/settings/lib/redirect-billing-role.test.ts
+++ b/apps/web/modules/settings/lib/redirect-billing-role.test.ts
@@ -1,0 +1,79 @@
+import { redirect } from "next/navigation";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TOrganizationRole } from "@formbricks/types/memberships";
+import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { getOrganizationAuth } from "@/modules/organization/lib/utils";
+import { redirectBillingRoleFromRestrictedOrgSettings } from "./redirect-billing-role";
+import { getOrganizationBillingPath } from "./routes";
+
+/**
+ * ENG-2409. This guard fronts five organization settings pages and had no test at all.
+ *
+ * `can` is deliberately left REAL. The rollout is disabled in the unit environment, so the
+ * coordinator short-circuits to the legacy evaluator, which answers `organization.read_access` from
+ * `getMembershipByUserIdOrganizationId` — mocked below. That makes the role the only input and the
+ * decision path the real one.
+ *
+ * Note what this deliberately does NOT do: the workspace-scoped analogue
+ * (`app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role.test.ts`) mocks the auth
+ * helper and hands it a ready-made `isBilling` boolean, so it only ever asserted "if the flag is
+ * true we redirect" — an assertion that stops meaning anything the moment the flag stops being the
+ * decision, which is exactly what this ticket changed.
+ */
+vi.mock("@/lib/membership/service", () => ({ getMembershipByUserIdOrganizationId: vi.fn() }));
+vi.mock("@/modules/organization/lib/utils", () => ({ getOrganizationAuth: vi.fn() }));
+
+const ORGANIZATION_ID = "org-1";
+const USER_ID = "user-1";
+
+const arrangeRole = (role: TOrganizationRole) => {
+  vi.mocked(getOrganizationAuth).mockResolvedValue({
+    session: { user: { id: USER_ID }, expires: new Date().toISOString() },
+  } as Awaited<ReturnType<typeof getOrganizationAuth>>);
+  vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue({
+    role,
+    organizationId: ORGANIZATION_ID,
+    userId: USER_ID,
+    accepted: true,
+  });
+};
+
+describe("redirectBillingRoleFromRestrictedOrgSettings", () => {
+  beforeEach(() => {
+    vi.mocked(redirect).mockClear();
+  });
+
+  test.each<TOrganizationRole>(["owner", "manager", "member"])(
+    "lets a %s through to the settings page",
+    async (role) => {
+      arrangeRole(role);
+
+      await redirectBillingRoleFromRestrictedOrgSettings(ORGANIZATION_ID);
+
+      expect(redirect).not.toHaveBeenCalled();
+    }
+  );
+
+  test("redirects the billing role to its billing home", async () => {
+    arrangeRole("billing");
+
+    await redirectBillingRoleFromRestrictedOrgSettings(ORGANIZATION_ID);
+
+    // `redirect` is globally mocked and does NOT throw (vitestSetup.ts), so execution continues past
+    // it — assert on the call rather than on the guard aborting.
+    expect(redirect).toHaveBeenCalledExactlyOnceWith(getOrganizationBillingPath(ORGANIZATION_ID, false));
+  });
+
+  test("refuses a caller with no membership row", async () => {
+    vi.mocked(getOrganizationAuth).mockResolvedValue({
+      session: { user: { id: USER_ID }, expires: new Date().toISOString() },
+    } as Awaited<ReturnType<typeof getOrganizationAuth>>);
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(null);
+
+    await redirectBillingRoleFromRestrictedOrgSettings(ORGANIZATION_ID);
+
+    // Unreachable in production — `getOrganizationAuth` throws first — but pinned so that the guard
+    // fails closed rather than open if that ordering is ever disturbed.
+    expect(redirect).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/modules/settings/lib/redirect-billing-role.ts
+++ b/apps/web/modules/settings/lib/redirect-billing-role.ts
@@ -26,7 +26,7 @@ import { getOrganizationBillingPath } from "@/modules/settings/lib/routes";
 export const redirectBillingRoleFromRestrictedOrgSettings = async (organizationId: string): Promise<void> => {
   const { session } = await getOrganizationAuth(organizationId);
 
-  const hasOrganizationAccess = await withAuthorizationSurface("page", () =>
+  const hasOrganizationReadAccess = await withAuthorizationSurface("page", () =>
     can({ type: "user", id: session.user.id }, "organization.read_access", {
       type: "organization",
       id: organizationId,
@@ -36,7 +36,7 @@ export const redirectBillingRoleFromRestrictedOrgSettings = async (organizationI
   // Deliberately outside the surface callback: redirect() throws a Next control-flow error, and
   // keeping it out here means the drain scheduled by withAuthorizationSurface never has to survive
   // a throw from inside its own callback.
-  if (!hasOrganizationAccess) {
+  if (!hasOrganizationReadAccess) {
     redirect(getOrganizationBillingPath(organizationId, IS_FORMBRICKS_CLOUD));
   }
 };

--- a/apps/web/modules/settings/lib/redirect-billing-role.ts
+++ b/apps/web/modules/settings/lib/redirect-billing-role.ts
@@ -1,4 +1,6 @@
 import { redirect } from "next/navigation";
+import { can } from "@/lib/authorization";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getOrganizationAuth } from "@/modules/organization/lib/utils";
 import { getOrganizationBillingPath } from "@/modules/settings/lib/routes";
@@ -6,10 +8,35 @@ import { getOrganizationBillingPath } from "@/modules/settings/lib/routes";
 // Org-scoped equivalent of redirectBillingRoleFromRestrictedSettings (the workspace-scoped guard).
 // Bounces a billing-role member away from a restricted org settings page to their billing/enterprise
 // home. getOrganizationAuth is React-cached, so calling it here in addition to the page is free.
+//
+// ENG-2409: was `isBilling -> redirect`, a role-name test that never reached the central interface,
+// so the widest gate in the organization settings area (five pages) produced no parity evidence.
+//
+// `organization.read_access` is the same set. It expands to owner + manager + member — every
+// membership role except billing — and getOrganizationAuth has already thrown for a caller with no
+// membership at all, so `!read_access` and `isBilling` select exactly the same principals here.
+//
+// The name is admittedly a stretch: read_access is documented around access-control resources, and
+// four of the five pages it guards are not that. It is used anyway because it is the only permission
+// whose expansion is "holds a product-eligible membership role", which is what this guard means, and
+// because ORGANIZATION_ACTION_BY_ROLE_SET already maps that role set to it. The alternative with the
+// right expansion, `product_member`, is deliberately absent from the permission map — it exists only
+// to intersect into `team#member`, and giving it a second job would mean a future edit to it
+// silently changed team-derived workspace access.
 export const redirectBillingRoleFromRestrictedOrgSettings = async (organizationId: string): Promise<void> => {
-  const { isBilling } = await getOrganizationAuth(organizationId);
+  const { session } = await getOrganizationAuth(organizationId);
 
-  if (isBilling) {
+  const hasOrganizationAccess = await withAuthorizationSurface("page", () =>
+    can({ type: "user", id: session.user.id }, "organization.read_access", {
+      type: "organization",
+      id: organizationId,
+    })
+  );
+
+  // Deliberately outside the surface callback: redirect() throws a Next control-flow error, and
+  // keeping it out here means the drain scheduled by withAuthorizationSurface never has to survive
+  // a throw from inside its own callback.
+  if (!hasOrganizationAccess) {
     redirect(getOrganizationBillingPath(organizationId, IS_FORMBRICKS_CLOUD));
   }
 };

--- a/apps/web/modules/setup/organization/[organizationId]/invite/actions.ts
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/actions.ts
@@ -27,7 +27,7 @@ export const inviteOrganizationMemberAction = authenticatedActionClient
         throw new AuthenticationError("Invite disabled");
       }
 
-      // Owner-only — see `SETUP_INVITE_ROLES` for why this path is narrower than the org settings
+      // Owner-only — see `SETUP_INVITE_ACTION` for why this path is narrower than the org settings
       // invite path.
       await checkSetupInviteAuthorization(ctx.user.id, parsedInput.organizationId);
 

--- a/apps/web/modules/setup/organization/[organizationId]/invite/lib/authorization.test.ts
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/lib/authorization.test.ts
@@ -4,9 +4,11 @@ import { TOrganizationRole } from "@formbricks/types/memberships";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { checkSetupInviteAuthorization, hasSetupInviteAccess } from "./authorization";
 
-// Only the storage boundary is mocked: the real `checkAuthorizationUpdated` role matching runs, so
-// these assertions describe the actual authorization outcome per role rather than the arguments a
-// mock was called with.
+// Only the storage boundary is mocked: the real `can`/`assertCan` path runs (the rollout is off in
+// the unit environment, so the coordinator resolves through the legacy evaluator), so these
+// assertions describe the actual authorization outcome per role rather than the arguments a mock was
+// called with. ENG-2409 swapped the implementation from a role list to `organization.write` without
+// touching a single assertion below — that equivalence is the point.
 vi.mock("@/lib/membership/service", () => ({
   getMembershipByUserIdOrganizationId: vi.fn(),
 }));

--- a/apps/web/modules/setup/organization/[organizationId]/invite/lib/authorization.ts
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/lib/authorization.ts
@@ -1,40 +1,38 @@
-import { TOrganizationRole } from "@formbricks/types/memberships";
-import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+import { assertCan, can } from "@/lib/authorization";
 
 /**
- * The organization roles allowed on the onboarding invite path (ENG-2169).
+ * The capability required on the onboarding invite path (ENG-2169).
  *
  * Deliberately narrower than the org settings invite path, where managers may invite members: this
- * path takes no role input and `inviteUser` always persists an owner invite, so adding "manager"
- * here lets a manager mint an owner without an existing owner's approval. Nothing legitimate is
- * lost — the only entry to this screen is the redirect right after `createOrganizationAction`,
- * which makes the creator an owner.
+ * path takes no role input and `inviteUser` always persists an owner invite, so admitting a manager
+ * here lets them mint an owner without an existing owner's approval. Nothing legitimate is lost —
+ * the only entry to this screen is the redirect right after `createOrganizationAction`, which makes
+ * the creator an owner.
  *
- * Both the page gate and the action authorization derive from this list so the two cannot drift.
+ * `organization.write` is the vocabulary's owner-only capability (`permission write: user = owner`
+ * in the schema). Naming it here rather than a role list is what keeps the page gate and the action
+ * gate the same question: both now ask the central interface, so neither can drift from the other
+ * or from the schema.
+ *
+ * ENG-2409: this replaced a `SETUP_INVITE_ROLES = ["owner"]` list that the page tested by reading a
+ * membership row and the action tested through the deprecated action-client adapter. The adapter
+ * already mapped the role set `["owner"]` onto `organization.write`, so the action's decision is
+ * unchanged; what changed is that the page's decision now goes through `can()` too, which is what
+ * makes it visible to AuthZed shadow comparison instead of silently legacy-only.
  */
-export const SETUP_INVITE_ROLES: TOrganizationRole[] = ["owner"];
+export const SETUP_INVITE_ACTION = "organization.write" as const;
 
 /** Throws `AuthorizationError` unless the user may invite through the onboarding path. */
 export const checkSetupInviteAuthorization = async (
   userId: string,
   organizationId: string
 ): Promise<void> => {
-  await checkAuthorizationUpdated({
-    userId,
-    organizationId,
-    access: [
-      {
-        type: "organization",
-        roles: SETUP_INVITE_ROLES,
-      },
-    ],
+  await assertCan({ type: "user", id: userId }, SETUP_INVITE_ACTION, {
+    type: "organization",
+    id: organizationId,
   });
 };
 
 /** Non-throwing variant for the page gate, which renders a 404 instead of surfacing an error. */
-export const hasSetupInviteAccess = async (userId: string, organizationId: string): Promise<boolean> => {
-  const membership = await getMembershipByUserIdOrganizationId(userId, organizationId);
-
-  return membership ? SETUP_INVITE_ROLES.includes(membership.role) : false;
-};
+export const hasSetupInviteAccess = async (userId: string, organizationId: string): Promise<boolean> =>
+  can({ type: "user", id: userId }, SETUP_INVITE_ACTION, { type: "organization", id: organizationId });

--- a/apps/web/modules/setup/organization/[organizationId]/invite/page.tsx
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { AuthenticationError } from "@formbricks/types/errors";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_USER } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { getSession } from "@/modules/auth/lib/session";
@@ -27,9 +28,21 @@ export const InvitePage = async (props: InvitePageProps) => {
   const session = await getSession();
   if (!session) throw new AuthenticationError(t("common.session_not_found"));
 
-  // Not the security boundary — `inviteOrganizationMemberAction` is — but this shares the action's
-  // role list so a manager gets a 404 instead of a form that fails on submit.
-  if (!(await hasSetupInviteAccess(session.user.id, params.organizationId))) return notFound();
+  // Not the security boundary — `inviteOrganizationMemberAction` is — but this asks the action's
+  // exact question (`organization.write`, owner-only) so a manager gets a 404 rather than a form
+  // that fails on submit. Owner-only is deliberate: `inviteUser` always persists an OWNER invite
+  // (ENG-2169).
+  //
+  // The surface is back (ENG-2409). It was dropped when main replaced `verifyUserRoleAccess` with a
+  // `hasSetupInviteAccess` that read a membership row directly — wrapping that would have declared a
+  // surface over no `can()` call at all and emitted a zero-check observation. Now that the helper
+  // routes through the central interface, the wrapper does what it did before: gives the decision a
+  // rollout target so it is comparable instead of silently legacy-only.
+  const mayInvite = await withAuthorizationSurface("page", () =>
+    hasSetupInviteAccess(session.user.id, params.organizationId)
+  );
+
+  if (!mayInvite) return notFound();
 
   return <InviteMembers IS_SMTP_CONFIGURED={IS_SMTP_CONFIGURED} organizationId={params.organizationId} />;
 };

--- a/authzed/schema-validation.yaml
+++ b/authzed/schema-validation.yaml
@@ -216,6 +216,12 @@ assertions:
     - organization:acme#manage@user:mia
     - organization:acme#manage_access@user:mia
     - organization:acme#manage_api_keys@user:mia
+    # ENG-2409: the enterprise settings page maps `isMember -> notFound` onto `manage_billing`, and
+    # that mapping is only correct because a plain member does not hold it. `manage_billing` had no
+    # assertFalse anywhere — both mentions were assertTrue — so adding `+ member` to it in the schema
+    # would have kept this suite green while opening the billing surface to every member. Same shape
+    # as the read_access gap closed above.
+    - organization:acme#manage_billing@user:mia
     - workspace:main#read@user:mia
     - survey:onboarding#read@user:mia
     - dashboard:insights#read@user:mia
@@ -346,6 +352,24 @@ validation:
     - "[user:tom] is <organization:acme#member>"
     - "[user:uma] is <organization:acme#member>"
   organization:acme#manage_api_keys:
+    - "[user:mark] is <organization:acme#manager>"
+    - "[user:olivia] is <organization:acme#owner>"
+  # ENG-2409: `read` backs the getOrganizationAuth tenancy gate and `manage_billing` backs the
+  # enterprise settings page, so both are page-gate permissions now and both are enumerated for the
+  # same reason as the two above — an assertion proves a role holds it, only this block makes a
+  # *widening* show up as a diff.
+  organization:acme#read:
+    - "[api_key:org_reader_key] is <organization:acme#api_key_reader>"
+    - "[api_key:org_writer_key] is <organization:acme#api_key_writer>"
+    - "[user:bella] is <organization:acme#billing>"
+    - "[user:mark] is <organization:acme#manager>"
+    - "[user:mia] is <organization:acme#member>"
+    - "[user:olivia] is <organization:acme#owner>"
+    - "[user:tina] is <organization:acme#member>"
+    - "[user:tom] is <organization:acme#member>"
+    - "[user:uma] is <organization:acme#member>"
+  organization:acme#manage_billing:
+    - "[user:bella] is <organization:acme#billing>"
     - "[user:mark] is <organization:acme#manager>"
     - "[user:olivia] is <organization:acme#owner>"
   response:r1#export:

--- a/authzed/schema-validation.yaml
+++ b/authzed/schema-validation.yaml
@@ -93,7 +93,13 @@ assertions:
     - organization:acme#manage_access@user:olivia
     - organization:acme#manage_access@user:mark
     - organization:acme#manage_api_keys@user:mark
+    - organization:acme#manage_api_keys@user:olivia
     - organization:acme#manage_billing@user:mark
+    # ENG-2409: read_access is the "holds a product-eligible membership role" permission, and it
+    # now gates five organization settings pages. Its owner/manager arms were never asserted —
+    # only the member arm below was — so the permission could have narrowed without a red suite.
+    - organization:acme#read_access@user:olivia
+    - organization:acme#read_access@user:mark
     - workspace:main#manage@user:olivia
     - workspace:main#manage@user:mark
     - workspace:other#read@user:olivia
@@ -206,8 +212,10 @@ assertions:
     # Scenario 1 — managers must not update/delete the organization itself;
     # a teamless member has organization visibility but zero product access.
     - organization:acme#write@user:mark
+    - organization:acme#write@user:mia
     - organization:acme#manage@user:mia
     - organization:acme#manage_access@user:mia
+    - organization:acme#manage_api_keys@user:mia
     - workspace:main#read@user:mia
     - survey:onboarding#read@user:mia
     - dashboard:insights#read@user:mia
@@ -231,6 +239,13 @@ assertions:
     - organization:acme#write@user:bella
     - organization:acme#manage_access@user:bella
     - organization:acme#manage_api_keys@user:bella
+    # ENG-2409: the load-bearing one. `read_access` is the only permission whose expansion is
+    # "holds a product-eligible membership role", which is what makes it the central expression of
+    # "not the billing role" — and it is what five organization settings pages now gate on. Until
+    # this line existed the suite had NO assertFalse for read_access at all, so adding `billing` to
+    # it in the schema kept every assertion green. Exactly the shape of the ENG-2340 gap: a
+    # guarantee written in prose and asserted nowhere.
+    - organization:acme#read_access@user:bella
     - workspace:main#read@user:bella
     - survey:onboarding#read@user:bella
     - survey:onboarding#response_read@user:bella
@@ -298,6 +313,10 @@ assertions:
     - team:product#manage@api_key:org_reader_key
     - team:product#delete@api_key:org_reader_key
     - organization:acme#manage_api_keys@api_key:org_writer_key
+    # ENG-2409: a workspace-scoped key holds no organization-level access-control right. Asserted
+    # because `read_access` gained org-page gates and its api_key arm is granted by the
+    # `api_key_reader`/`api_key_writer` relations on the organization, which ci_reader lacks.
+    - organization:acme#read_access@api_key:ci_reader
 
 # Expected-relations documentation: enumerates, for key permissions, every
 # subject that holds them and through which relation. Kept exact so any
@@ -314,6 +333,21 @@ validation:
     - "[user:tina] is <organization:acme#member>/<team:product#contributor>"
     - "[user:tom] is <organization:acme#member>/<team:product#admin>"
     - "[user:uma] is <organization:acme#member>/<team:analysts#contributor>"
+  # ENG-2409: both of these became organization page gates, so enumerate their subjects here as
+  # well. The assertions above prove the roles that must and must not hold them; this block is what
+  # turns a *widening* into a visible diff rather than a still-green suite.
+  organization:acme#read_access:
+    - "[api_key:org_reader_key] is <organization:acme#api_key_reader>"
+    - "[api_key:org_writer_key] is <organization:acme#api_key_writer>"
+    - "[user:mark] is <organization:acme#manager>"
+    - "[user:mia] is <organization:acme#member>"
+    - "[user:olivia] is <organization:acme#owner>"
+    - "[user:tina] is <organization:acme#member>"
+    - "[user:tom] is <organization:acme#member>"
+    - "[user:uma] is <organization:acme#member>"
+  organization:acme#manage_api_keys:
+    - "[user:mark] is <organization:acme#manager>"
+    - "[user:olivia] is <organization:acme#owner>"
   response:r1#export:
     - "[api_key:ci_reader] is <workspace:main#reader>"
     - "[api_key:ci_writer] is <workspace:main#writer>"


### PR DESCRIPTION
> **#8872 (ENG-2388) has merged**, so this now targets `epic/authzed` directly and no longer depends on an open PR. It was rebased onto the post-merge epic head — see *Stack maintenance* at the bottom.

## What & why

ENG-2388 made server-rendered route checks comparable, but it could only cover gates that already called `can()`. Sweeping for the rest turned up gates that decide access **without going through `can()` at all** — they read a membership row and test a role flag. A surface there would wrap nothing; they need *routing*.

That was the whole organization settings area: 13 pages behind `getOrganizationAuth`. Legacy stays authoritative so nothing was exploitable, but these decisions produced no parity evidence, and the cutover depends on that evidence.

| Gate | Was | Now |
| --- | --- | --- |
| `getOrganizationAuth` tenancy check (13 pages) | `if (!membership) throw` | `organization.read` |
| `redirectBillingRoleFromRestrictedOrgSettings` (5 pages) | `isBilling` | `organization.read_access` |
| Enterprise settings page | `isMember` | `organization.manage_billing` |
| Feedback directories page | `isOwner \|\| isManager` | `organization.manage` |
| API keys page | `role === "owner" \|\| "manager"` | `organization.manage_api_keys` |
| Onboarding setup-invite (page **and** action) | `SETUP_INVITE_ROLES = ["owner"]` | `organization.write` |

**Every mapping is set-equivalent** — no principal changes side. Each gate sits after `getOrganizationAuth`, which throws for a caller with no membership, so the reachable set is always the four membership roles and they partition cleanly.

**No schema change.** Every gate landed on an existing permission whose expansion already matched.

### The ticket's stated objection was wrong

ENG-2409 was filed saying this would be *additive* — an extra check per render, against the epic's own no-amplification criterion. It is not. The legacy evaluator's `canOrganization` resolves organization actions through `getMembershipByUserIdOrganizationId`, the same `reactCache`-memoized function `getOrganizationAuth` already calls. **Net added DB queries: zero.** Under enforcement `can()` takes the scope-resolver path and issues no membership query at all. I have corrected the ticket.

### Two mappings where the obvious choice is wrong

**`manage_billing`, not `manage`, for the enterprise page.** This is the one that would have shipped a real regression. `getOrganizationBillingPath(orgId, false)` resolves to `settings/enterprise` — so on self-hosted that page *is* where the billing role gets redirected **to**. Gating it on `organization.manage` (owner+manager) would 404 that role on its own landing page. `manage_billing` is owner+manager+billing, exactly `!isMember`.

Worth noting how nearly this slipped through: `playwright/billing-role-access.spec.ts` asserts on URL, and a 404 keeps the URL, so the existing E2E would have stayed green.

**`read_access`, not `read`, for the billing redirect.** `read` admits billing — the exact role being excluded. `read_access` is the only permission whose expansion is "holds a product-eligible membership role". The name is a stretch (it is documented around access-control resources) and the call site says so. `product_member` has the right expansion but is deliberately absent from the permission map: it exists to intersect into `team#member`, and giving it a second job would mean a future edit silently changed team-derived workspace access.

### The setup-invite gate (both halves)

Filed as instance 2 of the ticket and originally deferred, because the file did not exist on the epic until #8863 landed. It does now, so it is in.

That path decided access from a `SETUP_INVITE_ROLES = ["owner"]` list **two different ways**: the page read a membership row and tested the list; the action passed the list to the deprecated `checkAuthorizationUpdated` adapter. Both now ask `organization.write`.

The action's decision is unchanged *by construction* — the adapter's `ORGANIZATION_ACTION_BY_ROLE_SET` already maps `["owner"]` onto `organization.write`, so it was resolving to this exact question already. What changes is the page: its decision now reaches the coordinator. It also retires a `checkAuthorizationUpdated` caller, which the module README asks for.

**Both were converted together deliberately.** They agreed only because of that adapter mapping, so converting one and leaving the other would have made the file's own "cannot drift" comment false.

The owner-only restriction is load-bearing and preserved exactly: `inviteUser` always persists an *owner* invite, so admitting a manager would let them mint an owner without an existing owner's approval (ENG-2169). `organization.write` is `permission write: user = owner` — the vocabulary's owner-only capability.

This also restores the `page` surface that the #8863 merge dropped from the invite page, now that there is a `can()` beneath it to make comparable.

### Deliberate non-changes

- The enterprise page's Cloud-only `isBilling → redirect` is **not** routed. It decides 302-vs-404 for a principal the next line refuses anyway; expressing it centrally would need a "billing role only" capability, and inventing one would encode a role name as a permission.
- `getOrganizationAuth` still gates on membership only, never on a product permission. Unlike `getWorkspaceAuth` it must not exclude billing — the billing settings page is that role's own page. Recorded in the README so the symmetry isn't "fixed" later.
- The role flags stay on the return value for UI props (`isReadOnly`, `isDeleteDisabled`, `membershipRole`). Retained by design; only gates moved.

### Two small behavior changes, both deliberate

1. **API keys page throws `AuthorizationError` instead of a bare `Error`.** The bare `Error` is not in `EXPECTED_ERROR_NAMES`, so every unauthorized load of that page was being reported to Sentry as an unexpected exception. `app/error.tsx` renders both identically — nothing user-visible moves, the noise stops.
2. **That gate now runs before the workspace/locale fetch it protects**, rather than after. Harmless before (nothing was rendered), but the wrong order to leave in place.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2409

## How this was tested

**The schema suite had a hole this change would have depended on.** `organization#read_access` appeared three times in `schema-validation.yaml`, all in `assertTrue`. There was **no `assertFalse` for it anywhere** — so the billing-exclusion property that five settings pages now rest on was asserted nowhere, and adding `billing` to `read_access` in the schema left all 149 assertions green. Same shape as the ENG-2340 gap. Closed here: 149 → **156 assertions**, 2 → 4 expected relations, and `read_access`/`manage_api_keys` are now enumerated in the expected-relations block so a widening shows as a diff.

- `pnpm authzed:validate` → **36 relationships, 156 assertions, 4 expected relations** ✅. Verified by mutation: adding `billing` to `read_access` now **fails** the suite.
- **New** `modules/settings/lib/redirect-billing-role.test.ts` → 5 passing ✅. This guard fronts five pages and had no test at all. `can()` is left **real** — the rollout is off in the unit env, so the legacy evaluator answers from the mocked membership service and the role is the only input. Verified by mutation: swapping `read_access` for `read`, which billing does hold, fails the billing case.
- `modules/organization/lib/utils.test.ts` → the four existing tests pass **unmodified**, which is the equivalence evidence; two added (the authorization arm of the throw, isolated from the row; and the actor/action/resource). Verified by mutation: dropping `hasOrganizationAccess` from the condition fails the first.
- `modules/setup/.../invite/lib/authorization.test.ts` → **16 passing with no assertion touched** ✅ — only its header comment changed, which named the adapter that no longer runs. That equivalence is the strongest evidence in this PR. Verified by mutation: widening the action to `organization.manage` fails exactly the two manager cases, which is the escalation ENG-2169 exists to prevent.
- **New** `lib/authorization/org-page-gates.integration.test.ts` → **11 passing against a real database** ✅. Asserts the full four-role partition for all five permissions through the real coordinator and legacy evaluator, the no-membership case for each, and that a page's gates cost one check each.
- Full web unit suite → `6 failed | 8242 passed`. All 6 are the pre-existing `scripts/authzed-entrypoints.test.ts` failures from a Node 26 deprecation warning breaking a `stderr === ""` assertion — absent from this diff, and CI runs Node 24 where they are green.
- `pnpm turbo run typecheck --filter=@formbricks/web` → 10/10 ✅; eslint + prettier clean.

**Smoke-tested against the running app.** Started the dev server, seeded an owner and a plain member, and hit `/organizations/<id>/settings/api-keys` as each: the owner renders the page, the member is refused, and the server log shows exactly **one** `AuthorizationError` from `assertCan` across the two loads — so the gate fires for the member and not for the owner.

**Security review.** gitleaks clean over the branch range. No new data access, logging, or outbound calls. All seven new `can`/`assertCan` call sites take the actor from `session.user.id` — never from a parameter — and the resource is the organization the caller already resolved through `getOrganizationAuth`.

## Breaking changes

None. No schema change, no new env var, no migration, no default altered.

## QA / Test Plan

**How to test**

- [ ] As an **owner** → `/organizations/<id>/settings/{general,domain,api-keys,teams,feedback-directories}` → all render as before.
- [ ] As a **manager** → same five → all render as before.
- [ ] As a **plain member** → same five → `general`, `domain` and `teams` render (role only controls affordances there); `api-keys` shows the error page; `feedback-directories` shows its no-access message.
- [ ] As a **billing-role** user → same five → redirected to the billing home (Cloud) or the enterprise page (self-hosted). This is the widest gate; check all five.
- [ ] **Self-hosted only:** as a **billing-role** user → `/organizations/<id>/settings/enterprise` → the page **renders**. It is that role's landing target, so a 404 here is the regression to watch for.
- [ ] Self-hosted, as a **plain member** → `/organizations/<id>/settings/enterprise` → 404, unchanged.
- [ ] As a user who is **not a member of that organization** → any of the above → refused, unchanged.
- [ ] Sanity: creating and revoking an API key as an owner still works (the gate moved ahead of the data fetch).
- [ ] **Onboarding invite path.** Create a new organization → you land on the invite screen as its owner → it renders, and sending an invite still works.
- [ ] As a **manager/member/billing** user of an existing org, open that org's setup invite URL directly → **404**, unchanged. (Owner-only is intentional here — the invite always creates an *owner* invite, so a manager must not be able to send one.)

**Preconditions / test data**

- One organization with an owner, a manager, a plain member, and a billing-role member; a second organization the first org's users do not belong to.
- The enterprise-page case needs a **self-hosted** instance (`IS_FORMBRICKS_CLOUD` unset) — on Cloud that page 404s for everyone by design.
- No feature flag required; nothing changes by default. To exercise the new decisions under shadow comparison, add `page:user` to the authorization shadow targets.

**Risks & regressions**

- The billing-role redirect covers five pages from one helper — if it regresses, it regresses everywhere at once.
- The setup-invite path changed on **both** sides (page gate and action). The action's decision is unchanged by construction, but it is worth confirming an owner can still actually send an invite end to end, not just load the screen.
- The self-hosted enterprise page for the billing role is the specific case a wrong mapping would break, and URL-based checks cannot see it. Confirm the page content renders.
- Organization settings renders now report under the `page` metric surface. A dashboard filtering on `server_action` will look like it dropped — reporting change, not behavior.

**Migrations / env / cutover**

- none.


## Stack maintenance (2026-08-16)

After repairing #8872 onto the current `epic/authzed` head, this PR's single ENG-2409 commit was rebased onto the repaired parent `e56d27dde`. The two overlaps were resolved semantically: the feedback-dataset page keeps the newly merged central authorization and adds the `page` shadow surface without serializing the license lookup; the setup-invite path keeps owner-only `organization.write` semantics and now emits a valid page comparison.

The repaired child head is `e60d524c2`. Its review diff remains only ENG-2409: 14 files, 478 additions, and 52 deletions. Exact-head validation: 21 focused unit tests, 11 organization-gate PostgreSQL integration tests, 4 page-surface/check-amplification PostgreSQL integration tests, 12/12 web typecheck tasks, changed-file ESLint and Prettier, and AuthZed validation with 36 relationships, 156 assertions, and 4 expected relations.



## Stack maintenance (2026-08-18) — rebased onto the merged epic

#8872 merged as a squash, which left this branch based on the *pre-squash* copies of that work and of Bhagya's feedback-dataset stack. Merging `epic/authzed` produced **33 conflicting files**, nearly all of them other people's already-merged code — resolving those by hand would have meant reconstructing a state that already exists in epic, with a real chance of silently reverting a merged guard.

So the six real ENG-2409 commits were replayed onto the current epic head instead. The result is **14 files, +478/−52** across 7 commits — the other 8 files the PR used to show were #8872's, now upstream.

- Two semantic conflicts, resolved the way this PR always said they would be. The feedback-dataset page keeps epic's central authorization and takes this PR's earlier, surface-wrapped gate — the license check still runs first, so an unlicensed organization still gets the upgrade prompt rather than a no-access message. The setup-invite path keeps owner-only `organization.write` and re-applies the `page` wrapper.
- The 162-file accidental Prisma-migration commit and its revert are gone. They did carry a genuine README reformat, so that was re-derived by running Prettier rather than dropped.
- Verified before force-pushing: the remote head was a commit this session had not seen (`e60d524c2`), and `--force-with-lease` refused the first push because of it. Diffed against it — **12 of the 14 files are byte-identical**, and the only two that differ are the review fix below plus epic's newer README content flowing in. Nothing was lost.

### Review fix — Bhagya's P2

The expected-relations block covered `read_access` and `manage_api_keys`, but this PR also turns `organization.read` (the `getOrganizationAuth` tenancy gate) and `organization.manage_billing` (the enterprise settings page) into page-gate permissions, and neither was enumerated. Both are now. An assertion proves a role *holds* a permission; only this block makes a **widening** show up as a diff.

Adding them surfaced a gap that was not raised: **`manage_billing` had no `assertFalse` anywhere** — both mentions were `assertTrue`. The enterprise page maps `isMember -> notFound` onto `manage_billing`, and that mapping is only correct because a plain member does not hold it, so adding `+ member` to it in the schema would have kept the suite green while opening the billing surface to every member. That is the same shape as the `read_access` gap this PR already closed, and as ENG-2340 before it. `assertFalse: organization:acme#manage_billing@user:mia` now pins it.

Suite is 83 `assertTrue` / 74 `assertFalse` with 6 expected-relations blocks; the YAML parses. `pnpm authzed:validate` needs the `zed` CLI, which is not on this machine, so that assertion set is CI-verified only.
