### PR TITLE
fix(helm): let the AuthZed bootstrap use an existing admin role

### DIFF
--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -291,3 +291,12 @@ jobs:
             --set formbricks.webappUrl=https://qa.example.com \
             --show-only charts/postgresql/templates/primary/statefulset.yaml > "$render_dir/postgresql.yaml"
           grep -q 'argocd.argoproj.io/sync-wave: "-2"' "$render_dir/postgresql.yaml"
+
+      # The render tests cannot execute the bootstrap SQL, and the SQL is where ENG-2390 actually
+      # broke: an administrator holding the documented CREATEROLE and CREATEDB could not run
+      # `CREATE DATABASE ... OWNER`. This runs the *rendered* script against real PostgreSQL, on both
+      # sides of the 16 CREATEROLE change. It skips itself when Docker is unavailable, so the suite
+      # stays runnable locally.
+      - name: Validate the AuthZed bootstrap against real PostgreSQL
+        shell: bash
+        run: bash charts/formbricks/tests/authzed-bootstrap-runtime.sh

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -147,8 +147,11 @@ authzed:
 ```
 
 `adminPasswordSecretName` is required whenever `adminUsername` is not the bundled superuser — otherwise the Job
-would silently fall back to the bundled admin password and fail to authenticate. The Job creates the role and
-database only when they are absent, so re-running it against an already initialised database is a no-op, and
+would silently fall back to the bundled admin password and fail to authenticate.
+
+Re-running is safe but not inert: the role and the database are created only when absent, while the `spicedb`
+role's password is reconciled to the chart's Secret on **every** run. If you rotate that password outside Helm,
+update the Secret too, or the next upgrade will set it back.
 `authzed.bundledPostgresqlBootstrap.enabled=false` remains available for operators who provision both by hand.
 
 Then reference it from the release:

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -131,6 +131,26 @@ The administrator URL must explicitly set `sslmode=require`, `sslmode=verify-ca`
 The bootstrap Job validates the TLS mode without logging the URL and passes the URL through unchanged, so other
 connection parameters and certificate settings are preserved.
 
+### Bootstrapping against an existing PostgreSQL without a `postgres` role
+
+The bundled bootstrap connects as the `postgres` superuser the subchart normally creates. An existing
+installation deployed with `postgresql.auth.enablePostgresUser=false` has no such role, so point the Job at a
+role that does hold `CREATEROLE` and `CREATEDB` instead:
+
+```yaml
+authzed:
+  bundledPostgresqlBootstrap:
+    adminUsername: fbadmin
+    adminDatabase: formbricks # the maintenance database to attach to
+    adminPasswordSecretName: existing-pg-admin
+    adminPasswordKey: password
+```
+
+`adminPasswordSecretName` is required whenever `adminUsername` is not the bundled superuser — otherwise the Job
+would silently fall back to the bundled admin password and fail to authenticate. The Job creates the role and
+database only when they are absent, so re-running it against an already initialised database is a no-op, and
+`authzed.bundledPostgresqlBootstrap.enabled=false` remains available for operators who provision both by hand.
+
 Then reference it from the release:
 
 ```yaml

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -147,7 +147,17 @@ authzed:
 ```
 
 `adminPasswordSecretName` is required whenever `adminUsername` is not the bundled superuser — otherwise the Job
-would silently fall back to the bundled admin password and fail to authenticate.
+would silently fall back to the bundled admin password and fail to authenticate. `adminPasswordKey` is required
+whenever that Secret is configured explicitly, since it otherwise defaults to the bundled subchart's key name
+looked up inside your own Secret.
+
+`CREATEROLE` and `CREATEDB` cover the normal case, in which this administrator also creates the `spicedb` role.
+`CREATE DATABASE ... OWNER spicedb` additionally requires being able to `SET ROLE` to that owner, so the Job
+grants itself the `spicedb` role first; from PostgreSQL 16 that is only possible for a role it holds
+`ADMIN OPTION` on, which creating the role confers. A `spicedb` role that already exists and was created by
+someone else is therefore the one case the Job cannot adopt on PostgreSQL 16+ — grant it explicitly
+(`GRANT spicedb TO fbadmin WITH ADMIN OPTION`) or run the bootstrap once as a superuser. PostgreSQL 15 and
+older are unaffected.
 
 Re-running is safe but not inert: the role and the database are created only when absent, while the `spicedb`
 role's password is reconciled to the chart's Secret on **every** run. If you rotate that password outside Helm,

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -146,10 +146,12 @@ authzed:
     adminPasswordKey: password
 ```
 
-`adminPasswordSecretName` is required whenever `adminUsername` is not the bundled superuser — otherwise the Job
-would silently fall back to the bundled admin password and fail to authenticate. `adminPasswordKey` is required
-whenever that Secret is configured explicitly, since it otherwise defaults to the bundled subchart's key name
-looked up inside your own Secret.
+`adminPasswordSecretName` is required whenever `adminUsername` is not the bundled superuser, and
+`adminPasswordKey` whenever that Secret is configured explicitly. **Both are enforced when the chart renders**,
+so a missing one fails `helm template`/`upgrade` with a named value rather than producing a Job. That is the
+point of the guards: without them the first would silently fall back to the bundled admin password and the
+second would look up the subchart's key name inside your own Secret — neither of which surfaces until the Pod
+is created in the cluster.
 
 `CREATEROLE` and `CREATEDB` cover the normal case, in which this administrator also creates the `spicedb` role.
 `CREATE DATABASE ... OWNER spicedb` additionally requires being able to `SET ROLE` to that owner, so the Job

--- a/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
+++ b/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
@@ -8,11 +8,25 @@
 {{- if and $externalBootstrap (not .Values.authzed.externalPostgresqlBootstrap.adminSecretName) -}}
 {{- fail "authzed.externalPostgresqlBootstrap.adminSecretName is required when external bootstrap is enabled" -}}
 {{- end -}}
-{{- if and $bundledBootstrap (not .Values.postgresql.auth.enablePostgresUser) -}}
-{{- fail "postgresql.auth.enablePostgresUser must be true when bundled AuthZed PostgreSQL bootstrap is enabled" -}}
+{{- $bundledAdminUsername := .Values.authzed.bundledPostgresqlBootstrap.adminUsername | default "postgres" -}}
+{{- $bundledAdminDatabase := .Values.authzed.bundledPostgresqlBootstrap.adminDatabase | default "postgres" -}}
+{{- $bundledAdminSecret := .Values.authzed.bundledPostgresqlBootstrap.adminPasswordSecretName | default $postgresSecretName -}}
+{{- $bundledAdminKey := .Values.authzed.bundledPostgresqlBootstrap.adminPasswordKey | default .Values.postgresql.auth.secretKeys.adminPasswordKey -}}
+{{- $usesBundledPostgresSuperuser := eq $bundledAdminUsername "postgres" -}}
+{{- /*
+  Only the bundled `postgres` superuser depends on enablePostgresUser. An operator who pointed
+  adminUsername at their own CREATEROLE/CREATEDB role has no reason to also materialise a superuser
+  the subchart was told not to create — requiring it is what forced existing installations to turn
+  bootstrap off entirely (ENG-2390).
+*/ -}}
+{{- if and $bundledBootstrap $usesBundledPostgresSuperuser (not .Values.postgresql.auth.enablePostgresUser) -}}
+{{- fail "Set authzed.bundledPostgresqlBootstrap.adminUsername (with adminPasswordSecretName and adminPasswordKey) to an existing role with CREATEROLE and CREATEDB, or enable postgresql.auth.enablePostgresUser, or disable authzed.bundledPostgresqlBootstrap.enabled" -}}
 {{- end -}}
