### PR TITLE
docs(authzed): state the backfill output's identifier set and retention

### DIFF
--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -259,8 +259,9 @@ procedure.
 The command prints one JSON result. It never prints credentials, database passwords, raw SDK errors, schema
 text, or raw relationship strings.
 
-It does print Formbricks record identifiers, deliberately: naming the affected records is what makes a drift
-report actionable. Treat the result as sensitive operational data.
+It does print identifiers, deliberately: naming the affected records is what makes a drift report actionable.
+Most are Formbricks record IDs, but not all — `unmanaged` can surface object IDs belonging to no Formbricks
+record at all. Treat the result as sensitive operational data.
 
 - `orphans`, `mismatchedParents` and `mismatchedPermissions` name the records that disagree, carrying
   organization, user, workspace, team, API-key, feedback-directory and feedback-directory-assignment IDs.
@@ -274,9 +275,9 @@ report actionable. Treat the result as sensitive operational data.
 
 The cursor is an intentional operational identifier, not an oversight. An interrupted sweep resumes with
 `--after-organization-id=<cuid>` taken straight from it, so an opaque token would have to be stored and mapped
-back somewhere to stay useful. It is also the one field that can name a clean organization: every other
-identifier here belongs to a record that drifted or failed, while the cursor is simply wherever the sweep
-stopped. Redact it on the same terms as the rest.
+back somewhere to stay useful. It is also the one field that can name an organization with nothing wrong: every
+other identifier here comes from a record or relationship that drifted or failed, while the cursor is simply
+wherever the sweep stopped. Redact it on the same terms as the rest.
 
 <Warning>
   Handle the result like a database export, not like a log line. Store it in the same place you keep other
@@ -286,11 +287,13 @@ stopped. Redact it on the same terms as the rest.
 </Warning>
 
 Redirecting to a file keeps the result out of terminal scrollback and out of CI logs that capture stdout. Set
-`umask 077` first — `>` creates the file with the process umask, so under a typical `umask 022` the export
-lands world-readable:
+`umask 077` and remove any earlier export first. The umask governs file *creation* only, so under a typical
+`umask 022` a new `backfill.json` lands world-readable — and redirecting over one that already exists truncates
+it while leaving its existing mode untouched:
 
 ```bash
 umask 077
+rm -f backfill.json
 formbricks-authzed backfill > backfill.json
 ```
 
@@ -337,6 +340,14 @@ reached no organization, so there is nothing to resume after — rerun the sweep
 formbricks-authzed backfill --apply --after-organization-id=<last-organization-id>
 ```
 
+The cursor advances past every organization the sweep reached, and a failed organization does not stop the
+sweep — so anything listed in `failures` sits behind the cursor and a resume will not retry it. Rerun each
+failed organization explicitly, in addition to resuming from the cursor:
+
+```bash
+formbricks-authzed backfill --apply --organization-id=<failed-organization-id>
+```
+
 ### Prune orphans
 
 Pruning is the only mode that removes relationships observed only in SpiceDB. It requires every safeguard:
@@ -360,6 +371,7 @@ restore, or shared SpiceDB before proceeding.
 | Category            | Meaning and response                                                                                                                        |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `missing`           | PostgreSQL contains a source record without the expected SpiceDB relationship. An applying run repairs it.                                  |
+| `mismatchedPermissions` | An existing source record's projected role or grant relation differs from PostgreSQL. An applying run repairs it deterministically.     |
 | `orphaned`          | SpiceDB contains a managed relationship whose source record is gone. A confirmed prune removes it.                                          |
 | `invalid`           | PostgreSQL contains a cross-organization source row. Investigate and correct PostgreSQL manually.                                           |
 | `unmanaged`         | A relationship outside Formbricks' managed vocabulary exists. Investigate its writer; the tool never deletes it.                            |

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -269,7 +269,8 @@ record at all. Treat the result as sensitive operational data.
 - `unmanaged` reports relationships outside the managed vocabulary as an object type, an object ID and a
   relation name. Those object IDs are not limited to the kinds above — anything else sharing the SpiceDB
   instance appears here.
-- `failures` carries the organization ID of each unit that failed, so even a failed run emits identifiers.
+- `failures` carries an organization ID for each failed unit that has one, so even a failed run emits
+  identifiers. It is empty when the read that would have identified the organization is what failed.
 - `lastOrganizationId` is the resume cursor: the last organization the sweep reached, or `null` if it reached
   none.
 
@@ -340,13 +341,17 @@ reached no organization, so there is nothing to resume after — rerun the sweep
 formbricks-authzed backfill --apply --after-organization-id=<last-organization-id>
 ```
 
