### PR TITLE
test(embedded-data): pin the legacy variables / hiddenFields payload contract [ENG-1838]

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.test.ts
@@ -480,3 +480,46 @@ describe("getWorkspaceStateData", () => {
     ]);
   });
 });
+
+/**
+ * ENG-1838. Already-deployed SDK bundles on customer sites read `survey.variables` and
+ * `survey.hiddenFields.fieldIds` straight off this payload, and we do not control when a customer
+ * upgrades their embed. The Embedded Data work added `embeddedDataLinks` *alongside* those keys
+ * rather than replacing them, and ENG-2404 will eventually drop the columns they come from.
+ *
+ * When that happens this test fails, and whoever drops the columns has to derive the two keys from
+ * the EmbeddedData rows instead. That failure is the whole point of the test — without it the
+ * payload would quietly stop carrying them and every old bundle in the wild would break silently.
+ */
+describe("legacy Embedded Data shape on the wire (ENG-1838)", () => {
+  const surveyWithFields = {
+    ...mockWorkspaceData.surveys[0],
+    variables: [{ id: "clx000000000000000000001", name: "score", type: "number", value: 7 }],
+    hiddenFields: { enabled: true, fieldIds: ["utm_source", "plan"] },
+  };
+
+  test("the workspace-state payload still carries variables and hiddenFields", async () => {
+    vi.mocked(prisma.workspace.findUnique).mockResolvedValue({
+      ...mockWorkspaceData,
+      surveys: [surveyWithFields],
+    } as never);
+
+    const [survey] = (await getWorkspaceStateData(workspaceId)).surveys;
+
+    expect(survey.variables).toEqual(surveyWithFields.variables);
+    expect(survey.hiddenFields).toEqual(surveyWithFields.hiddenFields);
+  });
+
+  test("the query asks for both columns, so removing them from the select fails here", async () => {
+    vi.mocked(prisma.workspace.findUnique).mockResolvedValue(mockWorkspaceData as never);
+
+    await getWorkspaceStateData(workspaceId);
+
+    const [call] = vi.mocked(prisma.workspace.findUnique).mock.calls;
+    const surveySelect = (call[0] as { select: { surveys: { select: Record<string, unknown> } } }).select
+      .surveys.select;
+
+    expect(surveySelect.variables).toBe(true);
+    expect(surveySelect.hiddenFields).toBe(true);
+  });
+});

--- a/apps/web/app/api/v1/management/surveys/lib/surveys.test.ts
+++ b/apps/web/app/api/v1/management/surveys/lib/surveys.test.ts
@@ -174,3 +174,18 @@ describe("getSurveys (Management API)", () => {
     expect(prisma.survey.findMany).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * ENG-1838. `GET /api/v1/management/surveys` is a public contract: external integrations read
+ * `variables` and `hiddenFields` off it, and both come straight from `selectSurvey`. The Embedded
+ * Data work added the joined rows alongside them; ENG-2404 will drop the columns underneath.
+ *
+ * Asserting the select rather than a response body keeps this cheap and still catches the only way
+ * it breaks — the keys leaving `selectSurvey`. v2 reads the same constant.
+ */
+describe("legacy Embedded Data shape on the wire (ENG-1838)", () => {
+  test("selectSurvey still carries variables and hiddenFields", () => {
+    expect(selectSurvey.variables).toBe(true);
+    expect(selectSurvey.hiddenFields).toBe(true);
+  });
+});

--- a/apps/web/modules/survey/link/lib/data.test.ts
+++ b/apps/web/modules/survey/link/lib/data.test.ts
@@ -474,3 +474,26 @@ describe("data", () => {
     });
   });
 });
+
+/**
+ * ENG-1838. The link-survey page renders through a bundled `packages/surveys`, so this payload is
+ * never version-skewed the way an embedded SDK bundle is — but the shape is still a contract the
+ * renderer's recall and logic engines read, and it is the same two columns ENG-2404 will drop.
+ *
+ * This fails the moment `variables` / `hiddenFields` leave the select, which is exactly when someone
+ * has to replace them with a projection derived from the EmbeddedData rows.
+ */
+describe("legacy Embedded Data shape on the wire (ENG-1838)", () => {
+  test("the link-survey query asks for both legacy columns", async () => {
+    vi.mocked(prisma.survey.findUnique).mockResolvedValue({ id: "survey-1" } as never);
+    vi.mocked(transformPrismaSurvey).mockReturnValue({ id: "survey-1" } as never);
+
+    await getSurveyWithMetadata("survey-1");
+
+    const [call] = vi.mocked(prisma.survey.findUnique).mock.calls;
+    const select = (call[0] as { select: Record<string, unknown> }).select;
+
+    expect(select.variables).toBe(true);
+    expect(select.hiddenFields).toBe(true);
+  });
+});