-{{- if and $bundledBootstrap (not .Values.postgresql.auth.secretKeys.adminPasswordKey) -}}
-{{- fail "postgresql.auth.secretKeys.adminPasswordKey is required when bundled AuthZed PostgreSQL bootstrap is enabled" -}}
+{{- if and $bundledBootstrap (not $bundledAdminKey) -}}
+{{- fail "authzed.bundledPostgresqlBootstrap.adminPasswordKey (or postgresql.auth.secretKeys.adminPasswordKey) is required when bundled AuthZed PostgreSQL bootstrap is enabled" -}}
+{{- end -}}
+{{- if and $bundledBootstrap (not $usesBundledPostgresSuperuser) (not .Values.authzed.bundledPostgresqlBootstrap.adminPasswordSecretName) -}}
+{{- fail "authzed.bundledPostgresqlBootstrap.adminPasswordSecretName is required when adminUsername is not the bundled postgres superuser" -}}
 {{- end -}}
 {{- $bootstrap := ternary .Values.authzed.bundledPostgresqlBootstrap .Values.authzed.externalPostgresqlBootstrap $bundledBootstrap -}}
 apiVersion: batch/v1
@@ -58,12 +72,14 @@ spec:
             - name: PGHOST
               value: formbricks-postgresql
             - name: PGUSER
-              value: postgres
+              value: {{ $bundledAdminUsername | quote }}
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $postgresSecretName }}
-                  key: {{ .Values.postgresql.auth.secretKeys.adminPasswordKey }}
+                  name: {{ $bundledAdminSecret }}
+                  key: {{ $bundledAdminKey }}
+            - name: ADMIN_DATABASE_NAME
+              value: {{ $bundledAdminDatabase | quote }}
             - name: SPICEDB_DATABASE_NAME
               value: spicedb
             - name: SPICEDB_DATABASE_USERNAME
@@ -130,7 +146,10 @@ spec:
                 esac
                 admin_database_url="$ADMIN_DATABASE_URL"
               else
-                admin_database_url=postgres
+                # Bundled mode connects through PGHOST/PGUSER/PGPASSWORD; this is the maintenance
+                # database to attach to, which is not necessarily named `postgres` on an existing
+                # server (ENG-2390).
+                admin_database_url="${ADMIN_DATABASE_NAME:-postgres}"
               fi
               readiness_attempt=1
               until pg_isready --dbname "$admin_database_url"; do

--- a/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
+++ b/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
@@ -30,6 +30,17 @@
 {{- if and $bundledBootstrap (not $isBundledSuperuserName) (not .Values.authzed.bundledPostgresqlBootstrap.adminPasswordSecretName) -}}
 {{- fail "authzed.bundledPostgresqlBootstrap.adminPasswordSecretName is required when adminUsername is not the bundled postgres superuser" -}}
 {{- end -}}
+{{- /*
+  The key needs its own explicit requirement, not just the non-empty check above. `$bundledAdminKey`
+  falls back to `postgresql.auth.secretKeys.adminPasswordKey`, which the subchart defaults to
+  `POSTGRES_ADMIN_PASSWORD` — never empty — so that check cannot fire for a custom role. Without this,
+  setting adminUsername and adminPasswordSecretName but forgetting the key renders happily and looks
+  up the *subchart's* key name inside the *operator's own* Secret, which fails in-cluster as
+  CreateContainerConfigError rather than at render. Fail-fast is the whole point of these guards.
+*/ -}}
+{{- if and $bundledBootstrap (not $isBundledSuperuserName) (not .Values.authzed.bundledPostgresqlBootstrap.adminPasswordKey) -}}
+{{- fail "authzed.bundledPostgresqlBootstrap.adminPasswordKey is required when adminUsername is not the bundled postgres superuser" -}}
+{{- end -}}
 {{- $bootstrap := ternary .Values.authzed.bundledPostgresqlBootstrap .Values.authzed.externalPostgresqlBootstrap $bundledBootstrap -}}
 apiVersion: batch/v1
 kind: Job
@@ -150,8 +161,10 @@ spec:
               else
                 # Bundled mode connects through PGHOST/PGUSER/PGPASSWORD; this is the maintenance
                 # database to attach to, which is not necessarily named `postgres` on an existing
-                # server (ENG-2390).
-                admin_database_url="${ADMIN_DATABASE_NAME:-postgres}"
+                # server (ENG-2390). No shell-level default: this branch only runs for bundled
+                # bootstrap, where the template always sets ADMIN_DATABASE_NAME, so a second
+                # fallback here would just be a competing source of truth for the same default.
+                admin_database_url="$ADMIN_DATABASE_NAME"
               fi
               readiness_attempt=1
               until pg_isready --dbname "$admin_database_url"; do

--- a/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
+++ b/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
@@ -37,9 +37,14 @@
   setting adminUsername and adminPasswordSecretName but forgetting the key renders happily and looks
   up the *subchart's* key name inside the *operator's own* Secret, which fails in-cluster as
   CreateContainerConfigError rather than at render. Fail-fast is the whole point of these guards.
+
+  Keyed off the *credential source*, not the username: an existing administrator that happens to be
+  called `postgres` still supplies its own Secret, and that Secret is no more likely to carry the
+  subchart's key name than any other. Keying off the name left exactly that configuration rendering
+  a dangling secretKeyRef.
 */ -}}
-{{- if and $bundledBootstrap (not $isBundledSuperuserName) (not .Values.authzed.bundledPostgresqlBootstrap.adminPasswordKey) -}}
-{{- fail "authzed.bundledPostgresqlBootstrap.adminPasswordKey is required when adminUsername is not the bundled postgres superuser" -}}
+{{- if and $bundledBootstrap (not $reliesOnBundledAdminSecret) (not .Values.authzed.bundledPostgresqlBootstrap.adminPasswordKey) -}}
+{{- fail "authzed.bundledPostgresqlBootstrap.adminPasswordKey is required when the administrator password comes from an explicitly configured Secret" -}}
 {{- end -}}
 {{- $bootstrap := ternary .Values.authzed.bundledPostgresqlBootstrap .Values.authzed.externalPostgresqlBootstrap $bundledBootstrap -}}
 apiVersion: batch/v1
@@ -181,6 +186,14 @@ spec:
                 --set database_password="$SPICEDB_DATABASE_PASSWORD" <<'SQL'
               SELECT format('CREATE ROLE %I LOGIN', :'database_username')
                 WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = :'database_username') \gexec