-The cursor advances past every organization the sweep reached, and a failed organization does not stop the
-sweep — so anything listed in `failures` sits behind the cursor and a resume will not retry it. Rerun each
-failed organization explicitly, in addition to resuming from the cursor:
+The cursor advances past every organization the sweep reached, and an organization-specific failure does not
+stop the sweep — so each failure carrying a non-empty `organizationId` sits behind the cursor, and a resume
+will not retry it. Rerun those explicitly, in addition to resuming from the cursor:
 
 ```bash
 formbricks-authzed backfill --apply --organization-id=<failed-organization-id>
 ```
+
+A failure with an **empty** `organizationId` is not one of those: the read that would have identified the
+organization is itself what failed, so there is nothing to target. Within a sweep those also set `truncated` —
+rerun the sweep rather than a single organization.
 
 ### Prune orphans
 

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -262,8 +262,11 @@ raw relationship strings.
 It does print Formbricks record identifiers, deliberately: naming the affected records is what makes a drift
 report actionable. Treat the result as sensitive operational data.
 
-- The drift lists (`orphans`, `mismatchedParents`, `unmanaged`) name the records that disagree — between them
-  they can carry organization, user, workspace, team, API-key and feedback-directory IDs.
+- `orphans` and `mismatchedParents` name the records that disagree, carrying organization, user, workspace,
+  team, API-key and feedback-directory IDs.
+- `unmanaged` reports relationships outside the managed vocabulary as an object type, an object ID and a
+  relation name. Those object IDs are not limited to the kinds above — anything else sharing the SpiceDB
+  instance appears here.
 - `failures` carries the organization ID of each unit that failed, so even a failed run emits identifiers.
 - `lastOrganizationId` is the resume cursor.
 
@@ -275,9 +278,14 @@ back somewhere to stay useful — and the value is already a subset of what the 
   Handle the result like a database export, not like a log line. Store it in the same place you keep other
   sensitive operational output, restrict access to operators, and delete it once the drift it describes is
   resolved — retain it no longer than your incident records. Do not paste it into shared chat, ticket
-  descriptions, or support bundles without redacting the identifier fields above. Redirecting it to a file
-  (`> backfill.json`) rather than leaving it in terminal scrollback keeps it out of shell history and CI logs.
+  descriptions, or support bundles without redacting the identifier fields above.
 </Warning>
+
+Redirecting to a file (`> backfill.json`) keeps the result out of terminal scrollback and out of CI logs that
+capture stdout, and lets you restrict access with file permissions. It does not keep identifiers out of your
+shell history, which records the command rather than its output — and the resume invocation is the one to watch
+there, because the cursor is an argument: `--after-organization-id=<cuid>` is recorded verbatim. On a shared or
+session-recorded host, read the cursor from the saved result instead of retyping it.
 
 ### Interpret exit codes
 

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -263,7 +263,7 @@ It does print Formbricks record identifiers, deliberately: naming the affected r
 report actionable. Treat the result as sensitive operational data.
 
 - `orphans` and `mismatchedParents` name the records that disagree, carrying organization, user, workspace,
-  team, API-key and feedback-directory IDs.
+  team, API-key, feedback-directory and feedback-directory-assignment IDs.
 - `unmanaged` reports relationships outside the managed vocabulary as an object type, an object ID and a
   relation name. Those object IDs are not limited to the kinds above — anything else sharing the SpiceDB
   instance appears here.

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -256,23 +256,27 @@ procedure.
 
 ## Audit and repair relationships
 
-The command prints one JSON result. It never prints tokens, database passwords, raw SDK errors, schema text, or
-raw relationship strings.
+The command prints one JSON result. It never prints credentials, database passwords, raw SDK errors, schema
+text, or raw relationship strings.
 
 It does print Formbricks record identifiers, deliberately: naming the affected records is what makes a drift
 report actionable. Treat the result as sensitive operational data.
 
-- `orphans` and `mismatchedParents` name the records that disagree, carrying organization, user, workspace,
-  team, API-key, feedback-directory and feedback-directory-assignment IDs.
+- `orphans`, `mismatchedParents` and `mismatchedPermissions` name the records that disagree, carrying
+  organization, user, workspace, team, API-key, feedback-directory and feedback-directory-assignment IDs.
+  `mismatchedPermissions` adds the expected and observed relation names alongside the record it names.
 - `unmanaged` reports relationships outside the managed vocabulary as an object type, an object ID and a
   relation name. Those object IDs are not limited to the kinds above — anything else sharing the SpiceDB
   instance appears here.
 - `failures` carries the organization ID of each unit that failed, so even a failed run emits identifiers.
