### PR TITLE
fix: assign exactly one reviewer via a single team code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,11 +35,11 @@
 #
 #  The whole engineering team is in the rotation and shares the review load.
 #
-#  DO NOT ADD PATH RULES, AND DO NOT NAME INDIVIDUALS. Either silently
-#  reintroduces the multi-reviewer problem this file exists to solve. CI blocks
-#  both: a credential-free step asserts this file is exactly the one rule below,
-#  and it runs on every pull request including those from forks, where the
-#  API-backed owner checks cannot run. See
+#  DO NOT ADD PATH RULES, AND DO NOT NAME INDIVIDUALS. Adding either one
+#  silently reintroduces the multi-reviewer problem this file exists to solve.
+#  CI blocks both: a credential-free step asserts this file is exactly the one
+#  rule below, and it runs on every pull request including those from forks,
+#  where the API-backed owner checks cannot run. See
 #  .github/workflows/codeowners-validation.yml.
 #
 #  KNOWN TRADE-OFF

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,17 +6,20 @@
 #
 #  WHY IT LOOKS LIKE THIS
 #
-#  GitHub requests review from EVERY owner of EVERY matching rule, and it never
-#  thins that set. The first version of this file named two to three individuals
-#  across 98 path rules, and auto-requested 3-6 reviewers per pull request
-#  (mean 3.6, max 6, measured across 25 merged PRs) — most of the team on every
-#  change.
+#  For each changed FILE, the last matching rule wins and every owner named on
+#  that one line is requested. A pull request's reviewers are then the union of
+#  those per-file winners, and GitHub never thins the result. So the count grows
+#  two ways: several owners on a line, and several areas touched in one PR.
+#
+#  The first version of this file named two to three individuals across 98 path
+#  rules and auto-requested 3-6 reviewers per pull request (mean 3.6, max 6,
+#  measured across 25 merged PRs) — most of the team on every change.
 #
 #  Naming fewer individuals does not fix it. Even one owner per rule measured
-#  2.1 reviewers on average, because a pull request touching several areas
-#  matches several rules and the owners are unioned. Splitting into domain teams
-#  does not fix it either, and gets worse the more teams you add: three teams
-#  measured 1.6, five measured 1.8.
+#  2.1 reviewers on average, because a pull request touching several areas has
+#  several different per-file winners. Splitting into domain teams does not fix
+#  it either, and gets worse the more teams you add: three teams measured 1.6,
+#  five measured 1.8.
 #
 #  A TEAM owner is the only thing GitHub will thin, so one team owns everything.
 #  @formbricks/engineering is configured under
@@ -32,9 +35,11 @@
 #
 #  The whole engineering team is in the rotation and shares the review load.
 #
-#  DO NOT ADD PATH RULES NAMING INDIVIDUALS. It silently reintroduces the
-#  multi-reviewer problem this file exists to solve. CI enforces team-only
-#  owners, so such a change fails the build rather than shipping quietly — see
+#  DO NOT ADD PATH RULES, AND DO NOT NAME INDIVIDUALS. Either silently
+#  reintroduces the multi-reviewer problem this file exists to solve. CI blocks
+#  both: a credential-free step asserts this file is exactly the one rule below,
+#  and it runs on every pull request including those from forks, where the
+#  API-backed owner checks cannot run. See
 #  .github/workflows/codeowners-validation.yml.
 #
 #  KNOWN TRADE-OFF

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,281 +2,57 @@
 #  Formbricks — Code Owners
 # ==============================================================================
 #
-#  WHAT THIS FILE IS FOR
+#  ONE RULE, ON PURPOSE. Every pull request gets exactly ONE reviewer.
 #
-#  Every rule below answers one question about a path: "who knows this part of
-#  the app best?" It exists so review requests can be routed automatically — by
-#  our AI review assignment, and by GitHub's own reviewer suggestions — to the
-#  people with the most context.
+#  WHY IT LOOKS LIKE THIS
 #
