### PR TITLE
fix(security): bump nanoid to 3.3.18 and patch advisory [ENG-2403]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   dompurify: 3.4.13
   fast-xml-parser: 5.7.0
   ip-address@10: 10.3.1
-  nanoid@3: 3.3.17
+  nanoid@3: 3.3.18
   typeorm: 0.3.31
   uuid@8: 11.1.1
   uuid@9: 11.1.1
@@ -9765,8 +9765,8 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -22468,7 +22468,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.3.6
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanostores@1.3.0: {}
 
@@ -23034,7 +23034,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -82,9 +82,10 @@ overrides:
   # vulnerabilities are all patched in 10.3.1.
   # load-bearing: socks and express-rate-limit resolve vulnerable 10.x versions.
   ip-address@10: 10.3.1
-  # GHSA-2v37-7h3g-55p8: nanoid 3.x predictable output is patched in 3.3.17.
-  # load-bearing: postcss resolves 3.3.16.
-  nanoid@3: 3.3.17
+  # ENG-2403 / GHSA-2v37-7h3g-55p8 (CVE-2026-67213): nanoid <3.3.18 customAlphabet/customRandom loop
+  # indefinitely when called with size 0 (DoS). Raises the 3.x pin from 3.3.17 to 3.3.18 (still <4).
+  # load-bearing: postcss resolves 3.3.17.
+  nanoid@3: 3.3.18
   # GHSA-9ggv-8w38-r7pm: @boxyhq/saml-jackson still resolves typeorm 0.3.28; patched in 0.3.29.
   # ENG-1990 / GHSA-2rp8-mm9q-fp49: typeorm <0.3.31 migration:generate template-literal code injection;
   # patched in 0.3.31.


### PR DESCRIPTION
## What & why

Daily Dependabot security sweep. One open Dependabot-sourced Linear issue survived triage (everything else in the `security` backlog is Done/Canceled or already covered by an open PR — see Triage notes below).

`nanoid`'s `customAlphabet`/`customRandom` functions spin in an infinite loop when called with `size: 0`, an unauthenticated denial-of-service (GHSA-2v37-7h3g-55p8 / CVE-2026-67213). This is the same advisory as the already-fixed alert #717 (ENG-2333), but GitHub raised the advisory's "first patched version" from 3.3.17 to 3.3.18 after that fix landed — so the repo's existing `nanoid@3: 3.3.17` override (added for #717) no longer closes it.

`nanoid` is not a direct dependency anywhere in the repo; it is pulled in transitively only through `postcss` (`postcss@8.5.23` → `nanoid@^3.3.16`). Raised the `nanoid@3` override in `pnpm-workspace.yaml` from `3.3.17` to `3.3.18` — the lowest version that closes the advisory — and updated its comment to match the file's existing convention.

## Batch table

| Package | Old version | New version | GHSA/CVE | Severity | Linear issue | Direct or override |
| --- | --- | --- | --- | --- | --- | --- |
| nanoid | 3.3.17 | 3.3.18 | GHSA-2v37-7h3g-55p8 / CVE-2026-67213 | High | ENG-2403 | Override (`pnpm-workspace.yaml`, transitive via `postcss`) |

### Triage notes (issues not included)

- Every other Dependabot-titled issue in the Engineering `security` backlog is already Done or Canceled.
- `pnpm audit` on `main` shows two other findings, both pre-existing accepted baseline, untouched by this PR: `brace-expansion` (tracked separately by ENG-2234) and `@better-auth/oauth-provider` (accepted finding, no patched stable release yet).
- An older open PR (#8797) also touches the `nanoid@3` override, but its own follow-up comment confirms that content (including the `3.3.17` nanoid pin) already landed on `main` via #8828/#8807, and it is expected to be closed as empty — it does not compete with or cover this bump to 3.3.18.

### Needs a human

None — this is a same-major, no-breaking-change patch bump to a transitive build-tooling dependency (`postcss`'s own `nanoid` range is `^3.3.16`, so 3.3.18 is within its accepted range).

## Linear ticket

Fixes ENG-2403

## How this was tested

- `pnpm install` — resolves `nanoid` to `3.3.18` everywhere in the lockfile (`pnpm why nanoid` shows a single resolved version, `postcss@8.5.23` → `nanoid@3.3.18`). ✅
- `pnpm audit` — the nanoid/GHSA-2v37-7h3g-55p8 finding is gone; only the two pre-existing accepted-baseline findings remain (`brace-expansion` / ENG-2234, `@better-auth/oauth-provider`). ✅
- `pnpm lint` — 21/21 tasks passed, 0 errors (46 pre-existing warnings, none new). ✅
- `pnpm test` — 6135 passed / 69 failed (106/609 test files failed). All failures are pre-existing and unrelated to this change: they're `Invalid environment variables` errors from `apps/web`'s env validation for secrets this sandbox doesn't have set (`ENCRYPTION_KEY`, `CUBEJS_API_SECRET`, `CUBEJS_API_URL`, `HUB_API_URL`, `HUB_API_KEY`, etc.) — no test failure references `nanoid`, `postcss`, or the changed files.
- `pnpm format` — no changes needed (`pnpm-workspace.yaml` reported unchanged). ✅
- No application code imports `nanoid` directly (`grep -rln "from ['"'"'"'"'"'"'"'"nanoid['"'"'"'"'"'"'"'"]"` over `apps/` and `packages/` returns nothing), so there is no runtime code path to exercise beyond the dependency resolution itself.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Run `pnpm why nanoid` on this branch → only `nanoid@3.3.18` is resolved, consumed solely via `postcss`.
- [ ] Run `pnpm audit` on this branch → GHSA-2v37-7h3g-55p8 (nanoid) is absent from the report.
- [ ] Build the app (`pnpm build`) and confirm PostCSS-based builds (Tailwind, Storybook, the surveys package) complete normally, since `postcss` is the only consumer of this transitive dependency.

**Preconditions / test data**

- None — this is a build-tooling dependency pin, not a runtime feature.

**Risks & regressions**

- Low risk: `nanoid` is used internally by `postcss` for generating short IDs during CSS processing, not by any Formbricks application code. `postcss@8.5.23` declares `nanoid: ^3.3.16`, so `3.3.18` is within its accepted range.

**Migrations / env / cutover**

- none


---
_Generated by [Claude Code](https://claude.ai/code/session_01ShcHiZhb8KdF5Lyk78BbEX)_