-- `lastOrganizationId` is the resume cursor.
+- `lastOrganizationId` is the resume cursor: the last organization the sweep reached, or `null` if it reached
+  none.
 
 The cursor is an intentional operational identifier, not an oversight. An interrupted sweep resumes with
 `--after-organization-id=<cuid>` taken straight from it, so an opaque token would have to be stored and mapped
-back somewhere to stay useful — and the value is already a subset of what the drift lists report.
+back somewhere to stay useful. It is also the one field that can name a clean organization: every other
+identifier here belongs to a record that drifted or failed, while the cursor is simply wherever the sweep
+stopped. Redact it on the same terms as the rest.
 
 <Warning>
   Handle the result like a database export, not like a log line. Store it in the same place you keep other
@@ -281,11 +285,19 @@ back somewhere to stay useful — and the value is already a subset of what the 
   descriptions, or support bundles without redacting the identifier fields above.
 </Warning>
 
-Redirecting to a file (`> backfill.json`) keeps the result out of terminal scrollback and out of CI logs that
-capture stdout, and lets you restrict access with file permissions. It does not keep identifiers out of your
-shell history, which records the command rather than its output — and the resume invocation is the one to watch
-there, because the cursor is an argument: `--after-organization-id=<cuid>` is recorded verbatim. On a shared or
-session-recorded host, read the cursor from the saved result instead of retyping it.
+Redirecting to a file keeps the result out of terminal scrollback and out of CI logs that capture stdout. Set
+`umask 077` first — `>` creates the file with the process umask, so under a typical `umask 022` the export
+lands world-readable:
+
+```bash
+umask 077
+formbricks-authzed backfill > backfill.json
+```
+
+Redirection does not keep identifiers out of your shell history, which records the command rather than its
+output — and the resume invocation is the one to watch there, because the cursor is an argument:
+`--after-organization-id=<cuid>` is recorded verbatim. On a shared or session-recorded host, read the cursor
+from the saved result instead of retyping it.
 
 ### Interpret exit codes
 
@@ -318,7 +330,8 @@ formbricks-authzed backfill --apply --workspace-id=<workspace-id>
 Applying fixes missing and incorrect current-state relationships. It does not remove relationships with no
 remaining PostgreSQL source record.
 
