### PR TITLE
feat(embedded-data): give SurveyEmbeddedData an explicit order column [ENG-2401]

### DIFF
--- a/apps/web/app/api/v3/surveys/patch.test.ts
+++ b/apps/web/app/api/v3/surveys/patch.test.ts
@@ -41,6 +41,7 @@ vi.mock("@formbricks/database", () => {
       findMany: vi.fn(),
       deleteMany: vi.fn(),
       create: vi.fn(),
+      updateMany: vi.fn(),
     },
     embeddedData: {
       create: vi.fn(),
@@ -857,6 +858,7 @@ describe("patchV3Survey", () => {
           findMany: vi.fn().mockResolvedValue([]),
           deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
           create: vi.fn().mockResolvedValue({}),
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
         },
         embeddedData: {
           create: vi.fn().mockResolvedValue({ id: "ed_1" }),

--- a/apps/web/integration/embedded-data-backfill.integration.test.ts
+++ b/apps/web/integration/embedded-data-backfill.integration.test.ts
@@ -117,7 +117,7 @@ describe("Embedded Data backfill (real Postgres)", () => {
       data: { workspaceId, surveyId, name: "plan", source: "ingested" },
     });
     await prisma.surveyEmbeddedData.create({
-      data: { workspaceId, surveyId, embeddedDataId: existing.id, storageKey: "plan" },
+      data: { workspaceId, surveyId, embeddedDataId: existing.id, storageKey: "plan", order: 0 },
     });
 
     const stats = await backfillEmbeddedDataRows(prisma);

--- a/apps/web/integration/embedded-data-read.integration.test.ts
+++ b/apps/web/integration/embedded-data-read.integration.test.ts
@@ -79,13 +79,14 @@ describe("Embedded Data read seam (real Postgres)", () => {
     expect(await loadSurvey(surveyId)).not.toHaveProperty("embeddedDataLinks");
   });
 
-  test("the inlined order is the declared order, not the database's", async () => {
+  test("the inlined order is the declared order, not the storage keys'", async () => {
     const { surveyId } = await seedSurvey();
 
     const survey = await loadSurvey(surveyId);
 
     // Declared order is variables-then-hidden-fields, and `tier` is declared before `score` even
-    // though `clx…001` sorts before `clx…002`. This is CSV/XLSX header order and picker order.
+    // though `clx…001` sorts before `clx…002`. Storage key is only the tie-break, so this passing
+    // means the `order` column is what decided it — and this is CSV/XLSX header and picker order.
     expect(survey.embeddedFields?.map(({ link }) => link.storageKey)).toEqual([
       "clx000000000000000000002",
       "clx000000000000000000001",
@@ -121,63 +122,35 @@ describe("Embedded Data read seam (real Postgres)", () => {
 
   /**
    * `variables` and `hiddenFields` are unvalidated `Json` columns, so a row can hold an object where
-   * an array belongs. `toDesiredEmbeddedFields` maps both with `?? []`, which does not catch a wrong
-   * type — so before the read-boundary guards this threw `(variables ?? []).map is not a function`
-   * inside `transformPrismaSurvey` and failed the whole survey read.
+   * an array belongs. That used to matter here: the read seam ranked the joined rows against those
+   * columns, so a malformed one first threw `(variables ?? []).map is not a function` and failed the
+   * whole survey read, and then — once guarded — cost that group its ordering.
+   *
+   * ENG-2401 removes the dependency outright. Order comes from the `order` column, the read never
+   * touches the legacy JSON, and a malformed column is simply irrelevant to it. These stay as the
+   * proof of that, since the guards they were written for are gone.
    *
    * The malformation is written with raw SQL on purpose: Prisma's generated types make the bad shape
    * unrepresentable through the client, so a fixture built in TypeScript would only resemble the row
    * this is defending against. These write the actual bytes.
    */
   describe("a survey whose legacy JSON is malformed", () => {
-    test("still loads when `variables` holds an object instead of an array", async () => {
+    const DECLARED_ORDER = ["clx000000000000000000002", "clx000000000000000000001", "utm_source", "plan"];
+
+    test.each([
+      ["`variables` holds an object instead of an array", `variables = '{}'::jsonb`],
+      [
+        "`hiddenFields.fieldIds` holds a string instead of an array",
+        `"hiddenFields" = '{"enabled": true, "fieldIds": "utm_source"}'::jsonb`,
+      ],
+      ["both columns are malformed", `variables = '"not-an-array"'::jsonb, "hiddenFields" = '[]'::jsonb`],
+    ])("reads in declared order when %s", async (_label, assignment) => {
       const { surveyId } = await seedSurvey();
-      await prisma.$executeRaw`UPDATE "Survey" SET variables = '{}'::jsonb WHERE id = ${surveyId}`;
+      await prisma.$executeRawUnsafe(`UPDATE "Survey" SET ${assignment} WHERE id = $1`, surveyId);
 
       const survey = await loadSurvey(surveyId);
 
-      // The hidden fields — the well-formed group — keep their declared order; only the malformed
-      // group loses its ranking and sorts last, in the select's storageKey order.
-      expect(getSurveyEmbeddedFields(survey).map(({ link }) => link.storageKey)).toEqual([
-        "utm_source",
-        "plan",
-        "clx000000000000000000001",
-        "clx000000000000000000002",
-      ]);
-    });
-
-    test("still loads when `hiddenFields.fieldIds` holds a string instead of an array", async () => {
-      const { surveyId } = await seedSurvey();
-      await prisma.$executeRaw`
-        UPDATE "Survey" SET "hiddenFields" = '{"enabled": true, "fieldIds": "utm_source"}'::jsonb
-        WHERE id = ${surveyId}`;
-
-      const survey = await loadSurvey(surveyId);
-
-      expect(getSurveyEmbeddedFields(survey).map(({ link }) => link.storageKey)).toEqual([
-        "clx000000000000000000002",
-        "clx000000000000000000001",
-        "plan",
-        "utm_source",
-      ]);
-    });
-
-    test("still loads when both columns are malformed", async () => {
-      const { surveyId } = await seedSurvey();
-      await prisma.$executeRaw`
-        UPDATE "Survey" SET variables = '"not-an-array"'::jsonb, "hiddenFields" = '[]'::jsonb
-        WHERE id = ${surveyId}`;
-
-      const survey = await loadSurvey(surveyId);
-
-      // Nothing ranks, so every row falls back to the select's storageKey order — and crucially the
-      // definitions are all still there.
-      expect(getSurveyEmbeddedFields(survey).map(({ link }) => link.storageKey)).toEqual([
-        "clx000000000000000000001",
-        "clx000000000000000000002",
-        "plan",
-        "utm_source",
-      ]);
+      expect(getSurveyEmbeddedFields(survey).map(({ link }) => link.storageKey)).toEqual(DECLARED_ORDER);
     });
   });
 

--- a/apps/web/integration/embedded-data-reconcile.integration.test.ts
+++ b/apps/web/integration/embedded-data-reconcile.integration.test.ts
@@ -42,6 +42,16 @@ const readFields = async (surveyId: string) =>
       }))
     );
 
+/** Stored positions, read back the way `selectSurveyEmbeddedDataLinks` reads them. */
+const readOrder = async (surveyId: string) =>
+  prisma.surveyEmbeddedData
+    .findMany({
+      where: { surveyId },
+      orderBy: [{ order: "asc" }, { storageKey: "asc" }],
+      select: { storageKey: true, order: true },
+    })
+    .then((links) => links.map((link) => [link.storageKey, link.order]));
+
 const reconcile = (
   surveyId: string,
   workspaceId: string,
@@ -84,6 +94,55 @@ describe("reconcileEmbeddedData (real Postgres)", () => {
         key: null,
         surveyId,
       },
+    ]);
+  });
+
+  test("numbers fields by declaration — every variable, then every hidden field", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+
+    // Added in the editor as h1, h2, then the variable, then h3 — but the cards write to two
+    // separate arrays, so what survives is "variables first", not the order they were typed in.
+    await reconcile(surveyId, workspaceId, {
+      variables: [{ id: "clx000000000000000000001", name: "score", type: "number", value: 7 }],
+      hiddenFields: { enabled: true, fieldIds: ["h1", "h2", "h3"] },
+    });
+
+    expect(await readOrder(surveyId)).toEqual([
+      ["clx000000000000000000001", 0],
+      ["h1", 1],
+      ["h2", 2],
+      ["h3", 3],
+    ]);
+  });
+
+  test("re-numbers the tail when a field is removed from the middle", async () => {
+    // The only thing that moves a position in v1 — the cards can append and delete, not reorder.
+    // Without this the tail keeps its stale numbers and the next inserted field collides with one.
+    const { surveyId, workspaceId } = await seedSurvey();
+    await reconcile(surveyId, workspaceId, {
+      hiddenFields: { enabled: true, fieldIds: ["h1", "h2", "h3"] },
+    });
+
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["h1", "h3"] } });
+
+    expect(await readOrder(surveyId)).toEqual([
+      ["h1", 0],
+      ["h3", 1],
+    ]);
+  });
+
+  test("repairs positions left behind by something that did not set them", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+    const legacy = { hiddenFields: { enabled: true, fieldIds: ["h1", "h2", "h3"] } };
+    await reconcile(surveyId, workspaceId, legacy);
+    await prisma.surveyEmbeddedData.updateMany({ where: { surveyId }, data: { order: 0 } });
+
+    await reconcile(surveyId, workspaceId, legacy);
+
+    expect(await readOrder(surveyId)).toEqual([
+      ["h1", 0],
+      ["h2", 1],
+      ["h3", 2],
     ]);
   });
 
@@ -174,7 +233,7 @@ describe("reconcileEmbeddedData (real Postgres)", () => {
       data: { workspaceId, key: "plan_tier", name: "Plan tier", source: "ingested" },
     });
     await prisma.surveyEmbeddedData.create({
-      data: { workspaceId, surveyId, embeddedDataId: shared.id, storageKey: "plan_tier" },
+      data: { workspaceId, surveyId, embeddedDataId: shared.id, storageKey: "plan_tier", order: 0 },
     });
 
     // The legacy cards know nothing about the shared library, so a save that omits the field must
@@ -198,7 +257,7 @@ describe("reconcileEmbeddedData (real Postgres)", () => {
 
     const borrower = await prisma.survey.create({ data: { name: "Borrower", workspaceId } });
     await prisma.surveyEmbeddedData.create({
-      data: { workspaceId, surveyId: borrower.id, embeddedDataId: field.id, storageKey: "plan" },
+      data: { workspaceId, surveyId: borrower.id, embeddedDataId: field.id, storageKey: "plan", order: 0 },
     });
 
     await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: [] } });

--- a/apps/web/integration/embedded-data-tenancy.integration.test.ts
+++ b/apps/web/integration/embedded-data-tenancy.integration.test.ts
@@ -114,6 +114,7 @@ describe("Embedded Data is scoped to a workspace by the database (real Postgres)
           surveyId: surveyB,
           embeddedDataId: fieldInA.id,
           storageKey: "plan_tier",
+          order: 0,
         },
       })
     );