+              -- CREATE DATABASE ... OWNER requires the administrator to be able to SET ROLE to the
+              -- owner, and merely holding CREATEROLE does not give that. PostgreSQL 16+ grants a
+              -- role's creator ADMIN but SET FALSE; PostgreSQL 15 and older grant nothing at all. So
+              -- a non-superuser administrator has to take the membership explicitly or the next
+              -- statement fails with "must be able to SET ROLE" (16+) / "must be member of role"
+              -- (15). Superusers already qualify and are skipped, so the bundled path is unchanged.
+              SELECT format('GRANT %I TO CURRENT_USER', :'database_username')
+                WHERE NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) \gexec
               SELECT format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'database_username', :'database_password') \gexec
               SELECT format('CREATE DATABASE %I OWNER %I', :'database_name', :'database_username')
                 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'database_name') \gexec

--- a/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
+++ b/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
@@ -12,20 +12,22 @@
 {{- $bundledAdminDatabase := .Values.authzed.bundledPostgresqlBootstrap.adminDatabase | default "postgres" -}}
 {{- $bundledAdminSecret := .Values.authzed.bundledPostgresqlBootstrap.adminPasswordSecretName | default $postgresSecretName -}}
 {{- $bundledAdminKey := .Values.authzed.bundledPostgresqlBootstrap.adminPasswordKey | default .Values.postgresql.auth.secretKeys.adminPasswordKey -}}
-{{- $usesBundledPostgresSuperuser := eq $bundledAdminUsername "postgres" -}}
+{{- $isBundledSuperuserName := eq $bundledAdminUsername "postgres" -}}
+{{- $reliesOnBundledAdminSecret := and $isBundledSuperuserName (not .Values.authzed.bundledPostgresqlBootstrap.adminPasswordSecretName) -}}
 {{- /*
-  Only the bundled `postgres` superuser depends on enablePostgresUser. An operator who pointed
-  adminUsername at their own CREATEROLE/CREATEDB role has no reason to also materialise a superuser
-  the subchart was told not to create — requiring it is what forced existing installations to turn
-  bootstrap off entirely (ENG-2390).
+  enablePostgresUser only matters when this Job is relying on the subchart to *create* the superuser
+  and hand over its password — that is, the default name AND the default Secret. Keying off the name
+  alone would refuse an existing server whose privileged role happens to be called `postgres` and
+  whose credentials the operator supplied explicitly, which is the same over-strict refusal that
+  forced installations to disable bootstrap entirely (ENG-2390).
 */ -}}
-{{- if and $bundledBootstrap $usesBundledPostgresSuperuser (not .Values.postgresql.auth.enablePostgresUser) -}}
+{{- if and $bundledBootstrap $reliesOnBundledAdminSecret (not .Values.postgresql.auth.enablePostgresUser) -}}
 {{- fail "Set authzed.bundledPostgresqlBootstrap.adminUsername (with adminPasswordSecretName and adminPasswordKey) to an existing role with CREATEROLE and CREATEDB, or enable postgresql.auth.enablePostgresUser, or disable authzed.bundledPostgresqlBootstrap.enabled" -}}
 {{- end -}}
 {{- if and $bundledBootstrap (not $bundledAdminKey) -}}
 {{- fail "authzed.bundledPostgresqlBootstrap.adminPasswordKey (or postgresql.auth.secretKeys.adminPasswordKey) is required when bundled AuthZed PostgreSQL bootstrap is enabled" -}}
 {{- end -}}
-{{- if and $bundledBootstrap (not $usesBundledPostgresSuperuser) (not .Values.authzed.bundledPostgresqlBootstrap.adminPasswordSecretName) -}}
+{{- if and $bundledBootstrap (not $isBundledSuperuserName) (not .Values.authzed.bundledPostgresqlBootstrap.adminPasswordSecretName) -}}
 {{- fail "authzed.bundledPostgresqlBootstrap.adminPasswordSecretName is required when adminUsername is not the bundled postgres superuser" -}}
 {{- end -}}
 {{- $bootstrap := ternary .Values.authzed.bundledPostgresqlBootstrap .Values.authzed.externalPostgresqlBootstrap $bundledBootstrap -}}