-#  It is ADVISORY. Nothing here is wired into branch protection, no owner is
-#  required to approve a pull request, and no rule in this file can block a
-#  merge.
+#  GitHub requests review from EVERY owner of EVERY matching rule, and it never
+#  thins that set. The first version of this file named two to three individuals
+#  across 98 path rules, and auto-requested 3-6 reviewers per pull request
+#  (mean 3.6, max 6, measured across 25 merged PRs) — most of the team on every
+#  change.
 #
-#  HOW TO READ IT
+#  Naming fewer individuals does not fix it. Even one owner per rule measured
+#  2.1 reviewers on average, because a pull request touching several areas
+#  matches several rules and the owners are unioned. Splitting into domain teams
+#  does not fix it either, and gets worse the more teams you add: three teams
+#  measured 1.6, five measured 1.8.
 #
-#  * Owners are listed PRIMARY FIRST. The first name is the person with the
-#    deepest context; the rest are fallbacks. GitHub ignores this order — it is
-#    here for humans and for review-routing tools.
-#  * Any ONE owner is enough. Extra names widen the pool, they do not multiply
-#    the review burden.
-#  * There is no catch-all `*` rule. A path with no rule means "no designated
-#    expert", and reviewer selection falls back to normal judgement. That is
-#    intentional, not an omission.
+#  A TEAM owner is the only thing GitHub will thin, so one team owns everything.
+#  @formbricks/engineering is configured under
+#  Organization -> Teams -> engineering -> Settings -> Code review with:
 #
-#  HOW TO EDIT IT
+#    * How many team members should be assigned to review?  =  1
+#    * Algorithm                                            =  Load balance
+#    * Only notify requested team members                    =  on
 #
-#  1. THE LAST MATCHING PATTERN WINS, and owners do not accumulate across
-#     rules — the winning line is the complete owner list. General rules go
-#     first, specific overrides go last. NEVER add a broad rule at the bottom
-#     of this file; it will silently take over every path above it. Section 14
-#     must stay last.
-#  2. All owners for one pattern MUST be on the SAME LINE. Split across two
-#     lines, only the last line counts. This fails silently.
-#  3. Anchor paths with a leading slash: `/apps/web/` not `apps/web/`. Without
-#     it, the pattern matches a directory of that name at ANY depth.
-#  4. `dir/` owns the whole subtree. `dir/*` owns only its direct children —
-#     almost always a bug in a monorepo.
-#  5. Unlike .gitignore, these DO NOT WORK here: `!` negation, `[a-z]` ranges,
-#     `\#` escaping, and `{a,b}` brace expansion. Never put a Next.js dynamic
-#     route segment such as `[workspaceId]` in a pattern — the brackets are
-#     unsupported. Own the `modules/` path instead of the `app/` route path.
-#  6. Owners must have WRITE access to this repo, or they are silently dropped.
-#  7. Within a section — or within a `# --- labelled group ---` inside one —
-#     keep rules in alphabetical order, with no exceptions, so there is exactly
-#     one obvious place to insert a new rule. Ordering *between* sections is
-#     what controls precedence (rule 1); ordering *within* one is purely for
-#     scannability, and no rule in this file relies on it.
+#  GitHub then replaces the team with exactly one of its members on each pull
+#  request. Load balance accounts for how many reviews each member already has
+#  outstanding, rather than only who was asked least recently.
 #
-#  Changes to this file only take effect once merged — GitHub always reads the
-#  version on the pull request's BASE branch.
+#  The whole engineering team is in the rotation and shares the review load.
 #
-#  CI validates this file on every change and weekly:
-#  .github/workflows/codeowners-validation.yml
+#  DO NOT ADD PATH RULES NAMING INDIVIDUALS. It silently reintroduces the
+#  multi-reviewer problem this file exists to solve. CI enforces team-only
+#  owners, so such a change fails the build rather than shipping quietly — see
+#  .github/workflows/codeowners-validation.yml.
+#
+#  KNOWN TRADE-OFF
+#
+#  The reviewer is chosen by availability, not by who knows the code best. That
+#  is deliberate. GitHub still surfaces expertise hints to humans in the PR
+#  sidebar ("Suggested reviewers are based on git blame data"), but those must be
+#  clicked and are never assigned automatically.
+#
+#  REQUESTING IS UNCONDITIONAL
+#
+#  Simply having this file causes review requests; there is no setting to turn
+#  that off. The separate "Require review from Code Owners" rule is currently
+#  OFF — it would make the review required to merge, and would not change who
+#  gets requested. Draft pull requests are exempt until marked ready for review.
 #
 #  Reference:
 #  https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ==============================================================================
 