@@ -134,6 +135,7 @@ describe("Embedded Data is scoped to a workspace by the database (real Postgres)
           surveyId: surveyB,
           embeddedDataId: fieldInA.id,
           storageKey: "plan_tier",
+          order: 0,
         },
       })
     );
@@ -163,6 +165,7 @@ describe("Embedded Data is scoped to a workspace by the database (real Postgres)
         surveyId: surveyA,
         embeddedDataId: shared.id,
         storageKey: "plan_tier",
+        order: 0,
       },
     });
 

--- a/apps/web/lib/embedded-data/reconcile.test.ts
+++ b/apps/web/lib/embedded-data/reconcile.test.ts
@@ -21,10 +21,20 @@ const desiredScore: TDesiredEmbeddedField = {
   defaultValue: 0,
 };
 
+/** A hidden field, which is addressed and labelled by the same name. */
+const ingested = (name: string): TDesiredEmbeddedField => ({
+  storageKey: name,
+  name,
+  source: "ingested",
+  dataType: "string",
+  defaultValue: null,
+});
+
 /** A link to a definition this survey owns — the only kind the legacy cards may edit or delete. */
-const localField = (desired: TDesiredEmbeddedField, fieldId: string): TCurrentEmbeddedField => ({
+const localField = (desired: TDesiredEmbeddedField, fieldId: string, order = 0): TCurrentEmbeddedField => ({
   linkId: `link_${fieldId}`,
   storageKey: desired.storageKey,
+  order,
   field: {
     id: fieldId,
     surveyId: SURVEY_ID,
@@ -37,17 +47,18 @@ const localField = (desired: TDesiredEmbeddedField, fieldId: string): TCurrentEm
 
 describe("planEmbeddedDataReconcile", () => {
   test("does nothing when the survey already matches", () => {
-    const current = [localField(desiredPlan, "ed_plan"), localField(desiredScore, "ed_score")];
+    const current = [localField(desiredPlan, "ed_plan", 0), localField(desiredScore, "ed_score", 1)];
     expect(planEmbeddedDataReconcile(SURVEY_ID, current, [desiredPlan, desiredScore])).toEqual({
       toCreate: [],
       toUpdate: [],
+      toReorder: [],
       toUnlink: [],
     });
   });
 
   test("creates a field the survey does not have yet", () => {
     const plan = planEmbeddedDataReconcile(SURVEY_ID, [], [desiredPlan]);
-    expect(plan.toCreate).toEqual([desiredPlan]);
+    expect(plan.toCreate).toEqual([{ ...desiredPlan, order: 0 }]);
     expect(plan.toUpdate).toEqual([]);
     expect(plan.toUnlink).toEqual([]);
   });
@@ -64,7 +75,7 @@ describe("planEmbeddedDataReconcile", () => {
     const renamed = { ...desiredPlan, storageKey: "plan_tier", name: "plan_tier" };
     const plan = planEmbeddedDataReconcile(SURVEY_ID, [localField(desiredPlan, "ed_plan")], [renamed]);
     expect(plan.toUnlink).toEqual([{ linkId: "link_ed_plan", fieldIdToDelete: "ed_plan" }]);
-    expect(plan.toCreate).toEqual([renamed]);
+    expect(plan.toCreate).toEqual([{ ...renamed, order: 0 }]);
   });
 
   test.each([
@@ -83,6 +94,7 @@ describe("planEmbeddedDataReconcile", () => {
     ]);
     expect(plan.toCreate).toEqual([]);
     expect(plan.toUnlink).toEqual([]);
+    expect(plan.toReorder).toEqual([]);
   });
 
   test("replaces rather than mutates a field whose source changed", () => {
@@ -91,26 +103,76 @@ describe("planEmbeddedDataReconcile", () => {
     const nowIngested = { ...desiredScore, source: "ingested" as const };
     const plan = planEmbeddedDataReconcile(SURVEY_ID, [localField(desiredScore, "ed_score")], [nowIngested]);
     expect(plan.toUnlink).toEqual([{ linkId: "link_ed_score", fieldIdToDelete: "ed_score" }]);
-    expect(plan.toCreate).toEqual([nowIngested]);
+    expect(plan.toCreate).toEqual([{ ...nowIngested, order: 0 }]);
     expect(plan.toUpdate).toEqual([]);
   });
 
+  describe("order", () => {
+    const h1 = ingested("h1");
+    const h2 = ingested("h2");
+    const h3 = ingested("h3");
+
+    test("re-numbers the tail when a field is removed from the middle", () => {
+      // The path that actually moves fields in v1. There is no drag-to-reorder UI for embedded
+      // fields — the cards only append and filter — so positions shift when a middle field is
+      // deleted, or when an API PATCH sends a reordered array. A two-field swap would not cover it.
+      const current = [localField(h1, "ed_h1", 0), localField(h2, "ed_h2", 1), localField(h3, "ed_h3", 2)];
+      const plan = planEmbeddedDataReconcile(SURVEY_ID, current, [h1, h3]);
+
+      expect(plan.toUnlink).toEqual([{ linkId: "link_ed_h2", fieldIdToDelete: "ed_h2" }]);
+      // Only h3 moved, and the link on its way out is not also reordered.
+      expect(plan.toReorder).toEqual([{ linkId: "link_ed_h3", order: 1 }]);
+    });
+
+    test("gives a newly inserted field its position and pushes the rest down", () => {
+      const current = [localField(h1, "ed_h1", 0), localField(h2, "ed_h2", 1)];
+      const plan = planEmbeddedDataReconcile(SURVEY_ID, current, [desiredScore, h1, h2]);
+
+      expect(plan.toCreate).toEqual([{ ...desiredScore, order: 0 }]);
+      expect(plan.toReorder).toEqual([
+        { linkId: "link_ed_h1", order: 1 },
+        { linkId: "link_ed_h2", order: 2 },
+      ]);
+    });
+
+    test("repairs links left at the wrong position, so a save is self-healing", () => {
+      // What a survey looks like if it never ran the backfill, or was written by something that did
+      // not set order. Comparing against the desired index rather than the current arrangement is
+      // what lets the next ordinary save fix it.
+      const current = [localField(h1, "ed_h1", 0), localField(h2, "ed_h2", 0), localField(h3, "ed_h3", 0)];
+      const plan = planEmbeddedDataReconcile(SURVEY_ID, current, [h1, h2, h3]);
+
+      expect(plan.toReorder).toEqual([
+        { linkId: "link_ed_h2", order: 1 },
+        { linkId: "link_ed_h3", order: 2 },
+      ]);
+      expect(plan.toUpdate).toEqual([]);
+    });
+  });
+
   describe("shared library definitions", () => {
-    const sharedField: TCurrentEmbeddedField = {
+    const sharedField = (order = 0): TCurrentEmbeddedField => ({
       linkId: "link_shared",
       storageKey: "plan",
+      order,
       field: { id: "ed_shared", surveyId: null, ...desiredPlan },
-    };
+    });
 
     test("unlinks a shared field without deleting the definition", () => {
-      const plan = planEmbeddedDataReconcile(SURVEY_ID, [sharedField], []);
+      const plan = planEmbeddedDataReconcile(SURVEY_ID, [sharedField()], []);
       expect(plan.toUnlink).toEqual([{ linkId: "link_shared", fieldIdToDelete: null }]);
     });
 
     test("ignores an edit to a shared field, which the workspace owns", () => {
       const edited = { ...desiredPlan, name: "Plan tier", dataType: "number" as const, defaultValue: 1 };
-      const plan = planEmbeddedDataReconcile(SURVEY_ID, [sharedField], [edited]);
-      expect(plan).toEqual({ toCreate: [], toUpdate: [], toUnlink: [] });
+      const plan = planEmbeddedDataReconcile(SURVEY_ID, [sharedField()], [edited]);
+      expect(plan).toEqual({ toCreate: [], toUpdate: [], toReorder: [], toUnlink: [] });
+    });
+
+    test("still moves a shared field, because position belongs to the link", () => {
+      const plan = planEmbeddedDataReconcile(SURVEY_ID, [sharedField(3)], [desiredPlan]);
+      expect(plan.toReorder).toEqual([{ linkId: "link_shared", order: 0 }]);
+      expect(plan.toUpdate).toEqual([]);
     });
   });
 
@@ -120,6 +182,7 @@ describe("planEmbeddedDataReconcile", () => {
     const foreignField: TCurrentEmbeddedField = {
       linkId: "link_foreign",
       storageKey: "plan",
+      order: 0,
       field: { id: "ed_foreign", surveyId: OTHER_SURVEY_ID, ...desiredPlan },
     };
     const plan = planEmbeddedDataReconcile(SURVEY_ID, [foreignField], []);

--- a/apps/web/lib/embedded-data/reconcile.ts
+++ b/apps/web/lib/embedded-data/reconcile.ts
@@ -58,6 +58,32 @@ const toStoredDefaultValue = (
 ): TEmbeddedDataDefaultValue | typeof Prisma.DbNull => defaultValue ?? Prisma.DbNull;
 
 /**
+ * Whether the stored definition says something different from what the survey now declares. Named
+ * apart from a position change on purpose: the two live on different rows — this one on
+ * `EmbeddedData`, position on the link — and take different writes.
+ */
+const definitionDiffers = (wanted: TDesiredEmbeddedField, field: TCurrentEmbeddedField["field"]): boolean =>
+  wanted.name !== field.name ||
+  wanted.dataType !== field.dataType ||
+  wanted.defaultValue !== field.defaultValue;
+
+/**
+ * The desired fields with no current row at the same address under the same source — the mirror of
+ * the unlink test in {@link planEmbeddedDataReconcile}'s first pass.
+ *
+ * `order` is stamped from the index in the **full** desired list and only then filtered, because a
+ * field's position is where it sits among everything the survey declares, not among the subset that
+ * happens to need creating.
+ */
+const plannedCreates = (
+  currentByKey: Map<string, TCurrentEmbeddedField>,
+  desired: TDesiredEmbeddedField[]
+): TEmbeddedDataReconcilePlan["toCreate"] =>
+  desired
+    .map((entry, order) => ({ ...entry, order }))
+    .filter((entry) => currentByKey.get(entry.storageKey)?.field.source !== entry.source);
+
+/**
  * Works out what has to change for a survey's Embedded Data to match `desired`.
  *
  * Pure, so the branching that actually matters — what may be edited, what may be deleted — is
@@ -110,12 +136,7 @@ export const planEmbeddedDataReconcile = (
 
     if (!isOwnedByThisSurvey) continue;
 
-    const changed =
-      wanted.entry.name !== entry.field.name ||
-      wanted.entry.dataType !== entry.field.dataType ||
-      wanted.entry.defaultValue !== entry.field.defaultValue;
-
-    if (changed) {
+    if (definitionDiffers(wanted.entry, entry.field)) {
       plan.toUpdate.push({
         fieldId: entry.field.id,
         name: wanted.entry.name,
@@ -125,15 +146,7 @@ export const planEmbeddedDataReconcile = (
     }
   }
 
-  for (const [order, entry] of desired.entries()) {
-    const existing = currentByKey.get(entry.storageKey);
-    // Mirror of the test above: absent, or present under a different source, both mean create.
-    // `order` is carried on the plan item rather than re-derived when the row is written, because
-    // `toCreate` is a filtered subset of `desired` and its own index is not the field's position.
-    if (existing?.field.source !== entry.source) {
-      plan.toCreate.push({ ...entry, order });
-    }
-  }
+  plan.toCreate.push(...plannedCreates(currentByKey, desired));
 
   return plan;
 };

--- a/apps/web/lib/embedded-data/reconcile.ts
+++ b/apps/web/lib/embedded-data/reconcile.ts
@@ -13,6 +13,8 @@ import { InvalidInputError } from "@formbricks/types/errors";
 export interface TCurrentEmbeddedField {
   linkId: string;
   storageKey: string;
+  /** On the link, not on `field`: one shared definition sits at a different position per survey. */
+  order: number;
   field: {
     id: string;
     /** The owning survey for a local definition, null for a shared library one. */
@@ -25,13 +27,15 @@ export interface TCurrentEmbeddedField {
 }
 
 export interface TEmbeddedDataReconcilePlan {
-  toCreate: TDesiredEmbeddedField[];
+  toCreate: (TDesiredEmbeddedField & { order: number })[];
   toUpdate: {
     fieldId: string;
     name: string;
     dataType: TEmbeddedDataType;
     defaultValue: TEmbeddedDataDefaultValue;
   }[];
+  /** Links whose position moved. Separate from `toUpdate`, which is keyed by definition, not link. */
+  toReorder: { linkId: string; order: number }[];
   /** Links to drop. `fieldIdToDelete` is null when the definition must outlive the link. */
   toUnlink: { linkId: string; fieldIdToDelete: string | null }[];
 }
@@ -39,6 +43,7 @@ export interface TEmbeddedDataReconcilePlan {
 const SELECT_CURRENT_FIELDS = {
   id: true,
   storageKey: true,
+  order: true,
   embeddedData: {
     select: { id: true, surveyId: true, name: true, source: true, dataType: true, defaultValue: true },
   },
@@ -63,6 +68,12 @@ const toStoredDefaultValue = (
  * it and leaves the row alone, and a change to its name or type is ignored rather than written back.
  * In v1 no shared rows exist yet (the manager is ENG-1851), but this reconcile keeps running once
  * they do.
+ *
+ * A field's position is its index in `desired`, and it is compared against the stored one rather
+ * than against how the other links are arranged. That makes every save self-healing: a link left at
+ * the wrong position by any route repairs itself the next time the survey is saved, so the ENG-1835
+ * backfill is not the only thing standing between a survey and a correct order. It matters on a
+ * fresh database in particular, where data migrations are baselined as applied without ever running.
  */
 export const planEmbeddedDataReconcile = (
   surveyId: string,
@@ -70,9 +81,9 @@ export const planEmbeddedDataReconcile = (
   desired: TDesiredEmbeddedField[]
 ): TEmbeddedDataReconcilePlan => {
   const currentByKey = new Map(current.map((entry) => [entry.storageKey, entry]));
-  const desiredByKey = new Map(desired.map((entry) => [entry.storageKey, entry]));
+  const desiredByKey = new Map(desired.map((entry, order) => [entry.storageKey, { entry, order }] as const));
 
-  const plan: TEmbeddedDataReconcilePlan = { toCreate: [], toUpdate: [], toUnlink: [] };
+  const plan: TEmbeddedDataReconcilePlan = { toCreate: [], toUpdate: [], toReorder: [], toUnlink: [] };
 
   for (const entry of current) {
     const wanted = desiredByKey.get(entry.storageKey);
@@ -82,8 +93,8 @@ export const planEmbeddedDataReconcile = (
 
     // Two cases, one test: the field is gone, or a storage key whose source changed is a different
     // field wearing the same address — replace it rather than mutating a computed field into an
-    // ingested one. `wanted?.source` is undefined in the first case, which no source ever equals.
-    if (wanted?.source !== entry.field.source) {
+    // ingested one. `wanted?.entry.source` is undefined in the first case, which no source ever equals.
+    if (wanted?.entry.source !== entry.field.source) {
       plan.toUnlink.push({
         linkId: entry.linkId,
         fieldIdToDelete: isOwnedByThisSurvey ? entry.field.id : null,
@@ -91,28 +102,36 @@ export const planEmbeddedDataReconcile = (
       continue;
     }
 
+    // Above the ownership guard on purpose: position belongs to the link, not to the definition, so
+    // a shared field this survey does not own still moves when the fields around it change.
+    if (entry.order !== wanted.order) {
+      plan.toReorder.push({ linkId: entry.linkId, order: wanted.order });
+    }
+
     if (!isOwnedByThisSurvey) continue;
 
     const changed =
-      wanted.name !== entry.field.name ||
-      wanted.dataType !== entry.field.dataType ||
-      wanted.defaultValue !== entry.field.defaultValue;
+      wanted.entry.name !== entry.field.name ||
+      wanted.entry.dataType !== entry.field.dataType ||
+      wanted.entry.defaultValue !== entry.field.defaultValue;
 
     if (changed) {
       plan.toUpdate.push({
         fieldId: entry.field.id,
-        name: wanted.name,
-        dataType: wanted.dataType,
-        defaultValue: wanted.defaultValue,
+        name: wanted.entry.name,
+        dataType: wanted.entry.dataType,
+        defaultValue: wanted.entry.defaultValue,
       });
     }
   }
 
-  for (const entry of desired) {
+  for (const [order, entry] of desired.entries()) {
     const existing = currentByKey.get(entry.storageKey);
     // Mirror of the test above: absent, or present under a different source, both mean create.
+    // `order` is carried on the plan item rather than re-derived when the row is written, because
+    // `toCreate` is a filtered subset of `desired` and its own index is not the field's position.
     if (existing?.field.source !== entry.source) {
-      plan.toCreate.push(entry);
+      plan.toCreate.push({ ...entry, order });
     }
   }
 
@@ -148,6 +167,7 @@ export const reconcileEmbeddedData = async (
   const current: TCurrentEmbeddedField[] = links.map((link) => ({
     linkId: link.id,
     storageKey: link.storageKey,
+    order: link.order,
     field: link.embeddedData,
   }));
 
@@ -194,6 +214,15 @@ export const reconcileEmbeddedData = async (
     });
   }
 
+  // Only links that actually moved. Rewriting every position on every save would turn a one-word
+  // rename on a field-heavy survey into an UPDATE per field, and survey saves are a hot path.
+  for (const entry of plan.toReorder) {
+    await tx.surveyEmbeddedData.updateMany({
+      where: { id: entry.linkId, surveyId },
+      data: { order: entry.order },
+    });
+  }
+
   // Sequential rather than batched: the link needs the id of the row it points at, and a survey
   // holds a handful of fields, not thousands.
   for (const entry of plan.toCreate) {
@@ -212,7 +241,13 @@ export const reconcileEmbeddedData = async (
     });
 
     await tx.surveyEmbeddedData.create({
-      data: { surveyId, workspaceId, embeddedDataId: field.id, storageKey: entry.storageKey },
+      data: {
+        surveyId,
+        workspaceId,
+        embeddedDataId: field.id,
+        storageKey: entry.storageKey,
+        order: entry.order,
+      },
     });
   }
 };

--- a/apps/web/lib/embedded-data/survey-fields.test.ts
+++ b/apps/web/lib/embedded-data/survey-fields.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "vitest";
-import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
 import { isDeepEqual } from "@/lib/utils/object";
 import { inlineSurveyEmbeddedFields, withInlinedEmbeddedFields } from "./survey-fields";
 
@@ -14,29 +13,30 @@ const link = (storageKey: string, name: string, source: "computed" | "ingested")
   },
 });
 
-const LEGACY = {
-  variables: [
-    { id: "clx000000000000000000002", name: "tier", type: "text" as const, value: "free" },
-    { id: "clx000000000000000000001", name: "score", type: "number" as const, value: 7 },
-  ],
-  hiddenFields: { enabled: true, fieldIds: ["utm_source", "plan"] },
-};
-
-/** The join's own output order: `orderBy: { storageKey: "asc" }`. */
+/**
+ * As the join returns them: `orderBy: [{ order: "asc" }, { storageKey: "asc" }]`. `tier` is declared
+ * before `score` even though its cuid sorts after, which is what the `order` column records.
+ */
 const JOINED_LINKS = [
-  link("clx000000000000000000001", "score", "computed"),
   link("clx000000000000000000002", "tier", "computed"),
-  link("plan", "plan", "ingested"),
+  link("clx000000000000000000001", "score", "computed"),
   link("utm_source", "utm_source", "ingested"),
+  link("plan", "plan", "ingested"),
 ];
+
+interface TTestSurvey {
+  id: string;
+  updatedAt?: Date;
+  embeddedDataLinks?: typeof JOINED_LINKS;
+}
 
 describe("inlineSurveyEmbeddedFields", () => {
   test("returns undefined when the select omitted the join, so the accessor can fall back", () => {
-    expect(inlineSurveyEmbeddedFields({ ...LEGACY })).toBeUndefined();
+    expect(inlineSurveyEmbeddedFields({})).toBeUndefined();
   });
 
   test("reshapes the rows into {field, link} pairs", () => {
-    const fields = inlineSurveyEmbeddedFields({ ...LEGACY, embeddedDataLinks: JOINED_LINKS });
+    const fields = inlineSurveyEmbeddedFields({ embeddedDataLinks: JOINED_LINKS });
 
     expect(fields?.[0]).toStrictEqual({
       field: { name: "tier", source: "computed", dataType: "string", defaultValue: null, locked: false },
@@ -44,40 +44,24 @@ describe("inlineSurveyEmbeddedFields", () => {
     });
   });
 
-  test("orders by the legacy declaration, not by storage key", () => {
-    // `tier` is declared before `score` even though its cuid sorts after. This is CSV/XLSX header
-    // order and picker order, so the join's `storageKey asc` is only the tie-break.
+  test("preserves the order the query returned, rather than re-sorting", () => {
+    // Load-bearing: ordering lives entirely in `selectSurveyEmbeddedDataLinks`' `orderBy` (ENG-2401).
+    // If this ever re-sorted, the `order` column would stop deciding CSV/XLSX header and picker order.
     expect(
-      inlineSurveyEmbeddedFields({ ...LEGACY, embeddedDataLinks: JOINED_LINKS })?.map(
+      inlineSurveyEmbeddedFields({ embeddedDataLinks: JOINED_LINKS })?.map(
         ({ link: { storageKey } }) => storageKey
       )
     ).toStrictEqual(["clx000000000000000000002", "clx000000000000000000001", "utm_source", "plan"]);
   });
 
-  test("keeps a row the legacy columns do not know, sorted last", () => {
-    const fields = inlineSurveyEmbeddedFields({
-      ...LEGACY,
-      embeddedDataLinks: [...JOINED_LINKS, link("orphan", "orphan", "ingested")],
-    });
-
-    expect(fields?.map(({ link: { storageKey } }) => storageKey).at(-1)).toBe("orphan");
-    expect(fields).toHaveLength(5);
-  });
-
-  test("a survey with no declarations and no rows inlines an empty list", () => {
-    expect(
-      inlineSurveyEmbeddedFields({
-        variables: [],
-        hiddenFields: { enabled: false, fieldIds: [] },
-        embeddedDataLinks: [],
-      })
-    ).toStrictEqual([]);
+  test("a survey with no rows inlines an empty list", () => {
+    expect(inlineSurveyEmbeddedFields({ embeddedDataLinks: [] })).toStrictEqual([]);
   });
 });
 
 describe("withInlinedEmbeddedFields", () => {
   test("swaps the raw relation for the inlined pairs", () => {
-    const survey = { id: "s1", ...LEGACY, embeddedDataLinks: JOINED_LINKS };
+    const survey: TTestSurvey = { id: "s1", embeddedDataLinks: JOINED_LINKS };
     const transformed = withInlinedEmbeddedFields(survey);
 
     expect(transformed).not.toHaveProperty("embeddedDataLinks");
@@ -85,7 +69,7 @@ describe("withInlinedEmbeddedFields", () => {
   });
 
   test("leaves a survey read without the join untouched, adding no key", () => {
-    const survey = { id: "s1", ...LEGACY };
+    const survey: TTestSurvey = { id: "s1" };
 
     expect(withInlinedEmbeddedFields(survey)).toStrictEqual(survey);
     expect(withInlinedEmbeddedFields(survey)).not.toHaveProperty("embeddedFields");
@@ -94,14 +78,9 @@ describe("withInlinedEmbeddedFields", () => {
   test("adds the key even when the survey has no fields at all", () => {
     // Load-bearing for the editor invariant below: once a select carries the join, EVERY survey read
     // through it has an `embeddedFields` key, empty list included.
-    const transformed = withInlinedEmbeddedFields({
-      id: "s1",
-      variables: [],
-      hiddenFields: { enabled: false, fieldIds: [] },
-      embeddedDataLinks: [],
-    });
+    const survey: TTestSurvey = { id: "s1", embeddedDataLinks: [] };
 
-    expect(transformed).toHaveProperty("embeddedFields", []);
+    expect(withInlinedEmbeddedFields(survey)).toHaveProperty("embeddedFields", []);
   });
 });
 
@@ -119,15 +98,12 @@ describe("the editor's clone stays comparable to the server survey", () => {
   const surveyWithRows = withInlinedEmbeddedFields({
     id: "s1",
     updatedAt: new Date("2026-08-13T10:00:00.000Z"),
-    ...LEGACY,
     embeddedDataLinks: JOINED_LINKS,
   });
 
   const surveyWithoutFields = withInlinedEmbeddedFields({
     id: "s1",
     updatedAt: new Date("2026-08-13T10:00:00.000Z"),
-    variables: [],
-    hiddenFields: { enabled: false, fieldIds: [] },
     embeddedDataLinks: [],
   });
 

--- a/apps/web/lib/embedded-data/survey-fields.ts
+++ b/apps/web/lib/embedded-data/survey-fields.ts
@@ -1,8 +1,6 @@
 import "server-only";
 import { Prisma } from "@formbricks/database/prisma";
-import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
 import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
-import { type TSurveyVariable } from "@formbricks/types/surveys/types";
 
 /**
  * The join that makes the `EmbeddedData` / `SurveyEmbeddedData` tables the read source of truth
@@ -14,9 +12,12 @@ import { type TSurveyVariable } from "@formbricks/types/surveys/types";
  * (the SDK workspace state and the link-survey page), so the row's ids, ownership and timestamps
  * stay server-side. It mirrors `SELECT_CURRENT_FIELDS` in reconcile.ts minus exactly those.
  *
- * `orderBy` is not optional: without it Postgres row order is unspecified, and this list drives
- * user-visible column and picker order. It is the tie-break, not the ordering rule — see
- * {@link inlineSurveyEmbeddedFields}.
+ * **`orderBy` carries the entire ordering rule, and it has to live in the query.**
+ * {@link withInlinedEmbeddedFields} only ever sees the rows the select returned, so a JS sort could
+ * not recover an order the query never imposed. `storageKey` is the tiebreak rather than decoration:
+ * `order` alone is not a total order, and `@@unique([surveyId, storageKey])` is what makes the pair
+ * one. Every survey select that embeds this relation must use this constant, so that the order every
+ * reader sees is decided in exactly one place.
  */
 export const selectSurveyEmbeddedDataLinks = {
   select: {
@@ -25,13 +26,11 @@ export const selectSurveyEmbeddedDataLinks = {
       select: { name: true, source: true, dataType: true, defaultValue: true, locked: true },
     },
   },
-  orderBy: { storageKey: "asc" },
+  orderBy: [{ order: "asc" }, { storageKey: "asc" }],
 } as const satisfies Prisma.SurveySelect["embeddedDataLinks"];
 
 /** The shape {@link selectSurveyEmbeddedDataLinks} produces, as much of it as the mapping needs. */
 interface TSurveyWithEmbeddedDataLinks {
-  variables?: unknown;
-  hiddenFields?: unknown;
   embeddedDataLinks?: {
     storageKey: string;
     embeddedData: TLinkedEmbeddedField["field"];
@@ -39,59 +38,13 @@ interface TSurveyWithEmbeddedDataLinks {
 }
 
 /**
- * `variables` and `hiddenFields` are `Json` columns. Prisma types them from the schema annotation,
- * but nothing enforces that shape in the database, so a row can hold an object where an array
- * belongs. `toDesiredEmbeddedFields` maps both with `?? []`, which catches `null` and `undefined`
- * but not a wrong type — one malformed row would throw `(variables ?? []).map is not a function`
- * inside `transformPrismaSurvey` and fail the **entire survey read**, not just its ordering.
- *
- * Guarded here rather than inside `toDesiredEmbeddedFields`, because that mapper is shared with
- * `reconcileEmbeddedData` on the WRITE path, where throwing is the correct behaviour: silently
- * mapping a malformed survey to an empty desired set would delete every row it has. Reads must
- * degrade, writes must fail loudly — so the leniency belongs at this boundary and nowhere else.
- * (ENG-1835's `planSurveyBackfill` makes the same call from the other side: it checks these shapes
- * and skips the survey.)
- *
- * The two groups are guarded independently on purpose. A survey whose `variables` are malformed
- * still ranks its hidden fields correctly; only the malformed group loses its declared order and
- * sorts last. A blanket `try`/`catch` would lose both — and would also swallow a genuine bug inside
- * the mapper.
- */
-
-/**
- * Not "is a valid variable list" — only that mapping over it cannot throw. Entries that are objects
- * but not variables yield a garbage `storageKey`, which simply matches no row and therefore ranks
- * nothing; entries that are `null` would throw on the property read, so they disqualify the list.
- */
-const toRankableVariables = (value: unknown): TSurveyVariable[] =>
-  Array.isArray(value) && value.every((entry) => typeof entry === "object" && entry !== null)
-    ? (value as TSurveyVariable[])
-    : [];
-
-/** Non-string ids cannot be storage keys, so they are dropped rather than disqualifying the list. */
-const toRankableFieldIds = (value: unknown): string[] =>
-  Array.isArray(value) ? value.filter((id): id is string => typeof id === "string") : [];
-
-/** Reads `hiddenFields.fieldIds` without assuming `hiddenFields` is an object at all. */
-const readFieldIds = (hiddenFields: unknown): string[] =>
-  toRankableFieldIds(
-    typeof hiddenFields === "object" && hiddenFields !== null
-      ? (hiddenFields as { fieldIds?: unknown }).fieldIds
-      : undefined
-  );
-
-/**
  * Reshapes the joined rows into the `{ field, link }` pairs the read seam consumes, or `undefined`
  * when the select omitted the join — which is exactly the input `getSurveyEmbeddedFields`' fallback
  * expects, so a survey read through a narrower select keeps resolving off its legacy columns.
  *
- * **Ordering.** Neither table carries an ordinal column, so the rows cannot reproduce the order the
- * author put their variables and hidden fields in — and that order is user-visible: it is the CSV
- * and XLSX header order and the order of every picker. Until the legacy JSON columns are dropped
- * they therefore remain the source of truth for *order* while the rows are the source of truth for
- * *definitions*, which is what this sort expresses. A row whose storage key the columns don't know
- * (impossible today — `reconcileEmbeddedData` writes exactly the derived set in one plan) sorts last
- * rather than being dropped, in the select's `storageKey` order.
+ * Ordering is not this function's job (ENG-2401): the rows carry an `order` column and arrive sorted
+ * by it. Before that column existed this ranked them against the legacy JSON, which needed guards
+ * here so that one malformed column could not take down an entire survey read.
  */
 export const inlineSurveyEmbeddedFields = (
   surveyPrisma: TSurveyWithEmbeddedDataLinks
@@ -99,22 +52,7 @@ export const inlineSurveyEmbeddedFields = (
   const links = surveyPrisma.embeddedDataLinks;
   if (!links) return undefined;
 
-  // Still routed through `toDesiredEmbeddedFields` rather than reading the ids here: which key a
-  // field is addressed by (a variable's cuid, a hidden field's name) is that function's rule, and
-  // re-deriving it at this boundary is how the ordering would silently drift from the rows.
-  const legacyRankByStorageKey = new Map(
-    toDesiredEmbeddedFields({
-      variables: toRankableVariables(surveyPrisma.variables),
-      hiddenFields: { enabled: false, fieldIds: readFieldIds(surveyPrisma.hiddenFields) },
-    }).map((field, index) => [field.storageKey, index] as const)
-  );
-  const rank = (storageKey: string): number =>
-    legacyRankByStorageKey.get(storageKey) ?? Number.MAX_SAFE_INTEGER;
-
-  // Array.prototype.sort is stable, so rows the columns don't rank keep the select's storageKey order.
-  return links
-    .map((link) => ({ field: link.embeddedData, link: { storageKey: link.storageKey } }))
-    .sort((a, b) => rank(a.link.storageKey) - rank(b.link.storageKey));
+  return links.map((link) => ({ field: link.embeddedData, link: { storageKey: link.storageKey } }));
 };
 
 /**

--- a/apps/web/modules/survey/list/lib/survey.test.ts
+++ b/apps/web/modules/survey/list/lib/survey.test.ts
@@ -118,6 +118,7 @@ vi.mock("@formbricks/database", () => ({
       findMany: vi.fn(),
       create: vi.fn(),
       deleteMany: vi.fn(),
+      updateMany: vi.fn(),
     },
     $transaction: vi.fn(),
   },
@@ -653,13 +654,17 @@ describe("copySurveyToOtherWorkspace", () => {
   test("re-creates the copied survey's variables and hidden fields under their original keys", async () => {
     await copySurveyToOtherWorkspace(sourceWorkspaceId, surveyId, targetWorkspaceId, userId);
 
-    const storageKeys = vi
+    const links = vi
       .mocked(prisma.surveyEmbeddedData.create)
-      .mock.calls.map(([args]) => (args as { data: { storageKey: string } }).data.storageKey);
+      .mock.calls.map(([args]) => (args as { data: { storageKey: string; order: number } }).data);
 
     // A variable keeps its cuid and a hidden field its name, so the copy's recall tokens — cloned
-    // verbatim from the source — still resolve.
-    expect(storageKeys).toEqual(["var_cuid", "plan"]);
+    // verbatim from the source — still resolve. The positions come across too, so the copy exports
+    // its columns in the same order as the survey it was made from.
+    expect(links.map(({ storageKey, order }) => [storageKey, order])).toEqual([
+      ["var_cuid", 0],
+      ["plan", 1],
+    ]);
   });
 
   test("should copy survey to the same workspace successfully", async () => {

--- a/packages/database/migration/20260806000000_add_embedded_data_tables/migration.sql
+++ b/packages/database/migration/20260806000000_add_embedded_data_tables/migration.sql
@@ -29,6 +29,7 @@ CREATE TABLE "SurveyEmbeddedData" (
     "surveyId" TEXT NOT NULL,
     "embeddedDataId" TEXT NOT NULL,
     "storageKey" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
 
     CONSTRAINT "SurveyEmbeddedData_pkey" PRIMARY KEY ("id")
 );
@@ -44,6 +45,9 @@ CREATE UNIQUE INDEX "EmbeddedData_id_workspaceId_key" ON "EmbeddedData"("id", "w
 
 -- CreateIndex
 CREATE INDEX "SurveyEmbeddedData_embeddedDataId_idx" ON "SurveyEmbeddedData"("embeddedDataId");
+
+-- CreateIndex
+CREATE INDEX "SurveyEmbeddedData_surveyId_order_idx" ON "SurveyEmbeddedData"("surveyId", "order");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "SurveyEmbeddedData_surveyId_embeddedDataId_key" ON "SurveyEmbeddedData"("surveyId", "embeddedDataId");

--- a/packages/database/migration/20260812121944_backfill_embedded_data/utils.test.ts
+++ b/packages/database/migration/20260812121944_backfill_embedded_data/utils.test.ts
@@ -65,9 +65,32 @@ describe("planSurveyBackfill", () => {
           surveyId: "srv_1",
           embeddedDataId: "id_1",
           storageKey: "plan",
+          order: 0,
         },
       ],
     });
+  });
+
+  test("orders links by declaration — every variable, then every hidden field", () => {
+    // The order the rows are created with has to be the one the read seam will sort by, because
+    // after ENG-2401 nothing re-derives it from the JSON. `toDesiredEmbeddedFields` concatenates
+    // computed then ingested, so a hidden field added before a variable still sorts after it.
+    const plan = planSurveyBackfill(
+      survey({
+        variables: [{ id: "clx000000000000000000001", name: "score", type: "number", value: 7 }],
+        hiddenFields: { enabled: true, fieldIds: ["h1", "h2", "h3"] },
+      }),
+      sequentialIds()
+    );
+
+    expect(plan.status).toBe("ok");
+    if (plan.status !== "ok") return;
+    expect(plan.links.map((link) => [link.storageKey, link.order])).toEqual([
+      ["clx000000000000000000001", 0],
+      ["h1", 1],
+      ["h2", 2],
+      ["h3", 3],
+    ]);
   });
 
   test("carries a variable's declared type and value onto the row", () => {

--- a/packages/database/migration/20260812121944_backfill_embedded_data/utils.ts
+++ b/packages/database/migration/20260812121944_backfill_embedded_data/utils.ts
@@ -36,6 +36,8 @@ export interface TSurveyEmbeddedDataInsert {
   surveyId: string;
   embeddedDataId: string;
   storageKey: string;
+  /** Index within `toDesiredEmbeddedFields` — variables in declaration order, then hidden fields. */
+  order: number;
 }
 
 export type TSurveyBackfillPlan =
@@ -126,7 +128,7 @@ export const planSurveyBackfill = (survey: TLegacySurveyRow, newId: () => string
   const fields: TEmbeddedDataInsert[] = [];
   const links: TSurveyEmbeddedDataInsert[] = [];
 
-  for (const desiredField of desired) {
+  for (const [order, desiredField] of desired.entries()) {
     if (desiredField.source === "reserved") {
       // Loud on purpose. Reserved fields are never stored as rows, so this means the shared mapping
       // changed under us — writing an `ingested` row instead would manufacture exactly the row the
@@ -152,6 +154,7 @@ export const planSurveyBackfill = (survey: TLegacySurveyRow, newId: () => string
       surveyId: survey.id,
       embeddedDataId,
       storageKey: desiredField.storageKey,
+      order,
     });
   }
 

--- a/packages/database/schema/main.prisma
+++ b/packages/database/schema/main.prisma
@@ -1226,12 +1226,18 @@ model EmbeddedData {
 /// @property storageKey - The key the value lives under: a cuid for computed fields, the field
 /// name for ingested ones. Migrated fields keep their original key, which is what lets existing
 /// recall tokens, logic conditions and stored responses keep resolving untouched.
+///
+/// @property order - Position within this survey's field list, dense from 0. Lives on the link
+/// rather than on `EmbeddedData` because a shared definition sits at a different position in each
+/// survey that links it. Deliberately has no default: every writer knows the position it is writing,
+/// so a missing one should be a type error rather than a row that silently sorts to the front.
 model SurveyEmbeddedData {
   id             String @id @default(cuid())
   workspaceId    String
   surveyId       String
   embeddedDataId String
   storageKey     String
+  order          Int
 
   survey       Survey       @relation(fields: [surveyId, workspaceId], references: [id, workspaceId], onDelete: Cascade)
   embeddedData EmbeddedData @relation(fields: [embeddedDataId, workspaceId], references: [id, workspaceId], onDelete: Cascade)
@@ -1239,6 +1245,7 @@ model SurveyEmbeddedData {
   @@unique([surveyId, embeddedDataId])
   @@unique([surveyId, storageKey])
   @@index([embeddedDataId])
+  @@index([surveyId, order])
 }
 
 /// Represents a team within an organization.


### PR DESCRIPTION
## What & why

`SurveyEmbeddedData` had no ordinal, so the order a survey's fields render in came from their index in the legacy `survey.variables` / `survey.hiddenFields` JSON arrays — `inlineSurveyEmbeddedFields` built a rank map from `toDesiredEmbeddedFields(<legacy columns>)` and stable-sorted the joined rows by it.

That order is user-visible, and the biggest consumer isn't the CSV. `handle-integrations.ts` builds `elements` — the live spreadsheet column header array for Google Sheets / Airtable / Notion — from `getIngestedStorageKeys()` / `getComputedEmbeddedFields()`, both of which resolve through the rows. A wrong order writes response values under shifted headers, per response, with no error. The column has to exist before the legacy JSON can ever be dropped, and it can only be derived while that JSON is still authoritative.

- **Schema** — `order Int` on `SurveyEmbeddedData`, no default, plus `@@index([surveyId, order])`. No default because this is a fresh `CREATE TABLE`, so a writer that forgets the position is a type error rather than a row that silently sorts to the front. The index is deliberately not unique — a two-field swap would otherwise collide mid-transaction, since reconcile writes rows one at a time.
- **Write bridge** — new `toReorder` bucket on the reconcile plan. The link table had no update path at all before this: every write to it was a create or a delete, and the only update targeted `EmbeddedData`. The check sits *above* the ownership guard, because position belongs to the link, not to the definition — a shared field this survey doesn't own still moves when the fields around it change.
- **Read seam** — `orderBy: [{ order: "asc" }, { storageKey: "asc" }]`. Ordering now lives entirely in the query (a JS sort can't recover an order the query never imposed), so `inlineSurveyEmbeddedFields` drops its rank map and the three JSON guards that existed only to stop a malformed column failing an entire survey read. `storageKey` is the tiebreak because `order` alone isn't a total order, and `@@unique([surveyId, storageKey])` is what makes the pair one.

**"Moved" is `storedOrder !== desiredIndex`**, not a relative rearrangement. That makes every save self-healing — a link left at the wrong position by any route repairs itself on the next save. It matters because on a fresh database data migrations are baselined as applied *without running*, so `order` there comes only from reconcile.

**The column is added to the original `20260806000000` migration and to the ENG-1835 backfill**, rather than layered on as an `ALTER` plus a second data migration. Neither has reached `main`, so no deployed database has run them. This keeps order and row creation in one pass — they can't disagree — and means a survey the backfill skips has no rows at all rather than rows with no order.

> [!IMPORTANT]
> **Anyone with this epic checked out needs to reset their local database.** Editing an applied migration breaks its Prisma checksum, so `migrate deploy` will fail loudly on a database that already ran `20260806000000_add_embedded_data_tables`. Nothing to do for CI or any deployed environment — the migration has never run outside dev.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2401/give-surveyembeddeddata-an-explicit-order-column

## How this was tested

- `pnpm vitest run` in `apps/web` — 593 files, **7673 passed** ✅
- `pnpm test:integration` in `apps/web` — 26 files, **123 passed** ✅ (against real Postgres)
- `pnpm --filter @formbricks/database test` — **50 passed** ✅
- `pnpm turbo run typecheck` (web + database) — 12/12 ✅, `eslint` on the changed files clean ✅
- Migrations applied from scratch against a real database; verified `order integer not null` with no default and both indexes present via `\d "SurveyEmbeddedData"`.
- The hand-edited `migration.sql` was diffed against `prisma migrate diff --from-empty --to-schema` — byte-identical, including column position, reserved-word quoting and the generated index name.

Tests added:

- `reconcile.test.ts` — a **middle delete re-numbers the tail** (the only thing that moves a position in v1: there's no drag-to-reorder UI, the cards only append and filter, so `toReorder` almost always fires alongside `toUnlink` and a two-field swap wouldn't cover it); an insert pushes the rest down; a shared link still moves; a link on its way out isn't also reordered; all-zero links repair themselves.
- `embedded-data-reconcile.integration.test.ts` — the same three against real Postgres, asserting the stored `order` values.
- `embedded-data-read.integration.test.ts` — the malformed-legacy-JSON cases now assert **declared order regardless**, since the read no longer touches those columns at all.
- backfill `utils.test.ts` — links come back numbered by declaration, variables then hidden fields.
- `modules/survey/list/lib/survey.test.ts` — a copy to another workspace carries the source's positions.

One thing worth calling out: the required (no-default) `order` earned its keep during this work — it caught a `surveyEmbeddedData.create` I'd missed in a tenancy test, loudly, instead of letting that row default to 0 and jump to the front of the list.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Open a survey, add two hidden fields (`h1`, `h2`), then a variable (`score`), then a third hidden field (`h3`). Save. → Export responses to CSV: the columns read `score`, `h1`, `h2`, `h3`. Variables always come before hidden fields, regardless of the order they were added in — the two editor cards write to separate lists, so the order you typed them in was never stored.
- [ ] In the same survey, delete `h2` and save. → CSV columns read `score`, `h1`, `h3`, with no gap or reshuffle.
- [ ] Add a new variable to that survey and save. → It appears immediately after `score` and before the hidden fields; nothing else changes position.
- [ ] Open a survey that already had variables and hidden fields *before* this change. → Its export column order and the field order in every picker (recall `@`-menu, logic builder operands, follow-up recipients) are unchanged from before.
- [ ] Duplicate a survey with several fields. → The copy's export columns are in the same order as the original's.
- [ ] Copy a survey to a different workspace. → Same, in the target workspace.
- [ ] **Integrations (highest risk).** Configure a Google Sheets or Notion integration on a survey with hidden fields, submit a response, then add a hidden field, submit another. → Both responses land under the correct headers; no column is shifted or re-labelled.
- [ ] Response table, response summary, single-response card, and both notification emails list fields in the same order as the export.

**Preconditions / test data**

- A survey with at least two variables and two hidden fields, ideally one created before this branch so the backfill path is exercised.
- Some existing responses on it, so export and integration column alignment can be checked against real values.
- For the integration step: a connected Google Sheets, Airtable or Notion integration with hidden fields mapped.

**Risks & regressions**

- **Field ordering everywhere it's user-visible** — CSV/XLSX headers, response table columns, response filters, the recall picker, logic operand lists, the calculate widget, follow-up recipients, both notification-email templates, and the Notion field-mapping modal. Nothing there changed in code; they all read the same accessor, but they're what a wrong `order` would surface in.
- **Live integration column alignment** is the one that fails silently rather than visibly — a shifted header writes values into the wrong spreadsheet column with no error. Worth an explicit check rather than assuming.
- Survey duplication and cross-workspace copy, since both create fresh links.

**Migrations / env / cutover**

- Two existing migrations are modified rather than added: `20260806000000_add_embedded_data_tables` (the column and index move into the original `CREATE TABLE`) and `20260812121944_backfill_embedded_data` (its links now carry a position).
- No action for CI or any deployed environment — neither migration has ever run outside local development.
- **Local dev databases on this epic must be reset**, or `migrate deploy` fails on the changed checksum.
- No env changes.
