### PR TITLE
feat(embedded-data): add the Tier-1 reserved field catalog [ENG-1839]

### DIFF
--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { ZEmbeddedData, ZLinkedEmbeddedField } from "./embedded-data";
 import {
   RESERVED_FIELD_CATALOG,
+  type TClientEmbeddedValueResponse,
   type TEmbeddedValueRef,
   type TEmbeddedValueResponse,
   type TLinkedEmbeddedField,
@@ -20,10 +21,12 @@ import {
   getLogicVariableValue,
   getSurveyEmbeddedFields,
   listReadableFields,
+  projectClientReservedValues,
   projectReservedValues,
   resolveEmbeddedValue,
 } from "./embedded-data-resolver";
 import type { TI18nString } from "./i18n";
+import { RESERVED_FIELD_NAMES } from "./reserved-field-names";
 import type { TResponseData, TResponseVariables } from "./responses";
 import type { TSurveyBlocks } from "./surveys/blocks";
 import { TSurveyElementTypeEnum } from "./surveys/elements";
@@ -96,40 +99,58 @@ const resolve = (
   onResponse: TEmbeddedValueResponse = response
 ) => resolveEmbeddedValue({ field, link: { storageKey } }, onResponse);
 
-/** Sample catalog entries — contents live in the tests only; the production catalog is ENG-1839's. */
+/**
+ * Sample catalog entries — synthetic names on purpose, so the mechanism tests keep exercising the
+ * seam rather than accidentally re-asserting the production catalog's contents (which have their own
+ * describe block below).
+ */
 const countryEntry: TReservedFieldCatalogEntry = {
   name: "country",
   dataType: "string",
+  availability: "server",
+  privacy: "drop",
   read: (r) => r.meta.country,
 };
 const browserEntry: TReservedFieldCatalogEntry = {
   name: "browser",
   dataType: "string",
+  availability: "server",
+  privacy: "drop",
   read: (r) => r.meta.userAgent?.browser,
 };
 const totalTimeEntry: TReservedFieldCatalogEntry = {
   name: "total_time",
   dataType: "number",
+  availability: "server",
+  privacy: "keep",
   read: (r) => r.ttc?._total,
 };
 const languageEntry: TReservedFieldCatalogEntry = {
   name: "response_language",
   dataType: "string",
+  availability: "both",
+  privacy: "keep",
   read: (r) => r.language,
 };
 const completedEntry: TReservedFieldCatalogEntry = {
   name: "completed",
   dataType: "boolean",
+  availability: "server",
+  privacy: "keep",
   read: (r) => r.finished,
 };
 const startedAtEntry: TReservedFieldCatalogEntry = {
   name: "started_at",
   dataType: "date",
+  availability: "server",
+  privacy: "keep",
   read: (r) => r.createdAt,
 };
 const actionEntry: TReservedFieldCatalogEntry = {
   name: "action",
   dataType: "string",
+  availability: "client",
+  privacy: "keep",
   read: (r) => r.meta.action,
 };
 
@@ -222,6 +243,8 @@ describe("resolveEmbeddedValue", () => {
       const hostnameEntry: TReservedFieldCatalogEntry = {
         name: "hostname",
         dataType: "string",
+        availability: "client",
+        privacy: "redactQuery",
         read: (r) => new URL(r.meta.url ?? "").hostname,
       };
       // sparseResponse has no meta.url, so the accessor throws on `new URL("")` — the resolver must
@@ -511,6 +534,8 @@ describe("projectReservedValues", () => {
     const miscastEntry: TReservedFieldCatalogEntry = {
       name: "total_time",
       dataType: "number",
+      availability: "server",
+      privacy: "keep",
       read: (r) => r.meta.source, // "web" — present, but not a number; projecting it would invent data
     };
     expect(projectReservedValues([miscastEntry], response)).toStrictEqual({});
@@ -520,11 +545,15 @@ describe("projectReservedValues", () => {
     const emptySourceEntry: TReservedFieldCatalogEntry = {
       name: "empty_source",
       dataType: "string",
+      availability: "client",
+      privacy: "keep",
       read: () => "",
     };
     const zeroTimeEntry: TReservedFieldCatalogEntry = {
       name: "zero_time",
       dataType: "number",
+      availability: "server",
+      privacy: "keep",
       read: () => 0,
     };
 
@@ -542,6 +571,8 @@ describe("projectReservedValues", () => {
     const hostnameEntry: TReservedFieldCatalogEntry = {
       name: "hostname",
       dataType: "string",
+      availability: "client",
+      privacy: "redactQuery",
       read: (r) => new URL(r.meta.url ?? "").hostname,
     };
 
@@ -551,10 +582,246 @@ describe("projectReservedValues", () => {
       response_language: "de",
     });
   });
+});
 
-  test("the production catalog is empty until ENG-1839 and projects to an empty map", () => {
-    expect(RESERVED_FIELD_CATALOG).toHaveLength(0);
-    expect(projectReservedValues(RESERVED_FIELD_CATALOG, response)).toStrictEqual({});
+describe("RESERVED_FIELD_CATALOG", () => {
+  /** Every Tier-1 location captured — today's ingest shape, with IP capture enabled. */
+  const capturedResponse: TEmbeddedValueResponse = {
+    id: "clx0000000000000000000r3",
+    surveyId: "clx0000000000000000000s2",
+    createdAt: new Date("2026-08-01T09:00:00.000Z"),
+    updatedAt: new Date("2026-08-01T09:02:30.000Z"),
+    finished: true,
+    language: "de",
+    data: { plan: "premium" },
+    variables: {},
+    // Milliseconds, and deliberately not a whole number of seconds.
+    ttc: { q1: 40_000, q2: 50_400, _total: 90_400 },
+    meta: {
+      source: "link",
+      url: "https://example.com/pricing?utm_source=news&email=a@b.co",
+      userAgent: { browser: "Chrome", os: "macOS", device: "desktop" },
+      country: "DE",
+      action: "Clicked Upgrade",
+      ipAddress: "203.0.113.7",
+    },
+  };
+
+  /**
+   * A response stored years before this catalog existed: `meta` holds only what was captured then
+   * (source + url), there is no `ttc` at all, and no language was selected. The catalog must resolve
+   * what is there and report the rest as unset — never throw, and never invent a value.
+   */
+  const historicalResponse: TEmbeddedValueResponse = {
+    id: "clx0000000000000000000r4",
+    surveyId: "clx0000000000000000000s2",
+    createdAt: new Date("2024-03-04T08:00:00.000Z"),
+    updatedAt: new Date("2024-03-04T08:01:00.000Z"),
+    finished: true,
+    language: null,
+    data: { plan: "free" },
+    variables: {},
+    meta: { source: "link", url: "https://example.com/old" },
+  };
+
+  const projectCatalog = (onResponse: TEmbeddedValueResponse) =>
+    projectReservedValues(RESERVED_FIELD_CATALOG, onResponse);
+
+  /** The named entry, failing loudly instead of resolving `undefined.read` if it is ever removed. */
+  const catalogEntry = (name: string): TReservedFieldCatalogEntry => {
+    const entry = RESERVED_FIELD_CATALOG.find((candidate) => candidate.name === name);
+    if (!entry) throw new Error(`No reserved catalog entry named ${name}`);
+    return entry;
+  };
+
+  test("declares exactly the Tier-1 entries, with their dataType, availability and privacy", () => {
+    // The catalog is a product decision, so it is pinned as a table rather than probed field by
+    // field: adding, removing or reclassifying an entry has to be a deliberate edit here too.
+    // `status` is absent on purpose — `Response` has no status column and `finished` already carries
+    // the complete/partial distinction.
+    expect(
+      RESERVED_FIELD_CATALOG.map(({ name, dataType, availability, privacy }) => ({
+        name,
+        dataType,
+        availability,
+        privacy,
+      }))
+    ).toStrictEqual([
+      { name: "source", dataType: "string", availability: "client", privacy: "keep" },
+      { name: "url", dataType: "string", availability: "client", privacy: "redactQuery" },
+      { name: "country", dataType: "string", availability: "server", privacy: "drop" },
+      { name: "action", dataType: "string", availability: "client", privacy: "keep" },
+      { name: "browser", dataType: "string", availability: "server", privacy: "drop" },
+      { name: "os", dataType: "string", availability: "server", privacy: "drop" },
+      { name: "deviceType", dataType: "string", availability: "server", privacy: "drop" },
+      { name: "ipAddress", dataType: "string", availability: "server", privacy: "drop" },
+      { name: "finished", dataType: "boolean", availability: "server", privacy: "keep" },
+      { name: "language", dataType: "string", availability: "both", privacy: "keep" },
+      { name: "responseId", dataType: "string", availability: "server", privacy: "keep" },
+      { name: "surveyId", dataType: "string", availability: "server", privacy: "keep" },
+      { name: "durationSeconds", dataType: "number", availability: "server", privacy: "keep" },
+      { name: "startedAt", dataType: "date", availability: "server", privacy: "keep" },
+      { name: "finishedAt", dataType: "date", availability: "server", privacy: "keep" },
+    ]);
+  });
+
+  test("every entry resolves against a fully captured response", () => {
+    // One exact-map assertion rather than fifteen lookups: a missing key is a failed entry, and an
+    // extra key is an entry nobody declared in the table above.
+    expect(projectCatalog(capturedResponse)).toStrictEqual({
+      source: "link",
+      url: "https://example.com/pricing?utm_source=news&email=a@b.co",
+      country: "DE",
+      action: "Clicked Upgrade",
+      browser: "Chrome",
+      os: "macOS",
+      deviceType: "desktop",
+      ipAddress: "203.0.113.7",
+      finished: "true",
+      language: "de",
+      responseId: "clx0000000000000000000r3",
+      surveyId: "clx0000000000000000000s2",
+      durationSeconds: 90,
+      startedAt: "2026-08-01T09:00:00.000Z",
+      finishedAt: "2026-08-01T09:02:30.000Z",
+    });
+  });
+
+  test("resolves what a historical response captured and reports the rest as unset", () => {
+    expect(projectCatalog(historicalResponse)).toStrictEqual({
+      source: "link",
+      url: "https://example.com/old",
+      finished: "true",
+      responseId: "clx0000000000000000000r4",
+      surveyId: "clx0000000000000000000s2",
+      startedAt: "2024-03-04T08:00:00.000Z",
+      finishedAt: "2024-03-04T08:01:00.000Z",
+    });
+  });
+
+  test("durationSeconds converts the stored milliseconds to whole seconds", () => {
+    // ttc is milliseconds (MAX_RESPONSE_TTC in responses.ts), so a raw read would publish 90400
+    // under a field named — and typed — in seconds.
+    expect(projectCatalog(capturedResponse).durationSeconds).toBe(90);
+  });
+
+  test("durationSeconds is unset on a partial response rather than a duration-so-far", () => {
+    // calculateTtcTotal is the only writer of `_total`, and every call site guards it behind
+    // `finished ?` — so a partial response has per-element timings and no total. Summing them here
+    // would report a duration no other surface agrees with.
+    const partialResponse: TEmbeddedValueResponse = {
+      ...capturedResponse,
+      finished: false,
+      ttc: { q1: 40_000, q2: 50_400 },
+    };
+    const projected = projectCatalog(partialResponse);
+
+    expect("durationSeconds" in projected).toBe(false);
+    expect(projected.finished).toBe("false");
+  });
+
+  test("startedAt and finishedAt resolve to ISO strings, never Date objects", () => {
+    const startedAt = resolveEmbeddedValue({ entry: catalogEntry("startedAt") }, capturedResponse);
+    const finishedAt = resolveEmbeddedValue({ entry: catalogEntry("finishedAt") }, capturedResponse);
+
+    expect(startedAt).toBe("2026-08-01T09:00:00.000Z");
+    expect(finishedAt).toBe("2026-08-01T09:02:30.000Z");
+    // A raw Date reaching the recall/logic maps would render as a locale-dependent string.
+    expect(startedAt).not.toBeInstanceOf(Date);
+    expect(finishedAt).not.toBeInstanceOf(Date);
+  });
+
+  test("finished resolves as a boolean and projects as the string the maps can hold", () => {
+    const entry = catalogEntry("finished");
+
+    expect(resolveEmbeddedValue({ entry }, capturedResponse)).toBe(true);
+    expect(resolveEmbeddedValue({ entry }, { ...capturedResponse, finished: false })).toBe(false);
+    // false is a value, not a gap: it must survive the projection as "false", not vanish.
+    expect(projectCatalog({ ...capturedResponse, finished: false }).finished).toBe("false");
+  });
+
+  test("no accessor throws on a response where every optional location is absent", () => {
+    // The catalog runs over responses nobody curated; an accessor that assumed today's meta shape
+    // would take a whole export loop down. sparseResponse is that worst case.
+    expect(() => projectCatalog(sparseResponse)).not.toThrow();
+    expect(projectCatalog(sparseResponse)).toStrictEqual({
+      finished: "false",
+      responseId: sparseResponse.id,
+      surveyId: sparseResponse.surveyId,
+      startedAt: "2026-08-02T12:00:00.000Z",
+      finishedAt: "2026-08-02T12:00:00.000Z",
+    });
+  });
+
+  test("RESERVED_FIELD_NAMES is exactly the catalog's names, lowercased", () => {
+    // The blocklist is a hand-written leaf module (it cannot import the catalog without closing an
+    // import cycle — see reserved-field-names.ts), so this is the only thing keeping the two in
+    // step. A name added to one side and not the other fails here.
+    expect([...RESERVED_FIELD_NAMES].sort()).toStrictEqual(
+      RESERVED_FIELD_CATALOG.map((entry) => entry.name.toLowerCase()).sort()
+    );
+  });
+});
+
+describe("projectClientReservedValues", () => {
+  /** What a running survey holds: no `id`, no `createdAt`/`updatedAt`, no final `finished`. */
+  const midSurvey: TClientEmbeddedValueResponse = {
+    surveyId: "clx0000000000000000000s2",
+    language: "de",
+    data: { plan: "premium" },
+    variables: {},
+    ttc: { q1: 40_000 },
+    meta: { source: "link", url: "https://example.com/pricing", action: "Clicked Upgrade" },
+  };
+
+  test("projects only the entries a client can read mid-survey", () => {
+    expect(projectClientReservedValues(RESERVED_FIELD_CATALOG, midSurvey)).toStrictEqual({
+      source: "link",
+      url: "https://example.com/pricing",
+      action: "Clicked Upgrade",
+      language: "de",
+    });
+  });
+
+  test("never invokes a server-only accessor", () => {
+    // Filtering by availability is not enough on its own: a server accessor invoked against the
+    // client slice would read `undefined` and be dropped by coercion anyway, so the output would look
+    // identical while the accessor had in fact run. Spies are what distinguish the two.
+    const serverRead = vi.fn(() => "should never be read");
+    const clientRead = vi.fn(() => "link");
+    const bothRead = vi.fn(() => "de");
+
+    const projected = projectClientReservedValues(
+      [
+        {
+          name: "server_only",
+          dataType: "string",
+          availability: "server",
+          privacy: "keep",
+          read: serverRead,
+        },
+        {
+          name: "client_only",
+          dataType: "string",
+          availability: "client",
+          privacy: "keep",
+          read: clientRead,
+        },
+        { name: "either_side", dataType: "string", availability: "both", privacy: "keep", read: bothRead },
+      ],
+      midSurvey
+    );
+
+    expect(projected).toStrictEqual({ client_only: "link", either_side: "de" });
+    expect(serverRead).not.toHaveBeenCalled();
+    expect(clientRead).toHaveBeenCalledTimes(1);
+    expect(bothRead).toHaveBeenCalledTimes(1);
+  });
+
+  test("omits a client entry whose value has not been captured yet", () => {
+    expect(
+      projectClientReservedValues(RESERVED_FIELD_CATALOG, { ...midSurvey, language: null, meta: {} })
+    ).toStrictEqual({});
   });
 });
 
@@ -742,6 +1009,8 @@ describe("listReadableFields", () => {
     const underscoreEntry: TReservedFieldCatalogEntry = {
       name: "_",
       dataType: "string",
+      availability: "server",
+      privacy: "keep",
       read: () => undefined,
     };
     const fields = listReadableFields({

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -41,6 +41,22 @@ export type TEmbeddedValueResponse = Pick<
 >;
 
 /**
+ * The slice a client holds **mid-survey**, while the respondent is still answering.
+ *
+ * What it omits is the point: `id`, `createdAt` and `updatedAt` are assigned by the database, and
+ * `finished` is only true once the respondent reaches the end — so none of them exist, or are
+ * final, at the moment a survey wants to recall a reserved value into visible copy. Typing the
+ * client seam against this narrower slice is what makes {@link projectClientReservedValues} able to
+ * refuse a server-only accessor at compile time instead of fabricating `id: ""`,
+ * `createdAt: new Date()` and `finished: false` to satisfy the wider type — fabrications that would
+ * resolve to values no response ever carried.
+ */
+export type TClientEmbeddedValueResponse = Pick<
+  TEmbeddedValueResponse,
+  "surveyId" | "language" | "data" | "variables" | "ttc" | "meta"
+>;
+
+/**
  * What a reserved-catalog accessor may return. Confined to scalars and `Date` on purpose: an entry
  * that could return `meta` or `data` wholesale would leak objects into the value maps, and the
  * compiler stops that here rather than a runtime check discovering it per response.
@@ -48,15 +64,42 @@ export type TEmbeddedValueResponse = Pick<
 export type TReservedFieldRawValue = string | number | boolean | Date | null | undefined;
 
 /**
- * One reserved field: auto-captured system metadata every survey can reference without declaring
- * anything (see `ZEmbeddedDataSource` — reserved fields are never stored as rows).
+ * **When** a reserved field's value can be known — not who is allowed to see it.
  *
- * The response location is a typed accessor rather than a dot-path string. Reserved fields are a
- * static catalog in code, so the "path" can be code too — which makes an entry that points at a
- * nonexistent response field a compile error instead of a silent `undefined`, and needs no
- * path-walking machinery whose edge cases would have to be tested separately.
+ * - `client` — knowable in the browser while the respondent is still answering.
+ * - `server` — only knowable once the request reaches the API, or once the row exists.
+ * - `both` — knowable on either side, and both sides agree.
+ *
+ * This gates what the mid-survey surfaces may offer: the recall and logic pickers inside a running
+ * survey can only list fields the renderer can actually resolve at that moment (ENG-1840), and
+ * {@link projectClientReservedValues} is the seam that enforces it. Server-side readers — exports,
+ * filters, summaries — ignore this and read the whole catalog, because by then everything is known.
  */
-export interface TReservedFieldCatalogEntry {
+export type TReservedFieldAvailability = "client" | "server" | "both";
+
+/**
+ * What the "Anonymize responses" toggle does to a reserved field at ingest.
+ *
+ * - `keep` — carries no information about who or where the respondent is; stored unchanged.
+ * - `drop` — not captured at all while anonymizing.
+ * - `redactQuery` — captured, but with the query string stripped, because that is where the
+ *   identifying part hides (a `?email=` or `?uid=` carried in a page URL) while the path itself is
+ *   the part analytics needs.
+ *
+ * Declared here rather than at the ingest routes so the classification lives next to the field it
+ * describes and a new entry cannot be added without deciding it. **Nothing consumes this yet** —
+ * the toggle does not exist on this branch; this is the catalog stating its own policy ahead of the
+ * surface that will apply it, so that surface has no per-field list of its own to drift from.
+ */
+export type TReservedFieldPrivacy = "keep" | "drop" | "redactQuery";
+
+/**
+ * What every reserved field declares regardless of which side can read it.
+ *
+ * A reserved field is auto-captured system metadata every survey can reference without declaring
+ * anything (see `ZEmbeddedDataSource` — reserved fields are never stored as rows).
+ */
+interface TReservedFieldCatalogEntryBase {
   /**
    * The key consumers reference the field by — the recall token id, the logic operand, the key in
    * the projected value map. This is the "storageKey" of a reserved field, except nothing is
@@ -64,6 +107,14 @@ export interface TReservedFieldCatalogEntry {
    */
   name: string;
   dataType: TEmbeddedDataType;
+  privacy: TReservedFieldPrivacy;
+}
+
+/**
+ * A field only the server can read, because its accessor needs part of a persisted response.
+ */
+export interface TServerReservedFieldCatalogEntry extends TReservedFieldCatalogEntryBase {
+  availability: Extract<TReservedFieldAvailability, "server">;
   /**
    * Reads the raw value off a response. Coercion to `dataType` is the resolver's job, not the
    * accessor's. Accessors should be total functions; one that throws is treated as "nothing
@@ -73,12 +124,174 @@ export interface TReservedFieldCatalogEntry {
 }
 
 /**
- * The production reserved-field catalog. Deliberately empty: ENG-1836 ships the mechanism, ENG-1839
- * decides the contents. It exists now so call sites (ENG-1837) can wire
- * `projectReservedValues(RESERVED_FIELD_CATALOG, response)` today and light up when the entries
- * land, without another round of call-site changes.
+ * A field a client can read mid-survey. Its accessor is typed against
+ * {@link TClientEmbeddedValueResponse}, so marking an entry `client`/`both` while reading `finished`
+ * or `createdAt` is a **compile error** rather than a value that silently resolves to whatever the
+ * caller happened to fabricate. That is the whole reason the entry type is a union: the availability
+ * claim and the accessor's real dependencies cannot drift apart.
+ *
+ * A narrower parameter also means such an accessor stays callable with a full response, so
+ * {@link resolveEmbeddedValue} and {@link projectReservedValues} treat both variants identically.
  */
-export const RESERVED_FIELD_CATALOG: readonly TReservedFieldCatalogEntry[] = [];
+export interface TClientReservedFieldCatalogEntry extends TReservedFieldCatalogEntryBase {
+  // Everything that is not `server` is client-readable, spelled as the complement rather than a
+  // second literal list so a fourth availability value cannot be added without landing in one of the
+  // two variants — and therefore without deciding which response slice its accessor may read.
+  availability: Exclude<TReservedFieldAvailability, "server">;
+  read: (response: TClientEmbeddedValueResponse) => TReservedFieldRawValue;
+}
+
+/**
+ * One reserved field.
+ *
+ * The response location is a typed accessor rather than a dot-path string. Reserved fields are a
+ * static catalog in code, so the "path" can be code too — which makes an entry that points at a
+ * nonexistent response field a compile error instead of a silent `undefined`, needs no path-walking
+ * machinery whose edge cases would have to be tested separately, and lets an entry compute (unit
+ * conversion, redaction) instead of only fetching.
+ */
+export type TReservedFieldCatalogEntry = TServerReservedFieldCatalogEntry | TClientReservedFieldCatalogEntry;
+
+/**
+ * **The production reserved-field catalog — Tier 1.** Auto-captured system metadata every survey can
+ * reference by name without declaring anything. A static list in code, never rows in the
+ * `EmbeddedData` table and never a per-survey link: the list is identical for every workspace and
+ * keeps growing, so adding a field stays a code change rather than a data migration, and there is
+ * nothing to migrate anyway — the values already sit on every response ever stored.
+ *
+ * Every entry therefore resolves against historical responses too, which is why each accessor
+ * tolerates the field being absent rather than assuming today's ingest shape.
+ *
+ * `name` collisions are real and deliberate: a survey may already declare a hidden field called
+ * `country` or `url`, and `RESERVED_FIELD_NAMES` (reserved-field-names.ts) keeps only *new*
+ * declarations off these names. Existing surveys keep resolving their own field — see the per-survey
+ * precedence rule this catalog is paired with.
+ *
+ * Not in Tier 1, on purpose:
+ * - `status` — `Response` has no status column, and `finished` already carries the only distinction
+ *   that exists (complete vs. partial). Deriving a second spelling of the same bit would give two
+ *   names for one fact.
+ * - `pageUrl`/`pagePath`/`pageReferrer`/`utm*`/`viewport*`/`timezone` — their values do not exist on
+ *   this branch. `ZResponseMeta` has no home for them until the SDK captures them (ENG-1841), and an
+ *   entry pointing at a field nothing writes would resolve as unset on every response.
+ */
+export const RESERVED_FIELD_CATALOG: readonly TReservedFieldCatalogEntry[] = [
+  /** How the response was collected — `link`, `app`, … Set by the client on the response input. */
+  { name: "source", dataType: "string", availability: "client", privacy: "keep", read: (r) => r.meta.source },
+  /**
+   * The page the survey ran on. `redactQuery`, not `drop`: the path is what analytics needs, while a
+   * query string is where an identifier rides along (`?email=`, `?uid=`).
+   */
+  {
+    name: "url",
+    dataType: "string",
+    availability: "client",
+    privacy: "redactQuery",
+    read: (r) => r.meta.url,
+  },
+  /**
+   * Geo-IP country, resolved from the request in the ingest routes — nothing client-side knows it.
+   */
+  {
+    name: "country",
+    dataType: "string",
+    availability: "server",
+    privacy: "drop",
+    read: (r) => r.meta.country,
+  },
+  /** The action that triggered an app survey. */
+  { name: "action", dataType: "string", availability: "client", privacy: "keep", read: (r) => r.meta.action },
+  /**
+   * browser/os/deviceType are `server` because that is where they come from: `UAParser` runs over
+   * the `user-agent` request header in the ingest routes (see the v1/v2 client response routes), and
+   * nothing client-side produces them on this branch. Marking them `client` would let a mid-survey
+   * picker offer a field the renderer cannot resolve. They flip to `both` only once a client
+   * actually captures them.
+   */
+  {
+    name: "browser",
+    dataType: "string",
+    availability: "server",
+    privacy: "drop",
+    read: (r) => r.meta.userAgent?.browser,
+  },
+  {
+    name: "os",
+    dataType: "string",
+    availability: "server",
+    privacy: "drop",
+    read: (r) => r.meta.userAgent?.os,
+  },
+  {
+    name: "deviceType",
+    dataType: "string",
+    availability: "server",
+    privacy: "drop",
+    read: (r) => r.meta.userAgent?.device,
+  },
+  /** Only captured when the survey has IP capture enabled, so unset on most responses. */
+  {
+    name: "ipAddress",
+    dataType: "string",
+    availability: "server",
+    privacy: "drop",
+    read: (r) => r.meta.ipAddress,
+  },
+  /**
+   * Complete vs. partial. `server`, because mid-survey the answer is always "not yet" — offering it
+   * to a running survey would mean offering a constant `false`.
+   */
+  { name: "finished", dataType: "boolean", availability: "server", privacy: "keep", read: (r) => r.finished },
+  /** The language the respondent is answering in; known on both sides and agreed between them. */
+  { name: "language", dataType: "string", availability: "both", privacy: "keep", read: (r) => r.language },
+  /**
+   * responseId/surveyId are `server` by decision, not by limitation — a client does know its survey
+   * id. Internal identifiers have no business being recalled into copy a respondent reads, and
+   * `availability` is what the mid-survey pickers filter on. They stay in the catalog because
+   * server-side readers (exports, filters, webhooks) legitimately want them as columns.
+   */
+  { name: "responseId", dataType: "string", availability: "server", privacy: "keep", read: (r) => r.id },
+  { name: "surveyId", dataType: "string", availability: "server", privacy: "keep", read: (r) => r.surveyId },
+  /**
+   * Total time to complete. **Only meaningful on finished responses**: `calculateTtcTotal` is the
+   * only writer of `ttc._total`, and every call site guards it behind `finished ?` (e.g.
+   * apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts:64, the v1 client and
+   * management routes, and apps/web/lib/response/service.ts). On a partial response the key is
+   * absent and this resolves as unset — deliberately, rather than summing the per-element entries to
+   * invent a "duration so far" that no other surface reports.
+   *
+   * The stored `ttc` values are **milliseconds** (see `MAX_RESPONSE_TTC` in responses.ts), so the
+   * accessor converts. The field is named and typed in seconds, and a typed accessor is exactly what
+   * lets the catalog honor that instead of publishing a `durationSeconds` holding milliseconds.
+   */
+  {
+    name: "durationSeconds",
+    dataType: "number",
+    availability: "server",
+    privacy: "keep",
+    read: (r) => {
+      const totalMs = r.ttc?._total;
+      return typeof totalMs === "number" ? Math.round(totalMs / 1000) : undefined;
+    },
+  },
+  /**
+   * startedAt/finishedAt map onto the row's timestamps: `createdAt` is when the response record was
+   * opened, `updatedAt` when it was last written — which for a finished response is its submission.
+   * Both resolve to ISO strings, never `Date` objects (see {@link TResolvedEmbeddedValue}).
+   *
+   * `finishedAt` is `updatedAt` and therefore only means "finished at" on a finished response; on a
+   * partial one it is the last partial write. The pair is the closest honest reading of the columns
+   * that exist — `Response` stores no separate completion timestamp.
+   */
+  { name: "startedAt", dataType: "date", availability: "server", privacy: "keep", read: (r) => r.createdAt },
+  {
+    name: "finishedAt",
+    dataType: "date",
+    availability: "server",
+    privacy: "keep",
+    read: (r) => r.updatedAt,
+  },
+];
 
 /**
  * The slice of a stored field definition the resolver needs — `TEmbeddedData` minus the ownership
@@ -195,6 +408,50 @@ export const coerceToEmbeddedDataType = (
 };
 
 /**
+ * Resolves one catalog entry against whatever response slice its accessor asks for.
+ *
+ * A throwing accessor reads as missing rather than escalating: one dirty response fed to a computing
+ * accessor (URL parsing, unit conversion) must degrade like every other dirty input here — one field
+ * unset — not abort a caller's whole render or export loop over the catalog.
+ *
+ * Generic over the slice so "how a reserved read resolves" has exactly one definition shared by the
+ * server seam ({@link resolveEmbeddedValue}) and the mid-survey one
+ * ({@link projectClientReservedValues}), which is what keeps the two from drifting on coercion or on
+ * error handling.
+ */
+const resolveCatalogEntry = <TSlice>(
+  entry: { dataType: TEmbeddedDataType; read: (response: TSlice) => TReservedFieldRawValue },
+  response: TSlice
+): TResolvedEmbeddedValue | undefined => {
+  try {
+    return coerceToEmbeddedDataType(entry.read(response), entry.dataType);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * The shared body of the two projections: entry name → resolved value, absent values omitted,
+ * booleans stringified because the recall/logic map types have no boolean slot.
+ */
+const projectEntries = <TSlice>(
+  entries: readonly {
+    name: string;
+    dataType: TEmbeddedDataType;
+    read: (response: TSlice) => TReservedFieldRawValue;
+  }[],
+  response: TSlice
+): Record<string, string | number> => {
+  const values: Record<string, string | number> = {};
+  for (const entry of entries) {
+    const value = resolveCatalogEntry(entry, response);
+    if (value === undefined) continue;
+    values[entry.name] = typeof value === "boolean" ? String(value) : value;
+  }
+  return values;
+};
+
+/**
  * The single read seam for Embedded Data: returns one field's value from a response, or `undefined`
  * when the field has no value there. Every downstream surface (recall, logic, export, pickers)
  * will read through this once ENG-1837 repoints them, so "where does a field's value live" is
@@ -240,16 +497,7 @@ export const resolveEmbeddedValue = (
   // Definedness, not `"entry" in ref`: the `entry?: never` exclusion prop keeps the `in` operator
   // from narrowing the union, and this way a degenerate `{ field, link, entry: undefined }` object
   // still resolves through its field instead of crashing on `undefined.read`.
-  if (ref.entry !== undefined) {
-    // A throwing accessor reads as missing rather than escalating: one dirty response row fed to a
-    // computing accessor (e.g. URL parsing) must degrade like every other dirty input here — one
-    // field unset — not abort a caller's whole render or export loop over the catalog.
-    try {
-      return coerceToEmbeddedDataType(ref.entry.read(response), ref.entry.dataType);
-    } catch {
-      return undefined;
-    }
-  }
+  if (ref.entry !== undefined) return resolveCatalogEntry(ref.entry, response);
 
   const { field, link } = ref;
   if (field.source === "reserved") return undefined;
@@ -331,21 +579,42 @@ export const getLogicVariableValue = (
  * `undefined`, exactly like an absent hidden field today), and booleans are stringified to
  * `"true"`/`"false"` — what `String()` would render anyway, in a map type that has no boolean slot.
  *
- * An entry name that matches an element id or hidden field name shadows it in the merged map, and
- * `FORBIDDEN_IDS` guards none of the names §9b proposes — so ENG-1839 picks names knowing that.
+ * An entry name that matches an element id or hidden field name shadows it in the merged map, which
+ * is why the caller — not this function — owns precedence. `FORBIDDEN_IDS` never guarded these names
+ * (only `source` overlaps), so surveys stored today can and do declare a field called `country` or
+ * `url`; `RESERVED_FIELD_NAMES` (reserved-field-names.ts) stops only *new* declarations, and a
+ * consumer merging this map must let an existing declared field win inside its own survey.
  */
 export const projectReservedValues = (
   entries: readonly TReservedFieldCatalogEntry[],
   response: TEmbeddedValueResponse
-): Record<string, string | number> => {
-  const values: Record<string, string | number> = {};
-  for (const entry of entries) {
-    const value = resolveEmbeddedValue({ entry }, response);
-    if (value === undefined) continue;
-    values[entry.name] = typeof value === "boolean" ? String(value) : value;
-  }
-  return values;
-};
+): Record<string, string | number> => projectEntries(entries, response);
+
+/**
+ * The mid-survey counterpart of {@link projectReservedValues}: what a **client** can project while
+ * the respondent is still answering.
+ *
+ * Two things make it a separate function rather than a flag:
+ *
+ * 1. It takes {@link TClientEmbeddedValueResponse}, the shape a running survey actually holds. The
+ *    persisted-only fields are not optional here, they are absent — so a caller cannot be tempted to
+ *    pass `id: ""`, `createdAt: new Date()` or `finished: false` and get values back that describe
+ *    the fabrication rather than the response.
+ * 2. It drops every `server` entry, and the type system guarantees the survivors never needed those
+ *    fields in the first place (see {@link TClientReservedFieldCatalogEntry}). A server-only accessor
+ *    is filtered out before it is ever invoked, so nothing throws and nothing resolves from a stub.
+ *
+ * Same output contract as {@link projectReservedValues} — absent values omitted, booleans
+ * stringified — so a consumer can merge either one into the same recall/logic map.
+ */
+export const projectClientReservedValues = (
+  entries: readonly TReservedFieldCatalogEntry[],
+  response: TClientEmbeddedValueResponse
+): Record<string, string | number> =>
+  projectEntries(
+    entries.filter((entry): entry is TClientReservedFieldCatalogEntry => entry.availability !== "server"),
+    response
+  );
 
 /** One referenceable field, carrying the key a consumer must use to address it. */
 export interface TReadableField {

--- a/packages/types/embedded-data.test.ts
+++ b/packages/types/embedded-data.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { ZEmbeddedData, ZSurveyEmbeddedData, isLocalEmbeddedData } from "./embedded-data";
+import { RESERVED_FIELD_NAMES } from "./reserved-field-names";
 import { RESERVED_DECLARED_FIELD_NAMES } from "./surveys/validation";
 
 const localField = {
@@ -92,8 +93,22 @@ describe("ZEmbeddedData", () => {
       }
     });
 
+    test("rejects every reserved catalog name", () => {
+      // A shared field keyed `country` could be created and filled, but the reserved read of the same
+      // name would shadow it everywhere it is referenced — so it is refused at authoring time. Note
+      // these names are NOT in RESERVED_DECLARED_FIELD_NAMES on purpose: that set also drives
+      // ingest's capture refusal, and adding them there would stop `?country=DE` from filling the
+      // hidden field of a survey that already declares one (see reserved-field-names.ts).
+      for (const reserved of RESERVED_FIELD_NAMES) {
+        const result = ZEmbeddedData.safeParse({ ...sharedField, key: reserved });
+        expect(failedPaths({ ...sharedField, key: reserved })).toContain("key");
+        expect(result.error?.issues.map((issue) => issue.message)).toContain("Key is reserved");
+      }
+    });
+
     test("accepts a name that merely contains a reserved word", () => {
       expect(ZEmbeddedData.safeParse({ ...sharedField, key: "language_pref" }).success).toBe(true);
+      expect(ZEmbeddedData.safeParse({ ...sharedField, key: "country_code" }).success).toBe(true);
     });
   });
 

--- a/packages/types/embedded-data.ts
+++ b/packages/types/embedded-data.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { RESERVED_FIELD_NAMES } from "./reserved-field-names";
 import { isLegacyIdCharset, isSafeIdentifier } from "./safe-identifier";
 import { RESERVED_DECLARED_FIELD_NAMES } from "./surveys/validation";
 
@@ -86,7 +87,17 @@ export const ZEmbeddedData = z
       // A library key is always newly authored (local fields carry `key: null`), so it goes through
       // the strict create-time rule. Without this a shared ingested field could be keyed `verify` or
       // `lang`, and ingestion would then refuse to fill it — a field that can never hold a value.
-      .refine((key) => !RESERVED_DECLARED_FIELD_NAMES.has(key.toLowerCase()), "Key is reserved")
+      //
+      // Two sets, not one, and they must stay separate. `RESERVED_DECLARED_FIELD_NAMES` is also the
+      // capture-refusal list used by `getHiddenFieldsFromSearchParams`, so a name added there stops
+      // being ingestible for surveys that already declare it; `RESERVED_FIELD_NAMES` is
+      // authoring-only, and merging the two would silently break live URL capture on existing
+      // surveys (see reserved-field-names.ts). A reserved-catalog name is refused for the same
+      // reason as the rest: the reserved read of that name would permanently shadow the field.
+      .refine((key) => {
+        const normalizedKey = key.toLowerCase();
+        return !RESERVED_DECLARED_FIELD_NAMES.has(normalizedKey) && !RESERVED_FIELD_NAMES.has(normalizedKey);
+      }, "Key is reserved")
       .nullable(),
     name: ZEmbeddedDataName,
     description: z.string().nullable(),

--- a/packages/types/reserved-field-names.ts
+++ b/packages/types/reserved-field-names.ts
@@ -1,0 +1,49 @@
+/**
+ * Every reserved field name, lowercased — the blocklist a **newly authored** Embedded Data name is
+ * refused for, because a field named `country` would be permanently shadowed by the reserved read of
+ * the same name.
+ *
+ * **Why this is its own module, and a literal rather than a derivation.**
+ *
+ * It is a deliberate leaf: it imports nothing. The set is consumed by `ZEmbeddedData` in
+ * embedded-data.ts, and deriving it from `RESERVED_FIELD_CATALOG` would make that schema module
+ * depend on embedded-data-resolver.ts — which type-imports embedded-data.ts back, and whose own
+ * imports reach surveys/validation.ts. Today those back-edges are type-only and erase at runtime, so
+ * the cycle is latent rather than live; the first time anyone needs a *value* from embedded-data.ts
+ * in the resolver it closes for real, and the failure mode is a half-initialized module during the
+ * `z.object(...)` evaluation at import time — the kind of bug that shows up as an inexplicable
+ * `undefined` in one bundler and not another. Keeping this a leaf makes that unreachable.
+ *
+ * It also cannot live in surveys/validation.ts next to `RESERVED_DECLARED_FIELD_NAMES`, for the same
+ * reason from the other direction: embedded-data-resolver.ts imports `getTextContent` from there, so
+ * importing the catalog back into it would close the cycle immediately.
+ *
+ * The cost is one duplicated list, and `embedded-data-resolver.test.ts` pays it down: an anti-drift
+ * test asserts this set is exactly the catalog's names lowercased, so an entry added to one and not
+ * the other fails the suite rather than shipping an unguarded name.
+ *
+ * **This is not `RESERVED_DECLARED_FIELD_NAMES`, and must never be merged into it.** That set is also
+ * the capture-refusal list read by `getHiddenFieldsFromSearchParams`
+ * (apps/web/modules/survey/link/lib/hidden-fields.ts): a param whose key is in it is dropped instead
+ * of stored. Adding `country` there would stop `?country=DE` from filling the hidden field of a
+ * survey that legitimately declares `country` today — silently breaking live data collection for a
+ * survey nobody changed. These names are refused at *authoring* time only; whatever an existing
+ * survey already declares keeps working, and keeps winning inside that survey.
+ */
+export const RESERVED_FIELD_NAMES: ReadonlySet<string> = new Set([
+  "source",
+  "url",
+  "country",
+  "action",
+  "browser",
+  "os",
+  "devicetype",
+  "ipaddress",
+  "finished",
+  "language",
+  "responseid",
+  "surveyid",
+  "durationseconds",
+  "startedat",
+  "finishedat",
+]);


### PR DESCRIPTION
## What & why

Milestone 1 shipped the reserved-field mechanism and left the catalog empty
(`RESERVED_FIELD_CATALOG: readonly TReservedFieldCatalogEntry[] = []`). Nothing could reference a
reserved field, because there were none. This fills it with the 15 Tier-1 entries and adds the two
classifications the sibling tickets need in order to consume it.

**The catalog.** 15 entries, each a `name` + `dataType` + a typed accessor: `source`, `url`,
`country`, `action`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`,
`responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`. A static list in code, never
rows in `EmbeddedData` and never a per-survey link — the values already sit on every response ever
stored, so every entry resolves against historical responses too.

`status` is deliberately not in Tier 1 (the ticket left it open): `Response` has no status column and
`finished` already carries the only distinction that exists, so a derived `status` would be a second
name for one bit. `pageUrl`/`utm*`/`viewport*`/`timezone` are also out — their values do not exist on
this branch, and an entry pointing at a field nothing writes would resolve as unset on every
response. ENG-1841 appends those together with the `ZResponseMeta` fields that carry them.

**Two new fields on each entry.**

- `availability: "client" | "server" | "both"` — *when* the value can be known, not who may see it.
  It gates what a mid-survey picker may offer (ENG-1840). `browser`/`os`/`deviceType` are `server`
  because that is where they come from: `UAParser` runs over the `user-agent` request header in the
  ingest routes and nothing client-side produces them on this branch (verified — no `UAParser`,
  `ua-parser` or `userAgent` read anywhere in `packages/surveys/src` or `packages/js-core/src`).
  `responseId`/`surveyId` are `server` by decision rather than limitation: internal ids have no
  business being recalled into copy a respondent reads.
- `privacy: "keep" | "drop" | "redactQuery"` — what the (not-yet-existing) "Anonymize responses"
  toggle does to the field at ingest. Declared on the entry so the eventual toggle has no per-field
  list of its own to drift from. **Nothing consumes it yet.**

**`projectClientReservedValues`.** The mid-survey counterpart of `projectReservedValues`: it drops
every `server` entry and resolves against `TClientEmbeddedValueResponse` — the slice a running survey
actually holds (`meta`, `data`, `variables`, `ttc`, `language`, `surveyId`), with no `id`,
`createdAt`, `updatedAt` or final `finished`. The entry type is now a union keyed on `availability`,
so a `client`/`both` accessor is typed against that narrower slice: marking an entry client-available
while reading `finished` or `createdAt` is a compile error, rather than something that resolves from a
fabricated `id: ""` / `new Date()` stub.

**Name collisions.** New leaf module `packages/types/reserved-field-names.ts` exports
`RESERVED_FIELD_NAMES`, and `ZEmbeddedData.key` now refines against it as well as against
`RESERVED_DECLARED_FIELD_NAMES`, so a newly authored library key cannot take a name the reserved read
would permanently shadow.

The two sets stay separate, which is the load-bearing part. `RESERVED_DECLARED_FIELD_NAMES` is *also*
the capture-refusal list read by `getHiddenFieldsFromSearchParams`
(`apps/web/modules/survey/link/lib/hidden-fields.ts:32`) — a param whose key is in it is dropped
instead of stored. Adding `country` there would stop `?country=DE` from filling the hidden field of a
survey that legitimately declares `country` today, silently breaking live data collection for a survey
nobody changed. These names are refused at *authoring* time only.

`reserved-field-names.ts` is a deliberate leaf that imports nothing rather than deriving the set from
the catalog: `embedded-data-resolver.ts` type-imports `embedded-data.ts` back and value-imports
`surveys/validation.ts`, so deriving would make the row schema depend on the resolver and leave a
latent import cycle that closes for real the first time anyone needs a *value* from
`embedded-data.ts` in the resolver. An anti-drift test pins the two lists together instead.

**Storage-key enforcement and the per-survey precedence rule are out of scope here** — they land in
part 2 of ENG-1839 (`surveys/validation.ts`, `apps/web/lib/survey/service.ts`).

### One deliberate deviation from the ticket table

The ticket lists `durationSeconds` with path `ttc._total`, read raw. The stored `ttc` values are
**milliseconds** (`MAX_RESPONSE_TTC` in `packages/types/responses.ts`, `// 24 hours per element`), so
a raw read would publish `90400` under a field named — and typed — in seconds. The accessor converts
(`Math.round(totalMs / 1000)`); that a reserved "path" is a typed accessor rather than a dot-path
string is exactly what makes this expressible. If you would rather ship the raw millisecond value,
it is a one-line change at `packages/types/embedded-data-resolver.ts:274`.

## Linear ticket

Fixes ENG-1839 — https://linear.app/formbricks/issue/ENG-1839/reserved-field-catalog-tier-1-name-collision-rules

Part 1 of 2 (the catalog only). Based on `epic/embedded-data-v1`, not `main`.

## How this was tested

Unit tests only — the diff is pure `.ts` logic in `packages/types` with no UI and no runtime surface
(see Risks: the catalog has no production consumer yet, so there is nothing to click).

| Command | Result |
| --- | --- |
| `pnpm test --filter=@formbricks/types` | ✅ 5 files, 242 tests passed |
| `packages/types` `tsc --noEmit` | ✅ clean |
| `apps/web` `tsc --noEmit` | ⚠️ 12 pre-existing errors in `playwright/survey-accessibility.spec.ts` and `proxy.test.ts`; **0** related to this change (neither file imports `@formbricks/types`) |
| `npx eslint .` in `packages/types` | ✅ 0 errors (4 pre-existing warnings in `surveys/*.ts`, untouched here) |
| `prettier --check "packages/types/**/*.ts"` | ✅ clean |

Tests added, all in `packages/types/embedded-data-resolver.test.ts` unless noted:

- the catalog is pinned as a table — all 15 entries with their `name`, `dataType`, `availability` and
  `privacy`, in order — so adding, removing or reclassifying one has to be a deliberate edit;
- every entry resolves against a fully captured response (one exact-map assertion, so a missing key
  is a failed entry and an extra key is an undeclared one);
- every entry resolves against a **historical** response whose `meta` holds only `source` + `url` and
  which has no `ttc` at all — the captured fields resolve, the rest report unset;
- `durationSeconds` converts ms → whole seconds, and is **unset on a partial response** rather than
  reporting a duration-so-far;
- `startedAt`/`finishedAt` resolve to ISO strings, asserted `not.toBeInstanceOf(Date)`;
- `finished` resolves as a boolean and projects as `"true"`/`"false"` through `projectReservedValues`;
- no accessor throws on a response where every optional location is absent;
- `projectClientReservedValues` projects only the client-readable entries, and **never invokes a
  server-only accessor** — proved with `vi.fn()` spies, because filtering alone would produce
  identical output either way (a server accessor run against the client slice reads `undefined` and is
  dropped by coercion);
- anti-drift: `RESERVED_FIELD_NAMES` is exactly the catalog's names lowercased;
- `ZEmbeddedData` rejects every reserved catalog name as a library `key` with the message
  `"Key is reserved"`, while still accepting `country_code` / `language_pref`
  (`packages/types/embedded-data.test.ts`).

**Every new test was proved able to fail.** Each mutation was applied to the source, the suite run,
then reverted:

| Mutation | Result |
| --- | --- |
| `reserved-field-names.ts:36` `"country"` → `"countryy"` | 1 failed — the anti-drift test |
| `embedded-data-resolver.ts:274` drop the `/ 1000` conversion | 2 failed |
| `embedded-data-resolver.ts:273` read `ttc.q1` instead of `ttc._total` | 3 failed, incl. the partial-response test |
| `embedded-data-resolver.ts:615` stop filtering `server` entries | 3 failed, incl. the spy test |
| `embedded-data.ts:99` drop the `RESERVED_FIELD_NAMES` refine | 1 failed |

The compile-time guarantee has no runtime test by nature: marking `finished` as
`availability: "client"` is a **type error**, which is the check. Reproduce by editing the `finished`
entry in `embedded-data-resolver.ts` and running `npx tsc --noEmit` in `packages/types`.

Not run: `pnpm test:e2e` (no behaviour reaches a browser — see Risks) and `pnpm build` for the full
workspace (unchanged build inputs outside `packages/types`).

## Breaking changes

None.

`TReservedFieldCatalogEntry` gains two required fields, which is a compile-time break for anyone
constructing an entry — but nothing outside `packages/types` does. The only external reference to the
catalog seam is `recall-item-select.tsx:110`, which passes `reservedEntries: []`. Both classifications
are new, so no existing value changes meaning.

## QA / Test Plan

**How to test**

Nothing in this PR is reachable from the running app or the API. The catalog has no production
consumer until ENG-1840 wires recall and logic onto it; `projectClientReservedValues` has no caller at
all. There is no screen to open and no request whose response changes.

The one behaviour a tester *could* reach is negative, and only via the workspace Embedded Data library
once its authoring UI exists on this epic — creating a **shared** field whose library key is a
reserved name is now refused:

- [ ] Create a shared (workspace-library) Embedded Data field with key `country` → rejected with
      "Key is reserved". Same for `url`, `browser`, `os`, `devicetype`, `ipaddress`, `finished`,
      `language`, `responseid`, `surveyid`, `durationseconds`, `startedat`, `finishedat`. Flagged as
      inferred: whether an authoring surface for shared library keys is reachable in the UI on this
      branch was not verified in this session.
- [ ] Create a shared field with key `country_code` or `language_pref` → accepted. Only exact
      (case-insensitive) matches are refused, not names that merely contain a reserved word.
- [ ] **Regression, the one that matters:** take an existing survey with a hidden field named
      `country`, open its link with `?country=DE`, submit → the response still stores `DE` under
      `country` and `#recall:country#` still renders `DE`. This must be unchanged; the reserved names
      were deliberately kept out of the ingest capture-refusal list so that it is.

**Preconditions / test data**

- Any workspace on `epic/embedded-data-v1`. No feature flag, no entitlement, no plan gate.
- For the regression check: a link survey with a hidden field literally named `country` (or `url`,
  `source`, `language`, `browser`, `os` — all plausible names authors already use).

**Risks & regressions**

- **There is no behaviour change to look for in this PR.** The catalog has no production consumer
  until ENG-1840 lands, and `projectClientReservedValues` has none at all. Reviewers should read this
  as a data + type change, not as a functional one.
- The real risk this PR consciously avoids is the ingest one: had the catalog names gone into
  `RESERVED_DECLARED_FIELD_NAMES`, `getHiddenFieldsFromSearchParams` would have stopped capturing
  `?country=`, `?url=`, `?language=` … for every existing survey declaring such a field. Worth
  re-checking in review that no follow-up merges the two sets.
- `ipAddress` is now a catalog entry, so once ENG-1840 wires server-side recall, `#recall:ipAddress#`
  would become renderable — including into follow-up emails. `availability: "server"` keeps it out of
  the mid-survey client projection, and `privacy: "drop"` records that anonymization must not capture
  it, but ENG-1840 should decide explicitly whether internal/PII entries are offered in pickers at
  all. Nothing in this PR exposes it.
- `finishedAt` reads `updatedAt`, so on a **partial** response it is the last partial write rather
  than a completion time. `Response` stores no separate completion timestamp, so this is the closest
  honest reading of the columns that exist; flagging it because a consumer could present it as a
  finish time. Unlike `durationSeconds` it is not guarded on `finished` — say so if you would prefer
  it were.
- `deviceType` etc. are blocked case-insensitively (`devicetype`), matching how the existing refine
  already lowercases. Slightly broader than a strict exact-name collision, and errs safe.

**Migrations / env / cutover**

- none