### PR DESCRIPTION
## What & why

This ticket was written as *"derive `variables` + `hiddenFields` from the EmbeddedData rows at serialisation"*. **That derivation is not needed.** All three payloads select both columns straight off the survey row, and those columns are still written on every save — so an already-deployed SDK bundle on a customer site sees exactly what it always did. Nothing to build.

What is missing is anything that would *notice* if that stopped being true. ENG-2404 drops those columns, and when it does these payloads quietly stop carrying the keys and every old bundle in the wild breaks — with no test failing.

So this PR is a tripwire rather than a shim. One test per surface, asserting the query still asks for both columns:

| Surface | Where |
| --- | --- |
| SDK / workspace-state payload | `app/api/v1/client/[workspaceId]/environment/lib/data.ts` |
| Link-survey payload | `modules/survey/link/lib/data.ts` |
| Management API v1 + v2 | the shared `selectSurvey` |

No production code changes — the diff is three test files.

**One thing worth knowing for whoever picks up ENG-2404.** `handleHiddenFields` (`packages/js-core/src/lib/common/utils.ts:272`) reads `enabled` off the *same* payload object, not just `fieldIds`. So dropping `hiddenFields` from the payload would not merely lose the field list — the SDK would log `"Hidden fields are not enabled for this survey"` and silently discard every incoming hidden field from `track()`. The inbound half breaks along with the outbound one.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1838/back-compat-keep-variables-hiddenfields-in-sdk-and-api-payloads

## How this was tested

- `pnpm vitest run` in `apps/web` — 593 files, **7674 passed** ✅
- `pnpm --filter @formbricks/js-core test` — 20 files, **288 passed** ✅ (the inbound `track({ hiddenFields })` path, already covered — verified, not changed)
- `pnpm turbo run typecheck --filter=@formbricks/web` — 10/10 ✅, `eslint` on the changed files clean ✅

**Each tripwire was mutation-tested.** Removing `variables: true` from a surface's select fails exactly that surface's test and nothing else:

| Mutation | Result |
| --- | --- |
| drop `variables: true` from the SDK select | SDK contract test fails, 19 others pass |
| drop it from the link-survey select | link contract test fails, 21 others pass |
| drop it from `selectSurvey` | management contract test fails, 6 others pass |

Worth being precise about which test does the work: **the select-shape assertion is the real tripwire.** The SDK surface also has a payload-content test, which documents the shape a consumer expects but did *not* fail under mutation — a mocked Prisma returns the full row regardless of the select. It earns its place as the spec for a future derivation, not as the guard.

Response payloads verified unchanged by inspection rather than a new test: no Embedded Data code reads or writes `Response` at all (`git grep` over `lib/embedded-data`, `packages/types/embedded-data*` and the backfill migration returns nothing), which is the same invariant every PR in this epic has asserted.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Open a survey with variables and hidden fields in an **app survey** embedded on a test page. → The SDK renders it, recall tokens resolve, and logic conditions on variables evaluate as before.
- [ ] Call `formbricks.track("event", { hiddenFields: { utm_source: "qa" } })` on that page for a survey declaring `utm_source`. → The value is stored on the response.
- [ ] Do the same with a field the survey does **not** declare. → It is dropped and the browser console logs `Unknown hidden fields: …`.
- [ ] Open a **link survey** with variables and hidden fields. → Renders and behaves as before; URL-prefilled hidden fields still land.
- [ ] `GET /api/v1/management/surveys/{id}` and the v2 equivalent. → The response body contains `variables` (array, each with a cuid `id`) and `hiddenFields` (`{ enabled, fieldIds }`), same as before this epic.
- [ ] Submit a response to any of the above and `GET` it back. → `response.data` and `response.variables` are unchanged, keyed exactly as before.

**Preconditions / test data**

- One app survey and one link survey, each with at least two variables and two hidden fields.
- A test page with the JS SDK embedded, using a bundle built **before** this epic if one is available — that is the consumer this contract exists for.
- API credentials for the v1 / v2 management checks.

**Risks & regressions**

- None expected from this PR — it adds tests only. The risk it covers is future: any change that stops these three payloads carrying the legacy keys.
- If a reviewer wants to see the tripwire work, delete `variables: true` from any of the three selects and run that file's suite.

**Migrations / env / cutover**

- none