-
-# ------------------------------------------------------------------------------
-#  1. Repo, build & tooling
-# ------------------------------------------------------------------------------
-/package.json                              @xernobyl @BhagyaAmarasinghe
-/packages/config-eslint/                   @xernobyl @itsjavi
-/packages/config-prettier/                 @xernobyl @itsjavi
-/packages/config-typescript/               @xernobyl @itsjavi
-/packages/vite-plugins/                    @xernobyl @itsjavi
-/pnpm-workspace.yaml                       @xernobyl @BhagyaAmarasinghe
-/prisma.config.mjs                         @Dhruwang @xernobyl
-/scripts/                                  @BhagyaAmarasinghe @xernobyl
-/sonar-project.properties                  @BhagyaAmarasinghe @xernobyl
-/turbo.json                                @xernobyl @BhagyaAmarasinghe
-
-
-# ------------------------------------------------------------------------------
-#  2. Data & platform packages
-# ------------------------------------------------------------------------------
-/packages/ai/                              @Dhruwang @xernobyl
-/packages/cache/                           @xernobyl @BhagyaAmarasinghe
-/packages/database/                        @Dhruwang @pandeymangg @xernobyl
-/packages/email/                           @Dhruwang @itsjavi
-/packages/i18n-utils/                      @Dhruwang @pandeymangg
-/packages/logger/                          @BhagyaAmarasinghe @xernobyl
-/packages/storage/                         @BhagyaAmarasinghe @pandeymangg
-/packages/types/                           @Dhruwang @pandeymangg @xernobyl
-
-
-# ------------------------------------------------------------------------------
-#  3. Background jobs
-#
-#  Job *infrastructure* is a backend concern. The workflows product that
-#  schedules them is owned separately — see section 9.
-# ------------------------------------------------------------------------------
-/packages/jobs/                            @xernobyl @itsjavi
-
-
-# ------------------------------------------------------------------------------
-#  4. Survey experience & embeddable SDK
-#
-#  `surveys` is the embeddable runtime and `js-core` the browser SDK. Both ship
-#  to end users' websites, so they carry the strictest compatibility bar in the
-#  repo.
-# ------------------------------------------------------------------------------
-/packages/js-core/                         @pandeymangg @Dhruwang
-/packages/surveys/                         @Dhruwang @pandeymangg @itsjavi
-
-
-# ------------------------------------------------------------------------------
-#  5. UI, design system & accessibility
-# ------------------------------------------------------------------------------
-/ACCESSIBILITY.md                          @itsjavi @Dhruwang
-/apps/storybook/                           @itsjavi @Dhruwang
-/packages/survey-ui/                       @itsjavi @Dhruwang
-
-
-# ------------------------------------------------------------------------------
-#  6. Testing & QA
-# ------------------------------------------------------------------------------
-/apps/web/playwright/                      @itsjavi @Dhruwang @pandeymangg
-/playwright.config.ts                      @itsjavi @Dhruwang
-/playwright.service.config.ts              @itsjavi @Dhruwang
-
-
-# ------------------------------------------------------------------------------
-#  7. apps/web — broad defaults, app config & instrumentation
-#
-#  `app/`, `lib/` and `modules/` are the broad defaults covering the whole
-#  Next.js app; sections 8-14 override them for narrower paths. Their position
-#  inside this section does not matter — precedence comes from section order —
-#  so they sit in the same alphabetical run as everything else here.
-#
-#  `scripts/` reads deployment secrets and validates env at container start;
-#  `proxy*` is the request-routing edge. Both are more sensitive than their
-#  location suggests.
-# ------------------------------------------------------------------------------
-/apps/web/app/                             @Dhruwang @pandeymangg @xernobyl
-/apps/web/instrumentation*                 @BhagyaAmarasinghe @xernobyl
-/apps/web/integration/                     @xernobyl @itsjavi
-/apps/web/lib/                             @Dhruwang @xernobyl @pandeymangg
-/apps/web/modules/                         @Dhruwang @pandeymangg @xernobyl
-/apps/web/next.config.mjs                  @xernobyl @BhagyaAmarasinghe
-/apps/web/prometheus.yml                   @BhagyaAmarasinghe @xernobyl
-/apps/web/proxy*                           @xernobyl @BhagyaAmarasinghe
-/apps/web/scripts/                         @BhagyaAmarasinghe @xernobyl
-/apps/web/sentry.*                         @BhagyaAmarasinghe @xernobyl
-/apps/web/vite*                            @itsjavi @xernobyl
-
-
-# ------------------------------------------------------------------------------
-#  8. apps/web — feature modules
-#
-#  Only modules whose ownership differs from the section 7 default are listed.
-#  A module that is absent here is covered by the default on purpose.
-# ------------------------------------------------------------------------------
-/apps/web/modules/analysis/                @Dhruwang @pandeymangg
-/apps/web/modules/api/                     @pandeymangg @xernobyl @BhagyaAmarasinghe
-/apps/web/modules/core/                    @xernobyl @Dhruwang
-/apps/web/modules/ee/contacts/             @pandeymangg @Dhruwang
-/apps/web/modules/hub/                     @xernobyl @Dhruwang
-/apps/web/modules/mcp/                     @xernobyl @pandeymangg
-/apps/web/modules/organization/            @pandeymangg @Dhruwang
-/apps/web/modules/setup/                   @BhagyaAmarasinghe @Dhruwang
-/apps/web/modules/storage/                 @BhagyaAmarasinghe @pandeymangg
-/apps/web/modules/survey/                  @Dhruwang @itsjavi @pandeymangg
-/apps/web/modules/ui/                      @itsjavi @Dhruwang
-/apps/web/modules/workspaces/              @pandeymangg @Dhruwang
-
-
-# ------------------------------------------------------------------------------
-#  9. Workflows
-# ------------------------------------------------------------------------------
-/apps/web/modules/ee/workflows/            @itsjavi @xernobyl
-/packages/workflows/                       @itsjavi @xernobyl
-
-
-# ------------------------------------------------------------------------------
-#  10. Public API surfaces
-#
-#  v1 and v2 are published contracts that self-hosters depend on; breaking them
-#  is a release event. v3 is the current surface for new work. `(internal)`
-#  carries no compatibility promise.
-# ------------------------------------------------------------------------------
-/apps/web/app/api/(internal)/              @xernobyl @BhagyaAmarasinghe
-/apps/web/app/api/v1/                      @pandeymangg @Dhruwang
-/apps/web/app/api/v2/                      @pandeymangg @xernobyl
-/apps/web/app/api/v3/                      @xernobyl @BhagyaAmarasinghe @pandeymangg
-/apps/web/modules/api/v2/                  @pandeymangg @xernobyl
-/openapi.yml                               @pandeymangg @xernobyl
-
-
-# ------------------------------------------------------------------------------
-#  11. Infrastructure, deployment & CI
-#
-#  `/.github/` also covers this CODEOWNERS file, which is GitHub's recommended
-#  way to protect it.
-# ------------------------------------------------------------------------------
-/.github/                                  @BhagyaAmarasinghe @xernobyl
-/apps/web/Dockerfile                       @BhagyaAmarasinghe @xernobyl
-/charts/                                   @BhagyaAmarasinghe @Dhruwang
-/docker/                                   @BhagyaAmarasinghe @xernobyl
-/docker-compose.dev.yml                    @BhagyaAmarasinghe @xernobyl
-
-
-# ------------------------------------------------------------------------------
-#  12. Documentation
-# ------------------------------------------------------------------------------
-/CONTRIBUTING.md                           @jobenjada @BhagyaAmarasinghe
-/docs/                                     @jobenjada @pandeymangg
-/docs/api-v3-reference/                    @xernobyl @jobenjada
-/docs/self-hosting/                        @BhagyaAmarasinghe @jobenjada
-/README.md                                 @jobenjada @pandeymangg
-
-
-# ------------------------------------------------------------------------------
-#  13. Localization
-#
-#  `en-US.json` is the hand-written source of truth. Every other locale file is
-#  machine-generated by Lingo.dev and is deliberately left without an owner —
-#  there is nothing for a human to review. Same for `i18n.lock` and the
-#  vendored tarball under apps/web/vendor/.
-# ------------------------------------------------------------------------------
-/apps/web/locales/en-US.json               @Dhruwang @pandeymangg
-/packages/surveys/locales/en-US.json       @Dhruwang @pandeymangg
-
-
-# ==============================================================================
-#  14. HIGH-RISK OVERRIDES  —  THIS SECTION MUST STAY LAST
-#
-#  Every rule below deliberately overrides a broader rule above it. Because the
-#  last matching pattern wins, anything added after this block would shadow
-#  these paths. Do not append to this file — insert into the section above that
-#  fits.
-#
-#  Note: LICENSE and apps/web/modules/ee/LICENSE intentionally have no rule.
-#  Licensing is a founder decision and is not routed through this file.
-# ==============================================================================
-
-# --- Auth & identity ---
-/apps/web/app/(auth)/                      @xernobyl @Dhruwang
-/apps/web/app/api/auth/                    @xernobyl @pandeymangg
-/apps/web/lib/auth.ts                      @xernobyl @Dhruwang
-/apps/web/lib/crypto.ts                    @xernobyl @BhagyaAmarasinghe
-/apps/web/lib/jwt.ts                       @xernobyl @BhagyaAmarasinghe
-/apps/web/lib/oauth/                       @xernobyl @pandeymangg
-/apps/web/modules/api/v2/auth/             @xernobyl @pandeymangg
-/apps/web/modules/auth/                    @xernobyl @Dhruwang
-/apps/web/modules/ee/auth/                 @xernobyl @Dhruwang
-/apps/web/modules/ee/sso/                  @xernobyl @pandeymangg
-/apps/web/modules/ee/two-factor-auth/      @xernobyl @Dhruwang
-
-# --- Internal gateway auth (Envoy / Traefik) ---
-/apps/web/modules/envoy-auth/              @BhagyaAmarasinghe @xernobyl
-/apps/web/modules/gateway-auth/            @BhagyaAmarasinghe @xernobyl
-/apps/web/modules/traefik-auth/            @BhagyaAmarasinghe @xernobyl
-
-# --- Billing, entitlements & licensing ---
-/apps/web/app/api/billing/                 @Dhruwang @pandeymangg
-/apps/web/modules/billing/                 @Dhruwang @pandeymangg
-/apps/web/modules/ee/billing/              @Dhruwang @pandeymangg
-/apps/web/modules/ee/license-check/        @xernobyl @Dhruwang
-/apps/web/modules/ee/quotas/               @Dhruwang @xernobyl
-/apps/web/modules/entitlements/            @Dhruwang @xernobyl
-
-# --- Audit logs & compliance ---
-/apps/web/modules/ee/audit-logs/           @xernobyl @BhagyaAmarasinghe
-
-# --- Database migrations ---
-#  Reviewing a migration needs the data model AND the rollout blast radius,
-#  which is why this differs from /packages/database/ above.
-/packages/database/migration/              @Dhruwang @xernobyl @BhagyaAmarasinghe
-
-# --- Environment, secrets & supply chain ---
-/.env.example                              @BhagyaAmarasinghe @xernobyl
-/apps/web/lib/constants.ts                 @xernobyl @Dhruwang
-/apps/web/lib/env-client.ts                @xernobyl @BhagyaAmarasinghe
-/apps/web/lib/env.ts                       @xernobyl @BhagyaAmarasinghe
-/pnpm-lock.yaml                            @xernobyl @BhagyaAmarasinghe
-
-# --- Security policy ---
-/SECURITY.md                               @xernobyl @BhagyaAmarasinghe
+*  @formbricks/engineering

