### PR TITLE
fix(security): scope response file deletion to the owning workspace [ENG-2291]

### DIFF
--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
-import { logger } from "@formbricks/logger";
 import { ZId, ZOptionalNumber, ZString } from "@formbricks/types/common";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import {
@@ -22,8 +21,8 @@ import { TTag } from "@formbricks/types/tags";
 import { getElementsFromBlocks } from "@/lib/survey/utils";
 import { getIsQuotasEnabled } from "@/modules/ee/license-check/lib/utils";
 import { reduceQuotaLimits } from "@/modules/ee/quotas/lib/quotas";
-import { deleteFile } from "@/modules/storage/service";
-import { parseStorageFileUrl, resolveStorageUrlsInObject } from "@/modules/storage/utils";
+import { deleteResponseFileUrls } from "@/modules/storage/lib/delete-response-files";
+import { resolveStorageUrlsInObject } from "@/modules/storage/utils";
 import { getOrganizationIdFromWorkspaceId } from "@/modules/survey/lib/organization";
 import { getOrganizationBilling } from "@/modules/survey/lib/survey";
 import { ITEMS_PER_PAGE } from "../constants";
@@ -643,26 +642,7 @@ const findAndDeleteUploadedFilesInResponse = async (response: TResponse, survey:
     .filter(([elementId]) => fileUploadElements.has(elementId))
     .flatMap(([, elementResponse]) => elementResponse as string[]);
 
-  const deletionPromises = fileUrls.map(async (fileUrl) => {
-    try {
-      const storageFile = parseStorageFileUrl(fileUrl);
-
-      if (!storageFile) {
-        throw new Error(`Invalid storage file URL: ${fileUrl}`);
-      }
-
-      return deleteFile(
-        storageFile.storageId,
-        storageFile.accessType,
-        storageFile.fileName,
-        survey.workspaceId
-      );
-    } catch (error) {
-      logger.error(error, `Failed to delete file ${fileUrl}`);
-    }
-  });
-
-  await Promise.all(deletionPromises);
+  await deleteResponseFileUrls(fileUrls, survey.workspaceId);
 };
 
 export const deleteResponse = async (

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/utils.test.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/utils.test.ts
@@ -2,6 +2,7 @@ import { fileUploadQuestion, openTextQuestion, responseData, workspaceId } from 
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { logger } from "@formbricks/logger";
 import { okVoid } from "@formbricks/types/error-handlers";
+import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
 import { deleteFile } from "@/modules/storage/service";
 import { findAndDeleteUploadedFilesInResponse } from "../utils";
 
@@ -11,6 +12,10 @@ vi.mock("@formbricks/logger", () => ({
   },
 }));
 
+vi.mock("@/lib/utils/resolve-client-id", () => ({
+  findWorkspaceByIdOrLegacyEnvId: vi.fn(),
+}));
+
 vi.mock("@/modules/storage/service", () => ({
   deleteFile: vi.fn(),
 }));
@@ -18,21 +23,48 @@ vi.mock("@/modules/storage/service", () => ({
 describe("findAndDeleteUploadedFilesInResponse", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: every storage id resolves back to the survey's own workspace, so deletion is authorized.
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValue({
+      id: workspaceId,
+      organizationId: "org-1",
+    });
+    vi.mocked(deleteFile).mockResolvedValue({ ok: true, data: undefined });
   });
 
   test("delete files for file upload questions and return okVoid", async () => {
-    vi.mocked(deleteFile).mockResolvedValue({ ok: true, data: undefined });
-
-    const result = await findAndDeleteUploadedFilesInResponse(responseData, [fileUploadQuestion]);
+    const result = await findAndDeleteUploadedFilesInResponse(
+      responseData,
+      [fileUploadQuestion],
+      workspaceId
+    );
 
     expect(deleteFile).toHaveBeenCalledTimes(2);
-    expect(deleteFile).toHaveBeenCalledWith(workspaceId, "private", "file1.png", undefined);
-    expect(deleteFile).toHaveBeenCalledWith(workspaceId, "private", "file2.pdf", undefined);
+    expect(deleteFile).toHaveBeenCalledWith(workspaceId, "private", "file1.png", workspaceId);
+    expect(deleteFile).toHaveBeenCalledWith(workspaceId, "private", "file2.pdf", workspaceId);
     expect(result).toEqual(okVoid());
   });
 
   test("not call deleteFile if no file upload questions match response data", async () => {
-    const result = await findAndDeleteUploadedFilesInResponse(responseData, [openTextQuestion]);
+    const result = await findAndDeleteUploadedFilesInResponse(responseData, [openTextQuestion], workspaceId);
+
+    expect(deleteFile).not.toHaveBeenCalled();
+    expect(result).toEqual(okVoid());
+  });
+
+  // A planted URL pointing into another tenant's storage prefix must not be deleted, even though the
+  // survey now lists a file-upload question whose id matches the planted response key (the TOCTOU).
+  test("refuse to delete a file whose storage id belongs to a different workspace", async () => {
+    const foreignWorkspaceId = "foreign-workspace-id";
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValue({
+      id: foreignWorkspaceId,
+      organizationId: "org-2",
+    });
+
+    const plantedData = {
+      [fileUploadQuestion.id]: [`https://example.com/storage/${foreignWorkspaceId}/public/victim.png`],
+    };
+
+    const result = await findAndDeleteUploadedFilesInResponse(plantedData, [fileUploadQuestion], workspaceId);
 
     expect(deleteFile).not.toHaveBeenCalled();
     expect(result).toEqual(okVoid());
@@ -40,13 +72,17 @@ describe("findAndDeleteUploadedFilesInResponse", () => {
 
   test("handle invalid file URLs and log errors", async () => {
     const invalidFileUrl = "https://example.com/invalid-url";
-    const responseData = {
+    const invalidResponseData = {
       [fileUploadQuestion.id]: [invalidFileUrl],
     };
 
     const loggerSpy = vi.spyOn(logger, "error");
 
-    const result = await findAndDeleteUploadedFilesInResponse(responseData, [fileUploadQuestion]);
+    const result = await findAndDeleteUploadedFilesInResponse(
+      invalidResponseData,
+      [fileUploadQuestion],
+      workspaceId
+    );
 
     expect(deleteFile).not.toHaveBeenCalled();
     expect(loggerSpy).toHaveBeenCalled();
@@ -56,13 +92,15 @@ describe("findAndDeleteUploadedFilesInResponse", () => {
   });
 
   test("process multiple file URLs", async () => {
-    vi.mocked(deleteFile).mockResolvedValue({ ok: true, data: undefined });
-
-    const result = await findAndDeleteUploadedFilesInResponse(responseData, [fileUploadQuestion]);
+    const result = await findAndDeleteUploadedFilesInResponse(
+      responseData,
+      [fileUploadQuestion],
+      workspaceId
+    );
 
     expect(deleteFile).toHaveBeenCalledTimes(2);
-    expect(deleteFile).toHaveBeenNthCalledWith(1, workspaceId, "private", "file1.png", undefined);
-    expect(deleteFile).toHaveBeenNthCalledWith(2, workspaceId, "private", "file2.pdf", undefined);
+    expect(deleteFile).toHaveBeenCalledWith(workspaceId, "private", "file1.png", workspaceId);
+    expect(deleteFile).toHaveBeenCalledWith(workspaceId, "private", "file2.pdf", workspaceId);
     expect(result).toEqual(okVoid());
   });
 });

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/utils.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/utils.ts
@@ -1,10 +1,8 @@
 import { Response, Survey } from "@formbricks/database/prisma";
-import { logger } from "@formbricks/logger";
 import { Result, okVoid } from "@formbricks/types/error-handlers";
 import { TSurveyQuestionTypeEnum } from "@formbricks/types/surveys/types";
 import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
-import { deleteFile } from "@/modules/storage/service";
-import { parseStorageFileUrl } from "@/modules/storage/utils";
+import { deleteResponseFileUrls } from "@/modules/storage/lib/delete-response-files";
 
 export const findAndDeleteUploadedFilesInResponse = async (
   responseData: Response["data"],
@@ -23,20 +21,7 @@ export const findAndDeleteUploadedFilesInResponse = async (
     .filter(([questionId]) => fileUploadQuestions.has(questionId))
     .flatMap(([, questionResponse]) => questionResponse as string[]);
 
-  const deletionPromises = fileUrls.map(async (fileUrl) => {
-    try {
-      const storageFile = parseStorageFileUrl(fileUrl);
-
-      if (!storageFile) {
-        throw new Error(`Invalid storage file URL: ${fileUrl}`);
-      }
-      return deleteFile(storageFile.storageId, storageFile.accessType, storageFile.fileName, workspaceId);
-    } catch (error) {
-      logger.error({ error, fileUrl }, "Failed to delete file");
-    }
-  });
-
-  await Promise.all(deletionPromises);
+  await deleteResponseFileUrls(fileUrls, workspaceId);
 
   return okVoid();
 };

--- a/apps/web/modules/storage/lib/delete-response-files.test.ts
+++ b/apps/web/modules/storage/lib/delete-response-files.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { logger } from "@formbricks/logger";
 import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
 import { deleteFile } from "@/modules/storage/service";
 import { deleteResponseFileUrls } from "./delete-response-files";
@@ -98,5 +99,32 @@ describe("deleteResponseFileUrls", () => {
 
     expect(mockedDeleteFile).toHaveBeenCalledTimes(1);
     expect(mockedDeleteFile).toHaveBeenCalledWith(OWN_WORKSPACE, "private", "mine.png", OWN_WORKSPACE);
+  });
+
+  // deleteFile returns an error result instead of throwing, so a failed storage deletion must still be
+  // logged — otherwise a leftover object looks like a clean success.
+  test("logs when deleteFile returns a failure result", async () => {
+    mockedResolve.mockResolvedValue({ id: OWN_WORKSPACE, organizationId: "org-1" });
+    mockedDeleteFile.mockResolvedValue({ ok: false, error: { code: "s3_client_error" } } as any);
+
+    await deleteResponseFileUrls([`/storage/${OWN_WORKSPACE}/private/answer.png`], OWN_WORKSPACE);
+
+    expect(mockedDeleteFile).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ error: { code: "s3_client_error" } }),
+      "Failed to delete a response file from storage"
+    );
+  });
+
+  test("resolves each distinct storage id only once for multiple files under it", async () => {
+    mockedResolve.mockResolvedValue({ id: OWN_WORKSPACE, organizationId: "org-1" });
+
+    await deleteResponseFileUrls(
+      [`/storage/${OWN_WORKSPACE}/private/one.png`, `/storage/${OWN_WORKSPACE}/private/two.png`],
+      OWN_WORKSPACE
+    );
+
+    expect(mockedResolve).toHaveBeenCalledTimes(1);
+    expect(mockedDeleteFile).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/modules/storage/lib/delete-response-files.test.ts
+++ b/apps/web/modules/storage/lib/delete-response-files.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
+import { deleteFile } from "@/modules/storage/service";
+import { deleteResponseFileUrls } from "./delete-response-files";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/utils/resolve-client-id", () => ({
+  findWorkspaceByIdOrLegacyEnvId: vi.fn(),
+}));
+
+vi.mock("@/modules/storage/service", () => ({
+  deleteFile: vi.fn(),
+}));
+
+const mockedResolve = vi.mocked(findWorkspaceByIdOrLegacyEnvId);
+const mockedDeleteFile = vi.mocked(deleteFile);
+
+const OWN_WORKSPACE = "ws-own";
+const FOREIGN_WORKSPACE = "ws-victim";
+
+describe("deleteResponseFileUrls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedDeleteFile.mockResolvedValue({ ok: true, data: undefined } as any);
+  });
+
+  test("deletes a file whose URL storage id belongs to the survey's workspace", async () => {
+    mockedResolve.mockResolvedValue({ id: OWN_WORKSPACE, organizationId: "org-1" });
+
+    await deleteResponseFileUrls([`/storage/${OWN_WORKSPACE}/private/answer.png`], OWN_WORKSPACE);
+
+    expect(mockedDeleteFile).toHaveBeenCalledTimes(1);
+    expect(mockedDeleteFile).toHaveBeenCalledWith(OWN_WORKSPACE, "private", "answer.png", OWN_WORKSPACE);
+  });
+
+  // The core cross-tenant guard: a planted URL pointing into another tenant's storage prefix must not be
+  // deleted, even though it survived write-time validation via the element-id flip TOCTOU.
+  test("refuses to delete a planted URL that resolves to a different workspace", async () => {
+    mockedResolve.mockResolvedValue({ id: FOREIGN_WORKSPACE, organizationId: "org-2" });
+
+    await deleteResponseFileUrls([`/storage/${FOREIGN_WORKSPACE}/public/bg--fid--uuid.png`], OWN_WORKSPACE);
+
+    expect(mockedDeleteFile).not.toHaveBeenCalled();
+  });
+
+  // Legacy uploads were prefixed with the environment id; the resolver maps that back to the owning
+  // workspace, so a same-workspace legacy prefix is still deletable — using its real (legacy) prefix.
+  test("allows a legacy environment-id prefix that maps back to the survey's workspace", async () => {
+    const legacyEnvId = "env-legacy";
+    mockedResolve.mockResolvedValue({ id: OWN_WORKSPACE, organizationId: "org-1" });
+
+    await deleteResponseFileUrls([`/storage/${legacyEnvId}/private/old.png`], OWN_WORKSPACE);
+
+    expect(mockedResolve).toHaveBeenCalledWith(legacyEnvId);
+    expect(mockedDeleteFile).toHaveBeenCalledWith(legacyEnvId, "private", "old.png", OWN_WORKSPACE);
+  });
+
+  test("refuses when the storage id resolves to no workspace", async () => {
+    mockedResolve.mockResolvedValue(null);
+
+    await deleteResponseFileUrls(["/storage/ws-unknown/public/x.png"], OWN_WORKSPACE);
+
+    expect(mockedDeleteFile).not.toHaveBeenCalled();
+  });
+
+  test("deletes nothing and never resolves when no survey workspace id is given", async () => {
+    await deleteResponseFileUrls([`/storage/${OWN_WORKSPACE}/private/answer.png`], undefined);
+
+    expect(mockedResolve).not.toHaveBeenCalled();
+    expect(mockedDeleteFile).not.toHaveBeenCalled();
+  });
+
+  test("skips an unparseable URL without throwing", async () => {
+    await deleteResponseFileUrls(["not-a-storage-url"], OWN_WORKSPACE);
+
+    expect(mockedResolve).not.toHaveBeenCalled();
+    expect(mockedDeleteFile).not.toHaveBeenCalled();
+  });
+
+  test("in a mixed batch, deletes the owned file and refuses the foreign one", async () => {
+    mockedResolve.mockImplementation(async (id: string) =>
+      id === OWN_WORKSPACE
+        ? { id: OWN_WORKSPACE, organizationId: "org-1" }
+        : { id: id, organizationId: "org-2" }
+    );
+
+    await deleteResponseFileUrls(
+      [`/storage/${OWN_WORKSPACE}/private/mine.png`, `/storage/${FOREIGN_WORKSPACE}/public/theirs.png`],
+      OWN_WORKSPACE
+    );
+
+    expect(mockedDeleteFile).toHaveBeenCalledTimes(1);
+    expect(mockedDeleteFile).toHaveBeenCalledWith(OWN_WORKSPACE, "private", "mine.png", OWN_WORKSPACE);
+  });
+});

--- a/apps/web/modules/storage/lib/delete-response-files.ts
+++ b/apps/web/modules/storage/lib/delete-response-files.ts
@@ -31,6 +31,18 @@ export const deleteResponseFileUrls = async (
     return;
   }
 
+  // Several files in one response usually share a storage id (same survey/workspace prefix). Cache the
+  // resolution promise per id so the batch does one lookup per distinct id instead of one per file.
+  const workspaceByStorageId = new Map<string, ReturnType<typeof findWorkspaceByIdOrLegacyEnvId>>();
+  const resolveStorageWorkspace = (storageId: string) => {
+    const cached = workspaceByStorageId.get(storageId);
+    if (cached) return cached;
+
+    const pending = findWorkspaceByIdOrLegacyEnvId(storageId);
+    workspaceByStorageId.set(storageId, pending);
+    return pending;
+  };
+
   await Promise.all(
     fileUrls.map(async (fileUrl) => {
       try {
@@ -40,7 +52,7 @@ export const deleteResponseFileUrls = async (
           throw new Error(`Invalid storage file URL: ${fileUrl}`);
         }
 
-        const storageWorkspace = await findWorkspaceByIdOrLegacyEnvId(storageFile.storageId);
+        const storageWorkspace = await resolveStorageWorkspace(storageFile.storageId);
         if (storageWorkspace?.id !== surveyWorkspaceId) {
           logger.error(
             { fileUrl, surveyWorkspaceId, storageId: storageFile.storageId },
@@ -49,12 +61,20 @@ export const deleteResponseFileUrls = async (
           return;
         }
 
-        await deleteFile(
+        // deleteFile returns an error result (it does not throw) on S3 failures, so a discarded result
+        // would treat a failed deletion as a success and leave the object behind unlogged.
+        const result = await deleteFile(
           storageFile.storageId,
           storageFile.accessType,
           storageFile.fileName,
           surveyWorkspaceId
         );
+        if (!result.ok) {
+          logger.error(
+            { fileUrl, surveyWorkspaceId, error: result.error },
+            "Failed to delete a response file from storage"
+          );
+        }
       } catch (error) {
         logger.error({ error, fileUrl }, "Failed to delete file");
       }

--- a/apps/web/modules/storage/lib/delete-response-files.ts
+++ b/apps/web/modules/storage/lib/delete-response-files.ts
@@ -1,0 +1,63 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
+import { deleteFile } from "@/modules/storage/service";
+import { parseStorageFileUrl } from "@/modules/storage/utils";
+
+/**
+ * Deletes the storage objects a response's file-upload answers point at, restricted to the survey's own
+ * workspace.
+ *
+ * The file URLs come out of `response.data`, i.e. from whoever wrote the response, and the S3 key is
+ * built from the id in the *URL* rather than the survey's workspace. Write-time validation
+ * (`validateClientFileUploads` -> `isScopedPrivateUploadUrl`) does pin uploaded URLs to the survey's
+ * workspace, but it only inspects keys that match a file-upload element that exists *at write time*. A
+ * caller can therefore plant a foreign URL under a key that is not yet an element, then edit the survey
+ * to turn that key into a file-upload element — a time-of-check/time-of-use gap that makes the planted,
+ * unvalidated URL look like a real answer at delete time.
+ *
+ * So the delete side cannot trust the URL's id. Re-resolve each URL's storage id here and drop anything
+ * that does not belong to this survey's workspace, regardless of which write path produced the data. The
+ * id may be a workspace id or a legacy environment id (older uploads were prefixed with the environment
+ * id), which is why it goes through `findWorkspaceByIdOrLegacyEnvId` rather than a plain string compare.
+ */
+export const deleteResponseFileUrls = async (
+  fileUrls: string[],
+  surveyWorkspaceId: string | undefined
+): Promise<void> => {
+  if (!surveyWorkspaceId) {
+    // Without the owning workspace there is nothing to authorize against, so delete nothing.
+    logger.error({ fileCount: fileUrls.length }, "Skipping response file deletion: no workspace id given");
+    return;
+  }
+
+  await Promise.all(
+    fileUrls.map(async (fileUrl) => {
+      try {
+        const storageFile = parseStorageFileUrl(fileUrl);
+
+        if (!storageFile) {
+          throw new Error(`Invalid storage file URL: ${fileUrl}`);
+        }
+
+        const storageWorkspace = await findWorkspaceByIdOrLegacyEnvId(storageFile.storageId);
+        if (storageWorkspace?.id !== surveyWorkspaceId) {
+          logger.error(
+            { fileUrl, surveyWorkspaceId, storageId: storageFile.storageId },
+            "Refusing to delete a response file stored outside the survey's workspace"
+          );
+          return;
+        }
+
+        await deleteFile(
+          storageFile.storageId,
+          storageFile.accessType,
+          storageFile.fileName,
+          surveyWorkspaceId
+        );
+      } catch (error) {
+        logger.error({ error, fileUrl }, "Failed to delete file");
+      }
+    })
+  );
+};


### PR DESCRIPTION
Ref ENG-2291 — [[Security] Cross-tenant storage object deletion via planted response data key](https://linear.app/formbricks/issue/ENG-2291/security-cross-tenant-storage-object-deletion-via-planted-response)

> [!IMPORTANT]
> Showcase duplicate of PR 8861 — do not merge. Same diff, kept open to test the PR template.

## What & why

Deleting a response could delete a storage object belonging to a **different workspace**. The storage
key for each file was rebuilt from the id in the **file URL**, and nothing on the delete path tied
that file to the survey's own workspace. Write-time validation does pin uploaded URLs to the
workspace, but only for response keys matching a file-upload element present at write time — so a URL
stored outside that check could later be treated as a real answer and deleted.

**Fix.** New helper `deleteResponseFileUrls` re-resolves each URL's storage id against the owning
survey's workspace and skips anything that resolves outside it. Both deletion sites — legacy
`lib/response/service.ts` (UI and v1) and the v2 management path — now go through it, so no
caller-supplied storage id is trusted. Two follow-ups from review: a failed storage delete is logged
instead of counted as a success, and workspace lookups are cached per storage id.

<details>
<summary>Why this wasn't caught earlier</summary>

Restores the delete-side scoping written in abandoned PR #8667 — closed when that large review branch
was split by severity, and this hunk was dropped on the assumption that the write-side binding
already covered it. Exploit path and severity stay in the Linear ticket, per `SECURITY.md` §III.C.

</details>

## Breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Planted cross-workspace URL refused, v2 management path | `unit (red on main)` — `refuse to delete a file whose storage id belongs to a different workspace` | 1 failed / 4 passed against `main`'s `utils.ts`: the foreign file was deleted before the fix |
| Planted cross-workspace URL refused, shared helper | `unit (mutation)` — `refuses to delete a planted URL that resolves to a different workspace`, `refuses when the storage id resolves to no workspace`, `in a mixed batch, deletes the owned file and refuses the foreign one` | 3 failed / 6 passed with the guard removed; all 9 pass with it |
| Own-workspace file deleted — UI, v1 and v2 paths | `manual`, local instance with S3-compatible storage | response gone and object gone from storage |
| Legacy env-id prefix mapping back to the same workspace | `unit (guard)`, `findWorkspaceByIdOrLegacyEnvId` mocked | file still deleted |
| Bad input — unparseable URL, unresolvable id, no workspace id | `unit (guard)`, both suites | skipped and logged, owned files still deleted |
| Failed storage delete (`deleteFile` returns an error result) | `unit (guard)` — `logs when deleteFile returns a failure result` | logged instead of counted as a success |
| Several files sharing one storage id | `unit (guard)` — `resolves each distinct storage id only once for multiple files under it` | one workspace lookup per distinct id |
| Response with no file-upload answers | `unit (guard)` + `manual` | no storage call at all |

14 cases total across `apps/web/modules/storage/lib/delete-response-files.test.ts` (9, new) and
`apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/utils.test.ts` (5, reworked) —
**1 red on main, 3 mutation, 10 guards**. Only one case can fail against `main`, because the other
suite tests a file that does not exist there; that is why the helper's own cases are tiered as
mutation rather than presented as proof the bug existed.

Rerun either tier:

```bash
# red on main — 1 failed | 4 passed
git checkout origin/main -- "apps/web/modules/api/v2/management/responses/[responseId]/lib/utils.ts"
cd apps/web && ../../node_modules/.bin/vitest run "modules/api/v2/management/responses/[responseId]/lib/tests/utils.test.ts"
git checkout HEAD -- "apps/web/modules/api/v2/management/responses/[responseId]/lib/utils.ts"

# mutation — delete the workspace check at delete-response-files.ts:55-62, then: 3 failed | 6 passed
cd apps/web && ../../node_modules/.bin/vitest run modules/storage/lib/delete-response-files.test.ts
```

Workspace packages must be built first (`pnpm turbo run build --filter=@formbricks/web^...`), or the
suites fail to resolve `@formbricks/logger` rather than reporting test results.

**Open gaps**

- The cross-workspace refusal has not been reproduced against live storage. It is proven at the
  helper boundary (`deleteFile` is never reached), but an end-to-end run needs two workspaces and a
  file URL planted directly into response data.
- The legacy environment-id prefix path has not been exercised against real keys — a fresh instance
  has no pre-workspace-rename objects, so that branch is proven only with the workspace lookup mocked,
  and it sits in the guard tier for that reason.

**Risks**

- Own-workspace cleanup must keep working; only files resolving to another workspace are refused.
- Legacy env-prefixed uploads must still be cleaned up on delete (see gap 2).
- A normal delete should log nothing — failed deletes are now logged rather than silent.
- Shared surface for cross-PR interplay: both delete paths now depend on `deleteResponseFileUrls`,
  `findWorkspaceByIdOrLegacyEnvId`, and the storage key format.

<details>
<summary>Call-site audit and manual-run setup</summary>

**Call sites.** Response-file deletion exists in exactly two places, both routed through the new
helper: `apps/web/lib/response/service.ts:645` (UI and v1 management delete) and
`apps/web/modules/api/v2/management/responses/[responseId]/lib/utils.ts:24` (v2 management delete).
The only other `deleteFile(` caller is
`apps/web/app/storage/[workspaceId]/[accessType]/[...filePath]/route.ts:142`, the direct file-delete
endpoint, which takes its workspace from the route path and is untouched by this PR.

**Manual runs.** UI delete from the Responses table; `DELETE /api/v1/management/responses/{id}`;
`DELETE /api/v2/management/responses/{id}`; and a response with no file-upload answers. In each of
the first three the response and its stored object were gone; in the fourth nothing else was touched.

**To reproduce.** A published file-upload survey with a response carrying an uploaded file, a
management API key for the API paths, and storage configured (S3 on Cloud, RustFS/MinIO on
self-host).

</details>

---

> [!NOTE]
> **AI model used** — `…`, reasoning effort `high`.
