### PR TITLE
fix(unify-feedback): drop the inert import-mode control from the edit source modal

### DIFF
--- a/apps/web/modules/ee/unify-feedback/sources/components/edit-feedback-source-modal.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/components/edit-feedback-source-modal.tsx
@@ -51,7 +51,6 @@ import {
 } from "../utils";
 import { getFeedbackSourceIcon, getFeedbackSourceTypeLabelKey } from "./feedback-source-display";
 import { FormbricksQuestionList } from "./formbricks-question-list";
-import { ImportModeField } from "./import-mode-field";
 import { MappingUI } from "./mapping-ui";
 
 interface EditFeedbackSourceModalProps {
@@ -119,8 +118,9 @@ export const EditFeedbackSourceModal = ({
           surveyId: mappedSurveyId,
           selectedQuestionIds: mappedQuestionIds,
           importHistorical: true,
-          // The persisted value, not the default — this dialog has to round-trip it, or saving any
-          // other field would silently reset the source back to completedOnly.
+          // Round-tripped, never edited here: importMode is read only by the historical import, and
+          // editing a source never runs one, so this dialog renders no control for it. Seeding the
+          // persisted value keeps saving any other field from resetting the source to completedOnly.
           importMode: feedbackSource.importMode,
         });
         setCsvFeedbackSourceName("");
@@ -350,8 +350,6 @@ export const EditFeedbackSourceModal = ({
                     </FormItem>
                   )}
                 />
-
-                <ImportModeField control={formbricksForm.control} disabled={isReadOnly} />
               </form>
             </FormProvider>
           ) : (

--- a/apps/web/modules/ee/unify-feedback/sources/components/import-mode-field.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/components/import-mode-field.tsx
@@ -3,26 +3,24 @@
 import { Control } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { TFeedbackSourceImportMode } from "@formbricks/types/feedback-source";
-import { cn } from "@/lib/cn";
 import { FormControl, FormField, FormItem, FormLabel } from "@/modules/ui/components/form";
 import { RadioGroup, RadioGroupItem } from "@/modules/ui/components/radio-group";
 import { TFormbricksFeedbackSourceForm } from "../types";
 
 interface ImportModeFieldProps {
   control: Control<TFormbricksFeedbackSourceForm>;
-  disabled?: boolean;
 }
 
 /**
  * Which responses this source imports: completed only, or partials too.
  *
- * Shared by the create and edit dialogs — unlike `importHistorical`, which is a one-shot toggle for
- * the create dialog, this is persisted on the source and has to round-trip on edit.
+ * Create dialog only. The value is persisted on the source, but the edit dialog never sent it, so
+ * the control it rendered there could not do anything and was removed.
  *
  * Deliberately a radio group rather than a switch: "all" carries a privacy consequence the user has
  * to be able to read before choosing it, and a switch has nowhere to put that.
  */
-export const ImportModeField = ({ control, disabled = false }: Readonly<ImportModeFieldProps>) => {
+export const ImportModeField = ({ control }: Readonly<ImportModeFieldProps>) => {
   const { t } = useTranslation();
 
   // Built here, with literal keys, rather than hoisted to a module constant holding key strings:
@@ -46,14 +44,13 @@ export const ImportModeField = ({ control, disabled = false }: Readonly<ImportMo
       control={control}
       name="importMode"
       render={({ field }) => (
-        <FormItem className={cn("rounded-md border border-slate-200 p-3", disabled && "opacity-70")}>
+        <FormItem className="rounded-md border border-slate-200 p-3">
           <FormLabel>{t("workspace.unify.import_mode_label")}</FormLabel>
           <FormControl>
             <RadioGroup
               className="mt-2 gap-y-3"
               value={field.value}
               onValueChange={field.onChange}
-              disabled={disabled}
               aria-label={t("workspace.unify.import_mode_label")}>
               {options.map((option) => (
                 <div key={option.value} className="flex items-start gap-3">


### PR DESCRIPTION
## What & why

The **Edit feedback source** modal rendered the "Which responses to import" radio group (Completed responses only / All responses, including partial ones). Changing it there did nothing.

`importMode` has exactly one runtime read — `apps/web/lib/feedback-source/import.ts:84`, inside `importHistoricalResponses`, where it becomes `{ finished: true }` or `undefined` in the response query filter. The live ingestion path (`pipeline-handler.ts`) fires on `responseFinished` and never reads it; it is finish-only in both modes. And editing a source never runs a historical import — `handleUpdateFeedbackSource` only calls `updateFeedbackSourceWithMappingsAction`, while the one call to `importHistoricalResponsesAction` hardcodes `completedOnly` and creates a *new* source. So nothing would ever read the edited value.

The create modal already guards against exactly this, gating the same field behind `importHistorical && selectedSurveyResponseCount > 0`, with a comment warning that offering it otherwise "would be a control that silently does nothing." The edit modal rendered it unconditionally, so it *was* that control — with copy written for the create context that read false on edit ("Also imports answers respondents started but never submitted" promised a back-fill that could not happen).

This removes `ImportModeField` from the edit modal only. The persisted value still round-trips: the form seeds `importMode: feedbackSource.importMode` on reset and submits it on save, so editing an unrelated field does not reset the source to `completedOnly`. `ImportModeField` itself is untouched — the create modal still uses it.

Before

<img width="804" height="830" alt="Screenshot 2026-08-17 at 11 56 27 AM" src="https://github.com/user-attachments/assets/04072735-ebc5-48f8-90e4-3969f8b366e9" />


After

<img width="803" height="659" alt="Screenshot 2026-08-17 at 12 23 55 PM" src="https://github.com/user-attachments/assets/c9293403-d9df-471d-a9e0-b7db35eb494d" />


## Linear ticket

Fixes ENG-2413

## How this was tested

- `npx vitest run lib/feedback-source/ modules/ee/unify-feedback/` → **30 files, 459 tests passing** ✅
- `npx eslint` on the changed file → clean ✅
- `npx prettier --check` on the changed file → clean ✅
- `npx tsc --noEmit` → **0 errors in the changed file**. The repo currently reports pre-existing errors in unrelated files (`unify-feedback/topics-subtopics/**` tests and others); none are introduced or touched by this diff, which only deletes a JSX element and its now-unused import.
- No tests were added or changed. Per `AGENTS.md` this is a `.tsx` component change, which the repo covers with Playwright rather than component unit tests, and no existing spec asserted on this field.

**Visual proof:** the only rendered change is the removal of the "Which responses to import" block from the bottom of the Edit feedback source dialog — the Source Name, Select Survey and Select questions sections are unchanged. Before/after screenshots to be attached on the PR, since the dialog needs a seeded `formbricks_survey` source to reach.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Workspace → Datasets → open an existing `formbricks_survey` source via **Edit** → the dialog shows Source Name, Select Survey and Select questions, and **no** "Which responses to import" section.
- [ ] In that dialog, rename the source (or change the ticked questions) → Save changes → reopen. The rename persists, and the source's import mode is unchanged.
- [ ] For a source previously set to **All responses, including partial ones**: edit any other field and save → the source still imports partials (its import mode was not silently reset to Completed responses only).
- [ ] Create a **new** source (Workspace → Datasets → Add Source → Formbricks survey), pick a survey that has responses, and leave "import historical responses" on → the "Which responses to import" choice still appears in the create flow, unchanged.
- [ ] Create a new source with "import historical responses" off, or against a survey with zero responses → the choice is still hidden, as before.
- [ ] Open a CSV source via **Edit** → unchanged (that branch of the dialog never showed this field).
- [ ] Open a source in a read-only seat → dialog renders without the field and without errors.

**Preconditions / test data**

- An organization with a feedback directory, a survey with at least one response, and an active `formbricks_survey` source.
- At least one source stored with import mode `all` to verify the round-trip case (set it via the create flow, since it can no longer be changed on edit).

**Risks & regressions**

- The stored `importMode` is now only settable at create time. That matches where it takes effect, but it does mean an existing source's mode cannot be changed from the UI — by design here, and noted on ENG-2413 as the reason the longer-term fix is to make it a parameter of an import run.
- Nearby: the create modal shares `ImportModeField`, so re-check that the create flow still shows and saves the choice.

**Migrations / env / cutover**

- none