--- a/.github/workflows/codeowners-validation.yml
+++ b/.github/workflows/codeowners-validation.yml
@@ -58,8 +58,15 @@ jobs:
           # an outside contributor's PR that says nothing about their change. The
           # weekly scheduled run covers `owners` against the default branch.
           checks: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'syntax,duppatterns,files,owners' || 'syntax,duppatterns,files' }}
-          # avoid-shadowing enforces the general-to-specific ordering the whole
-          # file depends on, since the last matching pattern wins.
+          # The guard that keeps CODEOWNERS to one reviewer. Only a TEAM owner can
+          # be thinned to a single reviewer by GitHub; naming individuals makes it
+          # request all of them, which is the bug this file was rewritten to fix.
+          # Rejecting individual owners here means a well-meant "just add an owner
+          # for this path" fails the build instead of quietly restoring 3-6
+          # reviewers per PR.
+          owner_checker_owners_must_be_teams: "true"
+          # Guards the last-matching-pattern-wins footgun if path rules are ever
+          # added back: a later broad rule would silently void the ones above it.
           experimental_checks: "avoid-shadowing"
           # The `owners` check reads organization membership, which the default
           # GITHUB_TOKEN cannot do. Requires a CLASSIC PAT with `read:org` —

--- a/.github/workflows/codeowners-validation.yml
+++ b/.github/workflows/codeowners-validation.yml
@@ -39,6 +39,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      # Runs on EVERY trigger, forks included, because it needs no credentials.
+      # The validator's `owners` checks are API-backed and are skipped on fork
+      # PRs (see below), which would otherwise let an outside contributor add a
+      # path rule or an individual owner and still show green. This step also
+      # catches what `owner_checker_owners_must_be_teams` cannot: extra rules,
+      # and extra owners on the single line.
+      - name: Enforce single-team ownership
+        run: |
+          expected='*  @formbricks/engineering'
+          rules="$(grep -vE '^[[:space:]]*(#|$)' .github/CODEOWNERS || true)"
+          count="$(printf '%s' "$rules" | grep -c . || true)"
+          # Compare on collapsed, trimmed whitespace so incidental spacing does
+          # not fail the build; nothing formats this file, so spacing drifts.
+          norm() { printf '%s' "$1" | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//'; }
+          if [ "$count" != "1" ] || [ "$(norm "$rules")" != "$(norm "$expected")" ]; then
+            echo "::error file=.github/CODEOWNERS::CODEOWNERS must contain exactly one rule -- '${expected}' -- so that GitHub assigns exactly one reviewer. Adding path rules or extra owners reverts to 3-6 reviewers per PR. Found ${count} rule(s):"
+            printf '%s\n' "$rules"
+            exit 1
+          fi
+          echo "CODEOWNERS is the expected single team rule."
+
       - name: Note reduced check set on fork pull requests
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: |


### PR DESCRIPTION
## What & why

The CODEOWNERS file added in #8851 auto-requests **3–6 reviewers per pull request** — most of the engineering team on every change. An engineer reproduced it with no agents involved and **no ruleset requiring code-owner review**: marking a draft PR ready for review assigned multiple people immediately. On #8840 the reviewers had to be removed by hand.

**Cause.** That file named two to three individuals across 98 path rules. For each changed *file* the last matching rule wins and every owner on that line is requested; a PR's reviewers are then the union of those per-file winners, and GitHub never thins the result. So the count grows two ways — several owners on a line, and several areas touched in one PR. Measured across the last 25 merged PRs on `main`: **mean 3.6 reviewers, max 6, every single PR over one.**

**Naming fewer individuals does not fix it.** One owner per rule still measured **2.1** on average (max 5), because a multi-area PR has several different per-file winners. Some PRs touched 9 distinct owner-groups.

**Domain teams do not fix it either, and degrade as you add more.** Counting distinct teams touched per PR with each team assigning 1:

| Topology | Mean reviewers | Max | PRs getting >1 |
|---|---|---|---|
| **1 team** | **1.0** | **1** | **0 / 25** |
| 2 teams (product / platform) | 1.4 | 2 | 10 / 25 |
| 3 teams (frontend / backend / infra) | 1.6 | 3 | 10 / 25 |
| 4–5 teams (+ docs, + sdk) | 1.8 | 4 | 16 / 25 |
| Current (individuals) | 3.6 | 6 | 25 / 25 |

Finer splits mean more distinct teams touched per PR, so more teams moves *away* from the goal. Only a single team reaches exactly one, because a team is the one owner type GitHub will reduce to N members.

**So one team owns everything.** `@formbricks/engineering` is configured to assign **1** member per pull request using the **load balance** algorithm, which accounts for each member's outstanding reviews rather than only who was asked least recently. GitHub replaces the team with that one member on each PR. The whole engineering team shares the rotation.

Net: **264 lines deleted, 73 added**, plus the CI guards below.

### CI guards against regression

Two layers, because the obvious one has a hole:

- **A credential-free shape check** asserting the file is exactly `*  @formbricks/engineering`. It runs on **every** trigger including fork PRs, and rejects extra path rules and extra owners on the line.
- **`owner_checker_owners_must_be_teams`** on the validator, plus the existing `owners` check for team existence and repository write access on trusted runs.

The shape check exists because `owner_checker_owners_must_be_teams` is a sub-option of the `owners` checker, which is deliberately skipped on fork PRs (no token forwarded). Without it, an outside contributor could add an individually-named owner and CI would show green. It also covers what that option cannot: it validates each owner's *type*, not the file's shape, so it would have passed two team owners on one line or extra team-owned rules.

### Documented behaviour, for the record

Requesting is **unconditional** and cannot be switched off — this was the main misunderstanding:

> "Code owners are automatically requested for review when someone opens a pull request that modifies code that they own."

> "Code owners are not automatically requested to review draft pull requests." … "When you mark a draft pull request as ready for review, code owners are automatically notified."

The second quote is exactly the reproduction. The separate "Require review from Code Owners" rule makes reviews *required to merge* — "an approval from *any* of the owners is sufficient" — and does not change who gets requested. It stays **off** here.

### Accepted trade-off

The reviewer is now chosen by **availability, not by who knows the code best**, and the per-path expertise map is removed. GitHub still surfaces blame-based hints to humans in the PR sidebar ("Suggested reviewers are based on git blame data"), but those must be clicked and never auto-assign.

## Linear ticket

No ticket — follow-up fixing a regression introduced by #8851.

## How this was tested

- **Every tracked file resolves to the single team.** Ran `hmarr/codeowners` over all 4,566 tracked files; one distinct owner results: `@formbricks/engineering`.
- **The shape check was tested against every way it should fail**, not just the happy path:
  ```
  real file            PASS
  whitespace variant   PASS   (collapsed/trimmed compare)
  extra path rule      FAIL (count=2)
  extra owner on line  FAIL (count=1)
  individual owner     FAIL (count=1)
  no rule at all       FAIL (count=0)
  ```
- **CI is green: 18/18 checks, no failures.** `Validate CODEOWNERS` runs the full set:
  ```
  CODEOWNERS is the expected single team rule.
  ==> Executing Duplicated Pattern Checker (182.364µs)             Check OK
  ==> Executing [Experimental] Avoid Shadowing Checker (242.658µs) Check OK
  ==> Executing Valid Syntax Checker (307.759µs)                   Check OK
  ==> Executing File Exist Checker (8.469258ms)                    Check OK
  ==> Executing Valid Owner Checker (306.220984ms)                 Check OK
  5 check(s) executed, no failure(s)
  ```
  `Valid Owner Checker` passing is the proof that `@formbricks/engineering` resolves as a real team **with repository write access** — the silent-failure mode this design depends on.
- `prettier --check` clean on `.github`; workflow YAML parses; the conditional `checks` expression resolves to four checks for same-repo PRs and three for forks.

### The owner check earned its place

On the first run, `Validate CODEOWNERS` failed with:

```
[err] line 63: Team "engineering" does not have permissions associated with the repository "formbricks".
```

The team's individual members all had write access; **the team itself did not**. GitHub silently ignores a team code owner that lacks repository access, so merging in that state would have assigned **zero** reviewers — worse than the 3–6 being fixed, and invisible until someone noticed PRs sitting unrouted. Granting the team write access turned the check green with no code change.

### Reviewer count on this PR is not evidence

Two reviewers were auto-assigned when this PR opened, and that is **not** a sign the fix failed: GitHub reads CODEOWNERS from the pull request's **base** branch, so this PR was routed by the old 98-rule file still on `main`, whose `/.github/` rule names exactly those two people. The new behaviour cannot be observed until this merges.

The approval on this PR was subsequently dismissed by the follow-up commits (stale-approval rule), so it needs a fresh one before merging.

## Breaking changes

None

## QA / Test Plan

Not user-facing: no product behaviour changes. Everything observable is in the GitHub UI.

**How to test**

- [ ] **The reproduction that found the bug.** Open a draft PR touching several areas — one file each under `apps/web/modules/ui/`, `packages/database/` and `charts/` — then mark it ready for review → **exactly one** reviewer is requested. That same PR shape drew 4–6 before.
- [ ] Open several single-file PRs → each gets exactly one reviewer, and the assignee varies rather than always being the same person (load balance rotating).
- [ ] **Author exclusion:** an engineer who is a team member opens a PR → they are not assigned to their own PR, and someone else is. (GitHub does not assign members who committed to the PR, or who have set their status to Busy.)
- [ ] Hover the shield icon on any file in the GitHub UI → an owner is shown.
- [ ] Open a **draft** PR → no reviewer is requested until it is marked ready for review.
- [ ] Regression guard: on a scratch branch add a second rule, or an individual owner → `Validate CODEOWNERS` fails at the shape check with the message naming the expected rule.

**Preconditions / test data**

The two GitHub settings this change depends on live outside the repository and have both been **applied**:

1. **Repo → Settings → Collaborators and teams** — `@formbricks/engineering` (6 members) now has **Direct access, Role: write**. Required, because a team without explicit repository access is silently ignored as a code owner.
2. **Org → Teams → engineering → Settings → Code review** — configured as:

   | Setting | Value |
   |---|---|
   | Only notify requested team members | on |
   | Enable auto assignment | on |
   | How many team members should be assigned to review? | **1** |
   | Routing algorithm | **Load balance** |
   | Never assign certain team members | off |
   | Child team members | **off** — keeps the rotation to the six members |
   | Count existing requests | on — no extra reviewer if one is already requested manually |
   | Team review request | on — removes the team request once a member is assigned, so it is one person, not person + team |

No app, database, seed data, or feature flag needed. The `CODEOWNERS_VALIDATOR_TOKEN` secret is unchanged: a **classic** PAT with `read:org`, belonging to an org member.

**Risks & regressions**

- Reviewer routing is the only behaviour introduced. Nothing is wired into branch protection, so a wrong or missing owner cannot block a merge — the worst case is a review request going to the wrong person.
- The two settings above are the load-bearing parts and can be changed without touching this repo. If **auto assignment** or the count is changed, GitHub requests the **whole team**. If the team's **write access** is removed, **no** reviewer is assigned and PRs sit unrouted; the `owners` check catches that on the next run.
- Expertise routing is gone. A reviewer may be assigned to code they have never touched and is expected to reassign or pull in the right person. The specialism research behind the deleted map is not recoverable from this repo's history without redoing it.
- The validator can fail for a token reason rather than an ownership one: classic PATs expire, and on expiry the weekly run goes red. That is a credential renewal, not a CODEOWNERS defect.
- Enabling "Require review from Code Owners" later **changes the request shape**: per the docs the team is then *not* replaced by an individual, and the team request appears in addition. Test that on one PR before adopting it.

**Migrations / env / cutover**

- No DB migrations, no application env vars, no `.env.example` change.
- No new secrets.
- Cutover was the two GitHub settings above, both already applied — so merging this file completes the change with nothing further to configure.