--- a/charts/formbricks/tests/authzed-bootstrap-runtime.sh
+++ b/charts/formbricks/tests/authzed-bootstrap-runtime.sh
@@ -77,9 +77,13 @@ start_postgres() {
   docker run --detach --name "${container}" \
     --env POSTGRES_PASSWORD=superuser-pw "postgres:${version}-alpine" >/dev/null
   containers+=("${container}")
+  # Probe over TCP, not the Unix socket. The postgres entrypoint runs a temporary socket-only server
+  # while it initialises the data directory, so a socket probe reports ready, the entrypoint then
+  # stops that server, and the next command fails with "No such file or directory" — which is exactly
+  # how this first went red in CI while passing locally. The real server is the one listening on TCP.
   local attempt=1
-  until docker exec "${container}" pg_isready --username postgres >/dev/null 2>&1; do
-    if [ "${attempt}" -ge 60 ]; then
+  until docker exec "${container}" pg_isready --host 127.0.0.1 --username postgres >/dev/null 2>&1; do
+    if [ "${attempt}" -ge 90 ]; then
       printf '%s\n' "PostgreSQL ${version} did not become ready." >&2
       exit 1
     fi
@@ -103,7 +107,8 @@ run_bootstrap() {
 }
 
 as_superuser() {
-  docker exec "$1" psql --username postgres --dbname postgres --tuples-only --no-align --command "$2"
+  docker exec --env PGPASSWORD=superuser-pw "$1" \
+    psql --host 127.0.0.1 --username postgres --dbname postgres --tuples-only --no-align --command "$2"
 }
 
 for version in "${postgres_versions[@]}"; do

--- a/charts/formbricks/tests/authzed-bootstrap-runtime.sh
+++ b/charts/formbricks/tests/authzed-bootstrap-runtime.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Runs the AuthZed bootstrap Job's *rendered* script against real PostgreSQL servers.
+#
+# The render tests in authzed-operations.sh prove the manifest says what we mean. They cannot prove
+# the SQL works, and the SQL is where this feature actually broke: a role with CREATEROLE and CREATEDB
+# — the privileges values.yaml tells operators to grant — could not run `CREATE DATABASE ... OWNER`,
+# because PostgreSQL 16+ grants a role's creator ADMIN but SET FALSE, and 15 and older grant nothing.
+# Both fail, with different messages, and no amount of template testing sees it.
+#
+# So this extracts the script from the rendered Job and runs it verbatim. Nothing here restates the
+# SQL: a fix that lands in the template but not in reality fails here, and a test that drifts from
+# the template is impossible by construction.
+#
+# Skipped when Docker is unavailable so the render suite still runs anywhere.
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! docker info >/dev/null 2>&1; then
+  printf '%s\n' "Docker unavailable — skipping the AuthZed bootstrap runtime tests."
+  exit 0
+fi
+
+# PostgreSQL 16 changed how a creator is granted its new role, and the bootstrap has to work either
+# way, so both sides of that change are covered.
+postgres_versions=("15" "17")
+admin_password="admin-pw"
+spicedb_password="spicedb-pw"
+containers=()
+container=""
+
+cleanup() {
+  for container in "${containers[@]:-}"; do
+    [ -n "${container}" ] && docker rm --force "${container}" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+# Pull the `args:` block scalar out of the rendered Job. Reading the shipped script rather than a
+# copy is the whole point: this test cannot pass against SQL the chart does not actually ship.
+extract_bootstrap_script() {
+  awk '
+    /^[[:space:]]*args:[[:space:]]*$/ { in_args = 1; next }
+    in_args && /^[[:space:]]*-[[:space:]]*\|[[:space:]]*$/ { in_block = 1; next }
+    in_block {
+      if (block_indent == 0 && $0 !~ /^[[:space:]]*$/) {
+        match($0, /^[[:space:]]*/)
+        block_indent = RLENGTH
+      }
+      if ($0 !~ /^[[:space:]]*$/) {
+        match($0, /^[[:space:]]*/)
+        if (RLENGTH < block_indent) { exit }
+      }
+      print substr($0, block_indent + 1)
+    }
+  '
+}
+
+bootstrap_script="$(helm template runtime "${chart_dir}" \
+  --set formbricks.webappUrl=https://qa.example.com \
+  --set authzed.enabled=true \
+  --set authzed.mode=selfHosted \
+  --show-only templates/authzed-postgresql-bootstrap.yaml | extract_bootstrap_script)"
+
+if ! grep --quiet 'CREATE DATABASE' <<<"${bootstrap_script}"; then
+  printf '%s\n' "Could not extract the bootstrap script from the rendered Job." >&2
+  exit 1
+fi
+
+# Sets the global `container` rather than echoing it: a `$(start_postgres …)` call would run this in a
+# subshell, so the name would never reach the cleanup list in the parent and a failing assertion
+# would leak the server.
+start_postgres() {
+  local version="$1"
+  container="authzed-bootstrap-runtime-${version}"
+  docker rm --force "${container}" >/dev/null 2>&1 || true
+  docker run --detach --name "${container}" \
+    --env POSTGRES_PASSWORD=superuser-pw "postgres:${version}-alpine" >/dev/null
+  containers+=("${container}")
+  local attempt=1
+  until docker exec "${container}" pg_isready --username postgres >/dev/null 2>&1; do
+    if [ "${attempt}" -ge 60 ]; then
+      printf '%s\n' "PostgreSQL ${version} did not become ready." >&2
+      exit 1
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+}
+
+# Runs the rendered script exactly as the Job does: same shell, same env contract.
+run_bootstrap() {
+  local container="$1" admin_user="$2" admin_pass="$3"
+  docker exec --interactive \
+    --env PGHOST=127.0.0.1 \
+    --env PGUSER="${admin_user}" \
+    --env PGPASSWORD="${admin_pass}" \
+    --env ADMIN_DATABASE_NAME=postgres \
+    --env SPICEDB_DATABASE_NAME=spicedb \
+    --env SPICEDB_DATABASE_USERNAME=spicedb \
+    --env SPICEDB_DATABASE_PASSWORD="${spicedb_password}" \
+    "${container}" /bin/sh -ec "${bootstrap_script}" 2>&1
+}
+
+as_superuser() {
+  docker exec "$1" psql --username postgres --dbname postgres --tuples-only --no-align --command "$2"
+}
+
+for version in "${postgres_versions[@]}"; do
+  start_postgres "${version}"
+  printf 'PostgreSQL %s\n' "$(as_superuser "${container}" 'SHOW server_version')"
+
+  # The privileges values.yaml documents, and nothing more.
+  as_superuser "${container}" \
+    "CREATE ROLE fbadmin LOGIN CREATEROLE CREATEDB PASSWORD '${admin_password}'" >/dev/null
+
+  # 1. A fresh server with only a CREATEROLE/CREATEDB administrator: the path this feature exists for.
+  if ! output="$(run_bootstrap "${container}" fbadmin "${admin_password}")"; then
+    printf '%s\n%s\n' "Bootstrap failed for a CREATEROLE/CREATEDB administrator on ${version}:" "${output}" >&2
+    exit 1
+  fi
+  [ "$(as_superuser "${container}" "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = 'spicedb'")" = "spicedb" ] || {
+    printf '%s\n' "The spicedb database must exist and be owned by the spicedb role on ${version}." >&2
+    exit 1
+  }
+  # Proves ALTER ROLE actually applied the password, not merely that the statement ran.
+  docker exec --env PGPASSWORD="${spicedb_password}" "${container}" \
+    psql --host 127.0.0.1 --username spicedb --dbname spicedb --command 'SELECT 1' >/dev/null || {
+    printf '%s\n' "The spicedb role must be able to log in with the configured password on ${version}." >&2
+    exit 1
+  }
+
+  # 2. Rerunning is safe: the Job is a post-install *and* post-upgrade hook, so it reruns every upgrade.
+  if ! output="$(run_bootstrap "${container}" fbadmin "${admin_password}")"; then
+    printf '%s\n%s\n' "Rerunning the bootstrap must succeed on ${version}:" "${output}" >&2
+    exit 1
+  fi
+
+  # 3. The bundled superuser path must be unchanged — and must not collect a role membership it has
+  #    no use for, which is why the GRANT is skipped for superusers rather than run unconditionally.
+  as_superuser "${container}" "DROP DATABASE spicedb" >/dev/null
+  as_superuser "${container}" "DROP ROLE spicedb" >/dev/null
+  if ! output="$(run_bootstrap "${container}" postgres superuser-pw)"; then
+    printf '%s\n%s\n' "Bootstrap failed for the bundled superuser on ${version}:" "${output}" >&2
+    exit 1
+  fi
+  [ "$(as_superuser "${container}" "SELECT count(*) FROM pg_auth_members m JOIN pg_roles r ON r.oid = m.roleid JOIN pg_roles u ON u.oid = m.member WHERE r.rolname = 'spicedb' AND u.rolname = 'postgres'")" = "0" ] || {
+    printf '%s\n' "A superuser administrator must not be granted the spicedb role on ${version}." >&2
+    exit 1
+  }
+
+  # 4. A spicedb role created by someone else. PostgreSQL 16 narrowed CREATEROLE: before it, the
+  #    privilege carried authority over every non-superuser role, so the bootstrap simply works;
+  #    from 16 on it only covers roles the administrator has ADMIN OPTION for, so this is the
+  #    documented limitation and must fail loudly rather than appear to succeed. Asserting one
+  #    outcome for both would either miss the failure or demand a fix the older server does not need.
+  as_superuser "${container}" "DROP DATABASE spicedb" >/dev/null
+  server_version_num="$(as_superuser "${container}" 'SHOW server_version_num')"
+  if output="$(run_bootstrap "${container}" fbadmin "${admin_password}")"; then
+    if [ "${server_version_num}" -ge 160000 ]; then
+      printf '%s\n' "Bootstrap must fail without ADMIN OPTION on a pre-existing spicedb role (${version})." >&2
+      exit 1
+    fi
+  else
+    if [ "${server_version_num}" -lt 160000 ]; then
+      printf '%s\n%s\n' "CREATEROLE alone must still adopt a pre-existing spicedb role on ${version}:" "${output}" >&2
+      exit 1
+    fi
+    grep --quiet --extended-regexp 'must have admin option|permission denied|must be able to SET ROLE|must be member of role' <<<"${output}" || {
+      printf '%s\n%s\n' "Expected a privilege error for a pre-existing foreign-owned spicedb role on ${version}, got:" "${output}" >&2
+      exit 1
+    }
+  fi
+
+  docker rm --force "${container}" >/dev/null 2>&1 || true
+done
+
+printf '%s\n' "AuthZed bootstrap runtime contracts are valid."

--- a/charts/formbricks/tests/authzed-operations.sh
+++ b/charts/formbricks/tests/authzed-operations.sh
@@ -162,6 +162,16 @@ grep --quiet 'value: "fbadmin"' <<<"${existing_admin_bootstrap}"
 grep --quiet 'value: "formbricks"' <<<"${existing_admin_bootstrap}"
 grep --quiet 'name: existing-pg-admin' <<<"${existing_admin_bootstrap}"
 
+# Matti's finding on #8875: the key needs its own guard. `$bundledAdminKey` falls back to the
+# subchart's non-empty default, so "is it set at all" can never fail for a custom role, and forgetting
+# the key silently looks up the subchart's key name inside the operator's own Secret.
+if render_bootstrap authzed-bootstrap-admin-without-key \
+  --set authzed.bundledPostgresqlBootstrap.adminUsername=fbadmin \
+  --set authzed.bundledPostgresqlBootstrap.adminPasswordSecretName=existing-pg-admin >/dev/null 2>&1; then
+  printf '%s\n' "Bootstrap must require adminPasswordKey when adminUsername is overridden." >&2
+  exit 1
+fi
+
 # An existing server whose privileged role is called `postgres` is a configured administrator, not the
 # bundled superuser — supplying its Secret explicitly must be accepted even with enablePostgresUser=false.
 explicit_postgres_bootstrap="$(render_bootstrap authzed-bootstrap-explicit-postgres \

--- a/charts/formbricks/tests/authzed-operations.sh
+++ b/charts/formbricks/tests/authzed-operations.sh
@@ -162,6 +162,15 @@ grep --quiet 'value: "fbadmin"' <<<"${existing_admin_bootstrap}"
 grep --quiet 'value: "formbricks"' <<<"${existing_admin_bootstrap}"
 grep --quiet 'name: existing-pg-admin' <<<"${existing_admin_bootstrap}"
 
+# An existing server whose privileged role is called `postgres` is a configured administrator, not the
+# bundled superuser — supplying its Secret explicitly must be accepted even with enablePostgresUser=false.
+explicit_postgres_bootstrap="$(render_bootstrap authzed-bootstrap-explicit-postgres \
+  --set postgresql.auth.enablePostgresUser=false \
+  --set authzed.bundledPostgresqlBootstrap.adminPasswordSecretName=existing-pg-admin \
+  --set authzed.bundledPostgresqlBootstrap.adminPasswordKey=password)"
+grep --quiet 'value: "postgres"' <<<"${explicit_postgres_bootstrap}"
+grep --quiet 'name: existing-pg-admin' <<<"${explicit_postgres_bootstrap}"
+
 # A custom admin role with no Secret would silently fall back to the bundled superuser's password.
 if render_bootstrap authzed-bootstrap-admin-without-secret \
   --set authzed.bundledPostgresqlBootstrap.adminUsername=fbadmin >/dev/null 2>&1; then

--- a/charts/formbricks/tests/authzed-operations.sh
+++ b/charts/formbricks/tests/authzed-operations.sh
@@ -126,4 +126,53 @@ helm template authzed-external "${CHART_DIR}" "${COMMON_ARGS[@]}" \
   --set authzed.insecure=false \
   --set authzed.auth.existingSecret=formbricks-authzed >/dev/null
 
+# ENG-2390: the bundled database bootstrap must not hard-require a role named `postgres`.
+# An existing PostgreSQL installed without one previously had no option but to disable bootstrap
+# entirely, which left the SpiceDB role and database uncreated.
+
+render_bootstrap() {
+  helm template "$1" "${CHART_DIR}" "${COMMON_ARGS[@]}" \
+    --set authzed.enabled=true \
+    --set authzed.mode=selfHosted \
+    "${@:2}" \
+    --show-only templates/authzed-postgresql-bootstrap.yaml
+}
+
+# The default is unchanged: the bundled `postgres` superuser on the `postgres` database.
+default_bootstrap="$(render_bootstrap authzed-bootstrap-default)"
+grep --quiet 'value: "postgres"' <<<"${default_bootstrap}"
+
+# The regression itself. Without an override this still refuses, but it must name the way out
+# rather than simply asserting that enablePostgresUser is required.
+if bootstrap_refusal="$(render_bootstrap authzed-bootstrap-no-superuser \
+  --set postgresql.auth.enablePostgresUser=false 2>&1)"; then
+  printf '%s\n' "Bootstrap must refuse a missing postgres superuser when no admin role is configured." >&2
+  exit 1
+fi
+grep --quiet 'adminUsername' <<<"${bootstrap_refusal}"
+
+# ...and configuring an existing administrative role is what unblocks it.
+existing_admin_bootstrap="$(render_bootstrap authzed-bootstrap-existing-admin \
+  --set postgresql.auth.enablePostgresUser=false \
+  --set authzed.bundledPostgresqlBootstrap.adminUsername=fbadmin \
+  --set authzed.bundledPostgresqlBootstrap.adminDatabase=formbricks \
+  --set authzed.bundledPostgresqlBootstrap.adminPasswordSecretName=existing-pg-admin \
+  --set authzed.bundledPostgresqlBootstrap.adminPasswordKey=password)"
+grep --quiet 'value: "fbadmin"' <<<"${existing_admin_bootstrap}"
+grep --quiet 'value: "formbricks"' <<<"${existing_admin_bootstrap}"
+grep --quiet 'name: existing-pg-admin' <<<"${existing_admin_bootstrap}"
+
+# A custom admin role with no Secret would silently fall back to the bundled superuser's password.
+if render_bootstrap authzed-bootstrap-admin-without-secret \
+  --set authzed.bundledPostgresqlBootstrap.adminUsername=fbadmin >/dev/null 2>&1; then
+  printf '%s\n' "Bootstrap must require adminPasswordSecretName when adminUsername is overridden." >&2
+  exit 1
+fi
+
+# Credentials reach the Job only by reference, in every mode.
+if grep --extended-regexp 'PGPASSWORD: |password: [^{]' <<<"${existing_admin_bootstrap}" >/dev/null; then
+  printf '%s\n' "Bootstrap manifests must not contain credential values." >&2
+  exit 1
+fi
+
 printf '%s\n' "AuthZed Helm operations contracts are valid."

--- a/charts/formbricks/tests/authzed-operations.sh
+++ b/charts/formbricks/tests/authzed-operations.sh
@@ -181,6 +181,16 @@ explicit_postgres_bootstrap="$(render_bootstrap authzed-bootstrap-explicit-postg
 grep --quiet 'value: "postgres"' <<<"${explicit_postgres_bootstrap}"
 grep --quiet 'name: existing-pg-admin' <<<"${explicit_postgres_bootstrap}"
 
+# ...but that administrator still supplies its own Secret, which is no likelier to carry the
+# subchart's key name than any other. Keying the key guard off the username left this configuration
+# rendering a dangling secretKeyRef (Bhagya's finding on #8875, and CodeRabbit's before it), so the
+# guard keys off the credential source and this render must be refused.
+if render_bootstrap authzed-bootstrap-explicit-postgres-without-key \
+  --set authzed.bundledPostgresqlBootstrap.adminPasswordSecretName=existing-pg-admin >/dev/null 2>&1; then
+  printf '%s\n' "Bootstrap must require adminPasswordKey when the administrator Secret is configured explicitly." >&2
+  exit 1
+fi
+
 # A custom admin role with no Secret would silently fall back to the bundled superuser's password.
 if render_bootstrap authzed-bootstrap-admin-without-secret \
   --set authzed.bundledPostgresqlBootstrap.adminUsername=fbadmin >/dev/null 2>&1; then
@@ -189,9 +199,51 @@ if render_bootstrap authzed-bootstrap-admin-without-secret \
 fi
 
 # Credentials reach the Job only by reference, in every mode.
-if grep --extended-regexp 'PGPASSWORD: |password: [^{]' <<<"${existing_admin_bootstrap}" >/dev/null; then
-  printf '%s\n' "Bootstrap manifests must not contain credential values." >&2
-  exit 1
-fi
+#
+# Asserted structurally, per Bhagya's finding on #8875. The previous check grepped for `PGPASSWORD: `,
+# a shape the renderer never emits — env entries are `- name: PGPASSWORD` followed by `value:` or
+# `valueFrom:`. A literal leak therefore matched nothing and the test passed through the exact
+# regression it existed to catch. A whole-manifest regex cannot do better: it cannot tell a `value:`
+# under PGPASSWORD from the legitimate one under PGHOST. So walk the env list instead and check how
+# each sensitive entry is supplied.
+assert_env_supplied_by_reference() {
+  local manifest="$1" variable="$2"
+
+  awk -v target="${variable}" '
+    /^[[:space:]]*-[[:space:]]+name:[[:space:]]/ {
+      if (current == target) { seen = 1; if (source != "reference") literal = 1 }
+      current = $3
+      source = ""
+      next
+    }
+    current == target && /^[[:space:]]*value:/ { source = "literal" }
+    current == target && /^[[:space:]]*valueFrom:/ { source = "reference" }
+    END {
+      if (current == target) { seen = 1; if (source != "reference") literal = 1 }
+      if (!seen) { print "absent"; exit 2 }
+      if (literal) { print "literal"; exit 1 }
+      print "reference"
+    }
+  ' <<<"${manifest}"
+}
+
+for credential_variable in PGPASSWORD SPICEDB_DATABASE_PASSWORD; do
+  if ! supplied_by="$(assert_env_supplied_by_reference "${existing_admin_bootstrap}" "${credential_variable}")"; then
+    printf '%s\n' "Bootstrap must supply ${credential_variable} by secret reference, found: ${supplied_by}." >&2
+    exit 1
+  fi
+done
+
+external_bootstrap="$(render_bootstrap authzed-bootstrap-external \
+  --set authzed.bundledPostgresqlBootstrap.enabled=false \
+  --set authzed.externalPostgresqlBootstrap.enabled=true \
+  --set authzed.externalPostgresqlBootstrap.adminSecretName=external-pg-admin \
+  --set authzed.datastore.existingSecret=external-datastore)"
+for credential_variable in ADMIN_DATABASE_URL SPICEDB_DATABASE_PASSWORD; do
+  if ! supplied_by="$(assert_env_supplied_by_reference "${external_bootstrap}" "${credential_variable}")"; then
+    printf '%s\n' "External bootstrap must supply ${credential_variable} by secret reference, found: ${supplied_by}." >&2
+    exit 1
+  fi
+done
 
 printf '%s\n' "AuthZed Helm operations contracts are valid."

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -647,6 +647,22 @@ authzed:
     enabled: true
     image: postgres:17-alpine
     backoffLimit: 10
+    # The administrative role the bootstrap Job connects as to create the
+    # dedicated `spicedb` role and database. It needs CREATEROLE and CREATEDB,
+    # not necessarily superuser.
+    #
+    # Defaults to the `postgres` superuser the bundled subchart creates. An
+    # existing PostgreSQL that was installed without one (see
+    # postgresql.auth.enablePostgresUser) would otherwise fail this Job, so point
+    # these at whichever role does hold those privileges instead of disabling
+    # bootstrap wholesale.
+    adminUsername: postgres
+    adminDatabase: postgres
+    # Where that role's password lives. Both default to the bundled PostgreSQL
+    # admin credentials, so overriding adminUsername alone is not enough — set
+    # these too whenever the role is not the bundled `postgres` superuser.
+    adminPasswordSecretName: ""
+    adminPasswordKey: ""
 
   # Cloud installations can bootstrap a dedicated database on an existing
   # PostgreSQL server. The admin Secret is read only by the short-lived Job.

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -651,6 +651,13 @@ authzed:
     # dedicated `spicedb` role and database. It needs CREATEROLE and CREATEDB,
     # not necessarily superuser.
     #
+    # CREATE DATABASE ... OWNER also requires being able to SET ROLE to the
+    # owner, which CREATEROLE alone does not give, so the Job grants itself the
+    # `spicedb` role first. From PostgreSQL 16 that works only for a role it
+    # holds ADMIN OPTION on — which creating the role confers, so the only
+    # unsupported case is a `spicedb` role someone else already created. See the
+    # chart README.
+    #
     # Defaults to the `postgres` superuser the bundled subchart creates. An
     # existing PostgreSQL that was installed without one (see
     # postgresql.auth.enablePostgresUser) would otherwise fail this Job, so point
@@ -661,6 +668,9 @@ authzed:
     # Where that role's password lives. Both default to the bundled PostgreSQL
     # admin credentials, so overriding adminUsername alone is not enough — set
     # these too whenever the role is not the bundled `postgres` superuser.
+    # Setting the name without the key is refused as well: the key would
+    # otherwise fall back to the subchart's own key name and be looked up inside
+    # your Secret, which fails only once the Pod is created.
     adminPasswordSecretName: ""
     adminPasswordKey: ""
 

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -127,6 +127,37 @@ Production deployments should use a dedicated PostgreSQL database and role. Prov
 `datastore_uri` and `preshared_key`, then reference it through `authzed.datastore.existingSecret` and
 `authzed.auth.existingSecret`. Require `sslmode=require`, `verify-ca`, or `verify-full` for managed PostgreSQL.
 
+### Bootstrap the SpiceDB role and database
+
+A short-lived Job creates the dedicated `spicedb` role and database before SpiceDB starts. It creates each only
+when it is absent, so re-running it against an already initialised database changes nothing.
+
+By default it connects as the `postgres` superuser the bundled PostgreSQL subchart creates. **An existing
+PostgreSQL installed with `postgresql.auth.enablePostgresUser=false` has no such role**, and the upgrade fails
+until the Job is told which role to use instead:
+
+```yaml
+authzed:
+  bundledPostgresqlBootstrap:
+    adminUsername: fbadmin
+    adminDatabase: formbricks # maintenance database to attach to
+    adminPasswordSecretName: existing-pg-admin
+    adminPasswordKey: password
+```
+
+The role needs `CREATEROLE` and `CREATEDB`; it does not need to be a superuser. `adminPasswordSecretName` is
+required whenever `adminUsername` is overridden — without it the Job would fall back to the bundled admin
+password and fail to authenticate.
+
+Rendering fails fast with the three available remedies named — configure an administrative role, enable
+`postgresql.auth.enablePostgresUser`, or set `authzed.bundledPostgresqlBootstrap.enabled=false` — rather than
+letting the Job fail inside the cluster. Disabling bootstrap remains the correct choice when the role and
+database are provisioned by hand or by a platform team; the SpiceDB `datastore_uri` must then already point at
+them.
+
+For an externally managed PostgreSQL server, use `authzed.externalPostgresqlBootstrap` instead, which takes a
+full administrator URL from a Secret and enforces TLS on it.
+
 For an external AuthZed endpoint:
 
 ```yaml

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -130,7 +130,9 @@ Production deployments should use a dedicated PostgreSQL database and role. Prov
 ### Bootstrap the SpiceDB role and database
 
 A short-lived Job creates the dedicated `spicedb` role and database before SpiceDB starts. It creates each only
-when it is absent, so re-running it against an already initialised database changes nothing.
+when it is absent, so re-running it against an already initialised database is safe — but not inert: the role's
+password is reconciled to the chart's Secret on every run. Rotate that password outside Helm and the next
+upgrade will set it back, so update the Secret alongside it.
 
 By default it connects as the `postgres` superuser the bundled PostgreSQL subchart creates. **An existing
 PostgreSQL installed with `postgresql.auth.enablePostgresUser=false` has no such role**, and the upgrade fails

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -148,9 +148,11 @@ authzed:
 ```
 
 The role needs `CREATEROLE` and `CREATEDB`; it does not need to be a superuser. `adminPasswordSecretName` is
-required whenever `adminUsername` is overridden — without it the Job would fall back to the bundled admin
-password and fail to authenticate. `adminPasswordKey` is required whenever the Secret is configured
-explicitly, since it otherwise defaults to the bundled subchart's key name inside your own Secret.
+required whenever `adminUsername` is overridden, and `adminPasswordKey` whenever that Secret is configured
+explicitly. **Both are checked while the chart renders**, so omitting one fails the render with the missing
+value named — no Job is created. Without those guards the first would silently fall back to the bundled admin
+password and the second would look up the subchart's key name inside your own Secret, and neither shows up
+until the Pod fails to start in the cluster.
 
 <Note>
   `CREATEROLE` and `CREATEDB` are sufficient on their own only when the administrator also creates the

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -149,7 +149,22 @@ authzed:
 
 The role needs `CREATEROLE` and `CREATEDB`; it does not need to be a superuser. `adminPasswordSecretName` is
 required whenever `adminUsername` is overridden — without it the Job would fall back to the bundled admin
-password and fail to authenticate.
+password and fail to authenticate. `adminPasswordKey` is required whenever the Secret is configured
+explicitly, since it otherwise defaults to the bundled subchart's key name inside your own Secret.
+
+<Note>
+  `CREATEROLE` and `CREATEDB` are sufficient on their own only when the administrator also creates the
+  `spicedb` role — which is the normal case, including on re-runs. `CREATE DATABASE ... OWNER spicedb`
+  additionally requires the administrator to be able to `SET ROLE` to that owner, so the Job grants itself the
+  `spicedb` role before creating the database. From PostgreSQL 16 that grant is only possible for a role the
+  administrator holds `ADMIN OPTION` on, which it gets automatically by creating it.
+
+  The one case this cannot repair is a `spicedb` role that already exists and was created by *someone else*,
+  on PostgreSQL 16 or newer: the administrator then holds no `ADMIN OPTION` on it and the Job fails rather than
+  silently skipping work. Grant it explicitly — `GRANT spicedb TO fbadmin WITH ADMIN OPTION` as a superuser or
+  as the role's owner — or run the bootstrap as a superuser once. PostgreSQL 15 and older are unaffected:
+  `CREATEROLE` there carries authority over every non-superuser role.
+</Note>
 
 Rendering fails fast with the three available remedies named — configure an administrative role, enable
 `postgresql.auth.enablePostgresUser`, or set `authzed.bundledPostgresqlBootstrap.enabled=false` — rather than


### PR DESCRIPTION
## What & why

The bundled AuthZed database bootstrap connected as a hardcoded `postgres` superuser:

```yaml
- name: PGUSER
  value: postgres
```

An existing PostgreSQL installed with `postgresql.auth.enablePostgresUser=false` has no such role, so the Job could not authenticate. The only escape was `authzed.bundledPostgresqlBootstrap.enabled=false` — which doesn't just skip a step, it leaves the `spicedb` role and database **uncreated**. That is exactly what forced the values override during the `authzed-sandbox` upgrade.

The connection identity is now configurable:

```yaml
authzed:
  bundledPostgresqlBootstrap:
    adminUsername: fbadmin
    adminDatabase: formbricks # maintenance database to attach to
    adminPasswordSecretName: existing-pg-admin
    adminPasswordKey: password
```

The role needs `CREATEROLE` and `CREATEDB` — **not** superuser.

### Defaults are unchanged

`adminUsername` defaults to `postgres`, `adminDatabase` to `postgres`, and the password falls back to the bundled admin Secret and key. Existing releases render byte-identically; the render test asserts this.

### The precondition is now scoped, not removed

`postgresql.auth.enablePostgresUser` is still required — but only when the admin actually *is* the bundled superuser. An operator who pointed `adminUsername` at their own role has no reason to also materialise a superuser the subchart was told not to create; requiring it is what pushed people to disable bootstrap wholesale.

When it does fire it now names all three ways out rather than asserting one:

> Set `authzed.bundledPostgresqlBootstrap.adminUsername` (with `adminPasswordSecretName` and `adminPasswordKey`) to an existing role with CREATEROLE and CREATEDB, or enable `postgresql.auth.enablePostgresUser`, or disable `authzed.bundledPostgresqlBootstrap.enabled`

Two new guards close gaps this opened: a custom `adminUsername` **without** `adminPasswordSecretName` is refused rather than silently falling back to the bundled superuser's password (it would fail to authenticate at runtime instead of at render), and the admin password key is validated against the effective value rather than only the subchart's.

### What deliberately did not change

Only the *connection* moved. The SQL already detects existing state — role and database are created only when absent (`WHERE NOT EXISTS`) — which is the ticket's "safely detect that the target role/database are already initialized".

**Correction after review:** I first described a re-run as a no-op. It isn't. `ALTER ROLE … PASSWORD` is unconditional, so every run reconciles the `spicedb` role's password to the chart Secret. Rotating that password outside Helm is silently undone by the next upgrade. Both documents now say so. `bundledPostgresqlBootstrap.enabled=false` is untouched and remains correct when both are provisioned by hand. External bootstrap is untouched.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2390

## How this was tested

**The render suite could not have caught the bug this PR was for.** `charts/formbricks/tests/authzed-operations.sh` covered NOTES.txt only when I started; I added render assertions, and they proved the manifest said the right thing while the SQL underneath did not work at all. That gap is now closed from both ends.

### Render assertions (`authzed-operations.sh`, run by Helm Chart Validation)

| Assertion | Why |
| --- | --- |
| Default renders `postgres`/`postgres` | The no-op guarantee for existing releases |
| `enablePostgresUser=false` alone still refuses, and the message names `adminUsername` | The regression, and that the way out is discoverable |
| Configuring an existing admin role renders `fbadmin` / `formbricks` / `existing-pg-admin` | The ENG-2390 scenario itself |
| Custom `adminUsername` without a Secret is refused | Prevents the silent-wrong-password path |
| Custom `adminUsername` without a key is refused | The key falls back to the subchart's name inside a foreign Secret |
| `adminUsername=postgres` + explicit Secret + `enablePostgresUser=false` renders | An existing privileged `postgres` role is a configured admin, not the bundled superuser |
| ...and the same, **without** a key, is refused | The guard keys off the credential source, not the username |
| `PGPASSWORD`, `SPICEDB_DATABASE_PASSWORD`, `ADMIN_DATABASE_URL` are supplied by `secretKeyRef` | Secret-safety, asserted structurally, in both modes |

### Runtime assertions (`authzed-bootstrap-runtime.sh`, new)

Render tests cannot execute SQL, and the SQL was the actual defect. This extracts the script from the **rendered Job** and runs it against real PostgreSQL — so it cannot drift from the template, and cannot pass against SQL the chart does not ship. It runs on **15 and 17**, either side of the 16 `CREATEROLE` change, and skips itself when Docker is unavailable.

| Case | Asserted |
| --- | --- |
| Fresh server, `CREATEROLE`+`CREATEDB` admin | Succeeds; `spicedb` database exists, is owned by `spicedb`, and that role can actually log in with the configured password |
| Re-run | Succeeds — the Job is a post-upgrade hook, so this is the common path |
| Bundled superuser | Succeeds, and is *not* granted the `spicedb` role |
| Pre-existing `spicedb` role created by someone else | Fails loudly on 16+ (documented limitation), still succeeds on 15 |

**Mutation-tested, not just green:**

- removing the `GRANT` → runtime suite red (`must be member of role` on 15, `must be able to SET ROLE` on 17)
- restoring the username-keyed `adminPasswordKey` guard → render suite red
- the structural secret assertion checked directly against four manifests (`reference` / `literal` / literal-as-last-entry / absent), because the in-situ mutation trips an earlier assertion first and would not have exercised it

`helm lint`, both suites, `bash -n`, and `prettier --check` are clean.

**Not verified by me:** the ticket's final criterion — "verified in `authzed-sandbox` without the temporary values override". That needs a real cluster upgrade against the existing database, which I can't do from here. @BhagyaAmarasinghe you hit the original failure, so you're best placed to confirm; the values to use are in the QA plan below.

## Breaking changes

None.

## QA / Test Plan

**How to test**

- [ ] Fresh install with defaults (`authzed.enabled=true`, bundled PostgreSQL) → bootstrap Job succeeds, `spicedb` role and database exist.
- [ ] Re-run `helm upgrade` with no changes → Job runs again and succeeds (idempotent, nothing recreated).
- [ ] **The regression:** upgrade an existing release whose PostgreSQL has no `postgres` role, with no overrides → render fails with a message naming the three remedies (previously: an obscure runtime auth failure).
- [ ] **The acceptance case:** same upgrade with `adminUsername`/`adminDatabase`/`adminPasswordSecretName`/`adminPasswordKey` pointing at an existing role that holds only `CREATEROLE` and `CREATEDB` → succeeds without `bundledPostgresqlBootstrap.enabled=false`, and the `spicedb` database is owned by `spicedb`. Worth doing on a server that is PostgreSQL 16 or newer, since that is where the privilege rules are strictest.
- [ ] With that same non-superuser admin, run the upgrade a second time → still succeeds.
- [ ] Pre-create a `spicedb` role as a *different* role, then run the bootstrap as the non-superuser admin on PostgreSQL 16+ → fails with a privilege error rather than appearing to succeed, and the README's remedy (`GRANT spicedb TO <admin> WITH ADMIN OPTION`) clears it.
- [ ] Set `adminUsername` but omit `adminPasswordSecretName`, then omit `adminPasswordKey` → each refused at render.
- [ ] `adminUsername=postgres` with an explicit Secret but no `adminPasswordKey` → refused at render (previously rendered a dangling `secretKeyRef`).
- [ ] Externally managed mode (`externalPostgresqlBootstrap.enabled=true`) → unchanged.
- [ ] `helm template ... --show-only templates/authzed-postgresql-bootstrap.yaml` → no credential values, only `secretKeyRef`.

**Preconditions / test data**

- A cluster with an existing Formbricks PostgreSQL release, ideally one installed with `postgresql.auth.enablePostgresUser=false` (that is the failing shape).
- A Secret holding the administrative role's password, and a role with `CREATEROLE` and `CREATEDB`.

**Risks & regressions**

- The blast radius is the bootstrap Job's connection identity. Defaults are unchanged, so an existing release should see no diff — worth confirming with `helm diff` before upgrading.
- The Job now grants its administrator membership of the `spicedb` role. That is not an escalation — the administrator holds `CREATEROLE` and could grant itself anything — but it is a visible change in `pg_auth_members`, and it persists after the Job. It is skipped entirely for superusers.
- A misconfigured `adminUsername` still fails at Job runtime rather than at render, and that is where it belongs: the chart cannot know which roles exist on the server. The render guards now cover both credential mistakes (missing Secret name, missing key) that would otherwise have failed at Pod creation instead of in Job logs.
- One case is documented rather than fixed: a `spicedb` role that already exists and was created by someone else cannot be adopted by a non-superuser administrator on PostgreSQL 16+. The Job fails loudly; the remedy is in the README.

**Migrations / env / cutover**

- none. Existing values files keep working unchanged.

## Review fixes

Bhagya's three findings and CodeRabbit's open one, each reproduced before acting:

- **[P1] The documented non-superuser path did not work.** Confirmed against `postgres:17-alpine`, and it was broader than reported: PostgreSQL 15 fails too, with `must be member of role` instead of `must be able to SET ROLE`, because pre-16 a creator gets no membership at all. That also killed the obvious portable guard — `MEMBER` is true on 17 while the operation still fails, and `SET` is not a valid `pg_has_role` privilege type before 16. Fixed by granting the role explicitly, skipped for superusers, plus the runtime suite above.
- **[P2] The `adminPasswordKey` guard keyed off the username**, so an existing administrator still named `postgres` could supply a Secret without a key and render a dangling `secretKeyRef`. Now keyed off the credential source. This was also CodeRabbit's open finding on the same lines, which I had half-answered on a sibling thread and left open.
- **[P3] The secret-safety assertion could not fail.** It grepped for `PGPASSWORD: `, a shape the renderer never emits, so a literal `value:` under `- name: PGPASSWORD` passed the exact regression it existed to catch — verified. Replaced with a structural check over the env list, extended to the external mode, which had no such assertion at all.