-If a sweep is interrupted, resume after the reported `lastOrganizationId`:
+If a sweep is interrupted, resume after the reported `lastOrganizationId`. A `null` cursor means the run
+reached no organization, so there is nothing to resume after — rerun the sweep from the start instead:
 
 ```bash
 formbricks-authzed backfill --apply --after-organization-id=<last-organization-id>

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -256,9 +256,28 @@ procedure.
 
 ## Audit and repair relationships
 
-The command prints one JSON result. The output can contain source record identifiers needed to diagnose drift,
-so store it as sensitive operational data. It never prints tokens, database passwords, raw SDK errors, schema
-text, or raw relationship strings.
+The command prints one JSON result. It never prints tokens, database passwords, raw SDK errors, schema text, or
+raw relationship strings.
+
+It does print Formbricks record identifiers, deliberately: naming the affected records is what makes a drift
+report actionable. Treat the result as sensitive operational data.
+
+- The drift lists (`orphans`, `mismatchedParents`, `unmanaged`) name the records that disagree — between them
+  they can carry organization, user, workspace, team, API-key and feedback-directory IDs.
+- `failures` carries the organization ID of each unit that failed, so even a failed run emits identifiers.
+- `lastOrganizationId` is the resume cursor.
+
+The cursor is an intentional operational identifier, not an oversight. An interrupted sweep resumes with
+`--after-organization-id=<cuid>` taken straight from it, so an opaque token would have to be stored and mapped
+back somewhere to stay useful — and the value is already a subset of what the drift lists report.
+
+<Warning>
+  Handle the result like a database export, not like a log line. Store it in the same place you keep other
+  sensitive operational output, restrict access to operators, and delete it once the drift it describes is
+  resolved — retain it no longer than your incident records. Do not paste it into shared chat, ticket
+  descriptions, or support bundles without redacting the identifier fields above. Redirecting it to a file
+  (`> backfill.json`) rather than leaving it in terminal scrollback keeps it out of shell history and CI logs.
+</Warning>
 
 ### Interpret exit codes
 


### PR DESCRIPTION
## What & why

ENG-2359 asked for an opaque backfill resume cursor, on the premise that printing `lastOrganizationId` "conflicts with ENG-1740's requirement that the CLI must not print organization, actor, resource, relationship, or other identifiers."

**That requirement is not what shipped.** `authzed-operations.mdx` already documented the opposite, deliberately:

> The output can contain source record identifiers needed to diagnose drift, so store it as sensitive operational data. It never prints tokens, database passwords, raw SDK errors, schema text, or raw relationship strings.

So this PR takes the ticket's *own* second branch — "if exposing an organization ID is unavoidable, explicitly approve and document it as an intentional operational identifier, including handling and retention guidance" — rather than building the opaque cursor.

### Why not just sanitize the cursor

Checked against the code. The cursor is one organization ID in a result that already carries far more:

| Field | Carries |
| --- | --- |
| `orphans` (`TAuthzedSourceRef`) | organization, user, workspace, team, API-key, feedback-directory and assignment IDs |
| `mismatchedPermissions` (`TAuthzedPermissionMismatch`) | the same `TAuthzedSourceRef`, plus expected/observed relation names |
| `mismatchedParents` (`TAuthzedParentEdge`) | organization ID + child ID (`api_key` / `feedback_directory` / `team` / `workspace`) |
| `unmanaged` | `objectId`, `objectType`, `relation` — object IDs *not* limited to Formbricks record kinds |
| `failures` | an organization ID per failed unit that has one — so even a **failed** run emits them |
| `lastOrganizationId` | one organization ID |

Sanitizing only the cursor would have left every other identifier in place, and would have broken the documented resume flow: `--after-organization-id=<cuid>` takes that value verbatim, so an opaque token would have to be persisted and mapped back to stay useful.

Those identifiers are also the tool's whole diagnostic value — `mismatchedParents` is explicitly "reported and never touched… deliberately left for a human". Making them opaque degrades the thing the command exists to do.

**One correction from review:** the cursor is *not* merely a subset of what the drift lists already report. `processOrganization` sets it for every organization the sweep reaches, drift or not, so it is the one field in the result that can name a completely clean organization. That makes it a real exposure, small but distinct — the doc now says so rather than waving it away.

### What this adds

The gap that *is* real: the old text said "store it as sensitive operational data" and stopped. It gave handling, not **retention**, and never said which identifiers to expect.

- Names every identifier-bearing field in the result and the identifier kinds each one carries.
- Says why the cursor is intentional, what consumes it, that it can name a clean organization, and that it is `null` when the run reached no organization.
- Retention guidance: store it like a database export, restrict to operators, delete once the drift is resolved, retain no longer than incident records, redact before pasting into chat, tickets, or support bundles.
- An export recipe that actually protects the file — `umask 077` before redirecting, matching the idiom the backup section already uses — plus an accurate account of what redirection does and does not buy.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2359

## How this was tested

Documentation only — no code changes, so no behavior to test. Every claim is verified against the tree this **merges into** (`epic/authzed`, merged in at `2472bdf7b`), which is where the first round went wrong.

- `TAuthzedSourceRef` (9 kinds incl. `feedbackDirectory` and `feedbackDirectoryAssignment`), `TAuthzedParentEdge.childType` (`api_key | feedback_directory | team | workspace`), `TAuthzedPermissionMismatch`, `TAuthzedRelationshipRef` and `TAuthzedBackfillFailure` in `apps/web/lib/authzed/backfill-diff.ts`.
- `TAuthzedBackfillResult` in `apps/web/lib/authzed/backfill.ts` walked field by field, so the inventory covers every emitted field that carries an identifier and claims no field that does not.
- `lastOrganizationId` semantics read off `backfill.ts:770` (`processOrganization` assigns it before the source read, so it is set for clean, drifted and failed organizations alike) and its `string | null` type at `:195`.
- The emit path: `backfill.ts` → `JSON.stringify(result)` → `writeOutput` → `process.stdout`; and the resume flag `--after-organization-id` in the CLI parser.
- `pnpm exec prettier --check` on the changed file → clean ✅

## Breaking changes

None.

## QA / Test Plan

**How to test**

- [ ] Open the AuthZed operations guide → "Audit and repair relationships" → the section lists which identifiers the JSON result can contain and how long to keep it.
- [ ] Run a backfill against a deployment with drift → confirm the emitted JSON matches the documented field list (drift lists name records; `failures` carries an organization ID; `mismatchedPermissions` carries a record plus relation names).
- [ ] Interrupt a run and resume with `--after-organization-id=<lastOrganizationId>` → resumes from that organization, confirming the cursor is still a usable operator input.
- [ ] Run the documented export recipe (`umask 077`, `rm -f`, then redirect) → `backfill.json` is `0600`. Repeat without the `umask` line under a default `umask 022` → `0644`, the exposure the recipe prevents. Then create a `0644` `backfill.json`, add `umask 077` but drop the `rm -f`, and redirect over it → still `0644`, which is why the removal is in the recipe.
- [ ] Run a backfill against a deployment with no organizations → `lastOrganizationId` is `null`, and the doc's guidance is to rerun from the start rather than pass the cursor.
- [ ] Force one organization to fail mid-sweep (e.g. revoke its source read) → it appears in `failures`, the sweep continues, and `lastOrganizationId` is a *later* organization. Confirm a `--after-organization-id` resume does not retry it, and that the documented `--organization-id` rerun does.
- [ ] Check the drift-category table covers every category the result can report, `mismatchedPermissions` included.

**Preconditions / test data**

- A self-hosted deployment with AuthZed enabled, and ideally some seeded drift so the lists are non-empty.

**Risks & regressions**

- Documentation only. The risk is the reverse of a code risk: if a reader concludes the output is safe to paste into a ticket, the guidance has failed. The identifier inventory and the redaction instruction are the parts to review closely.

**Migrations / env / cutover**

- none.

## Review fixes

Matti's finding and both CodeRabbit rounds, each verified against the merge target before acting:

- **`feedback-directory` over-claim** — correct against the branch as it stood, but the resolution was the opposite of deleting the word: #8864/#8867/#8868 had landed on `epic/authzed`, so the claim is true against the merge target. Merged the epic in and added the `feedbackDirectoryAssignment` ID the list had also missed.
- **Shell-history claim** — redirection cannot keep anything out of history, which records the command. Rewritten to name the real exposure path: the resume flag carries the cursor as an argument.
- **`unmanaged` object IDs** — split into its own bullet, because its object IDs are precisely the ones the known-record kinds do not cover.
- **Redirected file permissions** — `>` inherits the process umask, so the export landed world-readable under a default `umask 022`. Added the `umask 077` recipe.
- **Cursor semantics** — dropped the false "already a subset of what the drift lists report" claim; see the correction above.
- **Found while re-reviewing:** `mismatchedPermissions` is an emitted field carrying a `TAuthzedSourceRef`, and the inventory omitted it — so an operator redacting only the listed fields would have left those record IDs in place. Added. This is the same defect class as the `feedback-directory` finding, in the other direction.

Second and third CodeRabbit rounds on the fix commits, five more, all verified and all real:

- **Existing exports stayed world-readable.** `umask` governs creation only, so redirecting over a `backfill.json` created earlier under `umask 022` truncated it and kept mode `0644`. That is the likely path — you reach for hardening advice *after* producing the file once. Recipe now removes it first.
- **A resume never retried failed organizations.** `processOrganization` (`backfill.ts:767-779`) sets the cursor before the source read and, on failure, records it and returns without stopping the sweep. So anything in `failures` sits behind the final cursor by construction and `--after-organization-id` skips it — an operator would read the resume as complete. Documented the explicit `--organization-id` rerun. Normal path, not an edge case, so this is the round's most consequential fix.
- **`mismatchedPermissions` was missing from the drift-category table too.** Adding it to the identifier inventory one commit earlier left the doc naming a category it gave no operator response for. Added after `missing`, since both are repaired deterministically by an applying run.
- **`failures` can carry an empty `organizationId`.** `recordFailure` is called with `""` at three sites (`backfill.ts:1089`, `:1176`, `:1223`) — a workspace-scoped source read, the organization page read, and the global orphan sweep. That invalidated the previous bullet's fix rather than refining it: the targeted `--organization-id` rerun only applies to failures that carry one. The two sweep-level sites also set `truncated`, so those mean rerunning the sweep — a cursor resume would skip exactly the page that failed.
- **"Formbricks record identifiers" over-framed the payload.** `unmanaged` object IDs need not correspond to any Formbricks record, which its own bullet said three lines below — so the intro and my new cursor sentence contradicted it. Both reworded.
