### PR TITLE
fix(surveys): reject script-capable schemes in survey link URLs [ENG-2411]

### DIFF
--- a/apps/web/app/api/v3/surveys/schemas.test.ts
+++ b/apps/web/app/api/v3/surveys/schemas.test.ts
@@ -219,6 +219,51 @@ describe("ZV3CreateSurveyBody", () => {
     });
   });
 
+  // Regression (ENG-2411): `buttonUrl` used to be validated with `z.url()`, which accepts any value
+  // `new URL()` parses — `javascript:` included — so a script-capable scheme reached the renderer, where
+  // it is handed to `window.open()`.
+  const ctaCreateBody = (buttonUrl: string) => ({
+    ...validCreateBody,
+    blocks: [
+      {
+        ...validCreateBody.blocks[0],
+        elements: [
+          {
+            id: "cta",
+            type: "cta",
+            headline: { "en-US": "Read the docs" },
+            required: false,
+            buttonExternal: true,
+            ctaButtonLabel: { "en-US": "Open" },
+            buttonUrl,
+          },
+        ],
+      },
+    ],
+  });
+
+  test.each([
+    "javascript:alert(document.domain)",
+    "JavaScript:alert(1)",
+    "java\tscript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+  ])("rejects a cta buttonUrl with the script-capable scheme %j", (buttonUrl) => {
+    const result = ZV3CreateSurveyBody.safeParse(ctaCreateBody(buttonUrl));
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path.join("."))).toContain(
+      "blocks.0.elements.0.buttonUrl"
+    );
+  });
+
+  test.each(["https://formbricks.com/docs", "http://localhost:3000/docs", "mailto:support@example.com"])(
+    "accepts a cta buttonUrl with the safe scheme %j",
+    (buttonUrl) => {
+      expect(ZV3CreateSurveyBody.safeParse(ctaCreateBody(buttonUrl)).success).toBe(true);
+    }
+  );
+
   test("rejects choice fields that do not belong to the selected element type", () => {
     const result = ZV3CreateSurveyBody.safeParse({
       ...validCreateBody,

--- a/apps/web/modules/email/components/preview-email-template.tsx
+++ b/apps/web/modules/email/components/preview-email-template.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   render,
 } from "@formbricks/email";
+import { isSafeLinkUrl } from "@formbricks/types/common";
 import {
   type TSurveyAddressElement,
   type TSurveyCTAElement,
@@ -448,27 +449,33 @@ export async function PreviewEmailTemplate({
       const ctaElement = firstQuestion as TSurveyCTAElement;
       return (
         <PreviewQuestionCard headline={headline} styleTokens={styleTokens} subheader={subheader} t={t}>
-          {ctaElement.buttonExternal && ctaElement.ctaButtonLabel && ctaElement.buttonUrl && (
-            <Section className="mt-4 text-left" style={{ textAlign: "left" }}>
-              <EmailButton
-                className={SECONDARY_BUTTON_CLASSNAME}
-                style={getPrimaryButtonStyle(styleTokens)}
-                href={ctaElement.buttonUrl}
-                target={PREVIEW_LINK_TARGET}>
-                {getLocalizedValue(ctaElement.ctaButtonLabel, defaultLanguageCode)}
-                <SquareArrowOutUpRightIcon
-                  color={styleTokens.buttonTextColor}
-                  size={16}
-                  strokeWidth={2}
-                  style={{
-                    display: "inline-block",
-                    marginLeft: "8px",
-                    verticalAlign: "text-bottom",
-                  }}
-                />
-              </EmailButton>
-            </Section>
-          )}
+          {/* `isSafeLinkUrl`: the button URL is an editable survey field, and drafts are persisted
+              without schema validation, so a stored value can carry a `javascript:` scheme. Rendering
+              it into an `href` would ship that payload inside the email preview. */}
+          {ctaElement.buttonExternal &&
+            ctaElement.ctaButtonLabel &&
+            ctaElement.buttonUrl &&
+            isSafeLinkUrl(ctaElement.buttonUrl) && (
+              <Section className="mt-4 text-left" style={{ textAlign: "left" }}>
+                <EmailButton
+                  className={SECONDARY_BUTTON_CLASSNAME}
+                  style={getPrimaryButtonStyle(styleTokens)}
+                  href={ctaElement.buttonUrl}
+                  target={PREVIEW_LINK_TARGET}>
+                  {getLocalizedValue(ctaElement.ctaButtonLabel, defaultLanguageCode)}
+                  <SquareArrowOutUpRightIcon
+                    color={styleTokens.buttonTextColor}
+                    size={16}
+                    strokeWidth={2}
+                    style={{
+                      display: "inline-block",
+                      marginLeft: "8px",
+                      verticalAlign: "text-bottom",
+                    }}
+                  />
+                </EmailButton>
+              </Section>
+            )}
         </PreviewQuestionCard>
       );
     }

--- a/packages/survey-ui/src/components/elements/cta.tsx
+++ b/packages/survey-ui/src/components/elements/cta.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Button } from "@/components/general/button";
 import { ElementError, getElementErrorAria } from "@/components/general/element-error";
 import { ElementHeader } from "@/components/general/element-header";
+import { isSafeLinkUrl } from "@/lib/url";
 
 /**
  * Props for the CTA (Call to Action) element component
@@ -66,8 +67,12 @@ function CTA({
     if (disabled) return;
     onClick();
 
-    if (buttonExternal && buttonUrl) {
-      window.open(buttonUrl, "_blank")?.focus();
+    // `isSafeLinkUrl` gate: `buttonUrl` is an editable survey field, and a `javascript:` value reaching
+    // `window.open()` executes on the survey's own origin. `noopener` is what keeps the opened tab from
+    // reaching back through `window.opener` into the authenticated page that opened it; it also makes
+    // `window.open` return null, so there is no handle left to `focus()`.
+    if (buttonExternal && buttonUrl && isSafeLinkUrl(buttonUrl)) {
+      window.open(buttonUrl, "_blank", "noopener,noreferrer");
     }
   };
 

--- a/packages/survey-ui/src/index.ts
+++ b/packages/survey-ui/src/index.ts
@@ -37,6 +37,7 @@ export { DateElement, type DateElementProps } from "@/components/elements/date";
 export { getDateFnsLocale } from "@/lib/locale";
 export { sanitizeSurveyHtml } from "@/lib/utils";
 export { isSafeMediaUrl } from "@/lib/video";
+export { isSafeLinkUrl } from "@/lib/url";
 export {
   PictureSelect,
   type PictureSelectProps,

--- a/packages/survey-ui/src/lib/url.test.ts
+++ b/packages/survey-ui/src/lib/url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { isSafeLinkUrl } from "./url";
+
+describe("isSafeLinkUrl", () => {
+  // Regression (ENG-2411): a CTA `buttonUrl` comes from an editable survey field and used to be handed
+  // straight to `window.open()`, where a `javascript:` URL executes on the survey's own origin.
+  test.each([
+    "javascript:alert(document.domain)",
+    "JavaScript:alert(1)",
+    // Obfuscated scheme: browsers strip the control character, so a `startsWith("javascript:")` check
+    // misses this while `new URL()` normalizes it back to `javascript:`.
+    "java\tscript:alert(1)",
+    "java\nscript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "file:///etc/passwd",
+    "blob:https://example.com/abc",
+    "not a url",
+    "",
+    // Relative and protocol-relative values are not absolute link targets; the caller has no base to
+    // resolve them against, and `//host` lands on another origin despite looking like a path.
+    "/relative/path",
+    "//attacker.example/file",
+  ])("rejects %j", (url) => {
+    expect(isSafeLinkUrl(url)).toBe(false);
+  });
+
+  test.each([
+    "https://example.com",
+    "http://example.com/path?a=b#c",
+    "http://localhost:3000/survey",
+    "mailto:hello@example.com",
+    "tel:+123456789",
+    // Leading/trailing whitespace is tolerated: it is trimmed before parsing, matching the schema.
+    "  https://example.com  ",
+  ])("accepts %j", (url) => {
+    expect(isSafeLinkUrl(url)).toBe(true);
+  });
+});

--- a/packages/survey-ui/src/lib/url.ts
+++ b/packages/survey-ui/src/lib/url.ts
@@ -1,0 +1,22 @@
+/**
+ * True when a stored survey link target is safe to hand to `window.open()` or `location.replace()`.
+ *
+ * `@formbricks/types` constrains the scheme of these fields, but the renderer must not depend on that
+ * alone: it is handed survey JSON from the API, and rows written before that validation landed — or
+ * through a write path that skips validation, as draft survey updates do — can still carry a
+ * `javascript:`, `data:` or `vbscript:` URL, which executes on the survey's own origin when navigated
+ * to.
+ *
+ * Parsing (rather than a prefix test) normalizes obfuscated schemes such as `java\tscript:`, which a
+ * `startsWith` check would wave through. Kept local rather than imported from `@formbricks/types`
+ * because this package deliberately carries no dependency on it — the same reason `isSafeMediaUrl`
+ * lives here.
+ */
+export const isSafeLinkUrl = (url: string): boolean => {
+  try {
+    const { protocol } = new URL(url.trim());
+    return protocol === "https:" || protocol === "http:" || protocol === "mailto:" || protocol === "tel:";
+  } catch {
+    return false;
+  }
+};

--- a/packages/surveys/src/components/elements/cta-element.tsx
+++ b/packages/surveys/src/components/elements/cta-element.tsx
@@ -1,6 +1,6 @@
 import { useState } from "preact/hooks";
 // Import as Cta to fix sonar issue - "Imported JSX component CTA must be in PascalCase"
-import { CTA as Cta } from "@formbricks/survey-ui";
+import { CTA as Cta, isSafeLinkUrl } from "@formbricks/survey-ui";
 import { type TResponseData, type TResponseTtc } from "@formbricks/types/responses";
 import type { TSurveyCTAElement } from "@formbricks/types/surveys/elements";
 import { getLocalizedValue } from "@/lib/i18n";
@@ -36,12 +36,17 @@ export function CTAElement({
     setTtc(updatedTtcObj);
     onChange({ [element.id]: "clicked" });
 
-    // Handle external URL opening if needed
-    if (element.buttonExternal && element.buttonUrl) {
-      if (onOpenExternalURL) {
+    // `onOpenExternalURL` is a host-supplied hook (e.g. a native bridge), and nothing documents that the
+    // URL it receives is pre-validated — so the scheme is checked here too, exactly as the ending card
+    // does before handing its redirect over. The survey-ui CTA opens the URL itself and applies the same
+    // check independently; both fire when a host supplies this callback, so gating only one leaves the
+    // raw value reaching the other.
+    if (element.buttonExternal && element.buttonUrl && onOpenExternalURL) {
+      if (isSafeLinkUrl(element.buttonUrl)) {
         onOpenExternalURL(element.buttonUrl);
+      } else {
+        console.error("Refusing to open an unsafe CTA button URL");
       }
-      // Note: The survey-ui CTA component handles external URL opening itself
     }
   };
 

--- a/packages/surveys/src/components/general/ending-card.tsx
+++ b/packages/surveys/src/components/general/ending-card.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "preact/hooks";
 import { useTranslation } from "react-i18next";
+import { isSafeLinkUrl } from "@formbricks/survey-ui";
 import { type TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { type TResponseData, type TResponseVariables } from "@formbricks/types/responses";
 import { type TSurveyEndScreenCard, type TSurveyRedirectUrlCard } from "@formbricks/types/surveys/types";
@@ -85,12 +86,18 @@ export function EndingCard({
     (urlString: string) => {
       try {
         const url = replaceRecallInfo(urlString, responseData, variablesData, languageCode);
-        if (url && new URL(url)) {
+        // The scheme has to be constrained, not just parseable: `new URL()` accepts `javascript:`, which
+        // executes on the survey's own origin once it reaches `location.replace()`. Recall values are
+        // substituted into the URL first, so the check has to run on the final string. Draft surveys are
+        // written without schema validation, so a stored link can carry an unsafe scheme.
+        if (url && isSafeLinkUrl(url)) {
           if (onOpenExternalURL) {
             onOpenExternalURL(url);
           } else {
             window.top?.location.replace(url);
           }
+        } else if (url) {
+          console.error("Refusing to redirect to an unsafe URL after recall processing");
         }
       } catch (error) {
         console.error("Invalid URL after recall processing:", error);

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -36,6 +36,27 @@ export const ZStorageUrl = z.string().refine(
   }
 );
 
+/**
+ * True when a user-authored link target is safe to hand to `window.open()`, `location.replace()` or an
+ * `href`.
+ *
+ * `z.url()` only checks that the value parses as a URL, and `new URL()` happily accepts `javascript:`,
+ * `data:` and `vbscript:` — so validating a link field with `z.url()` turns it into stored XSS. Parsing
+ * (rather than a prefix/regex test) also normalizes obfuscated schemes such as `java\tscript:`, which a
+ * `startsWith` check would wave through.
+ *
+ * The scheme set is an allowlist: `http`/`https` for web links, plus `mailto` and `tel`, which are
+ * legitimate CTA targets, cannot execute script, and are already tolerated by `safeUrlRefinement`.
+ */
+export const isSafeLinkUrl = (url: string): boolean => {
+  try {
+    const { protocol } = new URL(url.trim());
+    return protocol === "https:" || protocol === "http:" || protocol === "mailto:" || protocol === "tel:";
+  } catch {
+    return false;
+  }
+};
+
 export const ZNumber = z.number();
 
 export const ZOptionalNumber = z.number().optional();

--- a/packages/types/surveys/elements.ts
+++ b/packages/types/surveys/elements.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ZStorageUrl, ZUrl } from "../common";
+import { ZStorageUrl, isSafeLinkUrl } from "../common";
 import { ZI18nString } from "../i18n";
 import { ZAllowedFileExtension } from "../storage";
 import { TSurveyElementTypeEnum } from "./constants";
@@ -204,16 +204,16 @@ export const ZSurveyCTAElement = ZSurveyElementBase.extend({
         message: "Button URL is required when external button is enabled",
         path: ["buttonUrl"],
       });
-    } else {
-      // Validate URL format only when buttonExternal is true and URL is provided
-      const urlValidation = ZUrl.safeParse(data.buttonUrl);
-      if (!urlValidation.success) {
-        ctx.addIssue({
-          code: "custom",
-          message: "Please enter a valid URL",
-          path: ["buttonUrl"],
-        });
-      }
+    } else if (!isSafeLinkUrl(data.buttonUrl)) {
+      // Validate URL format only when buttonExternal is true and URL is provided. The scheme has to be
+      // constrained, not just parseable: the renderer hands this value to `window.open()`, so accepting
+      // any `z.url()`-parseable value (which includes `javascript:`) made an editable survey field
+      // stored XSS — on a link survey that executes on the Formbricks origin.
+      ctx.addIssue({
+        code: "custom",
+        message: "Please enter a valid http(s), mailto: or tel: URL",
+        path: ["buttonUrl"],
+      });
     }
 
     if (!data.ctaButtonLabel?.default || data.ctaButtonLabel.default.trim() === "") {


### PR DESCRIPTION
## What & why

A CTA element's `buttonUrl` was validated with `ZUrl` (`z.url()`), which only checks that the value parses as a URL. `new URL()` accepts `javascript:`, `data:` and `vbscript:`, so `z.url().safeParse("javascript:alert(1)")` returns `success: true`. The renderer then hands that value straight to `window.open()` (`packages/survey-ui/src/components/elements/cta.tsx`) — stored XSS executing on the survey's own origin.

The inbound report describes this as reachable only through the draft skip-validation path (`updateSurveyInternal(survey, true)`), with a collaborator clicking the CTA in the editor preview. That path is real, but it is not the only one: because the scheme was never constrained, the payload also survives the **fully validated** path and `/api/v3/surveys`, which reuses `ZSurveyBlocks` from `@formbricks/types`. A published **link survey** can therefore carry the payload for every respondent, which is a wider blast radius than the editor preview.

<img width="1269" height="737" alt="Screenshot 2026-08-17 at 4 56 30 PM" src="https://github.com/user-attachments/assets/b5884990-998b-4f81-8857-e96c6ed4b5d3" />


Changes:

- `packages/types/common.ts` — new `isSafeLinkUrl()`: parses with `new URL()` and allowlists the scheme (`http`, `https`, `mailto`, `tel`). Parsing rather than a prefix test normalizes obfuscated schemes such as `java\tscript:`, which a `startsWith` check waves through. `mailto:`/`tel:` are kept because they are legitimate CTA targets that cannot execute script — a shipped template (`mailto:ceo@company.com`) relies on `mailto:`.
- `packages/types/surveys/elements.ts` — `ZSurveyCTAElement.buttonUrl` uses `isSafeLinkUrl` instead of `ZUrl`. This covers the editor's validated save path and every `/api/v3/surveys` write, since both parse through `ZSurveyBlocks`.
- `packages/survey-ui/src/lib/url.ts` (new) — the renderer-side twin of the same check. Kept local to the package rather than imported from `@formbricks/types` because `survey-ui` deliberately carries no dependency on it — the same reason `isSafeMediaUrl` lives there. Needed as defence in depth: the renderer is handed survey JSON from the API, so rows written before this validation landed, or through the draft path that skips validation, must not execute either.
- `packages/survey-ui/src/components/elements/cta.tsx` — gate `window.open()` on `isSafeLinkUrl`, and pass `noopener,noreferrer`. `noopener` is what removes the `window.opener` handle the reporter used to reach back into the authenticated page; it also makes `window.open` return `null`, so the now-pointless `?.focus()` is dropped.
- `packages/surveys/src/components/general/ending-card.tsx` — the sibling sink: `processAndRedirect` only checked `new URL(url)` was constructible before calling `window.top.location.replace(url)`, so a `javascript:` ending link executed the same way. Gated on the same check, applied *after* recall substitution so the final string is what gets validated.
- `apps/web/modules/email/components/preview-email-template.tsx` — the CTA button is rendered with `href={ctaElement.buttonUrl}`; skip the button entirely when the stored URL is unsafe.

## Linear ticket

Fixes ENG-2411

## How this was tested

### Regression proof

| Test | Tier | On main | Here |
| --- | --- | --- | --- |
| `rejects a cta buttonUrl with the script-capable scheme %j` — 5 cases: `javascript:`, `JavaScript:`, `java\tscript:`, `data:`, `vbscript:` (`apps/web/app/api/v3/surveys/schemas.test.ts`) | red on main | ❌ all 5 accepted — `ZUrl = z.url()` parses every one of them (checked against the repo's zod 4.3.6) | ✅ rejected, issue on `blocks.0.elements.0.buttonUrl` |
| `accepts a cta buttonUrl with the safe scheme %j` — 3 cases: `https:`, `http://localhost`, `mailto:` | guard | ✅ | ✅ |
| `rejects %j` — 12 cases over `isSafeLinkUrl` (`packages/survey-ui/src/lib/url.test.ts`) | mutation | ❌ all 12 accepted | ✅ |
| `accepts %j` — 6 cases incl. `mailto:`, `tel:`, whitespace-padded | guard | ✅ | ✅ |

**How the tiers were proven.** *Red on main:* `schemas.test.ts` runs unchanged against `main`, where
`ZSurveyCTAElement.buttonUrl` is validated with `ZUrl` (`z.url()`) — so the payload parses as valid and
the five rejection cases fail.

```bash
git stash push -- packages/types/surveys/elements.ts packages/types/common.ts
pnpm test apps/web/app/api/v3/surveys/schemas.test.ts                    # 5 failed
git stash pop && pnpm test apps/web/app/api/v3/surveys/schemas.test.ts   # 8 passed
```

*Mutation:* `packages/survey-ui/src/lib/url.ts` is a new file, so `url.test.ts` cannot run against
`main` at all — it fails on a missing import, which proves nothing about the bug. Proven instead by
relaxing the allowlist in `url.ts` to accept anything `new URL()` parses, i.e. the pre-fix behaviour:
all 12 rejection cases go red.

*Guard:* passes either way. Pins the schemes that must keep working — `mailto:` is used by a shipped
template — rather than evidencing the bug.

### Coverage

| Behaviour | How | Outcome |
| --- | --- | --- |
| Script schemes refused at the API boundary | unit — red on main | `400`, issue on `blocks.0.elements.0.buttonUrl` |
| Script schemes refused in the renderer | unit (mutation) + manual | `window.open` never called; no alert in editor preview |
| Obfuscated scheme (`java\tscript:`) normalized, not prefix-matched | unit — red on main | rejected |
| `mailto:` / `tel:` still accepted | unit + manual | mail client and dialler open |
| Ending-card redirect gated after recall substitution | manual | no navigation, console logs the refusal |
| Email preview drops an unsafe CTA button | manual | question renders without the button |
| `window.opener` removed on a valid CTA | manual | `null` in the opened tab |

Full suite: `pnpm test` → 26/26 tasks, apps/web 609 files / 8021 tests passed; survey-ui 108, surveys
668. `pnpm lint` 21/21 (0 errors, 46 pre-existing warnings, none in touched files), `pnpm typecheck`
27/27, `pnpm format:check` clean, `pnpm install` lockfile unchanged.

Per `AGENTS.md` (no component unit tests for `.tsx`), the three renderer sinks are not unit tested.

No UI change: the fix removes a link target that should never have been accepted. The CTA button
renders identically for every valid URL; only its `window.open` call gained `noopener,noreferrer`.

### Open gaps

- **The two copies of `isSafeLinkUrl` are not pinned to each other.** `packages/types/common.ts` and
  `packages/survey-ui/src/lib/url.ts` carry identical bodies for a deliberate reason (survey-ui has no
  dependency on types), but only the survey-ui copy has direct tests, and `packages/types` has no test
  runner at all — no `*.test.ts`, no vitest config. The types-side helper is covered only indirectly,
  through `schemas.test.ts`. If one copy is later relaxed, nothing goes red for the other.
- **No automated coverage of the three renderer sinks.** No Playwright spec touches `buttonUrl` or the
  redirect ending, so the editor-preview, ending-card and email paths rest on the manual runs above.
- **Existing rows with unsafe schemes were not surveyed.** The fix refuses them going forward and the
  renderer refuses to navigate to them, but no query was run against production data to see whether any
  already exist.

## Breaking changes

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| CTA element `buttonUrl` scheme validation | Any value `new URL()` could parse was accepted, including `javascript:`, `data:`, `ftp:` | Only `http:`, `https:`, `mailto:` and `tel:` are accepted; anything else is a `400` with the issue on the element's `buttonUrl` | API v3 (`POST`/`PATCH /api/v3/surveys`) and API v1 management consumers that set a CTA button URL with a non-web scheme | Send an `http(s)`, `mailto:` or `tel:` URL. Existing surveys are untouched until their next write; if one stores an unsupported scheme, the CTA button now renders without opening it |

## QA / Test Plan

**How to test**

- [ ] Create a survey, add a **CTA** element, enable the external-button toggle, set Button URL to `https://formbricks.com/docs` and a button label → survey saves and publishes as before; opening the survey and clicking the CTA opens the docs in a new tab.
- [ ] In the same CTA, replace the Button URL with `javascript:alert(document.domain)` and try to publish the survey → publishing is refused with a validation error naming the button URL. Before this change it published successfully.
- [ ] Save that same `javascript:` URL while the survey is still a **draft** (drafts are saved without validation, so this still persists), then open the survey editor **preview** and click the CTA button → nothing happens; no alert dialog appears and no new tab opens. Before this change the alert fired inside the authenticated editor.
- [ ] With a valid `https://` CTA, click the button in the live survey and inspect the opened tab's console: `window.opener` is `null` → the opened page cannot reach back into the survey page.
- [ ] Set a CTA Button URL to `mailto:support@example.com`, publish, and click the button → the mail client opens. Repeat with `tel:+123456789` → the dialler opens. Both must keep working.
- [ ] Add an **ending card** of type "Redirect to URL", save it as a draft with `javascript:alert(1)` as the URL, then complete the survey → the survey does not navigate and no alert appears (a "Refusing to redirect to an unsafe URL" line is logged to the browser console). With a normal `https://` URL, the redirect still happens on completion.
- [ ] Send the "email embed" survey preview for a survey whose CTA has a valid `https://` URL → the email shows the CTA button and it links to that URL. For a draft-stored `javascript:` URL, the email renders the question without the CTA button rather than a clickable payload.
- [ ] `POST /api/v3/surveys` with a `cta` element whose `buttonUrl` is `data:text/html,<script>alert(1)</script>` → `400`, with the invalid param pointing at `blocks.0.elements.0.buttonUrl`. The same request with `https://example.com` → `201`.

**Preconditions / test data**

- Two accounts in one workspace with `readWrite` (organization) or Editor (project) access, to reproduce the reporter's collaborator-to-collaborator scenario on a shared draft.
- External CTA URLs are plan-gated (`checkExternalUrlsPermission`): use an organization entitled to external URLs, or the enterprise licence/Cloud plan that grants it, otherwise the save is refused for billing reasons before validation is reached.
- Works on both Cloud and self-hosted; no feature flag involved.
- An API key with survey write scope for the `/api/v3/surveys` step.

**Risks & regressions**

- Narrowed input validation is the main risk: any pre-existing survey whose CTA URL uses a scheme outside `http`/`https`/`mailto`/`tel` will now fail validation on its next non-draft save. Worth a check for stored `buttonUrl` values with unusual schemes before release. The `mailto:ceo@company.com` shipped template was verified as still valid.
- `window.open` gained `noopener`, so it now returns `null`. Nothing else in the CTA path used that return value, but the button's "opens a new tab and focuses it" behavior is worth a click-through — the tab still opens, the browser simply owns focus.
- The ending-card guard runs after recall substitution, so a redirect URL built from recall/hidden-field values is re-checked at click time. Verify a legitimate ending redirect with a recall value in the query string still navigates.
- Both `packages/survey-ui` and `packages/surveys` changed, and `@formbricks/surveys` ships as a prebuilt bundle served from `apps/web/public/js/`. QA needs a build that includes the rebuilt bundle and a hard refresh, otherwise a cached `surveys.umd.cjs` will still show the old behavior.

**Migrations / env / cutover**

- none
