### PR TITLE
feat(embedded-data): write rows from the payload rather than the persisted columns [ENG-2412]

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
+import { deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TResponseFilterCriteria } from "@formbricks/types/responses";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
@@ -490,6 +491,8 @@ describe("getQuestionSummary", () => {
     ],
     questions: [],
     hiddenFields: { enabled: true, fieldIds: ["hidden1"] },
+    // The rows are what the accessors read since ENG-2412; a real survey read carries both.
+    embeddedFields: deriveLegacyEmbeddedData({ hiddenFields: { enabled: true, fieldIds: ["hidden1"] } }),
   };
   const responses = [
     {

--- a/apps/web/app/api/v3/surveys/patch.test.ts
+++ b/apps/web/app/api/v3/surveys/patch.test.ts
@@ -358,13 +358,16 @@ describe("patchV3Survey", () => {
       );
     });
 
-    test("reconciles from the PERSISTED survey, so a patch that omits the fields keeps its rows", async () => {
-      // The patch document carries neither key. Reading it instead of the persisted row would see
-      // them as absent and unlink every field the survey has.
+    test("a patch that omits the fields keeps the survey's existing rows", async () => {
+      // ENG-2412 moved the reconcile onto the patch document rather than the persisted row. That is
+      // safe here because `prepareV3SurveyPatchInput` merges the patch over the current survey first,
+      // so a body carrying only `name` still arrives with the survey's declared fields intact — this
+      // asserts the two halves agree, since a raw read of the request body would unlink everything.
       vi.mocked(prisma.surveyEmbeddedData.findMany).mockResolvedValueOnce([
         {
           id: "link_1",
           storageKey: "utm_source",
+          order: 0,
           embeddedData: {
             id: "ed_existing",
             surveyId: currentSurvey.id,
@@ -375,13 +378,13 @@ describe("patchV3Survey", () => {
           },
         },
       ] as never);
-      vi.mocked(prisma.survey.update).mockResolvedValueOnce({
-        ...currentSurvey,
-        name: "Renamed",
-        hiddenFields: { enabled: true, fieldIds: ["utm_source"] },
-      } as never);
 
-      await patchV3Survey(currentSurvey, { name: "Renamed" }, "req_qa", "org_1");
+      await patchV3Survey(
+        { ...currentSurvey, hiddenFields: { enabled: true, fieldIds: ["utm_source"] } } as never,
+        { name: "Renamed" },
+        "req_qa",
+        "org_1"
+      );
 
       expect(prisma.surveyEmbeddedData.deleteMany).not.toHaveBeenCalled();
       expect(prisma.embeddedData.create).not.toHaveBeenCalled();

--- a/apps/web/app/api/v3/surveys/patch.ts
+++ b/apps/web/app/api/v3/surveys/patch.ts
@@ -1,7 +1,6 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
-import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import { getActionClasses } from "@/lib/actionClass/service";
@@ -258,7 +257,7 @@ export async function executeV3SurveyPatch(params: {
         await reconcileEmbeddedData(tx, {
           surveyId: currentSurvey.id,
           workspaceId: currentSurvey.workspaceId,
-          desired: toDesiredEmbeddedFields(survey),
+          patch: { variables: document.variables, hiddenFields: document.hiddenFields },
         });
 
         return survey;

--- a/apps/web/app/api/v3/surveys/patch.ts
+++ b/apps/web/app/api/v3/surveys/patch.ts
@@ -244,9 +244,12 @@ export async function executeV3SurveyPatch(params: {
 
         const survey = await runSurveyUpdate(tx);
 
-        // Derived from the PERSISTED survey, not the patch document: a patch may omit `variables` or
-        // `hiddenFields` entirely, and reading the payload would see them as absent and delete every
-        // row. `workspaceId` comes from the stored survey, never the client (ENG-1749).
+        // ENG-2412: from the patch document, which is what makes the rows the write source of
+        // truth rather than a copy of the columns `data` just wrote. Safe on a partial patch for two
+        // reasons: `prepareV3SurveyPatchInput` merges the body over the current survey first, so both
+        // keys arrive populated; and `resolveDesiredEmbeddedFields` carries a group's current rows
+        // over untouched if its key is absent anyway. `workspaceId` comes from the stored survey,
+        // never the client (ENG-1749).
         //
         // NOTE for whoever moves the v3 serializer onto the tables (ENG-1853): `survey` was read
         // BEFORE this reconcile, so the `embeddedDataLinks` it carries — and the `embeddedFields`

--- a/apps/web/integration/embedded-data-read.integration.test.ts
+++ b/apps/web/integration/embedded-data-read.integration.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { prisma } from "@formbricks/database";
-import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
 import { deriveLegacyEmbeddedData, getSurveyEmbeddedFields } from "@formbricks/types/embedded-data-resolver";
 import { type TSurvey } from "@formbricks/types/surveys/types";
 import { resetDb } from "@/integration/reset-db";
@@ -43,7 +42,7 @@ const seedSurvey = async (): Promise<{ surveyId: string; workspaceId: string }> 
     reconcileEmbeddedData(tx, {
       surveyId: survey.id,
       workspaceId: workspace.id,
-      desired: toDesiredEmbeddedFields(LEGACY),
+      patch: LEGACY,
     })
   );
 
@@ -95,14 +94,18 @@ describe("Embedded Data read seam (real Postgres)", () => {
     ]);
   });
 
-  test("a survey that missed the backfill still resolves off its legacy columns", async () => {
+  test("a survey with no rows has no fields, whatever its legacy columns still say", async () => {
+    // ENG-2412 removed the fallback. The rows are the write source of truth now, so deleting them
+    // makes the fields disappear rather than reappear — the behaviour that made the previous model
+    // hard to reason about. `deriveLegacyEmbeddedData` still has the columns; nothing consults it.
     const { surveyId } = await seedSurvey();
     await prisma.surveyEmbeddedData.deleteMany({ where: { surveyId } });
 
     const survey = await loadSurvey(surveyId);
 
     expect(survey.embeddedFields).toEqual([]);
-    expect(getSurveyEmbeddedFields(survey)).toEqual(deriveLegacyEmbeddedData(LEGACY));
+    expect(getSurveyEmbeddedFields(survey)).toEqual([]);
+    expect(deriveLegacyEmbeddedData(LEGACY)).not.toEqual([]);
   });
 
   test("a partial row set wins outright — the rows are the source of truth once any exist", async () => {

--- a/apps/web/integration/embedded-data-reconcile.integration.test.ts
+++ b/apps/web/integration/embedded-data-reconcile.integration.test.ts
@@ -56,10 +56,7 @@ const reconcile = (
   surveyId: string,
   workspaceId: string,
   legacy: Parameters<typeof toDesiredEmbeddedFields>[0]
-) =>
-  prisma.$transaction((tx) =>
-    reconcileEmbeddedData(tx, { surveyId, workspaceId, desired: toDesiredEmbeddedFields(legacy) })
-  );
+) => prisma.$transaction((tx) => reconcileEmbeddedData(tx, { surveyId, workspaceId, patch: legacy }));
 
 beforeEach(async () => {
   await resetDb();
@@ -188,8 +185,13 @@ describe("reconcileEmbeddedData (real Postgres)", () => {
     const { surveyId, workspaceId } = await seedSurvey();
     await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["plan"] } });
 
+    // Both groups, because that is what a save sends — every caller merges over the loaded survey
+    // before calling in. Passing `variables` alone is a test-only shape now that an omitted group
+    // means "leave it alone": it would carry the ingested `plan` over and collide with the computed
+    // one, which `assertNoDuplicateStorageKeys` has always rejected.
     await reconcile(surveyId, workspaceId, {
       variables: [{ id: "plan", name: "plan", type: "text", value: "pro" }],
+      hiddenFields: { enabled: true, fieldIds: [] },
     });
 
     expect(await readFields(surveyId)).toMatchObject([{ storageKey: "plan", source: "computed" }]);

--- a/apps/web/integration/embedded-data-v3-patch.integration.test.ts
+++ b/apps/web/integration/embedded-data-v3-patch.integration.test.ts
@@ -65,7 +65,7 @@ const seedSurvey = async (legacy?: {
     reconcileEmbeddedData(tx, {
       surveyId: survey.id,
       workspaceId: workspace.id,
-      desired: toDesiredEmbeddedFields(survey),
+      patch: survey,
     })
   );
 

--- a/apps/web/lib/embedded-data/reconcile.test.ts
+++ b/apps/web/lib/embedded-data/reconcile.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { type TDesiredEmbeddedField } from "@formbricks/types/embedded-data-mapping";
-import { type TCurrentEmbeddedField, planEmbeddedDataReconcile } from "./reconcile";
+import {
+  type TCurrentEmbeddedField,
+  planEmbeddedDataReconcile,
+  resolveDesiredEmbeddedFields,
+} from "./reconcile";
 
 const SURVEY_ID = "srv_1";
 const OTHER_SURVEY_ID = "srv_2";
@@ -43,6 +47,55 @@ const localField = (desired: TDesiredEmbeddedField, fieldId: string, order = 0):
     dataType: desired.dataType,
     defaultValue: desired.defaultValue,
   },
+});
+
+describe("resolveDesiredEmbeddedFields", () => {
+  const currentScore: TDesiredEmbeddedField = { ...desiredScore };
+  const currentPlan: TDesiredEmbeddedField = { ...desiredPlan };
+  const current = [currentScore, currentPlan];
+
+  test("carries a group over untouched when the payload does not mention it", () => {
+    // The whole reason this is a merge. `updateSurveyInternal` and the v3 patch both take partial
+    // payloads, and a save that only renames the survey must not read as "delete every field".
+    expect(resolveDesiredEmbeddedFields(current, {})).toEqual(current);
+  });
+
+  test("treats an explicitly empty list as a clear, not as an omission", () => {
+    expect(resolveDesiredEmbeddedFields(current, { variables: [] })).toEqual([currentPlan]);
+  });
+
+  test("replaces only the group the payload carried", () => {
+    const renamed = { ...desiredScore, name: "total_score" };
+    const result = resolveDesiredEmbeddedFields(current, {
+      variables: [{ id: renamed.storageKey, name: renamed.name, type: "number", value: 0 }],
+    });
+
+    expect(result).toEqual([renamed, currentPlan]);
+  });
+
+  test("the ingested group is independent of the computed one", () => {
+    const result = resolveDesiredEmbeddedFields(current, {
+      hiddenFields: { enabled: true, fieldIds: ["plan", "tier"] },
+    });
+
+    expect(result.map(({ storageKey }) => storageKey)).toEqual(["var_score", "plan", "tier"]);
+  });
+
+  test("an undefined value is an omission, not a clear", () => {
+    // Load-bearing: every write seam spells both keys out and lets Prisma ignore the undefined ones,
+    // so an `in` check would read as "the payload carried this" and wipe the rows.
+    expect(resolveDesiredEmbeddedFields(current, { variables: undefined, hiddenFields: undefined })).toEqual(
+      current
+    );
+  });
+
+  test("keeps every computed field ahead of every ingested one, which is what order means", () => {
+    const result = resolveDesiredEmbeddedFields([currentPlan, currentScore], {
+      hiddenFields: { enabled: true, fieldIds: ["plan"] },
+    });
+
+    expect(result.map(({ source }) => source)).toEqual(["computed", "ingested"]);
+  });
 });
 
 describe("planEmbeddedDataReconcile", () => {

--- a/apps/web/lib/embedded-data/reconcile.ts
+++ b/apps/web/lib/embedded-data/reconcile.ts
@@ -68,6 +68,12 @@ const SELECT_CURRENT_FIELDS = {
  *
  * The two groups are merged independently because they arrive independently: a payload carrying
  * `variables` alone must leave the ingested rows exactly where they are.
+ *
+ * `computed` and `ingested` are the only two sources carried over, and that is the whole set a row
+ * can have: `ZEmbeddedData` rejects `source: "reserved"` outright, because reserved fields are a
+ * code catalog projected at read time rather than anything stored. A `reserved` row is therefore
+ * unrepresentable through every write path — and if one ever appeared through raw SQL, this would
+ * drop it, which is the correct outcome for a row the schema says cannot exist.
  */
 export const resolveDesiredEmbeddedFields = (
   current: TDesiredEmbeddedField[],

--- a/apps/web/lib/embedded-data/reconcile.ts
+++ b/apps/web/lib/embedded-data/reconcile.ts
@@ -6,7 +6,11 @@ import {
   type TEmbeddedDataType,
   isLocalEmbeddedData,
 } from "@formbricks/types/embedded-data";
-import { type TDesiredEmbeddedField } from "@formbricks/types/embedded-data-mapping";
+import {
+  type TDesiredEmbeddedField,
+  type TLegacyEmbeddedFields,
+  toDesiredEmbeddedFields,
+} from "@formbricks/types/embedded-data-mapping";
 import { InvalidInputError } from "@formbricks/types/errors";
 
 /** One field a survey currently has, as the link plus the definition it points at. */
@@ -48,6 +52,41 @@ const SELECT_CURRENT_FIELDS = {
     select: { id: true, surveyId: true, name: true, source: true, dataType: true, defaultValue: true },
   },
 } satisfies Prisma.SurveyEmbeddedDataSelect;
+
+/**
+ * Works out what a survey should have after a save: whichever of the two legacy groups the payload
+ * actually carried, and its current rows for the group it did not.
+ *
+ * This is what makes the rows the write source of truth rather than a copy of the columns. It has to
+ * be a merge rather than a straight read of the payload, because `updateSurveyInternal` and the v3
+ * patch both accept partial updates: a call carrying only `{ name }` would otherwise resolve to an
+ * empty set and delete every field the survey has. Renaming a survey would wipe its Embedded Data.
+ *
+ * **Presence is `!== undefined`, not the `in` operator.** Every write seam builds one object literal
+ * with both keys spelled out and lets Prisma ignore the undefined ones, so `"variables" in patch` is
+ * true even for a payload that never mentioned variables — and would clear them.
+ *
+ * The two groups are merged independently because they arrive independently: a payload carrying
+ * `variables` alone must leave the ingested rows exactly where they are.
+ */
+export const resolveDesiredEmbeddedFields = (
+  current: TDesiredEmbeddedField[],
+  patch: Partial<TLegacyEmbeddedFields>
+): TDesiredEmbeddedField[] => {
+  const carriedOver = (source: TEmbeddedDataSource): TDesiredEmbeddedField[] =>
+    current.filter((entry) => entry.source === source);
+
+  // Order matters: the index in this list becomes each field's stored position, and
+  // `toDesiredEmbeddedFields` puts every computed field before every ingested one.
+  return [
+    ...(patch.variables !== undefined
+      ? toDesiredEmbeddedFields({ variables: patch.variables })
+      : carriedOver("computed")),
+    ...(patch.hiddenFields !== undefined
+      ? toDesiredEmbeddedFields({ hiddenFields: patch.hiddenFields })
+      : carriedOver("ingested")),
+  ];
+};
 
 /**
  * Prisma distinguishes a JSON `null` from a SQL `NULL` on a nullable Json column, so "this field has
@@ -152,8 +191,13 @@ export const planEmbeddedDataReconcile = (
 };
 
 /**
- * Brings a survey's `EmbeddedData` rows and links in step with the legacy shape it was just saved
- * with.
+ * Brings a survey's `EmbeddedData` rows and links in step with the payload it was just saved with.
+ *
+ * **The payload, not the persisted survey** (ENG-2412). The rows are the write source of truth now;
+ * `survey.variables` / `survey.hiddenFields` are written from the same payload in the same
+ * transaction and kept only as a rollback path until they are dropped. Reading the persisted survey
+ * here instead would put the columns back in charge, and reading the rows would be circular — the
+ * target would always equal the current state and no edit would ever persist.
  *
  * Runs inside the caller's transaction so a survey never commits without its fields, and takes
  * `workspaceId` explicitly because the copy flow writes into a *different* workspace than the one it
@@ -167,13 +211,14 @@ export const reconcileEmbeddedData = async (
   {
     surveyId,
     workspaceId,
-    desired,
-  }: { surveyId: string; workspaceId: string; desired: TDesiredEmbeddedField[] }
+    patch,
+  }: { surveyId: string; workspaceId: string; patch: Partial<TLegacyEmbeddedFields> }
 ): Promise<void> => {
-  assertNoDuplicateStorageKeys(desired);
-
   const links = await tx.surveyEmbeddedData.findMany({
     where: { surveyId },
+    // The group the payload did not carry keeps its stored positions, and those become indexes in
+    // `desired` — so the rows have to arrive in the order they are stored in, not in Postgres' whim.
+    orderBy: [{ order: "asc" }, { storageKey: "asc" }],
     select: SELECT_CURRENT_FIELDS,
   });
 
@@ -183,6 +228,18 @@ export const reconcileEmbeddedData = async (
     order: link.order,
     field: link.embeddedData,
   }));
+
+  const desired = resolveDesiredEmbeddedFields(
+    current.map(({ storageKey, field }) => ({
+      storageKey,
+      name: field.name,
+      source: field.source,
+      dataType: field.dataType,
+      defaultValue: field.defaultValue,
+    })),
+    patch
+  );
+  assertNoDuplicateStorageKeys(desired);
 
   const plan = planEmbeddedDataReconcile(surveyId, current, desired);
 

--- a/apps/web/lib/response/utils.test.ts
+++ b/apps/web/lib/response/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { Prisma } from "@formbricks/database/prisma";
+import { deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
 import { TResponse } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -16,6 +17,14 @@ import {
   getResponsesJson,
 } from "./utils";
 import { buildWhereClause } from "./where-clause";
+
+/**
+ * A survey as a reader actually receives it: `transformPrismaSurvey` inlines the EmbeddedData rows
+ * next to the legacy columns, and since ENG-2412 those rows are the only thing the accessors read.
+ * Fixtures that declare `variables` / `hiddenFields` alone describe a row nobody reads.
+ */
+const asRead = <T extends Partial<TSurvey>>(survey: T): T =>
+  ({ ...survey, embeddedFields: deriveLegacyEmbeddedData(survey) }) as T;
 
 describe("Response Utils", () => {
   describe("calculateTtcTotal", () => {
@@ -37,7 +46,7 @@ describe("Response Utils", () => {
   });
 
   describe("buildWhereClause", () => {
-    const mockSurvey: Partial<TSurvey> = {
+    const mockSurvey: Partial<TSurvey> = asRead({
       id: "survey1",
       name: "Test Survey",
       blocks: [],
@@ -49,7 +58,7 @@ describe("Response Utils", () => {
       workspaceId: "env1",
       createdBy: "user1",
       status: "draft",
-    };
+    });
 
     test("should build where clause with finished filter", () => {
       const filterCriteria = { finished: true };
@@ -553,7 +562,7 @@ describe("Response Utils", () => {
 
   // TODO: Fix this test after the survey editor poc is merged
   describe("extractSurveyDetails", () => {
-    const mockSurvey: Partial<TSurvey> = {
+    const mockSurvey: Partial<TSurvey> = asRead({
       id: "survey1",
       name: "Test Survey",
       blocks: [
@@ -600,7 +609,7 @@ describe("Response Utils", () => {
       workspaceId: "env1",
       createdBy: "user1",
       status: "draft",
-    };
+    });
 
     const mockResponses: Partial<TResponse>[] = [
       {
@@ -637,6 +646,8 @@ describe("Response Utils", () => {
      * are asserted exactly, not by membership.
      */
     describe("Embedded Data columns", () => {
+      // Legacy columns populated, join absent — `embeddedFields` is cleared explicitly because
+      // `mockSurvey` carries the inlined rows a real read would have.
       const legacySurvey = {
         ...mockSurvey,
         variables: [
@@ -644,13 +655,17 @@ describe("Response Utils", () => {
           { id: "clx0000000000000000000v1", name: "score", type: "number", value: 0 },
         ],
         hiddenFields: { enabled: true, fieldIds: ["utm_source", "hidden1"] },
-      } as TSurvey;
+        embeddedFields: undefined,
+      } as unknown as TSurvey;
 
-      test("derives both column groups from the legacy columns when the join is absent", () => {
+      test("reports no Embedded Data columns when the join is absent", () => {
+        // ENG-2412 removed the legacy fallback, so the rows are the whole answer. A survey read
+        // through a select that omits `selectSurveyEmbeddedDataLinks` exports no variable or hidden
+        // field columns at all — which is why every reader's select has to carry that join.
         const result = extractSurveyDetails(legacySurvey, mockResponses as TResponse[]);
 
-        expect(result.variables).toEqual(["tier", "score"]);
-        expect(result.hiddenFields).toEqual(["utm_source", "hidden1"]);
+        expect(result.variables).toEqual([]);
+        expect(result.hiddenFields).toEqual([]);
       });
 
       test("takes the column labels from the rows when the join is present", () => {
@@ -699,7 +714,7 @@ describe("Response Utils", () => {
   });
 
   describe("getResponsesJson", () => {
-    const mockSurvey: Partial<TSurvey> = {
+    const mockSurvey: Partial<TSurvey> = asRead({
       id: "survey1",
       name: "Test Survey",
       blocks: [
@@ -730,7 +745,7 @@ describe("Response Utils", () => {
       workspaceId: "env1",
       createdBy: "user1",
       status: "draft",
-    };
+    });
 
     const mockResponses: Partial<TResponse>[] = [
       {
@@ -767,10 +782,10 @@ describe("Response Utils", () => {
     test("a computed field the response never captured leaves an empty cell", () => {
       // resolveEmbeddedValue would substitute the declared default here — i.e. display a value the
       // respondent's run never produced. The export deliberately reads the raw slot instead.
-      const surveyWithVariables = {
+      const surveyWithVariables = asRead({
         ...mockSurvey,
         variables: [{ id: "clx0000000000000000000v1", name: "score", type: "number", value: 5 }],
-      } as TSurvey;
+      }) as TSurvey;
 
       const result = getResponsesJson(
         surveyWithVariables,
@@ -786,10 +801,10 @@ describe("Response Utils", () => {
     });
 
     test("writes a captured computed value under the field's name, keyed by its storage key", () => {
-      const surveyWithVariables = {
+      const surveyWithVariables = asRead({
         ...mockSurvey,
         variables: [{ id: "clx0000000000000000000v1", name: "score", type: "number", value: 5 }],
-      } as TSurvey;
+      }) as TSurvey;
 
       const result = getResponsesJson(
         surveyWithVariables,
@@ -972,7 +987,7 @@ describe("Response Utils", () => {
   });
 
   describe("getResponseHiddenFields", () => {
-    const mockSurvey: Partial<TSurvey> = {
+    const mockSurvey: Partial<TSurvey> = asRead({
       id: "survey1",
       name: "Test Survey",
       questions: [],
@@ -983,7 +998,7 @@ describe("Response Utils", () => {
       workspaceId: "env1",
       createdBy: "user1",
       status: "draft",
-    };
+    });
 
     test("should extract hidden fields correctly", () => {
       const responses = [

--- a/apps/web/lib/survey/__mock__/survey.mock.ts
+++ b/apps/web/lib/survey/__mock__/survey.mock.ts
@@ -1,7 +1,10 @@
 import { Prisma } from "@formbricks/database/prisma";
 import { TActionClass } from "@formbricks/types/action-classes";
 import { TContactAttributeKey } from "@formbricks/types/contact-attribute-key";
-import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
+import {
+  type TLinkedEmbeddedField,
+  deriveLegacyEmbeddedData,
+} from "@formbricks/types/embedded-data-resolver";
 import { TOrganization } from "@formbricks/types/organizations";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import {
@@ -587,6 +590,14 @@ export const mockSurveyWithLogic: TSurvey = {
     { id: "siog1dabtpo3l0a3xoxw2922", type: "text", name: "var1", value: "lmao" },
     { id: "km1srr55owtn2r7lkoh5ny1u", type: "number", name: "var2", value: 32 },
   ],
+  // Since ENG-2412 the rows are the only thing `getSurveyEmbeddedFields` reads, so a survey that
+  // declares variables has to carry the matching rows — that is what a real read returns.
+  embeddedFields: deriveLegacyEmbeddedData({
+    variables: [
+      { id: "siog1dabtpo3l0a3xoxw2922", type: "text", name: "var1", value: "lmao" },
+      { id: "km1srr55owtn2r7lkoh5ny1u", type: "number", name: "var2", value: 32 },
+    ],
+  }),
   customHeadScripts: null,
   customHeadScriptsMode: null,
 };

--- a/apps/web/lib/survey/service.scheduling.test.ts
+++ b/apps/web/lib/survey/service.scheduling.test.ts
@@ -69,6 +69,12 @@ describe("survey service scheduling", () => {
     vi.mocked(prisma.surveyEmbeddedData.findMany).mockResolvedValue([]);
     vi.mocked(prisma.embeddedData.create).mockResolvedValue({ id: "ed_1" } as never);
     vi.mocked(prisma.surveyEmbeddedData.create).mockResolvedValue({} as never);
+    // `createSurvey` re-reads the survey after that reconcile (ENG-2412), so the read has to be
+    // answered too. Echoing `survey.create`'s resolved value keeps each test's own fixture in charge.
+    vi.mocked(prisma.survey.findUniqueOrThrow).mockImplementation((async () => {
+      const created = vi.mocked(prisma.survey.create).mock.results.at(-1)?.value;
+      return created instanceof Promise ? await created : created;
+    }) as never);
   });
 
   afterEach(() => {

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -829,6 +829,13 @@ describe("Tests for createSurvey", () => {
 
   beforeEach(() => {
     vi.mocked(getActionClasses).mockResolvedValue(mockActionClasses as TActionClass[]);
+    // `createSurvey` re-reads the survey after reconciling its Embedded Data rows (ENG-2412), so the
+    // mock has to answer that read too. Echoing whatever the test made `survey.create` resolve to
+    // keeps each test's own fixture the single source of truth for the created shape.
+    prisma.survey.findUniqueOrThrow.mockImplementation((async () => {
+      const created = prisma.survey.create.mock.results.at(-1)?.value;
+      return created instanceof Promise ? await created : created;
+    }) as never);
   });
 
   describe("Happy Path", () => {
@@ -843,6 +850,48 @@ describe("Tests for createSurvey", () => {
       expect(prisma.survey.create).toHaveBeenCalled();
       expect(result.name).toEqual(mockSurveyOutput.name);
       expect(subscribeOrganizationMembersToSurveyResponses).toHaveBeenCalled();
+    });
+
+    test("returns the survey as it stands AFTER its Embedded Data rows are written", async () => {
+      // ENG-2412: `createSurvey` used to return the row it selected before the reconcile, whose
+      // `embeddedDataLinks` is necessarily empty — the links do not exist yet. That was survivable
+      // only while `getSurveyEmbeddedFields` fell back to the legacy columns; without the fallback it
+      // reports a survey that just persisted fields as having none. The read has to happen after.
+      //
+      // `findUniqueOrThrow` is given links here while `create` is not, so this fails if the return
+      // ever goes back to the pre-reconcile object.
+      vi.mocked(getOrganizationByWorkspaceId).mockResolvedValueOnce(mockOrganizationOutput);
+      prisma.survey.create.mockResolvedValueOnce({ ...mockSurveyOutput, embeddedDataLinks: [] });
+      prisma.survey.findUniqueOrThrow.mockResolvedValueOnce({
+        ...mockSurveyOutput,
+        embeddedDataLinks: [
+          {
+            storageKey: "utm_source",
+            embeddedData: {
+              name: "utm_source",
+              source: "ingested",
+              dataType: "string",
+              defaultValue: null,
+              locked: false,
+            },
+          },
+        ],
+      } as never);
+
+      const result = await createSurvey(mockWorkspaceId, mockCreateSurveyInput);
+
+      expect(result.embeddedFields).toEqual([
+        {
+          field: {
+            name: "utm_source",
+            source: "ingested",
+            dataType: "string",
+            defaultValue: null,
+            locked: false,
+          },
+          link: { storageKey: "utm_source" },
+        },
+      ]);
     });
 
     test("strips archivedAt from a create payload so a caller can't create a pre-archived survey", async () => {

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -336,7 +336,7 @@ export const updateSurveyInternal = async (
       // the join below. `surveyData` is spread straight into `tx.survey.update`'s `data`, and
       // `Survey` owns relations named `embeddedData` / `embeddedDataLinks` — so leaving it in would
       // turn a read projection into a nested relation write. The rows are written by
-      // `reconcileEmbeddedData` from the persisted legacy columns instead.
+      // `reconcileEmbeddedData` from `updatedSurvey`'s legacy keys instead (ENG-2412).
       embeddedFields: _embeddedFields,
       ...surveyData
     } = updatedSurvey;

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -4,7 +4,6 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { ZId, ZOptionalNumber } from "@formbricks/types/common";
-import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
 import {
   DatabaseError,
   InvalidInputError,
@@ -632,11 +631,12 @@ export const updateSurveyInternal = async (
           select: selectSurvey,
         });
 
-        // ENG-1978: mirror the saved fields into the EmbeddedData tables in the same transaction, so a
-        // survey never commits without them. Derived from the PERSISTED survey rather than the payload:
-        // a partial update leaves `variables` / `hiddenFields` untouched in the column, and reading the
-        // payload instead would see them as absent and delete every row. workspaceId comes from the
-        // stored survey for the ENG-1749 reason above — never from the client.
+        // ENG-1978: write the saved fields into the EmbeddedData tables in the same transaction, so a
+        // survey never commits without them. ENG-2412: from the PAYLOAD, which is what makes the rows
+        // the write source of truth rather than a copy of the columns `data` just wrote. A caller that
+        // omits either key is not saying "delete these" — `reconcileEmbeddedData` carries that group's
+        // current rows over untouched. workspaceId comes from the stored survey for the ENG-1749
+        // reason above — never from the client.
         //
         // NOTE (ENG-1837): `survey` was read BEFORE this reconcile, so the `embeddedDataLinks` it
         // carries — and the `embeddedFields` inlined from them by `transformPrismaSurvey` below —
@@ -656,7 +656,7 @@ export const updateSurveyInternal = async (
         await reconcileEmbeddedData(tx, {
           surveyId,
           workspaceId: currentSurvey.workspaceId,
-          desired: toDesiredEmbeddedFields(survey),
+          patch: { variables: updatedSurvey.variables, hiddenFields: updatedSurvey.hiddenFields },
         });
 
         return survey;
@@ -915,7 +915,7 @@ export const createSurvey = async (
         await reconcileEmbeddedData(tx, {
           surveyId: createdSurvey.id,
           workspaceId: parsedWorkspaceId,
-          desired: toDesiredEmbeddedFields(createdSurvey),
+          patch: { variables: createdSurvey.variables, hiddenFields: createdSurvey.hiddenFields },
         });
 
         return createdSurvey;

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -918,7 +918,13 @@ export const createSurvey = async (
           patch: { variables: createdSurvey.variables, hiddenFields: createdSurvey.hiddenFields },
         });
 
-        return createdSurvey;
+        // Re-read after the reconcile, not before it. `createdSurvey` was selected before the links
+        // existed, so its `embeddedDataLinks` is empty — and since ENG-2412 removed the legacy
+        // fallback, returning it would report a freshly created survey as having no Embedded Data at
+        // all. Cheap here in a way it would not be on the editor-save path: creation happens once per
+        // survey, and this also picks up the private-segment connect above, which `createdSurvey`
+        // predates.
+        return tx.survey.findUniqueOrThrow({ where: { id: createdSurvey.id }, select: selectSurvey });
       },
       // This transaction predates ENG-1978, but the reconcile above adds a read plus two writes per
       // field inside it, and neither `variables` nor `hiddenFields` is bounded — so a large template or
@@ -933,8 +939,8 @@ export const createSurvey = async (
     const transformedSurvey: TSurvey = {
       // ENG-1837: this result is hand-built rather than routed through `transformPrismaSurvey`, so
       // the inlining has to happen here too — otherwise the raw relation leaks onto TSurvey. The
-      // rows are reconciled *after* the create above, so the list is empty here and the accessor
-      // falls back to the freshly written legacy columns, which carry the same definitions.
+      // rows are read back after the reconcile (see the transaction's return), so this list carries
+      // the definitions that were just written.
       ...withInlinedEmbeddedFields(survey),
       ...(survey.segment && {
         segment: {

--- a/apps/web/lib/surveyLogic/utils.test.ts
+++ b/apps/web/lib/surveyLogic/utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
 import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TResponseData, TResponseVariables } from "@formbricks/types/responses";
 import { TSurveyBlockLogic, TSurveyBlockLogicAction } from "@formbricks/types/surveys/blocks";
@@ -93,6 +94,11 @@ describe("surveyLogic", () => {
         value: 0,
       },
     ],
+    // The rows are the only thing `getSurveyEmbeddedFields` reads since ENG-2412, so a fixture that
+    // declares a variable has to carry the matching row — that is what a real survey read returns.
+    embeddedFields: deriveLegacyEmbeddedData({
+      variables: [{ id: "v", name: "num", type: "number", value: 0 }],
+    }),
     displayOption: "displayOnce",
     recontactDays: null,
     displayLimit: null,
@@ -109,6 +115,12 @@ describe("surveyLogic", () => {
     segment: null,
     recaptcha: null,
   };
+
+  /** Overridden by several cases below; the rows have to match, since they are what is read. */
+  const TWO_VARIABLES = [
+    { id: "numVar", name: "numberVar", type: "number" as const, value: 5 },
+    { id: "textVar", name: "textVar", type: "text" as const, value: "hello" },
+  ];
 
   const simpleGroup = (): TConditionGroup => ({
     id: "g1",
@@ -829,10 +841,8 @@ describe("surveyLogic", () => {
         },
       ],
       questions: [],
-      variables: [
-        { id: "numVar", name: "numberVar", type: "number", value: 5 },
-        { id: "textVar", name: "textVar", type: "text", value: "hello" },
-      ],
+      variables: TWO_VARIABLES,
+      embeddedFields: deriveLegacyEmbeddedData({ variables: TWO_VARIABLES }),
     };
 
     const data: TResponseData = {
@@ -1027,10 +1037,8 @@ describe("surveyLogic", () => {
         },
       ],
       questions: [],
-      variables: [
-        { id: "numVar", name: "numberVar", type: "number", value: 5 },
-        { id: "textVar", name: "textVar", type: "text", value: "hello" },
-      ],
+      variables: TWO_VARIABLES,
+      embeddedFields: deriveLegacyEmbeddedData({ variables: TWO_VARIABLES }),
     };
 
     const vars: TResponseVariables = {
@@ -1124,10 +1132,8 @@ describe("surveyLogic", () => {
   test("performCalculation handles different variable types and operations", () => {
     const surveyWithVars: TJsWorkspaceStateSurvey = {
       ...mockSurvey,
-      variables: [
-        { id: "numVar", name: "numberVar", type: "number", value: 5 },
-        { id: "textVar", name: "textVar", type: "text", value: "hello" },
-      ],
+      variables: TWO_VARIABLES,
+      embeddedFields: deriveLegacyEmbeddedData({ variables: TWO_VARIABLES }),
     };
 
     const data: TResponseData = {
@@ -1460,7 +1466,10 @@ describe("computed fields resolve through the inlined EmbeddedData rows", () => 
     ).toBe(false);
   });
 
-  test("an empty row list falls back to the legacy column rather than losing the field", () => {
+  test("an empty row list means the survey has no computed fields, whatever the legacy column says", () => {
+    // ENG-2412 removed the fallback: the rows are the whole answer, so a condition naming a field the
+    // rows do not carry no longer resolves off `survey.variables`. Deleting a survey's rows now makes
+    // its fields disappear rather than reappear.
     const legacyNumberVariable = [
       { id: STORAGE_KEY, name: "score", type: "number" as const, value: 0 },
     ] as TJsWorkspaceStateSurvey["variables"];
@@ -1473,7 +1482,7 @@ describe("computed fields resolve through the inlined EmbeddedData rows", () => 
         equalsStatic(42),
         "default"
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("delta (a): a non-numeric stored value is still 0, not the declared default", () => {

--- a/apps/web/modules/email/lib/survey-response-email.test.ts
+++ b/apps/web/modules/email/lib/survey-response-email.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
 import type { TResponse } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import type { TSurvey } from "@formbricks/types/surveys/types";
@@ -52,6 +53,11 @@ const survey = {
   languages: [],
   variables: [{ id: "var1", name: "plan", type: "text" }],
   hiddenFields: { enabled: true, fieldIds: ["utm"] },
+  // The rows are what the accessors read since ENG-2412; a real survey read carries both.
+  embeddedFields: deriveLegacyEmbeddedData({
+    variables: [{ id: "var1", name: "plan", type: "text", value: "" }],
+    hiddenFields: { enabled: true, fieldIds: ["utm"] },
+  }),
 } as unknown as TSurvey;
 
 describe("resolveResponseRecipient", () => {

--- a/apps/web/modules/response-pipeline/lib/handle-integrations.test.ts
+++ b/apps/web/modules/response-pipeline/lib/handle-integrations.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { logger } from "@formbricks/logger";
+import { deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
 import {
   TIntegrationAirtable,
   TIntegrationAirtableConfig,
@@ -146,6 +147,11 @@ const mockSurvey = {
     fieldIds: [hiddenFieldId],
   },
   variables: [{ id: variableId, name: "Variable 1" } as unknown as TSurvey["variables"][0]],
+  // The rows are what the accessors read since ENG-2412; a real survey read carries both.
+  embeddedFields: deriveLegacyEmbeddedData({
+    variables: [{ id: variableId, name: "Variable 1", type: "text", value: "" }],
+    hiddenFields: { enabled: true, fieldIds: [hiddenFieldId] },
+  }),
   autoClose: null,
   triggers: [],
   status: "inProgress",

--- a/apps/web/modules/survey/list/lib/survey.ts
+++ b/apps/web/modules/survey/list/lib/survey.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
-import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
 import { DatabaseError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import { TSurveyFilterCriteria } from "@formbricks/types/surveys/types";
@@ -535,7 +534,7 @@ export const copySurveyToOtherWorkspace = async (
         await reconcileEmbeddedData(tx, {
           surveyId: createdSurvey.id,
           workspaceId: createdSurvey.workspaceId,
-          desired: toDesiredEmbeddedFields(createdSurvey),
+          patch: { variables: createdSurvey.variables, hiddenFields: createdSurvey.hiddenFields },
         });
 
         return createdSurvey;

--- a/packages/surveys/src/lib/logic.test.ts
+++ b/packages/surveys/src/lib/logic.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
 import { type TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { type TResponseData, type TResponseVariables } from "@formbricks/types/responses";
 import { type TSurveyBlockLogicAction } from "@formbricks/types/surveys/blocks";
@@ -128,6 +129,13 @@ describe("Survey Logic", () => {
       enabled: true,
       fieldIds: ["fieldId1"],
     },
+    // ENG-2412: the rows are the only thing the resolver reads now, and a survey reaching the
+    // renderer always carries them inlined from the payload. A fixture with the legacy columns
+    // alone describes a survey nothing would resolve fields for.
+    embeddedFields: deriveLegacyEmbeddedData({
+      variables: mockVariables,
+      hiddenFields: { enabled: true, fieldIds: ["fieldId1"] },
+    }),
     autoClose: null,
     type: "link",
     delay: 0,
@@ -1611,7 +1619,10 @@ describe("computed fields resolve through the inlined EmbeddedData rows", () => 
     ).toBe(false);
   });
 
-  test("an empty row list falls back to the legacy column rather than losing the field", () => {
+  test("an empty row list means the survey has no computed fields, whatever the column says", () => {
+    // ENG-2412 removed the fallback, so a condition naming a field the rows do not carry no longer
+    // resolves off `survey.variables`. At runtime the payload always inlines the rows, so this is
+    // only reachable for a survey whose rows were deleted — and then the field really is gone.
     const legacyNumberVariable: TSurveyVariable[] = [
       { id: STORAGE_KEY, name: "score", type: "number", value: 0 },
     ];
@@ -1624,7 +1635,7 @@ describe("computed fields resolve through the inlined EmbeddedData rows", () => 
         equalsStatic(42),
         "default"
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("delta (a): a non-numeric stored value is still 0, not the declared default", () => {

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -915,18 +915,19 @@ describe("getSurveyEmbeddedFields", () => {
     expect(getSurveyEmbeddedFields({ ...legacySurvey, embeddedFields: rows })).toStrictEqual(rows);
   });
 
-  test("falls back to the legacy columns when the select omitted the join", () => {
-    expect(getSurveyEmbeddedFields(legacySurvey)).toStrictEqual(deriveLegacyEmbeddedData(legacySurvey));
-    expect(getSurveyEmbeddedFields({ ...legacySurvey, embeddedFields: null })).toStrictEqual(
-      deriveLegacyEmbeddedData(legacySurvey)
-    );
+  test("reports nothing when the select omitted the join, rather than reading the columns", () => {
+    // ENG-2412 removed the legacy fallback: the rows are the whole answer. The consequence is that
+    // every survey select reaching a reader has to carry `selectSurveyEmbeddedDataLinks` — one that
+    // does not makes the survey read as having no Embedded Data at all.
+    expect(getSurveyEmbeddedFields(legacySurvey)).toStrictEqual([]);
+    expect(getSurveyEmbeddedFields({ ...legacySurvey, embeddedFields: null })).toStrictEqual([]);
+    expect(deriveLegacyEmbeddedData(legacySurvey)).not.toStrictEqual([]);
   });
 
-  test("falls back on an empty row list, so a survey that missed the backfill still resolves", () => {
-    // The empty-list test is the reason this is `?.length` and not `!== undefined`.
-    expect(getSurveyEmbeddedFields({ ...legacySurvey, embeddedFields: [] })).toStrictEqual(
-      deriveLegacyEmbeddedData(legacySurvey)
-    );
+  test("an empty row list means no fields, so deleting a survey's rows removes them", () => {
+    // Previously this fell back to the columns, which is why deleting a survey's rows made its
+    // fields reappear. Now they disappear, which is what the tables being the source of truth means.
+    expect(getSurveyEmbeddedFields({ ...legacySurvey, embeddedFields: [] })).toStrictEqual([]);
   });
 
   test("a survey with no fields at all answers [] through either path", () => {
@@ -971,11 +972,9 @@ describe("getSurveyEmbeddedFields", () => {
     ]);
   });
 
-  test("the partitions fall back too, keeping variables-then-hidden-fields order", () => {
-    expect(getComputedEmbeddedFields(legacySurvey).map(({ link }) => link.storageKey)).toStrictEqual([
-      "clx0000000000000000000v1",
-    ]);
-    expect(getIngestedStorageKeys(legacySurvey)).toStrictEqual(["source_page"]);
+  test("the partitions report nothing too, rather than falling back independently", () => {
+    expect(getComputedEmbeddedFields(legacySurvey)).toStrictEqual([]);
+    expect(getIngestedStorageKeys(legacySurvey)).toStrictEqual([]);
   });
 });
 

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -493,11 +493,16 @@ export interface TEmbeddedFieldsSurvey extends TLegacyEmbeddedFields {
  * reader may call {@link deriveLegacyEmbeddedData} directly, which is what keeps "exactly two named
  * decisions, and no third" a property a reviewer can check with grep.
  *
- * Rows win when present. The empty-list test is deliberate rather than `!== undefined`: a select
- * that omits the join yields `undefined`, and a survey read through it must still resolve, while
- * `deriveLegacyEmbeddedData` returns `[]` for a survey whose legacy columns are empty — so a survey
- * that genuinely has zero fields answers `[]` either way, and one that missed the ENG-1835 backfill
- * falls back instead of silently losing every field.
+ * **The rows are the whole answer** (ENG-2412). This used to fall back to the legacy columns for a
+ * survey with no rows, which is why deleting a survey's rows made its fields reappear rather than
+ * disappear. The write path now writes the rows from the payload, so a survey with no rows is a
+ * survey with no fields, and that is what this reports.
+ *
+ * **Every survey select that reaches a reader must therefore carry the join** —
+ * `selectSurveyEmbeddedDataLinks`, inlined by `transformPrismaSurvey`. A select that omits it yields
+ * `undefined` here and the survey reads as having no fields at all. Audited when the fallback was
+ * removed: every reader gets its survey through `selectSurvey` or a select that embeds the same
+ * constant.
  *
  * This is a *definition* lookup only. ENG-1837 repoints where a field's name, source and dataType
  * come from; it deliberately does not repoint value arithmetic onto {@link resolveEmbeddedValue},
@@ -505,7 +510,7 @@ export interface TEmbeddedFieldsSurvey extends TLegacyEmbeddedFields {
  * on {@link resolveEmbeddedValue}) and would change what stored responses render as.
  */
 export const getSurveyEmbeddedFields = (survey: TEmbeddedFieldsSurvey): TLinkedEmbeddedField[] =>
-  survey.embeddedFields?.length ? survey.embeddedFields : deriveLegacyEmbeddedData(survey);
+  survey.embeddedFields ?? [];
 
 /** The computed (ex-variable) fields of a survey, in inlined order. */
 export const getComputedEmbeddedFields = (survey: TEmbeddedFieldsSurvey): TLinkedEmbeddedField[] =>

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -546,12 +546,12 @@ export const getIngestedStorageKeys = (survey: TEmbeddedFieldsSurvey): string[] 
  *    since the last save would render as a raw `#recall:…#` token, and a renamed one would stop
  *    matching. The same functions also label saved surveys for exports and summaries, where this is
  *    a no-op — a saved survey's rows and declarations agree element for element, because every write
- *    path that persists those columns calls `reconcileEmbeddedData` with
- *    `toDesiredEmbeddedFields(<the persisted survey>)` in the same transaction. There are exactly
- *    four: `updateSurveyInternal` and `createSurvey` (apps/web/lib/survey/service.ts), the copy flow
- *    (modules/survey/list/lib/survey.ts) and the v3 patch (app/api/v3/surveys/patch.ts) — a
- *    `reconcileEmbeddedData(` grep is the audit, and a fifth write that skips it reintroduces the
- *    divergence. They can also diverge once a shared library definition can be renamed independently
+ *    path that persists those columns calls `reconcileEmbeddedData` in the same transaction with the
+ *    same payload it wrote them from (ENG-2412 moved that call onto the payload; before it, onto the
+ *    row just written). There are exactly four: `updateSurveyInternal` and `createSurvey`
+ *    (apps/web/lib/survey/service.ts), the copy flow (modules/survey/list/lib/survey.ts) and the v3
+ *    patch (app/api/v3/surveys/patch.ts) — a `reconcileEmbeddedData(` grep is the audit, and a fifth
+ *    write that skips it reintroduces the divergence. They can also diverge once a shared library definition can be renamed independently
  *    of the survey (ENG-1851), which is when the unified picker (ENG-1853) moves recall and the
  *    pickers onto the tables together.
  */


### PR DESCRIPTION
> [!NOTE]
> Stacked on #8877 (ENG-2401). Base is that branch, so this diff shows only ENG-2412. Re-target to the epic once #8877 merges.

## What & why

`reconcileEmbeddedData` derived its target from the survey row it had **just written** — so `survey.variables` / `survey.hiddenFields` were the write source of truth and the `EmbeddedData` tables were a copy of them:

```
before:  payload → survey.variables → rows
after:   payload → rows              (columns still written, but nothing derives from them)
```

Reversing that is what M3's new write paths need — ENG-1844 (`setEmbeddedData()`) and ENG-1843 (URL params) both write Embedded Data from outside the editor, and would otherwise have to speak the legacy shape too. It is also what the eventual column drop (ENG-2404) is blocked on. And it is the cheapest moment to do it: nothing has reached production, so the blast radius is the epic branch.

**New `resolveDesiredEmbeddedFields`** — the payload patches the survey's current rows. The two legacy groups merge independently, so a payload carrying `variables` alone leaves the ingested rows exactly where they are, and a group the payload does not carry is left untouched rather than read as "delete these".

**Presence is `!== undefined`, not the `in` operator.** This one is load-bearing and easy to get wrong: every write seam builds a single object with both keys spelled out and lets Prisma ignore the undefined ones, so `"variables" in patch` is true even for a payload that never mentioned variables — and would clear its rows. There is a test pinning it.

**Reconcile reads its links ordered.** The carried-over group keeps its stored positions, and those become indexes in the desired list, so the rows have to arrive in the order they are stored in.

**`getSurveyEmbeddedFields` loses its legacy fallback.** Deleting a survey's rows now makes its fields disappear rather than reappear — the behaviour that made the previous model hard to reason about, and the thing this whole change is for. Audited before removing it: every reader gets its survey through `selectSurvey` or a select embedding the same `selectSurveyEmbeddedDataLinks` constant, including the ones that looked risky (`surveyLogic/utils.ts`'s `localSurvey`, the Notion integration modal's `selectedSurvey`).

## No behaviour change on any existing path

Worth stating explicitly, since M1 is the "nothing visible changes" milestone.

Every caller already merges over the loaded survey before calling in — `{ ...survey, singleUse }` in the summary action, `{ ...result.survey, ...surveyUpdate }` in the v1 management route, `mergeV3SurveyPatch(currentDocument, patch)` in v3. So both keys are always present, the payload and the persisted columns always agree, and `resolveDesiredEmbeddedFields` reduces to exactly what the old code computed. The duplicate-address guard is untouched and fires on the same inputs it always did.

The merge is therefore defensive today. It stops being defensive the moment ENG-1844 lands, which is the next milestone.

`hiddenFields.enabled` is untouched: it rides in the column as before, and `toDesiredEmbeddedFields` reads `fieldIds` alone by design. Audited it while here and recorded the findings on ENG-2404 — it is close to vestigial (schema default `false`, the card only ever writes `true`, never set back, one reader).

## Linear ticket

https://linear.app/formbricks/issue/ENG-2412/write-rows-from-the-payload-and-derive-the-legacy-columns-from-them

## How this was tested

- `pnpm vitest run` in `apps/web` — 593 files, **7679 passed** ✅
- `pnpm test:integration` in `apps/web` — 26 files, **123 passed** ✅ (real Postgres)
- `pnpm turbo run typecheck` (web + types + database) — 13/13 ✅, `eslint` on the changed files clean ✅

Tests added:

- `reconcile.test.ts` — six cases on the resolver: an omitted group carries over, an explicit `[]` clears, one group replaced leaves the other alone, `undefined` is an omission not a clear, and computed always precedes ingested (which is what `order` means).
- Integration — the reconcile and read seams re-pointed at the new signature; the read seam now asserts that a survey with no rows has no fields, where it previously asserted the fallback.
- Six test files had fixtures declaring `variables` / `hiddenFields` with no `embeddedFields`. They now carry the inlined rows, because that is what a real survey read returns — a fixture with columns alone describes a row nobody reads.

Not tested here: `hiddenFields.enabled` behaviour, since nothing in this change touches it.

<details>
<summary>Pre-existing failure, unrelated to this change</summary>

`modules/auth/actions.test.ts` has two failing cases (`TooManyRequestsError` from the real rate limiter). Verified by stashing this branch's changes and re-running — they fail without it too.
</details>

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Open a survey with variables and hidden fields, add one of each, save, reopen. → Both appear, in the same order as before; recall tokens, logic conditions and follow-up recipients still resolve.
- [ ] Rename the survey (nothing else) and save. → Its variables and hidden fields are all still there. This is the case that would break if the payload were read naively.
- [ ] Delete a hidden field, save, export responses to CSV. → The column is gone; the remaining columns keep their order.
- [ ] Update a survey through the **v1 management API** (`PUT /api/v1/management/surveys/:id`) with a body carrying `variables` and `hiddenFields`. → Both persist; a follow-up `GET` returns the same shape as before.
- [ ] Update one through the **v3 API** (`PATCH /api/v3/surveys/:id`) sending only `{ "name": "..." }`. → 200, and the survey's fields are unchanged.
- [ ] Send a v3 `PATCH` that puts the same name in both `variables` and `hiddenFields`. → 400, "Duplicate embedded data field" (unchanged from before this PR).
- [ ] Duplicate a survey, and copy one to another workspace. → Both carry the same fields in the same order.
- [ ] **The changed behaviour:** delete a survey's rows directly (`DELETE FROM "SurveyEmbeddedData" WHERE "surveyId" = '…'`), then reload it. → Its variables and hidden fields are now **gone** from the editor, pickers and exports. Before this PR they reappeared from the legacy columns. Save the survey and they come back, written from the editor's cards.

**Preconditions / test data**

- A survey with at least two variables and two hidden fields, with responses, so export and picker order can be checked.
- API credentials for the v1 and v3 checks.
- A follow-up configured with a hidden field as its recipient, to confirm `hiddenFields.enabled` still gates that label.

**Risks & regressions**

- Anything that reads a survey's Embedded Data: recall picker, logic builder operands, calculate widget, follow-up recipients, response table columns, response filters, summary, CSV/XLSX export, notification emails, and the Google Sheets / Airtable / Notion integrations.
- Survey creation from a template, duplication, and cross-workspace copy — all three write rows through this path.
- A survey read through a select that omits the Embedded Data join would now show no fields at all. Audited as none today; worth re-checking if a new survey select is added.

**Migrations / env / cutover**

- none
