### PR TITLE
feat(embedded-data): make reserved fields usable in recall and logic [ENG-1840]

### DIFF
--- a/apps/web/app/api/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/client/[workspaceId]/responses/lib/response.ts
@@ -45,6 +45,8 @@ export const createResponseWithQuotaEvaluation = async <TInput extends TQuotaEva
       variables: responseInput.variables,
       language: canonicalLanguage,
       responseFinished: response.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response,
       tx,
     });
 

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/response.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/response.test.ts
@@ -89,6 +89,8 @@ describe("updateResponseWithQuotaEvaluation", () => {
       variables: mockResponse.variables,
       language: mockResponse.language,
       responseFinished: mockResponse.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: expect.any(String) }),
       tx: mockTx,
     });
 
@@ -114,6 +116,8 @@ describe("updateResponseWithQuotaEvaluation", () => {
       variables: mockResponse.variables,
       language: mockResponse.language,
       responseFinished: mockResponse.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: expect.any(String) }),
       tx: mockTx,
     });
 
@@ -137,6 +141,8 @@ describe("updateResponseWithQuotaEvaluation", () => {
       variables: responseWithNullLanguage.variables,
       language: "default",
       responseFinished: responseWithNullLanguage.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: expect.any(String) }),
       tx: mockTx,
     });
 

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/response.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/response.ts
@@ -18,6 +18,8 @@ export const updateResponseWithQuotaEvaluation = async (
       variables: response.variables,
       language: response.language || "default",
       responseFinished: response.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response,
       tx,
     });
 

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
@@ -232,6 +232,8 @@ describe("createResponseWithQuotaEvaluation", () => {
       variables: mockResponseInput.variables,
       language: undefined, // null language is normalized to undefined for quota evaluation
       responseFinished: mockResponseInput.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: responseId }),
       tx: mockTx,
     });
 
@@ -286,6 +288,8 @@ describe("createResponseWithQuotaEvaluation", () => {
       variables: mockResponseInput.variables,
       language: undefined, // null language is normalized to undefined for quota evaluation
       responseFinished: mockResponseInput.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: responseId }),
       tx: mockTx,
     });
 

--- a/apps/web/app/api/v1/management/responses/[responseId]/lib/response.test.ts
+++ b/apps/web/app/api/v1/management/responses/[responseId]/lib/response.test.ts
@@ -102,6 +102,8 @@ describe("updateResponseWithQuotaEvaluation", () => {
       variables: mockResponse.variables,
       language: mockResponse.language,
       responseFinished: mockResponse.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: expect.any(String) }),
       tx: mockTx,
     });
 
@@ -125,6 +127,8 @@ describe("updateResponseWithQuotaEvaluation", () => {
       variables: mockResponse.variables,
       language: mockResponse.language,
       responseFinished: mockResponse.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: expect.any(String) }),
       tx: mockTx,
     });
 
@@ -152,6 +156,8 @@ describe("updateResponseWithQuotaEvaluation", () => {
       variables: mockResponse.variables,
       language: mockResponse.language,
       responseFinished: mockResponse.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: expect.any(String) }),
       tx: mockTx,
     });
 
@@ -187,6 +193,8 @@ describe("updateResponseWithQuotaEvaluation", () => {
       variables: responseWithNullLanguage.variables,
       language: "default",
       responseFinished: responseWithNullLanguage.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: expect.any(String) }),
       tx: mockTx,
     });
 

--- a/apps/web/app/api/v1/management/responses/[responseId]/lib/response.ts
+++ b/apps/web/app/api/v1/management/responses/[responseId]/lib/response.ts
@@ -18,6 +18,8 @@ export const updateResponseWithQuotaEvaluation = async (
       variables: response.variables,
       language: response.language || "default",
       responseFinished: response.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response,
       tx,
     });
 

--- a/apps/web/app/api/v1/management/responses/lib/response.ts
+++ b/apps/web/app/api/v1/management/responses/lib/response.ts
@@ -72,6 +72,8 @@ export const createResponseWithQuotaEvaluation = async (
       variables: responseInput.variables,
       language: response.language || "default",
       responseFinished: response.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response,
       tx,
     });
 

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
@@ -370,6 +370,8 @@ describe("createResponseWithQuotaEvaluation V2", () => {
       variables: mockResponseInput.variables,
       language: "en-US", // canonicalized from "en"
       responseFinished: expectedResponse.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: expectedResponse.id }),
       tx: mockTx,
     });
   });
@@ -393,6 +395,8 @@ describe("createResponseWithQuotaEvaluation V2", () => {
       variables: mockResponseInput.variables,
       language: "en-US", // canonicalized from "en"
       responseFinished: expectedResponse.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response: expect.objectContaining({ id: expectedResponse.id }),
       tx: mockTx,
     });
   });

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -473,6 +473,7 @@ checksums:
     common/summary: 13eb7b8a239fb4702dfdaee69100a220
     common/survey: b659d270a53dada994d926e0cc6e9a54
     common/survey_completed: 5d1974ef76d4436daee96b2b76eddd20
+    common/survey_data: f4a5130a1b0a188de060764e894b75b5
     common/survey_id: 08303e98b3d4134947256e494b0c829e
     common/survey_languages: 93e4a10ab190e6b1e1f7fe5f702df249
     common/survey_live: d1f370505c67509e7b2759952daba20d

--- a/apps/web/lib/surveyLogic/utils.test.ts
+++ b/apps/web/lib/surveyLogic/utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
-import { deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
+import {
+  type TEmbeddedValueResponse,
+  deriveLegacyEmbeddedData,
+} from "@formbricks/types/embedded-data-resolver";
 import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TResponseData, TResponseVariables } from "@formbricks/types/responses";
 import { TSurveyBlockLogic, TSurveyBlockLogicAction } from "@formbricks/types/surveys/blocks";
@@ -8,6 +11,7 @@ import { TConditionGroup, TSingleCondition } from "@formbricks/types/surveys/log
 import { TSurveyLogicAction } from "@formbricks/types/surveys/types";
 import {
   addConditionBelow,
+  buildServerEmbeddedValues,
   createGroupFromResource,
   deleteEmptyGroups,
   duplicateCondition,
@@ -1629,5 +1633,128 @@ describe("computed fields resolve through the inlined EmbeddedData rows", () => 
         {}
       )
     ).toEqual({});
+  });
+});
+
+describe("reserved field operands, server engine (ENG-1840)", () => {
+  const survey = {
+    id: "survey1",
+    name: "Survey 1",
+    questions: [],
+    blocks: [{ id: "block1", name: "Block 1", elements: [] }],
+    variables: [],
+    embeddedFields: [],
+    hiddenFields: { enabled: true, fieldIds: [] },
+    type: "link",
+    status: "inProgress",
+    languages: [],
+    endings: [],
+    welcomeCard: { enabled: false, showResponseCount: false, timeToFinish: false },
+  } as unknown as TJsWorkspaceStateSurvey;
+
+  const reservedGroup = (
+    name: string,
+    operator: TSingleCondition["operator"],
+    rightOperand?: TSingleCondition["rightOperand"]
+  ): TConditionGroup => ({
+    id: "group1",
+    connector: "and",
+    conditions: [
+      { id: "condition1", operator, leftOperand: { type: "reserved", value: name }, rightOperand },
+    ],
+  });
+
+  const response = {
+    id: "response1",
+    surveyId: "survey1",
+    createdAt: new Date("2026-01-01T10:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T10:02:30.000Z"),
+    finished: true,
+    language: "de",
+    data: {},
+    variables: {},
+    ttc: { _total: 150000 },
+    meta: { country: "DE", url: "https://app.test/s/abc", source: "link" },
+  } as unknown as TEmbeddedValueResponse;
+
+  test("the full catalog resolves server-side, including server-only fields", () => {
+    const values = buildServerEmbeddedValues(response);
+
+    expect(
+      evaluateLogic(
+        survey,
+        {},
+        {},
+        reservedGroup("country", "equals", { type: "static", value: "DE" }),
+        "en",
+        values
+      )
+    ).toBe(true);
+    // durationSeconds converts ttc milliseconds to seconds — 150000ms is 150s, so "> 60" holds.
+    expect(
+      evaluateLogic(
+        survey,
+        {},
+        {},
+        reservedGroup("durationSeconds", "isGreaterThan", { type: "static", value: 60 }),
+        "en",
+        values
+      )
+    ).toBe(true);
+    expect(
+      evaluateLogic(
+        survey,
+        {},
+        {},
+        reservedGroup("durationSeconds", "isLessThan", { type: "static", value: 60 }),
+        "en",
+        values
+      )
+    ).toBe(false);
+    expect(
+      evaluateLogic(
+        survey,
+        {},
+        {},
+        reservedGroup("finished", "equals", { type: "static", value: "true" }),
+        "en",
+        values
+      )
+    ).toBe(true);
+  });
+
+  test("a declared field of the same name still wins server-side", () => {
+    const values = buildServerEmbeddedValues({ ...response, data: { country: "Declared answer" } });
+
+    expect(
+      evaluateLogic(
+        survey,
+        {},
+        {},
+        reservedGroup("country", "equals", { type: "static", value: "Declared answer" }),
+        "en",
+        values
+      )
+    ).toBe(true);
+    expect(
+      evaluateLogic(
+        survey,
+        {},
+        {},
+        reservedGroup("country", "equals", { type: "static", value: "DE" }),
+        "en",
+        values
+      )
+    ).toBe(false);
+  });
+
+  test("an unknown reserved name and a missing map both read as unset", () => {
+    const values = buildServerEmbeddedValues(response);
+
+    expect(evaluateLogic(survey, {}, {}, reservedGroup("notACatalogEntry", "isSet"), "en", values)).toBe(
+      false
+    );
+    // Callers with no response in hand (quota screening) pass nothing and get unset, not a throw.
+    expect(evaluateLogic(survey, {}, {}, reservedGroup("country", "isSet"), "en")).toBe(false);
   });
 });

--- a/apps/web/lib/surveyLogic/utils.ts
+++ b/apps/web/lib/surveyLogic/utils.ts
@@ -18,6 +18,7 @@ import {
 } from "@formbricks/types/surveys/blocks";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TConditionGroup, TSingleCondition } from "@formbricks/types/surveys/logic";
+import { evaluateConditionGroup } from "@formbricks/types/surveys/logic-evaluation";
 import { TActionCalculate, TSurveyLogicAction } from "@formbricks/types/surveys/types";
 import { getLocalizedValue } from "@/lib/i18n/utils";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
@@ -263,28 +264,10 @@ export const evaluateLogic = (
   conditions: TConditionGroup,
   selectedLanguage: string,
   embeddedValues: TResponseData = {}
-): boolean => {
-  const evaluateConditionGroup = (group: TConditionGroup): boolean => {
-    const results = group.conditions.map((condition) => {
-      if (isConditionGroup(condition)) {
-        return evaluateConditionGroup(condition);
-      } else {
-        return evaluateSingleCondition(
-          localSurvey,
-          data,
-          variablesData,
-          condition,
-          selectedLanguage,
-          embeddedValues
-        );
-      }
-    });
-
-    return group.connector === "or" ? results.some((r) => r) : results.every((r) => r);
-  };
-
-  return evaluateConditionGroup(conditions);
-};
+): boolean =>
+  evaluateConditionGroup(conditions, (condition) =>
+    evaluateSingleCondition(localSurvey, data, variablesData, condition, selectedLanguage, embeddedValues)
+  );
 
 const evaluateSingleCondition = (
   localSurvey: TJsWorkspaceStateSurvey,

--- a/apps/web/lib/surveyLogic/utils.ts
+++ b/apps/web/lib/surveyLogic/utils.ts
@@ -1,9 +1,13 @@
 import { createId } from "@paralleldrive/cuid2";
 import {
+  RESERVED_FIELD_CATALOG,
+  type TEmbeddedValueResponse,
   findComputedEmbeddedField,
   getComputedEmbeddedFields,
   getComputedFieldDataType,
   getLogicVariableValue,
+  mergeReservedValues,
+  projectReservedValues,
 } from "@formbricks/types/embedded-data-resolver";
 import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TResponseData, TResponseVariables } from "@formbricks/types/responses";
@@ -232,19 +236,47 @@ export const getUpdatedActionBody = (
   }
 };
 
+/**
+ * The reserved-field lookup map for a **persisted** response: the full catalog projected, then
+ * shadowed by the response's own data so a declared field of the same name still wins
+ * (`mergeReservedValues` is the single expression carrying that guarantee).
+ *
+ * Server-side every reserved field is knowable, so this reads `RESERVED_FIELD_CATALOG` whole rather
+ * than the mid-survey subset — the renderer's `projectClientReservedValues` exists precisely because
+ * that is *not* true in the browser.
+ */
+export const buildServerEmbeddedValues = (response: TEmbeddedValueResponse): TResponseData =>
+  mergeReservedValues(projectReservedValues(RESERVED_FIELD_CATALOG, response), response.data);
+
+/**
+ * @param embeddedValues Reserved-field values merged UNDER `data` by `mergeReservedValues` — what a
+ *   `reserved` operand reads. Server-side callers holding a real `TResponse` should build this with
+ *   {@link buildServerEmbeddedValues} so the **full** catalog resolves (country, durationSeconds,
+ *   finished, …), not just the mid-survey subset the renderer can see. Defaults to `{}` for callers
+ *   with no response in hand — quota screening evaluates before the row exists — where every
+ *   reserved operand then reads as unset rather than throwing.
+ */
 export const evaluateLogic = (
   localSurvey: TJsWorkspaceStateSurvey,
   data: TResponseData,
   variablesData: TResponseVariables,
   conditions: TConditionGroup,
-  selectedLanguage: string
+  selectedLanguage: string,
+  embeddedValues: TResponseData = {}
 ): boolean => {
   const evaluateConditionGroup = (group: TConditionGroup): boolean => {
     const results = group.conditions.map((condition) => {
       if (isConditionGroup(condition)) {
         return evaluateConditionGroup(condition);
       } else {
-        return evaluateSingleCondition(localSurvey, data, variablesData, condition, selectedLanguage);
+        return evaluateSingleCondition(
+          localSurvey,
+          data,
+          variablesData,
+          condition,
+          selectedLanguage,
+          embeddedValues
+        );
       }
     });
 
@@ -259,7 +291,8 @@ const evaluateSingleCondition = (
   data: TResponseData,
   variablesData: TResponseVariables,
   condition: TSingleCondition,
-  selectedLanguage: string
+  selectedLanguage: string,
+  embeddedValues: TResponseData
 ): boolean => {
   try {
     let leftValue = getLeftOperandValue(
@@ -267,11 +300,12 @@ const evaluateSingleCondition = (
       data,
       variablesData,
       condition.leftOperand,
-      selectedLanguage
+      selectedLanguage,
+      embeddedValues
     );
 
     let rightValue = condition.rightOperand
-      ? getRightOperandValue(localSurvey, data, variablesData, condition.rightOperand)
+      ? getRightOperandValue(localSurvey, data, variablesData, condition.rightOperand, embeddedValues)
       : undefined;
 
     const elements = getElementsFromBlocks(localSurvey.blocks);
@@ -502,7 +536,8 @@ const getLeftOperandValue = (
   data: TResponseData,
   variablesData: TResponseVariables,
   leftOperand: TSingleCondition["leftOperand"],
-  selectedLanguage: string
+  selectedLanguage: string,
+  embeddedValues: TResponseData
 ) => {
   switch (leftOperand.type) {
     case "element":
@@ -588,6 +623,10 @@ const getLeftOperandValue = (
       return getLogicVariableValue(getComputedEmbeddedFields(localSurvey), leftOperand.value, variablesData);
     case "hiddenField":
       return data[leftOperand.value];
+    // Server-side the caller projects the FULL catalog, so country/durationSeconds/finished all
+    // resolve here — unlike the renderer, which only ever sees the client-available subset.
+    case "reserved":
+      return embeddedValues[leftOperand.value];
     default:
       return undefined;
   }
@@ -597,7 +636,8 @@ const getRightOperandValue = (
   localSurvey: TJsWorkspaceStateSurvey,
   data: TResponseData,
   variablesData: TResponseVariables,
-  rightOperand: TSingleCondition["rightOperand"]
+  rightOperand: TSingleCondition["rightOperand"],
+  embeddedValues: TResponseData
 ) => {
   if (!rightOperand) return undefined;
 
@@ -608,6 +648,8 @@ const getRightOperandValue = (
       return getLogicVariableValue(getComputedEmbeddedFields(localSurvey), rightOperand.value, variablesData);
     case "hiddenField":
       return data[rightOperand.value];
+    case "reserved":
+      return embeddedValues[rightOperand.value];
     case "static":
       return rightOperand.value;
     default:

--- a/apps/web/lib/utils/recall.test.ts
+++ b/apps/web/lib/utils/recall.test.ts
@@ -572,7 +572,9 @@ describe("recall utility functions", () => {
         mergeReservedValues(reserved, { country: "" })
       );
 
-      expect(result).not.toContain("DE");
+      // Asserted exactly, not as "does not contain DE": that weaker form also passes on an empty
+      // string or an unrendered raw token, neither of which would prove the declared field won.
+      expect(result).toBe("You are in your-country");
     });
   });
 

--- a/apps/web/lib/utils/recall.test.ts
+++ b/apps/web/lib/utils/recall.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { mergeReservedValues } from "@formbricks/types/embedded-data-resolver";
 import { TResponseData, TResponseVariables } from "@formbricks/types/responses";
 import { TSurvey, TSurveyRecallItem } from "@formbricks/types/surveys/types";
 import { structuredClone } from "@/lib/pollyfills/structuredClone";
@@ -483,6 +484,95 @@ describe("recall utility functions", () => {
       const result = getRecallItems("Text with #recall:shared/fallback:x#", survey, "en");
 
       expect(result).toEqual([{ id: "shared", label: "Question headline", type: "element" }]);
+    });
+  });
+
+  describe("reserved fields in recall (ENG-1840)", () => {
+    test("a reserved token is labelled and typed, not left as a raw tag", () => {
+      // `getRecallItems` drops any id it cannot label, and the editor then renders the untouched
+      // `#recall:country/fallback:x#` as literal text. This is the test that catches that.
+      const survey = {
+        blocks: [],
+        hiddenFields: { fieldIds: [] },
+        variables: [],
+      } as unknown as TSurvey;
+
+      const result = getRecallItems("You are in #recall:country/fallback:your-country#", survey, "en");
+
+      expect(result).toEqual([{ id: "country", label: "Country", type: "reserved" }]);
+      expect(result[0].label).not.toContain("#recall:");
+    });
+
+    test("a declared field of the same name shadows the reserved entry", () => {
+      // The grandfather rule, label side: a survey that already declares `country` keeps showing its
+      // own field, so the author never sees two identically-named rows.
+      const survey = {
+        blocks: [],
+        hiddenFields: { fieldIds: ["country"] },
+        variables: [],
+      } as unknown as TSurvey;
+
+      const result = getRecallItems("You are in #recall:country/fallback:x#", survey, "en");
+
+      expect(result).toEqual([{ id: "country", label: "country", type: "hiddenField" }]);
+    });
+
+    test("an unknown reserved-looking name stays unresolved", () => {
+      const survey = {
+        blocks: [],
+        hiddenFields: { fieldIds: [] },
+        variables: [],
+      } as unknown as TSurvey;
+
+      expect(getRecallItems("#recall:notACatalogEntry/fallback:x#", survey, "en")).toEqual([]);
+    });
+  });
+
+  describe("the grandfather rule at value-resolution time (ENG-1840)", () => {
+    // These exercise `mergeReservedValues` — the one expression the guarantee rests on. Flip the two
+    // spreads there and the second test goes red:
+    //   pnpm --filter=@formbricks/web test lib/utils/recall.test.ts
+    const reserved = { country: "DE", url: "https://app.test/s/abc" };
+
+    test("a reserved token resolves from the projected value", () => {
+      const result = parseRecallInfo(
+        "You are in #recall:country/fallback:your-country#",
+        mergeReservedValues(reserved, {})
+      );
+
+      expect(result).toBe("You are in DE");
+    });
+
+    test("a survey declaring its own `country` resolves from response.data instead", () => {
+      const responseData: TResponseData = { country: "Declared answer" };
+
+      const result = parseRecallInfo(
+        "You are in #recall:country/fallback:your-country#",
+        mergeReservedValues(reserved, responseData)
+      );
+
+      expect(result).toBe("You are in Declared answer");
+      expect(result).not.toContain("DE");
+    });
+
+    test("shadowing is per-key: other reserved values still resolve", () => {
+      const result = parseRecallInfo(
+        "#recall:country/fallback:a# at #recall:url/fallback:b#",
+        mergeReservedValues(reserved, { country: "Declared answer" })
+      );
+
+      expect(result).toBe("Declared answer at https://app.test/s/abc");
+    });
+
+    test("a declared field that is present but empty still wins", () => {
+      // The respondent left the declared hidden field blank. That is an answer, and it must not fall
+      // back to reserved metadata just because the string is empty.
+      const result = parseRecallInfo(
+        "You are in #recall:country/fallback:your-country#",
+        mergeReservedValues(reserved, { country: "" })
+      );
+
+      expect(result).not.toContain("DE");
     });
   });
 

--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -1,9 +1,11 @@
 import {
+  RESERVED_FIELD_CATALOG,
   type TLinkedEmbeddedField,
   getDeclaredEmbeddedFields,
 } from "@formbricks/types/embedded-data-resolver";
 import { type TI18nString } from "@formbricks/types/i18n";
 import { TResponseData, TResponseDataValue, TResponseVariables } from "@formbricks/types/responses";
+import { formatSnakeCaseToTitleCase } from "@formbricks/types/safe-identifier";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyRecallItem } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
@@ -106,6 +108,11 @@ const resolveRecallItemLabel = (
 
   const computedField = findEmbeddedField(embeddedFields, recallItemId, "computed");
   if (computedField) return computedField.field.name;
+
+  // Reserved is checked LAST, which is the grandfather rule in label form: a survey that declares its
+  // own `country` has already returned above, so the token keeps showing the declared field's name.
+  const reservedEntry = RESERVED_FIELD_CATALOG.find((entry) => entry.name === recallItemId);
+  if (reservedEntry) return formatSnakeCaseToTitleCase(reservedEntry.name);
 };
 
 export const getRecallItemLabel = <T extends TSurvey>(
@@ -224,6 +231,10 @@ export const getRecallItems = (text: string, survey: TSurvey, languageCode: stri
       if (isHiddenField) return "hiddenField";
       if (isSurveyQuestion) return "element";
       if (isVariable) return "variable";
+      // Same precedence as the label lookup, and load-bearing for the same reason: without this arm
+      // `getRecallItems` drops the id it could not type, and the editor renders the raw
+      // `#recall:country/fallback:x#` token as literal text instead of a chip.
+      if (RESERVED_FIELD_CATALOG.some((entry) => entry.name === recallItemId)) return "reserved";
     };
 
     if (recallItemLabel) {

--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -5,7 +5,7 @@ import {
 } from "@formbricks/types/embedded-data-resolver";
 import { type TI18nString } from "@formbricks/types/i18n";
 import { TResponseData, TResponseDataValue, TResponseVariables } from "@formbricks/types/responses";
-import { formatSnakeCaseToTitleCase } from "@formbricks/types/safe-identifier";
+import { formatFieldNameToTitleCase } from "@formbricks/types/safe-identifier";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyRecallItem } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
@@ -112,7 +112,7 @@ const resolveRecallItemLabel = (
   // Reserved is checked LAST, which is the grandfather rule in label form: a survey that declares its
   // own `country` has already returned above, so the token keeps showing the declared field's name.
   const reservedEntry = RESERVED_FIELD_CATALOG.find((entry) => entry.name === recallItemId);
-  if (reservedEntry) return formatSnakeCaseToTitleCase(reservedEntry.name);
+  if (reservedEntry) return formatFieldNameToTitleCase(reservedEntry.name);
 };
 
 export const getRecallItemLabel = <T extends TSurvey>(

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -502,6 +502,7 @@
     "summary": "Zusammenfassung",
     "survey": "Umfrage",
     "survey_completed": "Umfrage abgeschlossen.",
+    "survey_data": "Umfragedaten",
     "survey_id": "Umfrage-ID",
     "survey_languages": "Umfragesprachen",
     "survey_live": "Umfrage live",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -502,6 +502,7 @@
     "summary": "Summary",
     "survey": "Survey",
     "survey_completed": "Survey completed.",
+    "survey_data": "Survey data",
     "survey_id": "Survey ID",
     "survey_languages": "Survey Languages",
     "survey_live": "Survey live",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -502,6 +502,7 @@
     "summary": "Resumen",
     "survey": "Encuesta",
     "survey_completed": "Encuesta completada.",
+    "survey_data": "Datos de encuesta",
     "survey_id": "ID de encuesta",
     "survey_languages": "Idiomas de la encuesta",
     "survey_live": "Encuesta activa",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -502,6 +502,7 @@
     "summary": "Résumé",
     "survey": "Enquête",
     "survey_completed": "Enquête terminée.",
+    "survey_data": "Données d'enquête",
     "survey_id": "ID de l'enquête",
     "survey_languages": "Langues de l'enquête",
     "survey_live": "Sondage en direct",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -502,6 +502,7 @@
     "summary": "Összegzés",
     "survey": "Kérdőív",
     "survey_completed": "A kérdőív kitöltve.",
+    "survey_data": "Felmérési adatok",
     "survey_id": "Kérdőív-azonosító",
     "survey_languages": "Kérdőív nyelvei",
     "survey_live": "A kérdőív élő",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -502,6 +502,7 @@
     "summary": "概要",
     "survey": "フォーム",
     "survey_completed": "フォームが完了しました。",
+    "survey_data": "アンケートデータ",
     "survey_id": "フォームID",
     "survey_languages": "フォームの言語",
     "survey_live": "フォーム公開中",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -502,6 +502,7 @@
     "summary": "Samenvatting",
     "survey": "Vragenlijst",
     "survey_completed": "Enquête voltooid.",
+    "survey_data": "Enquêtegegevens",
     "survey_id": "Enquête-ID",
     "survey_languages": "Enquêtetalen",
     "survey_live": "Enquête live",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -502,6 +502,7 @@
     "summary": "Resumo",
     "survey": "Pesquisa",
     "survey_completed": "Pesquisa concluída.",
+    "survey_data": "Dados da pesquisa",
     "survey_id": "ID da Pesquisa",
     "survey_languages": "Idiomas da Pesquisa",
     "survey_live": "Pesquisa ao vivo",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -502,6 +502,7 @@
     "summary": "Resumo",
     "survey": "Inquérito",
     "survey_completed": "Inquérito concluído.",
+    "survey_data": "Dados do inquérito",
     "survey_id": "ID do Inquérito",
     "survey_languages": "Idiomas da Pesquisa",
     "survey_live": "Inquérito ao vivo",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -502,6 +502,7 @@
     "summary": "Sumar",
     "survey": "Chestionar",
     "survey_completed": "Sondaj finalizat",
+    "survey_data": "Date din sondaj",
     "survey_id": "ID Chestionar",
     "survey_languages": "Limbi chestionar",
     "survey_live": "Chestionar activ",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -502,6 +502,7 @@
     "summary": "Сводка",
     "survey": "Опрос",
     "survey_completed": "Опрос завершён.",
+    "survey_data": "Данные опроса",
     "survey_id": "ID опроса",
     "survey_languages": "Языки опроса",
     "survey_live": "Опрос активен",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -502,6 +502,7 @@
     "summary": "Sammanfattning",
     "survey": "Enkät",
     "survey_completed": "Enkät slutförd.",
+    "survey_data": "Enkätdata",
     "survey_id": "Enkät-ID",
     "survey_languages": "Enkätspråk",
     "survey_live": "Enkät live",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -502,6 +502,7 @@
     "summary": "Özet",
     "survey": "Anket",
     "survey_completed": "Anket tamamlandı.",
+    "survey_data": "Anket verileri",
     "survey_id": "Anket ID",
     "survey_languages": "Anket Dilleri",
     "survey_live": "Anket canlı",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -502,6 +502,7 @@
     "summary": "概要",
     "survey": "调查",
     "survey_completed": "调查 完成",
+    "survey_data": "调查数据",
     "survey_id": "调查 ID",
     "survey_languages": "调查 语言",
     "survey_live": "调查 运行中",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -502,6 +502,7 @@
     "summary": "摘要",
     "survey": "問卷",
     "survey_completed": "問卷已完成。",
+    "survey_data": "問卷資料",
     "survey_id": "問卷 ID",
     "survey_languages": "問卷語言",
     "survey_live": "問卷已上線",

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
@@ -318,6 +318,8 @@ export const updateResponseWithQuotaEvaluation = async (
       variables: response.variables,
       language: response.language || "default",
       responseFinished: response.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response,
       tx,
     });
 

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
@@ -659,6 +659,8 @@ describe("Response Lib", () => {
         variables: response.variables,
         language: response.language,
         responseFinished: response.finished,
+        // The row just written, so `reserved` quota operands resolve (ENG-1840).
+        response,
         tx: mockTx,
       });
       expect(result.ok).toBe(true);
@@ -685,6 +687,8 @@ describe("Response Lib", () => {
         variables: responseWithoutLanguage.variables,
         language: "default",
         responseFinished: responseWithoutLanguage.finished,
+        // The row just written, so `reserved` quota operands resolve (ENG-1840).
+        response: responseWithoutLanguage,
         tx: mockTx,
       });
       expect(result.ok).toBe(true);

--- a/apps/web/modules/api/v2/management/responses/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/lib/response.ts
@@ -197,6 +197,8 @@ export const createResponseWithQuotaEvaluation = async (
       variables: responseInput.variables,
       language: canonicalLanguage || "default",
       responseFinished: response.finished,
+      // The row just written, so `reserved` quota operands resolve (ENG-1840).
+      response,
       tx,
     });
 

--- a/apps/web/modules/ee/quotas/lib/evaluation-service.test.ts
+++ b/apps/web/modules/ee/quotas/lib/evaluation-service.test.ts
@@ -269,7 +269,8 @@ describe("Quota Evaluation Service", () => {
         mockResponseData,
         mockVariablesData,
         [continueSurveyQuota],
-        "en"
+        "en",
+        {}
       );
       expect(handleQuotas).toHaveBeenCalledWith(mockSurveyId, mockResponseId, evaluateResult, true, mockTx);
     });
@@ -311,7 +312,8 @@ describe("Quota Evaluation Service", () => {
         mockResponseData,
         mockVariablesData,
         [mockQuota],
-        "en"
+        "en",
+        {}
       );
       expect(handleQuotas).toHaveBeenCalledWith(mockSurveyId, mockResponseId, evaluateResult, true, mockTx);
       expect(mockTx.response.findUnique).toHaveBeenCalledWith({
@@ -360,7 +362,8 @@ describe("Quota Evaluation Service", () => {
         mockResponseData,
         mockVariablesData,
         [mockPartialSubmissionQuota],
-        "default"
+        "default",
+        {}
       );
       expect(handleQuotas).toHaveBeenCalledWith(mockSurveyId, mockResponseId, evaluateResult, false, mockTx);
       expect(mockTx.response.findUnique).toHaveBeenCalledWith({ where: { id: mockResponseId } });
@@ -443,6 +446,54 @@ describe("Quota Evaluation Service", () => {
       );
     });
 
+    test("resolves reserved-field values from the response so a reserved quota condition can match", async () => {
+      // The real `buildServerEmbeddedValues` runs here (only ./utils and the data loaders are mocked),
+      // so this asserts the actual catalog projection reaches `evaluateQuotas` — the wiring that was
+      // missing when the helper had no production caller.
+      const input: QuotaEvaluationInput = {
+        surveyId: mockSurveyId,
+        responseId: mockResponseId,
+        data: mockResponseData,
+        variables: mockVariablesData,
+        language: "en",
+        responseFinished: true,
+        response: {
+          id: mockResponseId,
+          surveyId: mockSurveyId,
+          createdAt: new Date("2026-08-01T09:00:00.000Z"),
+          updatedAt: new Date("2026-08-01T09:02:00.000Z"),
+          finished: true,
+          language: "en",
+          data: mockResponseData,
+          variables: mockVariablesData,
+          ttc: { _total: 120_000 },
+          meta: { country: "DE", userAgent: { browser: "Chrome" } },
+        },
+        tx: asTx(mockTx),
+      };
+
+      vi.mocked(getQuotas).mockResolvedValue([mockQuota]);
+      vi.mocked(getSurvey).mockResolvedValue(mockSurvey);
+      vi.mocked(evaluateQuotas).mockReturnValue({ passedQuotas: [mockQuota], failedQuotas: [] });
+      vi.mocked(handleQuotas).mockResolvedValue(null);
+
+      await evaluateResponseQuotas(input);
+
+      expect(evaluateQuotas).toHaveBeenCalledWith(
+        mockSurvey,
+        mockResponseData,
+        mockVariablesData,
+        [mockQuota],
+        "en",
+        expect.objectContaining({
+          country: "DE",
+          browser: "Chrome",
+          finished: "true",
+          durationSeconds: 120,
+        })
+      );
+    });
+
     test("should use 'default' language when provided language matches default language", async () => {
       const surveyWithLanguages = {
         ...mockSurvey,
@@ -479,7 +530,8 @@ describe("Quota Evaluation Service", () => {
         mockResponseData,
         mockVariablesData,
         [mockQuota],
-        "default"
+        "default",
+        {}
       );
     });
   });

--- a/apps/web/modules/ee/quotas/lib/evaluation-service.ts
+++ b/apps/web/modules/ee/quotas/lib/evaluation-service.ts
@@ -2,9 +2,11 @@ import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma, Response } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
+import { TEmbeddedValueResponse } from "@formbricks/types/embedded-data-resolver";
 import { TSurveyQuota } from "@formbricks/types/quota";
 import { toJsWorkspaceStateSurvey } from "@/lib/survey/client-utils";
 import { getSurvey } from "@/lib/survey/service";
+import { buildServerEmbeddedValues } from "@/lib/surveyLogic/utils";
 import { getQuotas } from "./quotas";
 import { evaluateQuotas, handleQuotas } from "./utils";
 
@@ -16,6 +18,15 @@ export interface QuotaEvaluationInput {
   variables?: Response["variables"];
   language?: string;
   tx?: Prisma.TransactionClient;
+  /**
+   * The persisted response, used only to resolve `reserved` quota operands (ENG-1840) — a quota
+   * condition on `country`, `browser` or `finished` reads its value from here via the reserved field
+   * catalog. Optional so a caller without the row in hand still evaluates: those operands then read
+   * as unset, exactly like an absent hidden field. Passed rather than re-fetched on purpose; every
+   * call site already holds the row it just wrote, and quota evaluation runs inside the ingest
+   * transaction where an extra query would be paid on every response.
+   */
+  response?: TEmbeddedValueResponse;
 }
 
 export interface QuotaEvaluationResult {
@@ -38,6 +49,7 @@ export const evaluateResponseQuotas = async (input: QuotaEvaluationInput): Promi
     language = "default",
     responseFinished = false,
     tx,
+    response,
   } = input;
   const prismaClient = tx ?? prisma;
 
@@ -58,7 +70,8 @@ export const evaluateResponseQuotas = async (input: QuotaEvaluationInput): Promi
       data,
       variables,
       quotas,
-      isDefaultLanguage ? "default" : language
+      isDefaultLanguage ? "default" : language,
+      response ? buildServerEmbeddedValues(response) : {}
     );
 
     const quotaFull = await handleQuotas(surveyId, responseId, result, responseFinished, prismaClient);

--- a/apps/web/modules/ee/quotas/lib/utils.test.ts
+++ b/apps/web/modules/ee/quotas/lib/utils.test.ts
@@ -228,7 +228,26 @@ describe("Quota Utils", () => {
           id: mockQuota.id,
           ...mockQuota.logic,
         },
-        "default"
+        "default",
+        {}
+      );
+    });
+
+    test("forwards reserved-field values so a quota condition on them can resolve", () => {
+      // Without this argument a `reserved` operand in a quota reads as unset and the quota silently
+      // never matches — the gap that left `buildServerEmbeddedValues` with no production caller.
+      vi.mocked(evaluateLogic).mockReturnValue(true);
+      const embeddedValues = { country: "DE", finished: "true" };
+
+      evaluateQuotas(mockSurvey, mockResponseData, mockVariablesData, [mockQuota], "default", embeddedValues);
+
+      expect(evaluateLogic).toHaveBeenCalledWith(
+        mockSurvey,
+        mockResponseData,
+        mockVariablesData,
+        { id: mockQuota.id, ...mockQuota.logic },
+        "default",
+        embeddedValues
       );
     });
 
@@ -271,7 +290,8 @@ describe("Quota Utils", () => {
           id: mockQuota.id,
           ...mockQuota.logic,
         },
-        "default"
+        "default",
+        {}
       );
     });
   });

--- a/apps/web/modules/ee/quotas/lib/utils.ts
+++ b/apps/web/modules/ee/quotas/lib/utils.ts
@@ -16,6 +16,10 @@ import { validateInputs } from "@/lib/utils/validate";
  * @param variablesData - Variables data for evaluation
  * @param quotas - Active quota definitions for the survey
  * @param selectedLanguage - Language for evaluation context
+ * @param embeddedValues - Reserved-field values (ENG-1840), built by `buildServerEmbeddedValues` from
+ *   the persisted response so a quota condition on `country` or `finished` resolves. Defaults to `{}`,
+ *   under which every `reserved` operand reads as unset — the same as an absent hidden field, so a
+ *   caller that cannot supply a response degrades rather than throwing.
  * @returns Object with passed and failed quotas
  */
 export const evaluateQuotas = (
@@ -23,7 +27,8 @@ export const evaluateQuotas = (
   responseData: TResponseData,
   variablesData: TResponseVariables,
   quotas: TSurveyQuota[],
-  selectedLanguage: string = "default"
+  selectedLanguage: string = "default",
+  embeddedValues: TResponseData = {}
 ): { passedQuotas: TSurveyQuota[]; failedQuotas: TSurveyQuota[] } => {
   const passedQuotas: TSurveyQuota[] = [];
   const failedQuotas: TSurveyQuota[] = [];
@@ -34,7 +39,14 @@ export const evaluateQuotas = (
       ...quota.logic,
     };
 
-    const conditionsMatch = evaluateLogic(survey, responseData, variablesData, conditions, selectedLanguage);
+    const conditionsMatch = evaluateLogic(
+      survey,
+      responseData,
+      variablesData,
+      conditions,
+      selectedLanguage,
+      embeddedValues
+    );
 
     if (conditionsMatch) {
       passedQuotas.push(quota);

--- a/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
+++ b/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
@@ -5,6 +5,7 @@ import {
   FileDigitIcon,
   FileTextIcon,
   GaugeIcon,
+  GlobeIcon,
   HomeIcon,
   ListIcon,
   ListOrderedIcon,
@@ -17,7 +18,12 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getDeclaredEmbeddedFields, listReadableFields } from "@formbricks/types/embedded-data-resolver";
+import {
+  RESERVED_FIELD_CATALOG,
+  getDeclaredEmbeddedFields,
+  listMidSurveyReservedEntries,
+  listReadableFields,
+} from "@formbricks/types/embedded-data-resolver";
 import { TSurveyElement, TSurveyElementId, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyHiddenFields, TSurveyRecallItem } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
@@ -63,7 +69,7 @@ export const RecallItemSelect = ({
   setShowRecallItemSelect,
   recallItems,
   selectedLanguageCode,
-}: RecallItemSelectProps) => {
+}: Readonly<RecallItemSelectProps>) => {
   const [searchValue, setSearchValue] = useState("");
   const { t } = useTranslation();
   const isNotAllowedElementType = (element: TSurveyElement): boolean => {
@@ -137,6 +143,30 @@ export const RecallItemSelect = ({
     [embeddedFieldEntries, recallItemIds]
   );
 
+  /**
+   * Reserved fields (ENG-1840). `listMidSurveyReservedEntries` applies both gates: it drops
+   * server-derived entries — recall renders while the respondent is still answering, so `country` or
+   * `durationSeconds` could only ever render as their fallback text — and it drops any entry this
+   * survey already declares under the same name, which would otherwise show twice with no way to
+   * tell the rows apart. Labels come from `listReadableFields`, the same enumerator the other groups
+   * use, so reserved rows are title-cased consistently rather than by a rule local to this file.
+   */
+  const reservedRecallItems = useMemo(() => {
+    const entries = listMidSurveyReservedEntries(
+      RESERVED_FIELD_CATALOG,
+      embeddedFieldEntries.map(({ key }) => key)
+    );
+
+    return listReadableFields({
+      blocks: [],
+      embeddedData: [],
+      reservedEntries: entries,
+      contactAttributeKeys: [],
+    })
+      .reserved.filter(({ key }) => !recallItemIds.includes(key))
+      .map(({ key, label }) => ({ id: key, label, type: "reserved" as const }));
+  }, [embeddedFieldEntries, recallItemIds]);
+
   const surveyElementRecallItems = useMemo(() => {
     const isWelcomeCard = elementId === "start";
     if (isWelcomeCard) return [];
@@ -162,17 +192,27 @@ export const RecallItemSelect = ({
   }, [elementId, elements, recallItemIds, selectedLanguageCode]);
 
   const filteredRecallItems: TSurveyRecallItem[] = useMemo(() => {
+    const allItems = [
+      ...surveyElementRecallItems,
+      ...hiddenFieldRecallItems,
+      ...variableRecallItems,
+      ...reservedRecallItems,
+    ];
     const query = searchValue.trim().toLowerCase();
-    if (!query) return [...surveyElementRecallItems, ...hiddenFieldRecallItems, ...variableRecallItems];
+    if (!query) return allItems;
 
     // Match the label's text content, not the label itself: an element's label is its raw headline HTML
     // (`<p class="fb-editor-paragraph">…`), so comparing against it made every query for question text
     // miss. `includes` rather than `startsWith` so a query also matches mid-headline words, and so it
     // still matches items whose displayed label is elided by the truncation below.
-    return [...surveyElementRecallItems, ...hiddenFieldRecallItems, ...variableRecallItems].filter(
-      (recallItem) => getTextContent(recallItem.label).toLowerCase().includes(query)
-    );
-  }, [surveyElementRecallItems, hiddenFieldRecallItems, variableRecallItems, searchValue]);
+    return allItems.filter((recallItem) => getTextContent(recallItem.label).toLowerCase().includes(query));
+  }, [
+    surveyElementRecallItems,
+    hiddenFieldRecallItems,
+    variableRecallItems,
+    reservedRecallItems,
+    searchValue,
+  ]);
 
   const getRecallItemIcon = (recallItem: TSurveyRecallItem) => {
     switch (recallItem.type) {
@@ -185,6 +225,8 @@ export const RecallItemSelect = ({
       }
       case "hiddenField":
         return EyeOffIcon;
+      case "reserved":
+        return GlobeIcon;
       case "variable": {
         const dataType = embeddedFieldEntries.find(({ key }) => key === recallItem.id)?.dataType;
         return dataType === "number" ? FileDigitIcon : FileTextIcon;

--- a/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
+++ b/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
@@ -152,10 +152,12 @@ export const RecallItemSelect = ({
    * use, so reserved rows are title-cased consistently rather than by a rule local to this file.
    */
   const reservedRecallItems = useMemo(() => {
-    const entries = listMidSurveyReservedEntries(
-      RESERVED_FIELD_CATALOG,
-      embeddedFieldEntries.map(({ key }) => key)
-    );
+    const entries = listMidSurveyReservedEntries(RESERVED_FIELD_CATALOG, [
+      ...embeddedFieldEntries.map(({ key }) => key),
+      // Element ids shadow reserved entries too: an element answered under the id `country` writes
+      // `responseData.country`, which the merged value map spreads over the reserved projection.
+      ...elements.map((element) => element.id),
+    ]);
 
     return listReadableFields({
       blocks: [],
@@ -165,7 +167,7 @@ export const RecallItemSelect = ({
     })
       .reserved.filter(({ key }) => !recallItemIds.includes(key))
       .map(({ key, label }) => ({ id: key, label, type: "reserved" as const }));
-  }, [embeddedFieldEntries, recallItemIds]);
+  }, [embeddedFieldEntries, elements, recallItemIds]);
 
   const surveyElementRecallItems = useMemo(() => {
     const isWelcomeCard = elementId === "start";

--- a/apps/web/modules/survey/editor/components/logic-editor-conditions.tsx
+++ b/apps/web/modules/survey/editor/components/logic-editor-conditions.tsx
@@ -43,6 +43,8 @@ export function LogicEditorConditions({
       blockIdx,
       getDefaultOperator: () => (firstElement ? getDefaultOperatorForElement(firstElement, t) : "equals"),
       includeCreateGroup: true,
+      // Block logic runs in the renderer, which projects the client-available reserved values.
+      includeReservedFields: true,
     },
     {
       onConditionsChange: (updater) => {

--- a/apps/web/modules/survey/editor/lib/logic-rule-engine.test.ts
+++ b/apps/web/modules/survey/editor/lib/logic-rule-engine.test.ts
@@ -548,3 +548,80 @@ describe("TLogicRuleOption type", () => {
     expect(sampleOption.value).toBe(ZSurveyLogicConditionsOperator.enum.equals);
   });
 });
+
+describe("reserved field rules (ENG-1840)", () => {
+  // Indexed explicitly rather than through a `Record<string, …>` cast: `getConditionOperatorOptions`
+  // reaches these keys as `reserved.${entry.dataType}`, and naming all four here means deleting one
+  // is a compile error in this test rather than a silently skipped loop iteration.
+  const reservedRules = {
+    string: logicRules["reserved.string"],
+    number: logicRules["reserved.number"],
+    boolean: logicRules["reserved.boolean"],
+    date: logicRules["reserved.date"],
+  };
+
+  const dataTypes = Object.keys(reservedRules) as (keyof typeof reservedRules)[];
+
+  const opValues = (dataType: keyof typeof reservedRules): string[] =>
+    reservedRules[dataType].options.map((option) => option.value);
+
+  test("there is a rule set for every embedded data type", () => {
+    // `TEmbeddedDataType` is exactly these four, so a catalog entry can never index a missing family.
+    expect(dataTypes.sort()).toStrictEqual(["boolean", "date", "number", "string"]);
+
+    for (const dataType of dataTypes) {
+      expect(opValues(dataType).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every family can branch on absence", () => {
+    // A reserved value is legitimately absent (`source` on a link opened without one), and isSet /
+    // isNotSet are the only operators that let an author handle that.
+    for (const dataType of dataTypes) {
+      expect(opValues(dataType)).toEqual(
+        expect.arrayContaining([
+          ZSurveyLogicConditionsOperator.enum.isSet,
+          ZSurveyLogicConditionsOperator.enum.isNotSet,
+        ])
+      );
+    }
+  });
+
+  test("numbers get ordering, strings get substring matching", () => {
+    expect(opValues("number")).toEqual(
+      expect.arrayContaining([
+        ZSurveyLogicConditionsOperator.enum.isGreaterThan,
+        ZSurveyLogicConditionsOperator.enum.isLessThan,
+      ])
+    );
+    expect(opValues("string")).toEqual(
+      expect.arrayContaining([
+        ZSurveyLogicConditionsOperator.enum.contains,
+        ZSurveyLogicConditionsOperator.enum.startsWith,
+      ])
+    );
+    expect(opValues("string")).not.toContain(ZSurveyLogicConditionsOperator.enum.isGreaterThan);
+  });
+
+  test("booleans offer equality only", () => {
+    // They project as the strings "true"/"false", so ordering or substring operators would read
+    // sensibly and never match.
+    expect(opValues("boolean").sort()).toStrictEqual(
+      [
+        ZSurveyLogicConditionsOperator.enum.equals,
+        ZSurveyLogicConditionsOperator.enum.doesNotEqual,
+        ZSurveyLogicConditionsOperator.enum.isSet,
+        ZSurveyLogicConditionsOperator.enum.isNotSet,
+      ].sort()
+    );
+  });
+
+  test("dates get chronological comparison", () => {
+    expect(opValues("date")).toEqual(
+      expect.arrayContaining([
+        ZSurveyLogicConditionsOperator.enum.isBefore,
+        ZSurveyLogicConditionsOperator.enum.isAfter,
+      ])
+    );
+  });
+});

--- a/apps/web/modules/survey/editor/lib/logic-rule-engine.ts
+++ b/apps/web/modules/survey/editor/lib/logic-rule-engine.ts
@@ -2,14 +2,51 @@ import { TFunction } from "i18next";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { ZSurveyLogicConditionsOperator } from "@formbricks/types/surveys/logic";
 
+const OP = ZSurveyLogicConditionsOperator.enum;
+
+/**
+ * The worded equality pair. Shared rather than repeated because every string-ish family opens with
+ * it, and Sonar counts a copied literal block as duplicated code even when the copies are correct.
+ */
+const getEqualityOptions = (t: TFunction) => [
+  { label: t("workspace.surveys.edit.equals"), value: OP.equals },
+  { label: t("workspace.surveys.edit.does_not_equal"), value: OP.doesNotEqual },
+];
+
+/** The six symbol-labelled numeric comparisons, shared by numeric scales, number variables and reserved numbers. */
+const getNumberComparisonOptions = () => [
+  { label: "=", value: OP.equals },
+  { label: "!=", value: OP.doesNotEqual },
+  { label: ">", value: OP.isGreaterThan },
+  { label: "<", value: OP.isLessThan },
+  { label: ">=", value: OP.isGreaterThanOrEqual },
+  { label: "<=", value: OP.isLessThanOrEqual },
+];
+
+/** Full string comparison set: equality plus the substring/affix operators. */
+const getTextOperatorOptions = (t: TFunction) => [
+  ...getEqualityOptions(t),
+  { label: t("workspace.surveys.edit.contains"), value: OP.contains },
+  { label: t("workspace.surveys.edit.does_not_contain"), value: OP.doesNotContain },
+  { label: t("workspace.surveys.edit.starts_with"), value: OP.startsWith },
+  { label: t("workspace.surveys.edit.does_not_start_with"), value: OP.doesNotStartWith },
+  { label: t("workspace.surveys.edit.ends_with"), value: OP.endsWith },
+  { label: t("workspace.surveys.edit.does_not_end_with"), value: OP.doesNotEndWith },
+];
+
+/**
+ * Presence checks, offered by every reserved family (ENG-1840): a reserved value can legitimately be
+ * absent - `source` on a link survey opened without one - and these are the only two operators that
+ * let an author branch on that.
+ */
+const getPresenceOptions = (t: TFunction) => [
+  { label: t("workspace.surveys.edit.is_set"), value: OP.isSet },
+  { label: t("workspace.surveys.edit.is_not_set"), value: OP.isNotSet },
+];
+
 const getNumericScaleOptions = (t: TFunction) => ({
   options: [
-    { label: "=", value: ZSurveyLogicConditionsOperator.enum.equals },
-    { label: "!=", value: ZSurveyLogicConditionsOperator.enum.doesNotEqual },
-    { label: ">", value: ZSurveyLogicConditionsOperator.enum.isGreaterThan },
-    { label: "<", value: ZSurveyLogicConditionsOperator.enum.isLessThan },
-    { label: ">=", value: ZSurveyLogicConditionsOperator.enum.isGreaterThanOrEqual },
-    { label: "<=", value: ZSurveyLogicConditionsOperator.enum.isLessThanOrEqual },
+    ...getNumberComparisonOptions(),
     {
       label: t("workspace.surveys.edit.is_submitted"),
       value: ZSurveyLogicConditionsOperator.enum.isSubmitted,
@@ -23,6 +60,10 @@ const getNumericScaleOptions = (t: TFunction) => ({
 
 export const getLogicRules = (t: TFunction) => {
   const numericScaleOptions = getNumericScaleOptions(t);
+  const equalityOptions = getEqualityOptions(t);
+  const textOperatorOptions = getTextOperatorOptions(t);
+  const numberComparisonOptions = getNumberComparisonOptions();
+  const presenceOptions = getPresenceOptions(t);
 
   return {
     element: {
@@ -360,70 +401,8 @@ export const getLogicRules = (t: TFunction) => {
         ],
       },
     },
-    ["variable.text"]: {
-      options: [
-        {
-          label: t("workspace.surveys.edit.equals"),
-          value: ZSurveyLogicConditionsOperator.enum.equals,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_equal"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
-        },
-        {
-          label: t("workspace.surveys.edit.contains"),
-          value: ZSurveyLogicConditionsOperator.enum.contains,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_contain"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotContain,
-        },
-        {
-          label: t("workspace.surveys.edit.starts_with"),
-          value: ZSurveyLogicConditionsOperator.enum.startsWith,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_start_with"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotStartWith,
-        },
-        {
-          label: t("workspace.surveys.edit.ends_with"),
-          value: ZSurveyLogicConditionsOperator.enum.endsWith,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_end_with"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotEndWith,
-        },
-      ],
-    },
-    ["variable.number"]: {
-      options: [
-        {
-          label: "=",
-          value: ZSurveyLogicConditionsOperator.enum.equals,
-        },
-        {
-          label: "!=",
-          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
-        },
-        {
-          label: ">",
-          value: ZSurveyLogicConditionsOperator.enum.isGreaterThan,
-        },
-        {
-          label: "<",
-          value: ZSurveyLogicConditionsOperator.enum.isLessThan,
-        },
-        {
-          label: ">=",
-          value: ZSurveyLogicConditionsOperator.enum.isGreaterThanOrEqual,
-        },
-        {
-          label: "<=",
-          value: ZSurveyLogicConditionsOperator.enum.isLessThanOrEqual,
-        },
-      ],
-    },
+    ["variable.text"]: { options: textOperatorOptions },
+    ["variable.number"]: { options: numberComparisonOptions },
     hiddenField: {
       options: [
         {
@@ -475,135 +454,25 @@ export const getLogicRules = (t: TFunction) => {
      * absent (`source` on a link survey opened without one), and those two are the only operators
      * that let an author branch on that.
      */
-    ["reserved.string"]: {
-      options: [
-        {
-          label: t("workspace.surveys.edit.equals"),
-          value: ZSurveyLogicConditionsOperator.enum.equals,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_equal"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
-        },
-        {
-          label: t("workspace.surveys.edit.contains"),
-          value: ZSurveyLogicConditionsOperator.enum.contains,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_contain"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotContain,
-        },
-        {
-          label: t("workspace.surveys.edit.starts_with"),
-          value: ZSurveyLogicConditionsOperator.enum.startsWith,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_start_with"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotStartWith,
-        },
-        {
-          label: t("workspace.surveys.edit.ends_with"),
-          value: ZSurveyLogicConditionsOperator.enum.endsWith,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_end_with"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotEndWith,
-        },
-        {
-          label: t("workspace.surveys.edit.is_set"),
-          value: ZSurveyLogicConditionsOperator.enum.isSet,
-        },
-        {
-          label: t("workspace.surveys.edit.is_not_set"),
-          value: ZSurveyLogicConditionsOperator.enum.isNotSet,
-        },
-      ],
-    },
-    ["reserved.number"]: {
-      options: [
-        {
-          label: "=",
-          value: ZSurveyLogicConditionsOperator.enum.equals,
-        },
-        {
-          label: "!=",
-          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
-        },
-        {
-          label: ">",
-          value: ZSurveyLogicConditionsOperator.enum.isGreaterThan,
-        },
-        {
-          label: "<",
-          value: ZSurveyLogicConditionsOperator.enum.isLessThan,
-        },
-        {
-          label: ">=",
-          value: ZSurveyLogicConditionsOperator.enum.isGreaterThanOrEqual,
-        },
-        {
-          label: "<=",
-          value: ZSurveyLogicConditionsOperator.enum.isLessThanOrEqual,
-        },
-        {
-          label: t("workspace.surveys.edit.is_set"),
-          value: ZSurveyLogicConditionsOperator.enum.isSet,
-        },
-        {
-          label: t("workspace.surveys.edit.is_not_set"),
-          value: ZSurveyLogicConditionsOperator.enum.isNotSet,
-        },
-      ],
-    },
+    /*
+     * Reserved fields (ENG-1840) are keyed by the catalog entry's `dataType`, so a new entry inherits
+     * the right operators from the type it already declares instead of needing a rule set of its own.
+     * Booleans project as the strings "true"/"false", so equality is the only comparison that means
+     * anything there - ordering or substring operators would invite a condition that reads sensibly
+     * and never matches.
+     */
+    ["reserved.string"]: { options: [...textOperatorOptions, ...presenceOptions] },
+    ["reserved.number"]: { options: [...numberComparisonOptions, ...presenceOptions] },
     // Booleans project as the strings "true"/"false" (see `projectReservedValues`), so equality is
     // the only comparison that means anything — ordering or substring operators would invite a
     // condition that reads sensibly and never matches.
-    ["reserved.boolean"]: {
-      options: [
-        {
-          label: t("workspace.surveys.edit.equals"),
-          value: ZSurveyLogicConditionsOperator.enum.equals,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_equal"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
-        },
-        {
-          label: t("workspace.surveys.edit.is_set"),
-          value: ZSurveyLogicConditionsOperator.enum.isSet,
-        },
-        {
-          label: t("workspace.surveys.edit.is_not_set"),
-          value: ZSurveyLogicConditionsOperator.enum.isNotSet,
-        },
-      ],
-    },
+    ["reserved.boolean"]: { options: [...equalityOptions, ...presenceOptions] },
     ["reserved.date"]: {
       options: [
-        {
-          label: t("workspace.surveys.edit.equals"),
-          value: ZSurveyLogicConditionsOperator.enum.equals,
-        },
-        {
-          label: t("workspace.surveys.edit.does_not_equal"),
-          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
-        },
-        {
-          label: t("workspace.surveys.edit.is_before"),
-          value: ZSurveyLogicConditionsOperator.enum.isBefore,
-        },
-        {
-          label: t("workspace.surveys.edit.is_after"),
-          value: ZSurveyLogicConditionsOperator.enum.isAfter,
-        },
-        {
-          label: t("workspace.surveys.edit.is_set"),
-          value: ZSurveyLogicConditionsOperator.enum.isSet,
-        },
-        {
-          label: t("workspace.surveys.edit.is_not_set"),
-          value: ZSurveyLogicConditionsOperator.enum.isNotSet,
-        },
+        ...equalityOptions,
+        { label: t("workspace.surveys.edit.is_before"), value: ZSurveyLogicConditionsOperator.enum.isBefore },
+        { label: t("workspace.surveys.edit.is_after"), value: ZSurveyLogicConditionsOperator.enum.isAfter },
+        ...presenceOptions,
       ],
     },
   };

--- a/apps/web/modules/survey/editor/lib/logic-rule-engine.ts
+++ b/apps/web/modules/survey/editor/lib/logic-rule-engine.ts
@@ -468,6 +468,144 @@ export const getLogicRules = (t: TFunction) => {
         },
       ],
     },
+    /*
+     * Reserved fields (ENG-1840) are keyed by the catalog entry's `dataType` rather than by name, so
+     * a new entry inherits the right operators from the type it already declares instead of needing a
+     * rule set of its own. Every family keeps isSet/isNotSet: a reserved value can legitimately be
+     * absent (`source` on a link survey opened without one), and those two are the only operators
+     * that let an author branch on that.
+     */
+    ["reserved.string"]: {
+      options: [
+        {
+          label: t("workspace.surveys.edit.equals"),
+          value: ZSurveyLogicConditionsOperator.enum.equals,
+        },
+        {
+          label: t("workspace.surveys.edit.does_not_equal"),
+          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
+        },
+        {
+          label: t("workspace.surveys.edit.contains"),
+          value: ZSurveyLogicConditionsOperator.enum.contains,
+        },
+        {
+          label: t("workspace.surveys.edit.does_not_contain"),
+          value: ZSurveyLogicConditionsOperator.enum.doesNotContain,
+        },
+        {
+          label: t("workspace.surveys.edit.starts_with"),
+          value: ZSurveyLogicConditionsOperator.enum.startsWith,
+        },
+        {
+          label: t("workspace.surveys.edit.does_not_start_with"),
+          value: ZSurveyLogicConditionsOperator.enum.doesNotStartWith,
+        },
+        {
+          label: t("workspace.surveys.edit.ends_with"),
+          value: ZSurveyLogicConditionsOperator.enum.endsWith,
+        },
+        {
+          label: t("workspace.surveys.edit.does_not_end_with"),
+          value: ZSurveyLogicConditionsOperator.enum.doesNotEndWith,
+        },
+        {
+          label: t("workspace.surveys.edit.is_set"),
+          value: ZSurveyLogicConditionsOperator.enum.isSet,
+        },
+        {
+          label: t("workspace.surveys.edit.is_not_set"),
+          value: ZSurveyLogicConditionsOperator.enum.isNotSet,
+        },
+      ],
+    },
+    ["reserved.number"]: {
+      options: [
+        {
+          label: "=",
+          value: ZSurveyLogicConditionsOperator.enum.equals,
+        },
+        {
+          label: "!=",
+          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
+        },
+        {
+          label: ">",
+          value: ZSurveyLogicConditionsOperator.enum.isGreaterThan,
+        },
+        {
+          label: "<",
+          value: ZSurveyLogicConditionsOperator.enum.isLessThan,
+        },
+        {
+          label: ">=",
+          value: ZSurveyLogicConditionsOperator.enum.isGreaterThanOrEqual,
+        },
+        {
+          label: "<=",
+          value: ZSurveyLogicConditionsOperator.enum.isLessThanOrEqual,
+        },
+        {
+          label: t("workspace.surveys.edit.is_set"),
+          value: ZSurveyLogicConditionsOperator.enum.isSet,
+        },
+        {
+          label: t("workspace.surveys.edit.is_not_set"),
+          value: ZSurveyLogicConditionsOperator.enum.isNotSet,
+        },
+      ],
+    },
+    // Booleans project as the strings "true"/"false" (see `projectReservedValues`), so equality is
+    // the only comparison that means anything — ordering or substring operators would invite a
+    // condition that reads sensibly and never matches.
+    ["reserved.boolean"]: {
+      options: [
+        {
+          label: t("workspace.surveys.edit.equals"),
+          value: ZSurveyLogicConditionsOperator.enum.equals,
+        },
+        {
+          label: t("workspace.surveys.edit.does_not_equal"),
+          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
+        },
+        {
+          label: t("workspace.surveys.edit.is_set"),
+          value: ZSurveyLogicConditionsOperator.enum.isSet,
+        },
+        {
+          label: t("workspace.surveys.edit.is_not_set"),
+          value: ZSurveyLogicConditionsOperator.enum.isNotSet,
+        },
+      ],
+    },
+    ["reserved.date"]: {
+      options: [
+        {
+          label: t("workspace.surveys.edit.equals"),
+          value: ZSurveyLogicConditionsOperator.enum.equals,
+        },
+        {
+          label: t("workspace.surveys.edit.does_not_equal"),
+          value: ZSurveyLogicConditionsOperator.enum.doesNotEqual,
+        },
+        {
+          label: t("workspace.surveys.edit.is_before"),
+          value: ZSurveyLogicConditionsOperator.enum.isBefore,
+        },
+        {
+          label: t("workspace.surveys.edit.is_after"),
+          value: ZSurveyLogicConditionsOperator.enum.isAfter,
+        },
+        {
+          label: t("workspace.surveys.edit.is_set"),
+          value: ZSurveyLogicConditionsOperator.enum.isSet,
+        },
+        {
+          label: t("workspace.surveys.edit.is_not_set"),
+          value: ZSurveyLogicConditionsOperator.enum.isNotSet,
+        },
+      ],
+    },
   };
 };
 

--- a/apps/web/modules/survey/editor/lib/logic-rule-engine.ts
+++ b/apps/web/modules/survey/editor/lib/logic-rule-engine.ts
@@ -454,13 +454,6 @@ export const getLogicRules = (t: TFunction) => {
      * absent (`source` on a link survey opened without one), and those two are the only operators
      * that let an author branch on that.
      */
-    /*
-     * Reserved fields (ENG-1840) are keyed by the catalog entry's `dataType`, so a new entry inherits
-     * the right operators from the type it already declares instead of needing a rule set of its own.
-     * Booleans project as the strings "true"/"false", so equality is the only comparison that means
-     * anything there - ordering or substring operators would invite a condition that reads sensibly
-     * and never matches.
-     */
     ["reserved.string"]: { options: [...textOperatorOptions, ...presenceOptions] },
     ["reserved.number"]: { options: [...numberComparisonOptions, ...presenceOptions] },
     // Booleans project as the strings "true"/"false" (see `projectReservedValues`), so equality is

--- a/apps/web/modules/survey/editor/lib/shared-conditions-factory.test.ts
+++ b/apps/web/modules/survey/editor/lib/shared-conditions-factory.test.ts
@@ -248,7 +248,9 @@ describe("shared-conditions-factory", () => {
       result.config.getLeftOperandOptions();
 
       const { getConditionValueOptions } = await import("@/modules/survey/editor/lib/utils");
-      expect(getConditionValueOptions).toHaveBeenCalledWith(mockSurvey, mockT, undefined);
+      // Reserved fields default to OFF: this factory also drives the quota condition builder, whose
+      // evaluator projects no reserved values (ENG-1840).
+      expect(getConditionValueOptions).toHaveBeenCalledWith(mockSurvey, mockT, undefined, false);
     });
 
     test("should call getConditionValueOptions with questionIdx", async () => {
@@ -261,7 +263,19 @@ describe("shared-conditions-factory", () => {
       result.config.getLeftOperandOptions();
 
       const { getConditionValueOptions } = await import("@/modules/survey/editor/lib/utils");
-      expect(getConditionValueOptions).toHaveBeenCalledWith(mockSurvey, mockT, 0);
+      expect(getConditionValueOptions).toHaveBeenCalledWith(mockSurvey, mockT, 0, false);
+    });
+
+    test("should forward includeReservedFields when the caller opts in", async () => {
+      const result = createSharedConditionsFactory(
+        { ...defaultParams, includeReservedFields: true },
+        defaultCallbacks
+      );
+
+      result.config.getLeftOperandOptions();
+
+      const { getConditionValueOptions } = await import("@/modules/survey/editor/lib/utils");
+      expect(getConditionValueOptions).toHaveBeenCalledWith(mockSurvey, mockT, undefined, true);
     });
 
     test("should call getMatchValueProps without questionIdx", async () => {

--- a/apps/web/modules/survey/editor/lib/shared-conditions-factory.ts
+++ b/apps/web/modules/survey/editor/lib/shared-conditions-factory.ts
@@ -38,6 +38,13 @@ export interface SharedConditionsFactoryParams {
   blockIdx?: number;
   getDefaultOperator: () => TSurveyLogicConditionsOperator;
   includeCreateGroup?: boolean;
+  /**
+   * Whether the left-operand picker offers reserved fields (ENG-1840). Survey block logic sets it:
+   * the renderer projects reserved values before evaluating. Quota conditions must NOT — they are
+   * evaluated by `evaluateQuotas`, which passes no reserved map, so a reserved operand there would
+   * read as unset and the condition would never match while looking perfectly valid in the editor.
+   */
+  includeReservedFields?: boolean;
 }
 
 // Callback parameters for different update patterns
@@ -53,7 +60,14 @@ export function createSharedConditionsFactory(
   config: TConditionsEditorConfig<TSingleCondition>;
   callbacks: TConditionsEditorCallbacks<TSingleCondition>;
 } {
-  const { survey, t, blockIdx, getDefaultOperator, includeCreateGroup = false } = params;
+  const {
+    survey,
+    t,
+    blockIdx,
+    getDefaultOperator,
+    includeCreateGroup = false,
+    includeReservedFields = false,
+  } = params;
   const { onConditionsChange } = updateCallbacks;
 
   // Derive elements from blocks
@@ -91,7 +105,7 @@ export function createSharedConditionsFactory(
   };
 
   const config: TConditionsEditorConfig<TSingleCondition> = {
-    getLeftOperandOptions: () => getConditionValueOptions(survey, t, blockIdx),
+    getLeftOperandOptions: () => getConditionValueOptions(survey, t, blockIdx, includeReservedFields),
     getOperatorOptions: (condition) => getConditionOperatorOptions(condition, survey, t),
     getValueProps: (condition) => getMatchValueProps(condition, survey, t, blockIdx),
     getDefaultOperator,

--- a/apps/web/modules/survey/editor/lib/utils.tsx
+++ b/apps/web/modules/survey/editor/lib/utils.tsx
@@ -1056,17 +1056,55 @@ export const getMatchValueProps = (
     // Without this branch a reserved condition falls through to `{ show: false }` and renders with no
     // right-hand side at all — an operator the author can never complete.
     const entry = RESERVED_FIELD_CATALOG.find((candidate) => candidate.name === condition.leftOperand.value);
+    const dataType = entry?.dataType ?? "string";
     const inputType: HTMLInputTypeAttribute =
-      entry?.dataType === "number" ? "number" : entry?.dataType === "date" ? "date" : "text";
+      dataType === "number" ? "number" : dataType === "date" ? "date" : "text";
 
-    const elementOptions = elements.map((element) => ({
+    /*
+     * Only operands that can actually hold this field's dataType. Without the filter a
+     * `reserved.number` condition could be pointed at a text variable, and a `reserved.date` one at a
+     * numeric answer — selectable, and silently never true. The per-type rules mirror the element and
+     * variable branches above. Hidden fields stay in every list because they are untyped strings,
+     * exactly as they do for a number variable.
+     */
+    const comparableElements = elements.filter((element) => {
+      if (dataType === "number") {
+        return (
+          [
+            TSurveyElementTypeEnum.Rating,
+            TSurveyElementTypeEnum.NPS,
+            TSurveyElementTypeEnum.CSAT,
+            TSurveyElementTypeEnum.CES,
+          ].includes(element.type) ||
+          (element.type === TSurveyElementTypeEnum.OpenText && element.inputType === "number")
+        );
+      }
+      if (dataType === "date") return element.type === TSurveyElementTypeEnum.Date;
+      // No element type answers with a boolean, so a boolean reserved field has no comparable answer.
+      if (dataType === "boolean") return false;
+
+      const allowedTextTypes = [TSurveyElementTypeEnum.OpenText, TSurveyElementTypeEnum.MultipleChoiceSingle];
+      if (["equals", "doesNotEqual"].includes(condition.operator)) {
+        allowedTextTypes.push(TSurveyElementTypeEnum.MultipleChoiceMulti, TSurveyElementTypeEnum.Date);
+      }
+      return allowedTextTypes.includes(element.type);
+    });
+
+    // Variables are only ever text or number, so date and boolean reserved fields have none to offer.
+    const comparableVariables = variables.filter((variable) => {
+      if (dataType === "number") return variable.type === "number";
+      if (dataType === "string") return variable.type === "text";
+      return false;
+    });
+
+    const elementOptions = comparableElements.map((element) => ({
       icon: getElementIconMapping(t)[element.type],
       label: getElementHeadline(localSurvey, element, "default", t),
       value: element.id,
       meta: { type: "element" },
     }));
 
-    const variableOptions = variables.map((variable) => ({
+    const variableOptions = comparableVariables.map((variable) => ({
       icon: variable.type === "number" ? FileDigitIcon : FileType2Icon,
       label: variable.name,
       value: variable.id,
@@ -1080,10 +1118,12 @@ export const getMatchValueProps = (
       meta: { type: "hiddenField" },
     }));
 
-    // Other reserved entries are comparable too (`source` equals `action`, say), minus the one
-    // already on the left — comparing a field to itself is never a useful condition.
+    // Other reserved entries of the SAME dataType are comparable (`source` equals `action`, say),
+    // minus the one already on the left — comparing a field to itself is never a useful condition.
     const reservedOptions = getPickerReservedEntries(localSurvey)
-      .filter((candidate) => candidate.name !== condition.leftOperand.value)
+      .filter(
+        (candidate) => candidate.name !== condition.leftOperand.value && candidate.dataType === dataType
+      )
       .map(toReservedOption);
 
     const groupedOptions: TComboboxGroupedOption[] = [];

--- a/apps/web/modules/survey/editor/lib/utils.tsx
+++ b/apps/web/modules/survey/editor/lib/utils.tsx
@@ -1,12 +1,16 @@
 import { TFunction } from "i18next";
-import { EyeOffIcon, FileDigitIcon, FileType2Icon } from "lucide-react";
+import { EyeOffIcon, FileDigitIcon, FileType2Icon, GlobeIcon } from "lucide-react";
 import { HTMLInputTypeAttribute, JSX } from "react";
 import {
+  RESERVED_FIELD_CATALOG,
+  type TReservedFieldCatalogEntry,
   getDeclaredComputedFields,
   getDeclaredIngestedStorageKeys,
+  listMidSurveyReservedEntries,
 } from "@formbricks/types/embedded-data-resolver";
 import { TI18nString } from "@formbricks/types/i18n";
 import { TSurveyQuota } from "@formbricks/types/quota";
+import { formatSnakeCaseToTitleCase } from "@formbricks/types/safe-identifier";
 import { TSurveyBlockLogic, TSurveyBlockLogicAction } from "@formbricks/types/surveys/blocks";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import {
@@ -160,13 +164,45 @@ const getComputedFieldOptions = (localSurvey: TSurvey): TComputedFieldOption[] =
     type: field.dataType === "number" ? "number" : "text",
   }));
 
+/**
+ * Every name a survey already declares — the shadow list the grandfather rule filters against. Both
+ * declaration kinds count: an ingested field and a variable are equally capable of being named
+ * `country`, and either one resolves ahead of the reserved entry at read time.
+ */
+const getDeclaredFieldNames = (localSurvey: TSurvey): string[] => [
+  ...getDeclaredIngestedStorageKeys(localSurvey),
+  ...getComputedFieldOptions(localSurvey).map((variable) => variable.id),
+];
+
+/** The reserved entries this survey may offer mid-survey, already availability- and shadow-filtered. */
+const getPickerReservedEntries = (localSurvey: TSurvey): TReservedFieldCatalogEntry[] =>
+  listMidSurveyReservedEntries(RESERVED_FIELD_CATALOG, getDeclaredFieldNames(localSurvey));
+
+const toReservedOption = (entry: TReservedFieldCatalogEntry): TComboboxOption => ({
+  icon: GlobeIcon,
+  label: formatSnakeCaseToTitleCase(entry.name),
+  value: entry.name,
+  meta: {
+    type: "reserved",
+  },
+});
+
 export const getConditionValueOptions = (
   localSurvey: TSurvey,
   t: TFunction,
-  blockIdx?: number // Optional - if provided, includes elements from this block and all previous blocks
+  blockIdx?: number, // Optional - if provided, includes elements from this block and all previous blocks
+  /**
+   * Off by default because this picker is shared with the quota condition builder, whose evaluation
+   * (`evaluateQuotas`) projects no reserved values — offering them there would let an author write a
+   * condition that silently never matches. Survey block logic opts in; see ENG-1840's PR notes.
+   */
+  includeReservedFields = false
 ): TComboboxGroupedOption[] => {
   const hiddenFields = getDeclaredIngestedStorageKeys(localSurvey);
   const variables = getComputedFieldOptions(localSurvey);
+  const reservedOptions = includeReservedFields
+    ? getPickerReservedEntries(localSurvey).map(toReservedOption)
+    : [];
 
   // If blockIdx is provided, get elements from current block and all previous blocks
   // Otherwise, get all elements from all blocks
@@ -276,6 +312,14 @@ export const getConditionValueOptions = (
     });
   }
 
+  if (reservedOptions.length > 0) {
+    groupedOptions.push({
+      label: t("common.survey_data"),
+      value: "reservedFields",
+      options: reservedOptions,
+    });
+  }
+
   return groupedOptions;
 };
 
@@ -358,6 +402,14 @@ export const getConditionOperatorOptions = (
     return getLogicRules(t)[`variable.${variableType}`].options;
   } else if (condition.leftOperand.type === "hiddenField") {
     return getLogicRules(t).hiddenField.options;
+  } else if (condition.leftOperand.type === "reserved") {
+    // Read off the whole catalog, not the picker's filtered list: a condition can outlive the entry
+    // being offered (the survey later declares a field of the same name), and an operand with no
+    // operators at all would strand the author in a broken row. Unknown names fall back to string,
+    // which is the widest safe set.
+    const entry = RESERVED_FIELD_CATALOG.find((candidate) => candidate.name === condition.leftOperand.value);
+    const dataType = entry?.dataType ?? "string";
+    return getLogicRules(t)[`reserved.${dataType}`].options;
   } else if (condition.leftOperand.type === "element") {
     // Derive elements from blocks
     const elements = getElementsFromBlocks(localSurvey.blocks);
@@ -998,6 +1050,80 @@ export const getMatchValueProps = (
       show: true,
       showInput: true,
       inputType: "text",
+      options: groupedOptions,
+    };
+  } else if (condition.leftOperand.type === "reserved") {
+    // Without this branch a reserved condition falls through to `{ show: false }` and renders with no
+    // right-hand side at all — an operator the author can never complete.
+    const entry = RESERVED_FIELD_CATALOG.find((candidate) => candidate.name === condition.leftOperand.value);
+    const inputType: HTMLInputTypeAttribute =
+      entry?.dataType === "number" ? "number" : entry?.dataType === "date" ? "date" : "text";
+
+    const elementOptions = elements.map((element) => ({
+      icon: getElementIconMapping(t)[element.type],
+      label: getElementHeadline(localSurvey, element, "default", t),
+      value: element.id,
+      meta: { type: "element" },
+    }));
+
+    const variableOptions = variables.map((variable) => ({
+      icon: variable.type === "number" ? FileDigitIcon : FileType2Icon,
+      label: variable.name,
+      value: variable.id,
+      meta: { type: "variable" },
+    }));
+
+    const hiddenFieldsOptions = hiddenFields.map((field) => ({
+      icon: EyeOffIcon,
+      label: field,
+      value: field,
+      meta: { type: "hiddenField" },
+    }));
+
+    // Other reserved entries are comparable too (`source` equals `action`, say), minus the one
+    // already on the left — comparing a field to itself is never a useful condition.
+    const reservedOptions = getPickerReservedEntries(localSurvey)
+      .filter((candidate) => candidate.name !== condition.leftOperand.value)
+      .map(toReservedOption);
+
+    const groupedOptions: TComboboxGroupedOption[] = [];
+
+    if (elementOptions.length > 0) {
+      groupedOptions.push({
+        label: t("common.questions"),
+        value: "elements",
+        options: elementOptions,
+      });
+    }
+
+    if (variableOptions.length > 0) {
+      groupedOptions.push({
+        label: t("common.variables"),
+        value: "variables",
+        options: variableOptions,
+      });
+    }
+
+    if (hiddenFieldsOptions.length > 0) {
+      groupedOptions.push({
+        label: t("common.hidden_fields"),
+        value: "hiddenFields",
+        options: hiddenFieldsOptions,
+      });
+    }
+
+    if (reservedOptions.length > 0) {
+      groupedOptions.push({
+        label: t("common.survey_data"),
+        value: "reservedFields",
+        options: reservedOptions,
+      });
+    }
+
+    return {
+      show: true,
+      showInput: true,
+      inputType,
       options: groupedOptions,
     };
   }

--- a/apps/web/modules/survey/editor/lib/utils.tsx
+++ b/apps/web/modules/survey/editor/lib/utils.tsx
@@ -1,6 +1,7 @@
 import { TFunction } from "i18next";
 import { EyeOffIcon, FileDigitIcon, FileType2Icon, GlobeIcon } from "lucide-react";
 import { HTMLInputTypeAttribute, JSX } from "react";
+import type { TEmbeddedDataType } from "@formbricks/types/embedded-data";
 import {
   RESERVED_FIELD_CATALOG,
   type TReservedFieldCatalogEntry,
@@ -177,6 +178,19 @@ const getDeclaredFieldNames = (localSurvey: TSurvey): string[] => [
 /** The reserved entries this survey may offer mid-survey, already availability- and shadow-filtered. */
 const getPickerReservedEntries = (localSurvey: TSurvey): TReservedFieldCatalogEntry[] =>
   listMidSurveyReservedEntries(RESERVED_FIELD_CATALOG, getDeclaredFieldNames(localSurvey));
+
+/**
+ * Which HTML input the literal comparison value gets, per reserved dataType. A map rather than a
+ * chain of ternaries so it stays exhaustive: adding a dataType is a compile error here instead of
+ * silently falling through to a text box. `boolean` is deliberately text — the value is compared as
+ * the string "true"/"false" (see `projectReservedValues`).
+ */
+const INPUT_TYPE_BY_DATA_TYPE: Record<TEmbeddedDataType, HTMLInputTypeAttribute> = {
+  string: "text",
+  number: "number",
+  boolean: "text",
+  date: "date",
+};
 
 const toReservedOption = (entry: TReservedFieldCatalogEntry): TComboboxOption => ({
   icon: GlobeIcon,
@@ -1057,8 +1071,7 @@ export const getMatchValueProps = (
     // right-hand side at all — an operator the author can never complete.
     const entry = RESERVED_FIELD_CATALOG.find((candidate) => candidate.name === condition.leftOperand.value);
     const dataType = entry?.dataType ?? "string";
-    const inputType: HTMLInputTypeAttribute =
-      dataType === "number" ? "number" : dataType === "date" ? "date" : "text";
+    const inputType = INPUT_TYPE_BY_DATA_TYPE[dataType];
 
     /*
      * Only operands that can actually hold this field's dataType. Without the filter a

--- a/apps/web/modules/survey/editor/lib/utils.tsx
+++ b/apps/web/modules/survey/editor/lib/utils.tsx
@@ -11,7 +11,7 @@ import {
 } from "@formbricks/types/embedded-data-resolver";
 import { TI18nString } from "@formbricks/types/i18n";
 import { TSurveyQuota } from "@formbricks/types/quota";
-import { formatSnakeCaseToTitleCase } from "@formbricks/types/safe-identifier";
+import { formatFieldNameToTitleCase } from "@formbricks/types/safe-identifier";
 import { TSurveyBlockLogic, TSurveyBlockLogicAction } from "@formbricks/types/surveys/blocks";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import {
@@ -166,13 +166,16 @@ const getComputedFieldOptions = (localSurvey: TSurvey): TComputedFieldOption[] =
   }));
 
 /**
- * Every name a survey already declares — the shadow list the grandfather rule filters against. Both
- * declaration kinds count: an ingested field and a variable are equally capable of being named
- * `country`, and either one resolves ahead of the reserved entry at read time.
+ * Every name a survey already declares — the shadow list the grandfather rule filters against. All
+ * three declaration kinds count: an ingested field, a variable and an element id are equally capable
+ * of being named `country`, and any of them resolves ahead of the reserved entry at read time,
+ * because the merged value map spreads `responseData` (which is keyed by element id) over the
+ * reserved projection.
  */
 const getDeclaredFieldNames = (localSurvey: TSurvey): string[] => [
   ...getDeclaredIngestedStorageKeys(localSurvey),
   ...getComputedFieldOptions(localSurvey).map((variable) => variable.id),
+  ...getElementsFromBlocks(localSurvey.blocks).map((element) => element.id),
 ];
 
 /** The reserved entries this survey may offer mid-survey, already availability- and shadow-filtered. */
@@ -194,7 +197,7 @@ const INPUT_TYPE_BY_DATA_TYPE: Record<TEmbeddedDataType, HTMLInputTypeAttribute>
 
 const toReservedOption = (entry: TReservedFieldCatalogEntry): TComboboxOption => ({
   icon: GlobeIcon,
-  label: formatSnakeCaseToTitleCase(entry.name),
+  label: formatFieldNameToTitleCase(entry.name),
   value: entry.name,
   meta: {
     type: "reserved",

--- a/apps/web/playwright/survey-reserved-fields.spec.ts
+++ b/apps/web/playwright/survey-reserved-fields.spec.ts
@@ -1,0 +1,126 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+import { test } from "./lib/fixtures";
+import { createSurveyFromScratch, fillRichTextEditor } from "./utils/helper";
+
+/**
+ * Reserved fields in recall and logic (ENG-1840).
+ *
+ * Reserved fields are auto-captured metadata (`url`, `source`, `action`, `language`, …) that every
+ * survey can reference without declaring anything. This spec covers the two things that can only be
+ * proven in a browser:
+ *
+ * 1. **The mid-survey availability gate.** Recall and logic evaluate client-side while the respondent
+ *    is answering, so the picker must offer only fields the renderer can actually resolve then.
+ *    `country` and `durationSeconds` are derived server-side at ingest; offering them would let an
+ *    author build copy or a condition that can never resolve. A unit test can assert the filter
+ *    function, but only this can assert what an author actually sees.
+ * 2. **End-to-end resolution in the rendered survey.** The renderer reads a prebuilt bundle
+ *    (`apps/web/public/js/surveys.umd.cjs`), so a recall token resolving correctly in the editor
+ *    proves nothing about the running survey. This drives the real link survey.
+ */
+
+const editorPanel = (page: Page): Locator => page.getByRole("main");
+
+/** The recall dropdown the `@` trigger opens inside a rich-text editor. */
+const recallDropdown = (page: Page): Locator => page.locator("[data-recall-dropdown]");
+
+/**
+ * Types `@` into a rich-text editor to open the recall picker. The editor commits the trigger
+ * character before the dropdown mounts, so the dropdown is awaited rather than assumed.
+ */
+const openRecallPicker = async (page: Page, labelText: string): Promise<void> => {
+  const label = editorPanel(page).locator(`label:has-text("${labelText}")`);
+  const container = label.locator("..").locator("..");
+  const editable = container.locator('[contenteditable="true"]').first();
+
+  await editable.click();
+  await editable.pressSequentially("@");
+  await expect(recallDropdown(page)).toBeVisible({ timeout: 15000 });
+};
+
+test.describe("Reserved fields in recall and logic", () => {
+  test.setTimeout(1000 * 60 * 5);
+
+  test("the recall picker offers client-available reserved fields and hides server-derived ones", async ({
+    page,
+    users,
+  }) => {
+    const user = await users.create();
+    await user.login();
+    await page.waitForURL(/\/workspaces\/[^/]+\/surveys/);
+
+    await createSurveyFromScratch(page);
+
+    await editorPanel(page).getByText("What would you like to know?").click();
+    await openRecallPicker(page, "Question*");
+
+    const dropdown = recallDropdown(page);
+
+    await test.step("client-available reserved fields are offered", async () => {
+      // Labels are title-cased from the catalog entry names by `formatSnakeCaseToTitleCase`.
+      await expect(dropdown.getByText("Url", { exact: true })).toBeVisible();
+      await expect(dropdown.getByText("Source", { exact: true })).toBeVisible();
+      await expect(dropdown.getByText("Language", { exact: true })).toBeVisible();
+    });
+
+    await test.step("server-derived reserved fields are absent", async () => {
+      // The acceptance criterion this ticket exists to enforce. NOTE: the ticket description lists
+      // browser/os/deviceType as available mid-survey — they are not. All three are parsed from the
+      // `user-agent` request header by UAParser in the ingest routes, so the renderer cannot know
+      // them; the catalog marks them `server` and the picker filters on that.
+      for (const serverOnly of ["Country", "Duration Seconds", "Ip Address", "Browser", "Os", "Finished"]) {
+        await expect(dropdown.getByText(serverOnly, { exact: true })).toHaveCount(0);
+      }
+    });
+  });
+
+  test("a link survey headline recalling the url renders the real URL mid-survey", async ({
+    page,
+    users,
+  }) => {
+    const user = await users.create();
+    await user.login();
+    await page.waitForURL(/\/workspaces\/[^/]+\/surveys/);
+
+    await createSurveyFromScratch(page);
+
+    await test.step("recall the url into the headline", async () => {
+      await editorPanel(page).getByText("What would you like to know?").click();
+      await fillRichTextEditor(page, "Question*", "You came from ");
+      await openRecallPicker(page, "Question*");
+      await recallDropdown(page).getByText("Url", { exact: true }).click();
+      await expect(recallDropdown(page)).toBeHidden();
+    });
+
+    const surveyUrl = await test.step("publish as a link survey", async () => {
+      await page.getByRole("button", { name: "Settings", exact: true }).click();
+      await page.locator("#howToSendCardTrigger").click();
+      await expect(page.locator("#howToSendCardOption-link")).toBeVisible();
+      await page.locator("#howToSendCardOption-link").click();
+
+      await page.getByRole("button", { name: "Save as draft", exact: true }).click();
+      await expect(page.getByText("Changes saved.")).toBeVisible();
+
+      await Promise.all([
+        page.waitForURL(/\/workspaces\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/, { timeout: 120000 }),
+        page.getByRole("button", { name: "Publish", exact: true }).click(),
+      ]);
+
+      await page.getByLabel("Copy survey link to clipboard").click();
+      return (await page.evaluate("navigator.clipboard.readText()")) as string;
+    });
+
+    expect(surveyUrl).toBeTruthy();
+
+    await test.step("the running survey resolves the token to its own URL", async () => {
+      await page.goto(surveyUrl);
+
+      // `url` is the page the survey runs on, so the headline must echo the link just opened —
+      // and must not still contain the raw storage token or fall through to its fallback text.
+      const headline = page.getByText(/You came from/);
+      await expect(headline).toBeVisible({ timeout: 30000 });
+      await expect(headline).toContainText(surveyUrl.split("?")[0]);
+      await expect(headline).not.toContainText("#recall:");
+    });
+  });
+});

--- a/apps/web/playwright/survey-reserved-fields.spec.ts
+++ b/apps/web/playwright/survey-reserved-fields.spec.ts
@@ -19,14 +19,39 @@ import { createSurveyFromScratch, fillRichTextEditor } from "./utils/helper";
  *    proves nothing about the running survey. This drives the real link survey.
  */
 
+const QUESTION_HEADLINE = "What would you like to know?";
+
 const editorPanel = (page: Page): Locator => page.getByRole("main");
 
 /** The recall dropdown the `@` trigger opens inside a rich-text editor. */
 const recallDropdown = (page: Page): Locator => page.locator("[data-recall-dropdown]");
 
 /**
+ * Expands the first question's card if it is collapsed.
+ *
+ * The editor activates the first element of the first block on mount, so the card is already open
+ * on arrival — clicking its headline would COLLAPSE it and take the rich-text editor with it. Open
+ * it only when the editor is not already there, the same idempotent shape `createSurveyFromScratch`
+ * and the embedded-fields spec use. The heading is matched by role because the headline text also
+ * appears inside the editor's own content, which is what made a plain text match ambiguous.
+ */
+const openQuestionCard = async (page: Page): Promise<void> => {
+  const questionLabel = editorPanel(page).locator('label:has-text("Question*")');
+
+  await expect(async () => {
+    if (!(await questionLabel.isVisible().catch(() => false))) {
+      await editorPanel(page).getByRole("heading", { name: QUESTION_HEADLINE }).click();
+    }
+    await expect(questionLabel).toBeVisible({ timeout: 5000 });
+  }).toPass({ timeout: 30000 });
+};
+
+/**
  * Types `@` into a rich-text editor to open the recall picker. The editor commits the trigger
  * character before the dropdown mounts, so the dropdown is awaited rather than assumed.
+ *
+ * The caret is moved to the end first: a click lands it wherever the pointer happened to fall, which
+ * on non-empty content splices the recall token into the middle of a word.
  */
 const openRecallPicker = async (page: Page, labelText: string): Promise<void> => {
   const label = editorPanel(page).locator(`label:has-text("${labelText}")`);
@@ -34,6 +59,7 @@ const openRecallPicker = async (page: Page, labelText: string): Promise<void> =>
   const editable = container.locator('[contenteditable="true"]').first();
 
   await editable.click();
+  await editable.press("End");
   await editable.pressSequentially("@");
   await expect(recallDropdown(page)).toBeVisible({ timeout: 15000 });
 };
@@ -51,7 +77,7 @@ test.describe("Reserved fields in recall and logic", () => {
 
     await createSurveyFromScratch(page);
 
-    await editorPanel(page).getByText("What would you like to know?").first().click();
+    await openQuestionCard(page);
     await openRecallPicker(page, "Question*");
 
     const dropdown = recallDropdown(page);
@@ -85,11 +111,23 @@ test.describe("Reserved fields in recall and logic", () => {
     await createSurveyFromScratch(page);
 
     await test.step("recall the url into the headline", async () => {
-      await editorPanel(page).getByText("What would you like to know?").first().click();
+      await openQuestionCard(page);
+      // Appends to the headline rather than replacing it: `fillRichTextEditor` clears with `Meta+A`,
+      // which selects nothing on Linux/Chromium where CI runs. What matters here is that the recall
+      // token that follows resolves, not what precedes it.
       await fillRichTextEditor(page, "Question*", "You came from ");
       await openRecallPicker(page, "Question*");
       await recallDropdown(page).getByText("Url", { exact: true }).click();
       await expect(recallDropdown(page)).toBeHidden();
+
+      // Picking a recall item opens the fallback popover, and its Save button stays disabled until
+      // a fallback is entered. Skipping it leaves the survey with an empty fallback, which the
+      // editor refuses to publish ("Fallback missing") — so the survey would never go live.
+      const fallbackInput = page.getByPlaceholder("Enter fallback value");
+      await expect(fallbackInput).toBeVisible();
+      await fallbackInput.fill("somewhere");
+      await page.getByRole("button", { name: "Save", exact: true }).click();
+      await expect(fallbackInput).toBeHidden();
     });
 
     const surveyUrl = await test.step("publish as a link survey", async () => {
@@ -117,7 +155,10 @@ test.describe("Reserved fields in recall and logic", () => {
 
       // `url` is the page the survey runs on, so the headline must echo the link just opened —
       // and must not still contain the raw storage token or fall through to its fallback text.
-      const headline = page.getByText(/You came from/);
+      // The resolved value renders as a text node beside the typed copy, so the assertions sit on
+      // the paragraph holding the whole headline rather than on the inner element a text matcher
+      // would return, which carries only the typed half.
+      const headline = editorPanel(page).locator("p").filter({ hasText: "You came from" }).first();
       await expect(headline).toBeVisible({ timeout: 30000 });
       await expect(headline).toContainText(surveyUrl.split("?")[0]);
       await expect(headline).not.toContainText("#recall:");

--- a/apps/web/playwright/survey-reserved-fields.spec.ts
+++ b/apps/web/playwright/survey-reserved-fields.spec.ts
@@ -51,7 +51,7 @@ test.describe("Reserved fields in recall and logic", () => {
 
     await createSurveyFromScratch(page);
 
-    await editorPanel(page).getByText("What would you like to know?").click();
+    await editorPanel(page).getByText("What would you like to know?").first().click();
     await openRecallPicker(page, "Question*");
 
     const dropdown = recallDropdown(page);
@@ -85,7 +85,7 @@ test.describe("Reserved fields in recall and logic", () => {
     await createSurveyFromScratch(page);
 
     await test.step("recall the url into the headline", async () => {
-      await editorPanel(page).getByText("What would you like to know?").click();
+      await editorPanel(page).getByText("What would you like to know?").first().click();
       await fillRichTextEditor(page, "Question*", "You came from ");
       await openRecallPicker(page, "Question*");
       await recallDropdown(page).getByText("Url", { exact: true }).click();

--- a/apps/web/playwright/survey-reserved-fields.spec.ts
+++ b/apps/web/playwright/survey-reserved-fields.spec.ts
@@ -83,7 +83,10 @@ test.describe("Reserved fields in recall and logic", () => {
     const dropdown = recallDropdown(page);
 
     await test.step("client-available reserved fields are offered", async () => {
-      // Labels are title-cased from the catalog entry names by `formatSnakeCaseToTitleCase`.
+      // Labels are title-cased from the catalog entry names by `formatFieldNameToTitleCase`, which
+      // splits camelCase as well as snake_case. Every client-available Group A entry happens to be a
+      // single word, so the split only shows here once ENG-1841's `utmSource`/`pagePath` land; it is
+      // load-bearing for the absence assertions below.
       await expect(dropdown.getByText("Url", { exact: true })).toBeVisible();
       await expect(dropdown.getByText("Source", { exact: true })).toBeVisible();
       await expect(dropdown.getByText("Language", { exact: true })).toBeVisible();
@@ -94,6 +97,9 @@ test.describe("Reserved fields in recall and logic", () => {
       // browser/os/deviceType as available mid-survey — they are not. All three are parsed from the
       // `user-agent` request header by UAParser in the ingest routes, so the renderer cannot know
       // them; the catalog marks them `server` and the picker filters on that.
+      // These are the labels the picker would actually render for these entries — before
+      // `formatFieldNameToTitleCase` they rendered as "DurationSeconds"/"IpAddress", so searching for
+      // the spaced forms passed no matter what the availability filter did.
       for (const serverOnly of ["Country", "Duration Seconds", "Ip Address", "Browser", "Os", "Finished"]) {
         await expect(dropdown.getByText(serverOnly, { exact: true })).toHaveCount(0);
       }

--- a/apps/web/playwright/utils/helper.ts
+++ b/apps/web/playwright/utils/helper.ts
@@ -671,6 +671,30 @@ export const createSurvey = async (page: Page, params: CreateSurveyParams) => {
   await page.getByPlaceholder("Option 5").fill(params.ranking.choices[4]);
 };
 
+/**
+ * Picks a condition's left operand, filtering the list before clicking it.
+ *
+ * This is the one combobox in the logic editor that also offers the reserved Embedded Data fields
+ * (ENG-1840) on top of every question, variable and hidden field, and that list overflows the 400px
+ * `CommandList`. A bare `getByRole("option").click()` then fails with "element is outside of the
+ * viewport" however long Playwright scrolls and retries — the click never lands and the test dies on
+ * its own timeout rather than on an assertion.
+ *
+ * Typing first is also what an author does with a list this long: the search box is `autoFocus`ed when
+ * the popover opens, and cmdk matches items on their label (`keywords`), so the wanted row ends up at
+ * the top. Only the left-operand picker needs this; the operator and action pickers are short and
+ * carry no reserved entries.
+ */
+const selectConditionLeftOperand = async (page: Page, conditionId: string, label: string) => {
+  await page.locator(`#${conditionId}`).first().click();
+
+  const search = page.getByPlaceholder("Search", { exact: true });
+  await expect(search).toBeVisible();
+  await search.fill(label);
+
+  await page.getByRole("option", { name: label }).first().click();
+};
+
 export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWithLogicParams) => {
   const addBlock = "Add BlockChoose the first question on your Block";
 
@@ -895,8 +919,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
   await page.getByRole("heading", { name: params.openTextQuestion.question }).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
-  await page.locator("#condition-0-0-conditionValue").first().click();
-  await page.getByRole("option", { name: params.openTextQuestion.question }).click();
+  await selectConditionLeftOperand(page, "condition-0-0-conditionValue", params.openTextQuestion.question);
   await page.locator("#condition-0-0-conditionOperator").first().click();
   await page.getByRole("option", { name: "is submitted" }).click();
   await page.locator("#action-0-objective").first().click();
@@ -934,8 +957,11 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
   await page.getByRole("heading", { name: params.singleSelectQuestion.question }).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
-  await page.locator("#condition-0-0-conditionValue").first().click();
-  await page.getByRole("option", { name: params.singleSelectQuestion.question }).click();
+  await selectConditionLeftOperand(
+    page,
+    "condition-0-0-conditionValue",
+    params.singleSelectQuestion.question
+  );
   await page.locator("#condition-0-0-conditionOperator").first().click();
   await page.getByRole("option", { name: "Equals one of" }).click();
   await page.locator("#condition-0-0-conditionMatchValue").first().click();
@@ -972,8 +998,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
   await page.getByRole("heading", { name: params.multiSelectQuestion.question }).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
-  await page.locator("#condition-0-0-conditionValue").click();
-  await page.getByRole("option", { name: params.multiSelectQuestion.question }).click();
+  await selectConditionLeftOperand(page, "condition-0-0-conditionValue", params.multiSelectQuestion.question);
   await page.locator("#condition-0-0-conditionOperator").click();
   await page.getByRole("option", { name: "Includes all of" }).click();
   await page.locator("#condition-0-0-conditionMatchValue").click();
@@ -984,8 +1009,11 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
   await page.waitForSelector('[data-testid="dropdown-menu-content"]', { state: "hidden", timeout: 3000 });
   await page.locator("#condition-0-0-dropdown").click();
   await page.getByRole("menuitem", { name: "Add condition below" }).click();
-  await page.locator("#condition-0-1-conditionValue").click();
-  await page.getByRole("option", { name: params.singleSelectQuestion.question }).click();
+  await selectConditionLeftOperand(
+    page,
+    "condition-0-1-conditionValue",
+    params.singleSelectQuestion.question
+  );
   await page.locator("#condition-0-1-conditionOperator").click();
   await page.getByRole("option", { name: "is submitted" }).click();
   await page.locator("#action-0-objective").first().click();
@@ -1023,8 +1051,11 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
   await page.getByRole("heading", { name: params.pictureSelectQuestion.question }).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
-  await page.locator("#condition-0-0-conditionValue").click();
-  await page.getByRole("option", { name: params.pictureSelectQuestion.question }).click();
+  await selectConditionLeftOperand(
+    page,
+    "condition-0-0-conditionValue",
+    params.pictureSelectQuestion.question
+  );
   await page.locator("#condition-0-0-conditionOperator").click();
   await page.getByRole("option", { name: "is submitted" }).click();
   await page.locator("#action-0-objective").first().click();

--- a/packages/surveys/src/components/general/ending-card.tsx
+++ b/packages/surveys/src/components/general/ending-card.tsx
@@ -20,6 +20,13 @@ interface EndingCardProps {
   autoFocusEnabled: boolean;
   isCurrent: boolean;
   languageCode: string;
+  /**
+   * The recall lookup map, not the raw response: `survey.tsx` merges reserved-field values UNDER the
+   * response data (`mergeReservedValues`) before passing it, so reserved fields resolve in ending
+   * copy *and* in the redirect URL that `processAndRedirect` interpolates. A declared field of the
+   * same name still wins. Read only by `replaceRecallInfo` — anything that needs the respondent's
+   * actual answers must take its own prop rather than reusing this one.
+   */
   responseData: TResponseData;
   variablesData: TResponseVariables;
   onOpenExternalURL?: (url: string) => void | Promise<void>;

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -1,8 +1,11 @@
 import { type JSX } from "preact";
 import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
 import {
+  RESERVED_FIELD_CATALOG,
   coerceToEmbeddedDataType,
   getComputedEmbeddedFields,
+  mergeReservedValues,
+  projectClientReservedValues,
 } from "@formbricks/types/embedded-data-resolver";
 import { SurveyContainerProps } from "@formbricks/types/formbricks-surveys";
 import { TJsFileUploadParams, type TJsWorkspaceStateSurvey } from "@formbricks/types/js";
@@ -750,7 +753,13 @@ export function Survey({
   };
 
   const evaluateLogicAndGetNextBlockId = (
-    data: TResponseData
+    data: TResponseData,
+    /**
+     * Reserved-field values, passed in rather than closed over: this is declared above the memo that
+     * produces them, and taking them as a parameter keeps the sole call site explicit about the fact
+     * that logic reads the same map recall does.
+     */
+    reservedFieldValues: Record<string, string | number>
   ): { nextBlockId: string | undefined; calculatedVariables: TResponseVariables } => {
     const firstEndingId = survey.endings.length > 0 ? survey.endings[0].id : undefined;
 
@@ -784,7 +793,10 @@ export function Survey({
         localResponseData,
         calculationResults,
         logic.conditions,
-        selectedLanguage
+        selectedLanguage,
+        // Merged against the in-flight response data (answers from this block included), so a
+        // declared field shadows a same-named reserved entry here exactly as it does in recall.
+        mergeReservedValues(reservedFieldValues, localResponseData)
       );
 
       if (!isLogicMet) {
@@ -951,6 +963,39 @@ export function Survey({
     ]
   );
 
+  /**
+   * Reserved-field values this renderer can resolve *right now* (ENG-1840).
+   *
+   * `projectClientReservedValues` drops every `server` catalog entry, so the map holds only what a
+   * browser mid-survey actually knows (url, source, action, language today; the SDK-captured entries
+   * light up automatically once they land in the catalog). A recall token or logic operand naming a
+   * server-derived field — country, durationSeconds, browser — finds no key and reads as unset,
+   * which is the correct answer rather than a fabricated empty string.
+   *
+   * The meta slice is the same expression the response queue persists, so what recall shows and what
+   * ingest stores cannot drift apart. `language` is resolved the same way too: `"default"` is a
+   * renderer-internal sentinel, and `#recall:language#` must render the real language code.
+   */
+  const reservedValues = useMemo(
+    () =>
+      projectClientReservedValues(RESERVED_FIELD_CATALOG, {
+        surveyId: localSurvey.id,
+        language:
+          selectedLanguage === "default" ? (getDefaultLanguageCode(survey) ?? null) : selectedLanguage,
+        data: responseData,
+        variables: currentVariables,
+        ttc,
+        meta: { ...getWebSurveyMeta(), action },
+      }),
+    [localSurvey.id, selectedLanguage, survey, responseData, currentVariables, ttc, getWebSurveyMeta, action]
+  );
+
+  /** Recall's lookup map: reserved values first, so a declared field of the same name still wins. */
+  const recallValues = useMemo(
+    () => mergeReservedValues(reservedValues, responseData),
+    [reservedValues, responseData]
+  );
+
   useEffect(() => {
     if (isPreviewMode || !survey.recaptcha?.enabled) return;
 
@@ -1012,8 +1057,10 @@ export function Survey({
 
     pushVariableState(firstRespondedElementId);
 
-    const { nextBlockId: rawNextBlockId, calculatedVariables } =
-      evaluateLogicAndGetNextBlockId(surveyResponseData);
+    const { nextBlockId: rawNextBlockId, calculatedVariables } = evaluateLogicAndGetNextBlockId(
+      surveyResponseData,
+      reservedValues
+    );
     // A jump target may reference a deleted block or ending; treat such stale ids as "no target"
     // so the shown ending and the persisted endingId stay in sync
     const targetIsBlock = localSurvey.blocks.some((block) => block.id === rawNextBlockId);
@@ -1193,7 +1240,7 @@ export function Survey({
             responseCount={responseCount}
             autoFocusEnabled={autoFocusEnabled || hasUserNavigatedRef.current}
             isCurrent={offset === 0}
-            responseData={responseData}
+            responseData={recallValues}
             variablesData={currentVariables}
             isPreviewMode={isPreviewMode}
             fullSizeCards={fullSizeCards}
@@ -1214,7 +1261,7 @@ export function Survey({
               isCurrent={offset === 0}
               languageCode={selectedLanguage}
               isResponseSendingFinished={isResponseSendingFinished}
-              responseData={responseData}
+              responseData={recallValues}
               variablesData={currentVariables}
               onOpenExternalURL={onOpenExternalURL}
               isPreviewMode={isPreviewMode}
@@ -1235,7 +1282,7 @@ export function Survey({
               block={{
                 ...block,
                 elements: block.elements.map((element) =>
-                  parseRecallInformation(element, selectedLanguage, responseData, currentVariables)
+                  parseRecallInformation(element, selectedLanguage, recallValues, currentVariables)
                 ),
               }}
               value={responseData}

--- a/packages/surveys/src/components/general/welcome-card.tsx
+++ b/packages/surveys/src/components/general/welcome-card.tsx
@@ -24,6 +24,12 @@ interface WelcomeCardProps {
   responseCount?: number;
   autoFocusEnabled: boolean;
   isCurrent: boolean;
+  /**
+   * The recall lookup map, not the raw response: `survey.tsx` merges reserved-field values UNDER the
+   * response data (`mergeReservedValues`) before passing it, so `#recall:url#` resolves here while a
+   * declared field of the same name still wins. Read only by `replaceRecallInfo` — anything that
+   * needs the respondent's actual answers must take its own prop rather than reusing this one.
+   */
   responseData: TResponseData;
   variablesData: TResponseVariables;
   fullSizeCards: boolean;

--- a/packages/surveys/src/lib/logic.test.ts
+++ b/packages/surveys/src/lib/logic.test.ts
@@ -1847,3 +1847,149 @@ describe("computed fields resolve through the inlined EmbeddedData rows", () => 
     });
   });
 });
+
+describe("reserved field operands (ENG-1840)", () => {
+  const buildSurvey = (): TJsWorkspaceStateSurvey =>
+    ({
+      id: "survey1",
+      name: "Survey 1",
+      questions: [],
+      blocks: [{ id: "block1", name: "Block 1", elements: [] }],
+      variables: [],
+      embeddedFields: [],
+      hiddenFields: { enabled: true, fieldIds: [] },
+      autoClose: null,
+      type: "link",
+      delay: 0,
+      displayLimit: 0,
+      displayOption: "displayMultiple",
+      displayPercentage: 0,
+      recaptcha: { enabled: false, threshold: 0.5 },
+      isBackButtonHidden: false,
+      isAutoProgressingEnabled: false,
+      segment: null,
+      welcomeCard: { enabled: false, showResponseCount: false, timeToFinish: false },
+      triggers: [],
+      styling: null,
+      status: "inProgress",
+      showLanguageSwitch: false,
+      languages: [],
+      endings: [],
+      workspaceOverwrites: null,
+      recontactDays: null,
+    }) as TJsWorkspaceStateSurvey;
+
+  const reservedCondition = (
+    name: string,
+    operator: TSingleCondition["operator"],
+    rightOperand?: TSingleCondition["rightOperand"]
+  ): TConditionGroup => ({
+    id: "group1",
+    connector: "and",
+    conditions: [
+      { id: "condition1", operator, leftOperand: { type: "reserved", value: name }, rightOperand },
+    ],
+  });
+
+  const evaluate = (conditions: TConditionGroup, embeddedValues: TResponseData): boolean =>
+    evaluateLogic(buildSurvey(), {}, {}, conditions, "default", embeddedValues);
+
+  test("a reserved left operand evaluates against the projected value", () => {
+    const values = { country: "DE" };
+
+    expect(evaluate(reservedCondition("country", "equals", { type: "static", value: "DE" }), values)).toBe(
+      true
+    );
+    expect(evaluate(reservedCondition("country", "equals", { type: "static", value: "FR" }), values)).toBe(
+      false
+    );
+    expect(evaluate(reservedCondition("country", "isSet"), values)).toBe(true);
+  });
+
+  test("a server-only field is unset mid-survey — not 0, not empty string", () => {
+    // `projectClientReservedValues` filters these out entirely, so the map has no key at all. The
+    // distinction matters: `durationSeconds` reading as 0 would make "< 60" silently true for every
+    // respondent, and `country` reading as "" would make "does not equal DE" true.
+    const midSurveyValues: TResponseData = {};
+
+    expect(evaluate(reservedCondition("durationSeconds", "isSet"), midSurveyValues)).toBe(false);
+    expect(evaluate(reservedCondition("durationSeconds", "isNotSet"), midSurveyValues)).toBe(true);
+    expect(
+      evaluate(
+        reservedCondition("durationSeconds", "isLessThan", { type: "static", value: 60 }),
+        midSurveyValues
+      )
+    ).toBe(false);
+    expect(
+      evaluate(reservedCondition("country", "equals", { type: "static", value: "" }), midSurveyValues)
+    ).toBe(false);
+  });
+
+  test("an unset reserved field behaves exactly like an unset hidden field", () => {
+    // Pinning the parity rather than inventing a rule for reserved fields: `doesNotEqual` falls
+    // through to `leftValue !== rightValue`, so BOTH report true when the value is absent. The arm
+    // this ticket adds resolves the value; it deliberately does not change operator semantics.
+    const survey = buildSurvey();
+    const rightOperand = { type: "static" as const, value: "DE" };
+
+    const reservedResult = evaluateLogic(
+      survey,
+      {},
+      {},
+      reservedCondition("country", "doesNotEqual", rightOperand),
+      "default",
+      {}
+    );
+    const hiddenFieldResult = evaluateLogic(
+      survey,
+      {},
+      {},
+      {
+        id: "group1",
+        connector: "and",
+        conditions: [
+          {
+            id: "condition1",
+            operator: "doesNotEqual",
+            leftOperand: { type: "hiddenField", value: "country" },
+            rightOperand,
+          },
+        ],
+      },
+      "default",
+      {}
+    );
+
+    expect(reservedResult).toBe(hiddenFieldResult);
+  });
+
+  test("an unknown reserved name resolves to undefined rather than throwing", () => {
+    expect(evaluate(reservedCondition("notACatalogEntry", "isSet"), { url: "https://x.test" })).toBe(false);
+    expect(evaluate(reservedCondition("notACatalogEntry", "equals", { type: "static", value: "" }), {})).toBe(
+      false
+    );
+  });
+
+  test("a reserved right operand reads the same map", () => {
+    const values = { source: "link", action: "link" };
+    const sameSource: TConditionGroup = {
+      id: "group1",
+      connector: "and",
+      conditions: [
+        {
+          id: "condition1",
+          operator: "equals",
+          leftOperand: { type: "reserved", value: "source" },
+          rightOperand: { type: "reserved", value: "action" },
+        },
+      ],
+    };
+
+    expect(evaluate(sameSource, values)).toBe(true);
+    expect(evaluate(sameSource, { source: "link", action: "app" })).toBe(false);
+  });
+
+  test("omitting the map keeps every reserved operand unset (already-deployed callers)", () => {
+    expect(evaluateLogic(buildSurvey(), {}, {}, reservedCondition("url", "isSet"), "default")).toBe(false);
+  });
+});

--- a/packages/surveys/src/lib/logic.ts
+++ b/packages/surveys/src/lib/logic.ts
@@ -19,19 +19,35 @@ export const isConditionGroup = (condition: TCondition): condition is TCondition
   return (condition as TConditionGroup).connector !== undefined;
 };
 
+/**
+ * @param embeddedValues Reserved-field values merged UNDER `data` by `mergeReservedValues` — the map
+ *   a `reserved` operand reads. Only that operand consults it; the `element` and `hiddenField` arms
+ *   keep reading `data` alone, so a declared field that happens to share a reserved name can never
+ *   pick up reserved metadata just because the respondent left it blank. Defaults to `{}` so a
+ *   caller with nothing to project evaluates exactly as it does today, and every reserved operand
+ *   reads as unset rather than throwing.
+ */
 export const evaluateLogic = (
   localSurvey: TJsWorkspaceStateSurvey,
   data: TResponseData,
   variablesData: TResponseVariables,
   conditions: TConditionGroup,
-  selectedLanguage: string
+  selectedLanguage: string,
+  embeddedValues: TResponseData = {}
 ): boolean => {
   const evaluateConditionGroup = (group: TConditionGroup): boolean => {
     const results = group.conditions.map((condition) => {
       if (isConditionGroup(condition)) {
         return evaluateConditionGroup(condition);
       } else {
-        return evaluateSingleCondition(localSurvey, data, variablesData, condition, selectedLanguage);
+        return evaluateSingleCondition(
+          localSurvey,
+          data,
+          variablesData,
+          condition,
+          selectedLanguage,
+          embeddedValues
+        );
       }
     });
 
@@ -80,7 +96,8 @@ const getLeftOperandValue = (
   data: TResponseData,
   variablesData: TResponseVariables,
   leftOperand: TSingleCondition["leftOperand"],
-  selectedLanguage: string
+  selectedLanguage: string,
+  embeddedValues: TResponseData
 ) => {
   switch (leftOperand.type) {
     case "element":
@@ -168,6 +185,10 @@ const getLeftOperandValue = (
       return getLogicVariableValue(getComputedEmbeddedFields(localSurvey), leftOperand.value, variablesData);
     case "hiddenField":
       return data[leftOperand.value];
+    // Mid-survey the map holds client-available entries only, so a server-derived name
+    // (country, durationSeconds, …) is absent here and reads as unset — never a fabricated 0 or "".
+    case "reserved":
+      return embeddedValues[leftOperand.value];
     default:
       return undefined;
   }
@@ -177,7 +198,8 @@ const getRightOperandValue = (
   localSurvey: TJsWorkspaceStateSurvey,
   data: TResponseData,
   variablesData: TResponseVariables,
-  rightOperand: TSingleCondition["rightOperand"]
+  rightOperand: TSingleCondition["rightOperand"],
+  embeddedValues: TResponseData
 ) => {
   if (!rightOperand) return undefined;
 
@@ -188,6 +210,8 @@ const getRightOperandValue = (
       return getLogicVariableValue(getComputedEmbeddedFields(localSurvey), rightOperand.value, variablesData);
     case "hiddenField":
       return data[rightOperand.value];
+    case "reserved":
+      return embeddedValues[rightOperand.value];
     case "static":
       return rightOperand.value;
     default:
@@ -200,7 +224,8 @@ const evaluateSingleCondition = (
   data: TResponseData,
   variablesData: TResponseVariables,
   condition: TSingleCondition,
-  selectedLanguage: string
+  selectedLanguage: string,
+  embeddedValues: TResponseData
 ): boolean => {
   try {
     let leftValue = getLeftOperandValue(
@@ -208,10 +233,11 @@ const evaluateSingleCondition = (
       data,
       variablesData,
       condition.leftOperand,
-      selectedLanguage
+      selectedLanguage,
+      embeddedValues
     );
     let rightValue = condition.rightOperand
-      ? getRightOperandValue(localSurvey, data, variablesData, condition.rightOperand)
+      ? getRightOperandValue(localSurvey, data, variablesData, condition.rightOperand, embeddedValues)
       : undefined;
 
     // Only element and hiddenField operands are inspected below; a `variable` operand's declared

--- a/packages/surveys/src/lib/logic.ts
+++ b/packages/surveys/src/lib/logic.ts
@@ -10,6 +10,7 @@ import { type TActionCalculate, type TSurveyBlockLogicAction } from "@formbricks
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
 import type { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { type TConditionGroup, type TSingleCondition } from "@formbricks/types/surveys/logic";
+import { evaluateConditionGroup } from "@formbricks/types/surveys/logic-evaluation";
 import { getLocalizedValue } from "@/lib/i18n";
 import { getElementsFromSurveyBlocks } from "./utils";
 
@@ -34,28 +35,10 @@ export const evaluateLogic = (
   conditions: TConditionGroup,
   selectedLanguage: string,
   embeddedValues: TResponseData = {}
-): boolean => {
-  const evaluateConditionGroup = (group: TConditionGroup): boolean => {
-    const results = group.conditions.map((condition) => {
-      if (isConditionGroup(condition)) {
-        return evaluateConditionGroup(condition);
-      } else {
-        return evaluateSingleCondition(
-          localSurvey,
-          data,
-          variablesData,
-          condition,
-          selectedLanguage,
-          embeddedValues
-        );
-      }
-    });
-
-    return group.connector === "or" ? results.some((r) => r) : results.every((r) => r);
-  };
-
-  return evaluateConditionGroup(conditions);
-};
+): boolean =>
+  evaluateConditionGroup(conditions, (condition) =>
+    evaluateSingleCondition(localSurvey, data, variablesData, condition, selectedLanguage, embeddedValues)
+  );
 
 export const performActions = (
   survey: TJsWorkspaceStateSurvey,

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -20,7 +20,9 @@ import {
   getIngestedStorageKeys,
   getLogicVariableValue,
   getSurveyEmbeddedFields,
+  listMidSurveyReservedEntries,
   listReadableFields,
+  mergeReservedValues,
   projectClientReservedValues,
   projectReservedValues,
   resolveEmbeddedValue,
@@ -1410,5 +1412,92 @@ describe("getComputedFieldDataType", () => {
     // swallowed by `evaluateSingleCondition`'s try/catch into a silent `false`.
     expect(getComputedFieldDataType(fields, "deleted_variable")).toBeUndefined();
     expect(findComputedEmbeddedField(fields, "deleted_variable")).toBeUndefined();
+  });
+});
+
+describe("mergeReservedValues", () => {
+  test("reserved values fill keys the response does not have", () => {
+    expect(mergeReservedValues({ country: "DE", url: "https://x.test" }, { q1: "answer" })).toStrictEqual({
+      country: "DE",
+      url: "https://x.test",
+      q1: "answer",
+    });
+  });
+
+  test("THE GRANDFATHER RULE: response data wins on a colliding key", () => {
+    // Flip the two spreads in `mergeReservedValues` and this goes red. A survey stored today may
+    // legitimately declare a hidden field named `country`; its value lives in `response.data` and
+    // must keep resolving from there forever.
+    expect(mergeReservedValues({ country: "DE" }, { country: "Declared answer" })).toStrictEqual({
+      country: "Declared answer",
+    });
+  });
+
+  test("a declared key wins even when its value is empty or zero", () => {
+    // Falsy is still an answer — a `??`-style merge would wrongly fall through to the reserved value.
+    expect(mergeReservedValues({ country: "DE" }, { country: "" })).toStrictEqual({ country: "" });
+    expect(mergeReservedValues({ durationSeconds: 42 }, { durationSeconds: 0 })).toStrictEqual({
+      durationSeconds: 0,
+    });
+  });
+
+  test("neither input is mutated", () => {
+    const reserved = { country: "DE" };
+    const responseData = { q1: "answer" };
+
+    mergeReservedValues(reserved, responseData);
+
+    expect(reserved).toStrictEqual({ country: "DE" });
+    expect(responseData).toStrictEqual({ q1: "answer" });
+  });
+});
+
+describe("listMidSurveyReservedEntries", () => {
+  const names = (declared: string[]): string[] =>
+    listMidSurveyReservedEntries(RESERVED_FIELD_CATALOG, declared).map((entry) => entry.name);
+
+  test("offers only what a browser can resolve mid-survey", () => {
+    expect(names([]).sort()).toStrictEqual(["action", "language", "source", "url"]);
+  });
+
+  test("every server-derived field named by the ticket is absent", () => {
+    // The ticket's own description lists browser/os/deviceType as available during the survey. They
+    // are not on this branch: UAParser derives all three from the `user-agent` header in the ingest
+    // routes, so the renderer cannot know them. The catalog's `availability` is the authority.
+    const offered = names([]);
+
+    for (const serverOnly of [
+      "country",
+      "ipAddress",
+      "browser",
+      "os",
+      "deviceType",
+      "durationSeconds",
+      "finished",
+      "responseId",
+      "startedAt",
+      "finishedAt",
+    ]) {
+      expect(offered).not.toContain(serverOnly);
+    }
+  });
+
+  test("a declared field of the same name removes the reserved entry from the picker", () => {
+    // Otherwise the author sees two identically-named rows with no way to tell them apart, and the
+    // reserved one would be a lie: `mergeReservedValues` already resolves that name to the declared
+    // field's value.
+    expect(names(["url"])).not.toContain("url");
+    expect(names(["url"])).toContain("source");
+  });
+
+  test("shadowing a server-only name changes nothing, since it was never offered", () => {
+    expect(names(["country"]).sort()).toStrictEqual(["action", "language", "source", "url"]);
+  });
+
+  test("entries are returned as catalog entries, carrying their dataType", () => {
+    const entry = listMidSurveyReservedEntries(RESERVED_FIELD_CATALOG, []).find((e) => e.name === "url");
+
+    expect(entry?.dataType).toBe("string");
+    expect(entry?.availability).not.toBe("server");
   });
 });

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -672,7 +672,9 @@ describe("RESERVED_FIELD_CATALOG", () => {
     // extra key is an entry nobody declared in the table above.
     expect(projectCatalog(capturedResponse)).toStrictEqual({
       source: "link",
-      url: "https://example.com/pricing?utm_source=news&email=a@b.co",
+      // `privacy: "redactQuery"` applied by the projection: the stored meta still holds
+      // `?utm_source=news&email=a@b.co`, but a projected value can be recalled into a redirect URL.
+      url: "https://example.com/pricing",
       country: "DE",
       action: "Clicked Upgrade",
       browser: "Chrome",
@@ -687,6 +689,20 @@ describe("RESERVED_FIELD_CATALOG", () => {
       startedAt: "2026-08-01T09:00:00.000Z",
       finishedAt: "2026-08-01T09:02:30.000Z",
     });
+  });
+
+  test("a redactQuery entry projects without its query string, while storage keeps it", () => {
+    // The finding this pins: reserved `url` is interpolable into an ending card's redirect URL and a
+    // follow-up email, so projecting the href verbatim forwards whatever the survey link carried —
+    // for a link survey that includes the single-use `suToken`, which is a credential.
+    const tokenised = {
+      ...capturedResponse,
+      meta: { ...capturedResponse.meta, url: "https://app.test/s/abc?suToken=secret&lang=de#top" },
+    };
+
+    expect(projectCatalog(tokenised).url).toBe("https://app.test/s/abc");
+    // Read-side narrowing only — capture is the Anonymize toggle's job, and it is off here.
+    expect(tokenised.meta.url).toBe("https://app.test/s/abc?suToken=secret&lang=de#top");
   });
 
   test("resolves what a historical response captured and reports the rest as unset", () => {
@@ -775,6 +791,18 @@ describe("projectClientReservedValues", () => {
     ttc: { q1: 40_000 },
     meta: { source: "link", url: "https://example.com/pricing", action: "Clicked Upgrade" },
   };
+
+  test("redacts the query from a mid-survey url, which is the interpolable one", () => {
+    // The leak path this closes: an author can put `#recall:url#` in an ending card's redirect URL, so
+    // the mid-survey projection is what a third-party host would receive. On a single-use link the
+    // href carries `suToken`, a credential, plus whatever prefill params the link was built with.
+    const projected = projectClientReservedValues(RESERVED_FIELD_CATALOG, {
+      ...midSurvey,
+      meta: { ...midSurvey.meta, url: "https://app.test/s/abc?suToken=secret&country=DE" },
+    });
+
+    expect(projected.url).toBe("https://app.test/s/abc");
+  });
 
   test("projects only the entries a client can read mid-survey", () => {
     expect(projectClientReservedValues(RESERVED_FIELD_CATALOG, midSurvey)).toStrictEqual({
@@ -1023,6 +1051,27 @@ describe("listReadableFields", () => {
     });
 
     expect(fields.reserved).toEqual([{ key: "_", label: "_" }]);
+  });
+
+  test("camelCase reserved names get a spaced label, not a run-together one", () => {
+    // The catalog names mirror the `meta` keys they read, so they are camelCase rather than
+    // snake_case. Labelling them with the snake_case formatter alone rendered "DurationSeconds" in
+    // the pickers, and made the Playwright assertions that a server-only field is ABSENT pass for the
+    // wrong reason: they searched for "Duration Seconds", a string nothing ever rendered.
+    const fields = listReadableFields({
+      blocks: [],
+      embeddedData: [],
+      reservedEntries: RESERVED_FIELD_CATALOG.filter((entry) =>
+        ["durationSeconds", "ipAddress", "responseId"].includes(entry.name)
+      ),
+      contactAttributeKeys: [],
+    });
+
+    expect(fields.reserved).toEqual([
+      { key: "ipAddress", label: "Ip Address" },
+      { key: "responseId", label: "Response Id" },
+      { key: "durationSeconds", label: "Duration Seconds" },
+    ]);
   });
 
   test("embedded data labels fall back to the storageKey when the definition name is blank", () => {

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -3,7 +3,7 @@ import type { TContactAttributeKey } from "./contact-attribute-key";
 import type { TEmbeddedData, TEmbeddedDataType, TSurveyEmbeddedData } from "./embedded-data";
 import { type TLegacyEmbeddedFields, toDesiredEmbeddedFields } from "./embedded-data-mapping";
 import type { TI18nString } from "./i18n";
-import type { TResponse, TResponseVariables } from "./responses";
+import type { TResponse, TResponseData, TResponseVariables } from "./responses";
 import { formatSnakeCaseToTitleCase } from "./safe-identifier";
 import type { TSurveyBlocks } from "./surveys/blocks";
 import { getTextContent } from "./surveys/validation";
@@ -615,6 +615,50 @@ export const projectClientReservedValues = (
     entries.filter((entry): entry is TClientReservedFieldCatalogEntry => entry.availability !== "server"),
     response
   );
+
+/**
+ * **The grandfather rule, as one expression.** Reserved values go in FIRST so `responseData` spreads
+ * over them and wins on every colliding key.
+ *
+ * `FORBIDDEN_IDS` never guarded the reserved names, so surveys stored today legitimately declare a
+ * hidden field called `country` or `url`. Its value lives at `response.data["country"]`, and
+ * `#recall:country#` in such a survey must keep resolving from there — unchanged, forever.
+ * `RESERVED_FIELD_NAMES` (reserved-field-names.ts) stops only *new* declarations, so the collision
+ * set is frozen but non-empty, and this ordering is what keeps those surveys working.
+ *
+ * Flipping the two spreads is the whole regression: reserved metadata would start overwriting
+ * answers respondents actually gave. It lives here, called from every consumer, rather than being
+ * open-coded per surface, so there is exactly one line to audit and one line to test.
+ */
+export const mergeReservedValues = (
+  reservedValues: Record<string, string | number>,
+  responseData: TResponseData
+): TResponseData => ({ ...reservedValues, ...responseData });
+
+/**
+ * Which reserved entries a **mid-survey** picker may offer for one survey (ENG-1840). Both filters
+ * exist for a reason a reviewer should be able to check separately:
+ *
+ * 1. `availability !== "server"` — recall and logic evaluate in the browser while the respondent is
+ *    answering, so offering `country` or `durationSeconds` would let an author build a condition
+ *    that can never be true. Filtering on the catalog's own field (rather than a list here) means
+ *    entries added later light up automatically, and none can be offered without declaring when it
+ *    is knowable.
+ * 2. Not shadowed by a declared field — the picker counterpart of {@link mergeReservedValues}. If a
+ *    survey declares its own `country`, that name already resolves to the declared value, so listing
+ *    the reserved entry too would show two identically-named rows with no way to tell them apart and
+ *    the reserved one would be a lie. The declared field is already offered by its own group.
+ *
+ * Pass the survey's declared storage keys (hidden/ingested fields and variables) as
+ * `declaredStorageKeys`.
+ */
+export const listMidSurveyReservedEntries = (
+  entries: readonly TReservedFieldCatalogEntry[],
+  declaredStorageKeys: readonly string[]
+): TReservedFieldCatalogEntry[] => {
+  const declared = new Set(declaredStorageKeys);
+  return entries.filter((entry) => entry.availability !== "server" && !declared.has(entry.name));
+};
 
 /** One referenceable field, carrying the key a consumer must use to address it. */
 export interface TReadableField {

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -4,7 +4,7 @@ import type { TEmbeddedData, TEmbeddedDataType, TSurveyEmbeddedData } from "./em
 import { type TLegacyEmbeddedFields, toDesiredEmbeddedFields } from "./embedded-data-mapping";
 import type { TI18nString } from "./i18n";
 import type { TResponse, TResponseData, TResponseVariables } from "./responses";
-import { formatSnakeCaseToTitleCase } from "./safe-identifier";
+import { formatFieldNameToTitleCase } from "./safe-identifier";
 import type { TSurveyBlocks } from "./surveys/blocks";
 import { getTextContent } from "./surveys/validation";
 
@@ -87,9 +87,16 @@ export type TReservedFieldAvailability = "client" | "server" | "both";
  *   the part analytics needs.
  *
  * Declared here rather than at the ingest routes so the classification lives next to the field it
- * describes and a new entry cannot be added without deciding it. **Nothing consumes this yet** —
- * the toggle does not exist on this branch; this is the catalog stating its own policy ahead of the
- * surface that will apply it, so that surface has no per-field list of its own to drift from.
+ * describes and a new entry cannot be added without deciding it, and so no surface applying the
+ * policy needs a per-field list of its own to drift from.
+ *
+ * Two surfaces apply it, and they apply it at different times for different reasons:
+ *
+ * - the "Anonymize responses" toggle, at ingest, gated on the survey's setting — it decides what is
+ *   *captured*, and `drop` only means anything there;
+ * - {@link projectReservedValues} / {@link projectClientReservedValues}, at read, unconditionally —
+ *   `redactQuery` narrows what recall and logic may forward, because a recall token can end up in a
+ *   redirect URL or an email. Storage is untouched by that one.
  */
 export type TReservedFieldPrivacy = "keep" | "drop" | "redactQuery";
 
@@ -431,13 +438,48 @@ const resolveCatalogEntry = <TSlice>(
 };
 
 /**
+ * Strips the query string (and fragment) from a URL, keeping origin and path — the redaction
+ * `privacy: "redactQuery"` names.
+ *
+ * Falls back to a textual cut for anything `URL` cannot parse or parses to an opaque origin (a
+ * relative path, a `data:`/`about:` URL, plain junk), so it never throws and never widens what it
+ * returns beyond the input.
+ */
+export const redactUrlQuery = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    if (parsed.origin !== "null") {
+      return `${parsed.origin}${parsed.pathname}`;
+    }
+  } catch {
+    // Not an absolute URL. Fall through to the cut, which needs no parser and cannot throw.
+  }
+
+  const separatorIndex = url.search(/[?#]/);
+  return separatorIndex === -1 ? url : url.slice(0, separatorIndex);
+};
+
+/**
  * The shared body of the two projections: entry name → resolved value, absent values omitted,
  * booleans stringified because the recall/logic map types have no boolean slot.
+ *
+ * `privacy: "redactQuery"` is honoured HERE, on every projection, not only when the "Anonymize
+ * responses" toggle is on. The projection is a *forwarding* surface in a way storage is not: a
+ * reserved value reaches a recall token, and a recall token can be interpolated into an ending card's
+ * redirect URL (`ending-card.tsx`) or a follow-up email body. Projecting `url` verbatim therefore
+ * hands a third party whatever the survey URL carried — including a link survey's single-use
+ * `suToken`, which is a credential. Stripping the query costs an author nothing that was ever a
+ * documented capability (query params surface as their own `utm*` entries), so the safe form is the
+ * only form recall and logic ever see.
+ *
+ * Storage is deliberately untouched: `response.meta.url` still holds the full href unless the
+ * Anonymize toggle redacted it at ingest. This is a read-side narrowing, not a capture change.
  */
 const projectEntries = <TSlice>(
   entries: readonly {
     name: string;
     dataType: TEmbeddedDataType;
+    privacy: TReservedFieldPrivacy;
     read: (response: TSlice) => TReservedFieldRawValue;
   }[],
   response: TSlice
@@ -446,7 +488,11 @@ const projectEntries = <TSlice>(
   for (const entry of entries) {
     const value = resolveCatalogEntry(entry, response);
     if (value === undefined) continue;
-    values[entry.name] = typeof value === "boolean" ? String(value) : value;
+    const projected = typeof value === "boolean" ? String(value) : value;
+    values[entry.name] =
+      entry.privacy === "redactQuery" && typeof projected === "string"
+        ? redactUrlQuery(projected)
+        : projected;
   }
   return values;
 };
@@ -756,7 +802,7 @@ export const listReadableFields = (input: TListReadableFieldsInput): TReadableFi
 
   const reserved = input.reservedEntries.map((entry) => ({
     key: entry.name,
-    label: labelOrKey(formatSnakeCaseToTitleCase(entry.name), entry.name),
+    label: labelOrKey(formatFieldNameToTitleCase(entry.name), entry.name),
   }));
 
   const contactAttribute = input.contactAttributeKeys.map((attributeKey) => ({

--- a/packages/types/safe-identifier.test.ts
+++ b/packages/types/safe-identifier.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  formatFieldNameToTitleCase,
   formatSnakeCaseToTitleCase,
   isLegacyIdCharset,
   isLegacyVariableName,
@@ -56,6 +57,32 @@ describe("safe-identifier", () => {
 
     test("keeps already safe identifiers unchanged", () => {
       expect(toSafeIdentifier("country_code")).toBe("country_code");
+    });
+  });
+
+  describe("formatFieldNameToTitleCase", () => {
+    test("splits camelCase, which the snake_case formatter cannot", () => {
+      expect(formatFieldNameToTitleCase("durationSeconds")).toBe("Duration Seconds");
+      expect(formatFieldNameToTitleCase("ipAddress")).toBe("Ip Address");
+      expect(formatFieldNameToTitleCase("utmSource")).toBe("Utm Source");
+      expect(formatFieldNameToTitleCase("viewportWidth")).toBe("Viewport Width");
+    });
+
+    test("still handles the snake_case and single-word cases", () => {
+      expect(formatFieldNameToTitleCase("job_description")).toBe("Job Description");
+      expect(formatFieldNameToTitleCase("url")).toBe("Url");
+      expect(formatFieldNameToTitleCase("")).toBe("");
+    });
+
+    test("splits on a digit-to-uppercase boundary too", () => {
+      expect(formatFieldNameToTitleCase("utm2Source")).toBe("Utm2 Source");
+    });
+
+    test("leaves the shared snake_case formatter's camelCase behaviour alone", () => {
+      // Load-bearing: `formatSnakeCaseToTitleCase` also derives the stored display name for newly
+      // created contact attribute keys, and those arrive camelCase from the SDK and CSV import. This
+      // pins that the reserved-field fix did not leak into that path.
+      expect(formatSnakeCaseToTitleCase("firstName")).toBe("FirstName");
     });
   });
 

--- a/packages/types/safe-identifier.ts
+++ b/packages/types/safe-identifier.ts
@@ -82,6 +82,22 @@ export const formatSnakeCaseToTitleCase = (key: string): string => {
 };
 
 /**
+ * Label formatter for names that may be camelCase, which `formatSnakeCaseToTitleCase` cannot split.
+ * Example: "durationSeconds" -> "Duration Seconds", "ip_address" -> "Ip Address".
+ *
+ * Reserved field catalog names are camelCase by convention, because they mirror the `meta` keys they
+ * read (`utmSource`, `viewportWidth`, `ipAddress`). Run through the snake_case formatter alone they
+ * render as "DurationSeconds", which is not a label anyone would write by hand.
+ *
+ * Deliberately NOT folded into `formatSnakeCaseToTitleCase`: that helper also derives the stored
+ * display name for newly created contact attribute keys, and those genuinely arrive camelCase from
+ * the SDK and CSV import — `contacts.ts` dedupes `firstName` against `firstname` precisely because
+ * both show up. Splitting there would rename attribute keys as a side effect of a survey-editor fix.
+ */
+export const formatFieldNameToTitleCase = (key: string): string =>
+  formatSnakeCaseToTitleCase(key.replace(/([a-z0-9])([A-Z])/g, "$1_$2"));
+
+/**
  * Legacy shim for the load path: the character rule every declared id was stored under before
  * `isSafeIdentifier` existed. Via `validateId` this governs element and question ids as well as
  * hidden field ids, hence the charset-level name. Survey schemas validate already-persisted names

--- a/packages/types/surveys/logic-evaluation.ts
+++ b/packages/types/surveys/logic-evaluation.ts
@@ -1,0 +1,28 @@
+import type { TConditionGroup, TSingleCondition } from "./logic";
+
+/**
+ * Evaluates a condition group: recurse into nested groups, delegate leaf conditions to the caller,
+ * then combine with the group's connector (`or` → any, otherwise → all).
+ *
+ * Shared because the two logic engines — `packages/surveys/src/lib/logic.ts` (the renderer) and
+ * `apps/web/lib/surveyLogic/utils.ts` (quotas, summaries, follow-up conditions) — are near-copies of
+ * each other, and this recursion was byte-identical in both. Same reasoning as `getLogicVariableValue`
+ * in embedded-data-resolver.ts: the two engines disagreeing about how a survey evaluates is its own
+ * bug class, so the rule gets one definition rather than two that can drift.
+ *
+ * Only the *grouping* is shared. How an individual condition resolves stays with each engine, which
+ * is where they legitimately differ — the renderer sees a mid-survey response, the server a persisted
+ * one.
+ */
+export const evaluateConditionGroup = (
+  group: TConditionGroup,
+  evaluateCondition: (condition: TSingleCondition) => boolean
+): boolean => {
+  const results = group.conditions.map((condition) =>
+    "conditions" in condition
+      ? evaluateConditionGroup(condition, evaluateCondition)
+      : evaluateCondition(condition)
+  );
+
+  return group.connector === "or" ? results.some((result) => result) : results.every((result) => result);
+};

--- a/packages/types/surveys/logic.ts
+++ b/packages/types/surveys/logic.ts
@@ -79,9 +79,27 @@ const ZDynamicHiddenField = z.object({
   value: z.string().min(1, "Conditional Logic: Hidden field id cannot be empty"),
 });
 
-export const ZDynamicLogicFieldValue = z.union([ZDynamicElement, ZDynamicVariable, ZDynamicHiddenField], {
-  error: "Conditional Logic: Invalid dynamic field value",
+/**
+ * A reserved field operand (ENG-1840): auto-captured metadata a survey references without declaring
+ * it, addressed by its `RESERVED_FIELD_CATALOG` entry name rather than by a stored id.
+ *
+ * The name is validated as non-empty only, deliberately NOT against the catalog: the catalog grows
+ * (ENG-1841 adds the SDK-captured entries), and a survey saved against a newer catalog must still
+ * parse on an older deployment instead of failing validation for the whole survey. An operand naming
+ * an entry that does not exist resolves as unset, which is the same outcome as a stale variable or
+ * hidden-field operand already has today.
+ */
+const ZDynamicReservedField = z.object({
+  type: z.literal("reserved"),
+  value: z.string().min(1, "Conditional Logic: Reserved field name cannot be empty"),
 });
+
+export const ZDynamicLogicFieldValue = z.union(
+  [ZDynamicElement, ZDynamicVariable, ZDynamicHiddenField, ZDynamicReservedField],
+  {
+    error: "Conditional Logic: Invalid dynamic field value",
+  }
+);
 
 export type TDynamicLogicFieldValue = z.infer<typeof ZDynamicLogicFieldValue>;
 
@@ -94,7 +112,7 @@ const ZDynamicQuestion = z.object({
 });
 
 export const ZDynamicLogicFieldValueDeprecated = z.union(
-  [ZDynamicQuestion, ZDynamicElement, ZDynamicVariable, ZDynamicHiddenField],
+  [ZDynamicQuestion, ZDynamicElement, ZDynamicVariable, ZDynamicHiddenField, ZDynamicReservedField],
   {
     error: "Conditional Logic: Invalid dynamic field value",
   }

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -4464,7 +4464,8 @@ export type TSortOption = z.infer<typeof ZSortOption>;
 export const ZSurveyRecallItem = z.object({
   id: z.string(),
   label: z.string(),
-  type: z.enum(["element", "hiddenField", "attributeClass", "variable"]),
+  // "reserved" (ENG-1840) addresses a RESERVED_FIELD_CATALOG entry by name rather than a stored id.
+  type: z.enum(["element", "hiddenField", "attributeClass", "variable", "reserved"]),
 });
 
 export type TSurveyRecallItem = z.infer<typeof ZSurveyRecallItem>;


### PR DESCRIPTION
> **Stacked on #8892** (`javier/eng-1839-reserved-field-catalog-tier-1-name-collision-rules`), which carries the populated reserved-field catalog, `projectClientReservedValues`, and the `availability` field this PR depends on. **#8892 has merged**, so GitHub has retargeted this PR to `epic/embedded-data-v1` and the diff below is this PR's own changes only.

## What & why

Reserved fields (`url`, `source`, `country`, `durationSeconds`, …) are auto-captured metadata every survey can reference without declaring anything. The catalog existed, and `projectReservedValues()` existed — but with **zero production call sites**, so none of it was reachable from recall tokens, logic conditions, redirect URLs, or the field pickers. This wires it up.

**The ordering rule is the whole "nothing breaks" guarantee.** Every recall/logic value map is now built as `{ ...reservedValues, ...responseData }` — reserved first, so response data **shadows** it. A survey in production may legitimately declare a hidden field named `country`; its value lives at `response.data["country"]` and `#recall:country#` must keep resolving from there, unchanged. `FORBIDDEN_IDS` never guarded these names, so that collision set is frozen but non-empty. That ordering lives in exactly one expression:

**`packages/types/embedded-data-resolver.ts` → `mergeReservedValues()` — one line, called from every consumer.** That is the line to review.

What changed:

- **Types.** `ZDynamicReservedField` (`{ type: "reserved", value }`) added to both `ZDynamicLogicFieldValue` and the API back-compat `ZDynamicLogicFieldValueDeprecated`; `"reserved"` added to `ZSurveyRecallItem.type`. Widening only. The operand name is validated non-empty, deliberately *not* against the catalog, so a survey saved against a newer catalog still parses on an older deployment.
- **Both logic engines** get a `reserved` arm. The renderer (`packages/surveys`) resolves against the client-available projection; the server engine (`apps/web/lib/surveyLogic/utils.ts`) resolves against the **full** catalog via the new `buildServerEmbeddedValues()`. Only the `reserved` arm reads the merged map — `element` and `hiddenField` still read `data` alone, so a declared field can never pick up reserved metadata just because the respondent left it blank.
- **Renderer wiring** in `survey.tsx`: one memo projects the client-available values, one merges them under `responseData`. That single merged map feeds `parseRecallInformation`, `WelcomeCard`, `EndingCard` (which covers redirect-URL interpolation at `ending-card.tsx:87` for free), and `evaluateLogic`.
- **Mid-survey availability, enforced in the picker.** `listMidSurveyReservedEntries()` applies both gates: `availability !== "server"`, and drop any entry the survey already declares under the same name (grandfathering in the picker, so the author never sees two identically-named rows). The shadow list counts all three declaration kinds — ingested fields, variables **and element ids** — because all three win at value time.
- **Picker data sources**: the recall picker, the block-logic operand picker, and an operator set per `dataType` (string / number / boolean / date).
- **Quota evaluation resolves reserved operands.** `evaluateResponseQuotas` builds `buildServerEmbeddedValues(response)` from the row its callers already hold inside the ingest transaction (no extra query) and threads it through `evaluateQuotas` to `evaluateLogic`.
- **`privacy: "redactQuery"` is honoured at read time.** The projection narrows `url` to origin + path, so a recall token can never forward a query string. See Security below.

### Security: reserved `url` is redacted in the projection

A reserved value is interpolable — an author can put `#recall:url#` in an ending card's redirect URL (`redirect-url-form.tsx` wraps that field in `RecallWrapper`, and `ending-card.tsx` runs `replaceRecallInfo` over it before navigating) or in a follow-up email body. Projecting `window.location.href` verbatim therefore handed a third-party host whatever the survey link carried — on a single-use link that includes `suToken`, described in `validation.ts` as a credential, plus any prefill params. `LINK_SURVEY_SYSTEM_PARAMS` deliberately refuses to *capture* those into hidden fields; the reserved read routed around that refusal.

`projectEntries` — the shared body of `projectReservedValues` and `projectClientReservedValues` — now applies `redactQuery` to matching entries, so both engines narrow to origin + path from one place, and a future `redactQuery` entry is covered by declaring its policy.

Two deliberate choices:

1. **Unconditional, not gated on the Anonymize toggle.** A projection is a forwarding surface in a way storage is not. It costs an author nothing that was ever a documented capability — query params surface as their own `utm*` entries once ENG-1841 lands them.
2. **Storage is untouched.** `response.meta.url` still holds the full href unless the Anonymize toggle redacts it at ingest. This is a read-side narrowing; capture and history are unchanged.

**Follow-up for the epic branch, not this PR:** ENG-1842 (#8895) has its own `redactUrlQueryParams` for the ingest side — same behaviour, fragment included — but it is a sibling stacked on the same parent and cannot import this one's helper. Once both are merged, the ingest side should point at `redactUrlQuery` in `packages/types` and the local copy should go away.

### Correction to the ticket

The ticket description lists `browser`, `os` and `deviceType` as available during the survey. **That is wrong on this branch.** All three are parsed server-side by `UAParser` from the `user-agent` request header in the ingest routes; no client-side UA read exists in `packages/surveys/src` or `packages/js-core/src`. They are `availability: "server"` in the catalog and are correctly absent from mid-survey pickers. The pickers filter on the catalog's `availability` field rather than a hand-maintained list, so the ENG-1841 entries (`pageUrl`, `utm*`, `viewport*`, …) light up automatically when that branch merges — nothing here needs to change.

### Deliberately out of scope

Exports and response filters are untouched (ENG-1847 / ENG-1848) — an acceptance criterion is that their behaviour does not change. Picker *visual* treatment is ENG-1853.

**The quota condition *picker* stays opted out, while quota *evaluation* now works.** `includeReservedFields` still defaults to `false`, so only survey block logic offers reserved operands in the editor. The reason is no longer "evaluation would silently never match" — that is fixed — but that quota conditions evaluate server-side against a persisted response, where the **full** catalog is knowable. Offering them through the mid-survey filter would expose only the client-available subset and hide `country`, `browser` and `durationSeconds`, which are the ones an author would actually want in a quota. A server-availability picker variant is presentation work owned by ENG-1853. A reserved quota condition created through the API evaluates correctly today.

## Linear ticket

Fixes ENG-1840 — https://linear.app/formbricks/issue/ENG-1840/make-reserved-fields-usable-in-recall-and-logic

## On PR size

The size bot flags ~826 lines. This ticket is already the recall/logic slice of a five-way split of milestone 2 (#8892 catalog, #8894 capture, #8895 anonymize, #8897 collision guard, this one), and it cannot be split further without shipping something that does nothing: the operand schema, the two engine arms, the renderer wiring and the picker data sources are one behaviour, and half of them would be dead code on their own. Roughly a third of the diff is the review round documented above — the element-id shadow fix, the label formatter, the projection redaction and the quota threading — which touch many small call sites rather than adding surface.

## How this was tested

Unit tests and static checks all run locally and green. **Playwright was NOT run** — see Open gaps.

| Command | Result |
| --- | --- |
| `pnpm --filter=@formbricks/types test` | ✅ 258 passed / 5 files |
| `pnpm --filter=@formbricks/surveys test` | ✅ 683 passed / 26 files |
| `pnpm --filter=@formbricks/web test` (full suite) | ⚠️ 7656 passed, 8 failed / 589 passed, 4 failed files. All four are the same pre-existing sandbox problem: `@formbricks/jobs` does not resolve here, so `instrumentation-jobs.test.ts` fails 8 tests and `pipelines.test.ts` / `process-response-pipeline-job.test.ts` / `workflows/lib/runner/dispatch.test.ts` collect 0 tests. **Verified pre-existing:** re-run with every change in this PR stashed, `instrumentation-jobs.test.ts` fails identically. None of the four is in a path this PR touches |
| `npx tsc --noEmit` (types, surveys, apps/web) | ✅ no errors in any touched file |
| `npx eslint` (all touched files) + lint-staged on commit | ✅ clean |
| `npx prettier --write` (all touched files) | ✅ clean |
| `pnpm i18n` | ✅ "All translation validations passed", one key generated into every locale |
| `pnpm build --filter=@formbricks/surveys... --force` (after `rm -rf packages/surveys/dist apps/web/public/js/surveys.* node_modules/.cache/turbo`) | ✅ 3/3 tasks, bundle re-emitted to `apps/web/public/js/` |

Coverage per acceptance criterion:

| Acceptance criterion | Coverage |
| --- | --- |
| `#recall:country#` and a logic condition on a reserved field resolve on a real response | unit (`recall.test.ts`, `surveyLogic/utils.test.ts`) |
| Server-derived fields absent from mid-survey pickers | unit (`embedded-data-resolver.test.ts`, asserts all 10 server-only names) |
| Server-derived fields resolve as **unset** if referenced mid-survey — not `0`, not `""` | unit (`packages/surveys/src/lib/logic.test.ts`) |
| **A survey with a declared field of the same name still resolves to the declared value (grandfather)** | **unit (red on main)** |
| An element id colliding with a reserved name shadows it in both pickers | unit (`embedded-data-resolver.test.ts` → `listMidSurveyReservedEntries`) |
| A `redactQuery` field projects without its query string, while storage keeps it | unit (`embedded-data-resolver.test.ts`, both projections) |
| A reserved quota operand resolves from the response | unit (`quotas/lib/evaluation-service.test.ts`, real `buildServerEmbeddedValues`) |
| Reserved labels are readable (`Duration Seconds`, not `DurationSeconds`) | unit (`safe-identifier.test.ts`, `embedded-data-resolver.test.ts`) |
| No change to export or filter behaviour | no diff in those paths |
| Reserved recall token renders a human label, not a raw `#recall:…#` tag | unit (`recall.test.ts`) |

**Proving the grandfather row is red on main.** Flip the two spreads in `mergeReservedValues` (`packages/types/embedded-data-resolver.ts`) to `{ ...responseData, ...reservedValues }`, then:

```
pnpm --filter=@formbricks/web test lib/utils/recall.test.ts
```

Observed with the order flipped: **3 failed | 60 passed**, failing exactly —

- `a survey declaring its own 'country' resolves from response.data instead`
- `shadowing is per-key: other reserved values still resolve`
- `a declared field that is present but empty still wins`

Restored, the same command is 63/63 green. `packages/types/embedded-data-resolver.test.ts` carries the same guarantee at the unit level (`THE GRANDFATHER RULE: response data wins on a colliding key`), including the falsy cases (`""` and `0`), which a `??`-style merge would get wrong.

Tests added: reserved-operand coverage in both logic engines (including an explicit assertion that an unset reserved field behaves **identically** to an unset hidden field); `mergeReservedValues` and `listMidSurveyReservedEntries` in the resolver; reserved rule sets in `logic-rule-engine.test.ts`; recall label/type/shadowing in `recall.test.ts`; and from the review round — the camelCase label formatter (including a guard that the shared snake_case helper is unchanged, since it also names contact attribute keys), the projection redaction on both sides, and the quota threading through all six `evaluateResponseQuotas` call sites.

> **UI change without a screenshot.** The picker gains a "Survey data" group. I could not capture it — the sandbox has no Postgres and no Docker, so the app never booted (see Open gaps). `apps/web/playwright/survey-reserved-fields.spec.ts` asserts exactly what the screenshot would have shown: `Url`/`Source`/`Language` present, and `Country`/`Duration Seconds`/`Ip Address`/`Browser`/`Os`/`Finished` absent. **A reviewer with a running stack should run that spec, or attach the screenshot, before this is merged.**

### Open gaps

- **Playwright was not executed.** `pg_isready` finds no server and Docker is unavailable in this sandbox, so migrations/seed/dev-server never came up. The new spec is written and typechecks, but it is **unverified** — treat it as unrun until CI or a reviewer runs it.
- **The "already-deployed SDK" claim under Risks is reasoning, not observation.** I read the `default: return undefined` arm in the current source and confirmed the pre-change engine has no `reserved` case; I did **not** execute a stored `reserved` operand against a published `surveys.umd.cjs` from npm.
- Reserved recall in **server-rendered** surfaces (response summaries, follow-up emails) is not wired: those call `parseRecallInfo` with raw `response.data`. They would only need to pass `buildServerEmbeddedValues(response)` instead, but that touches summary/export paths this ticket is scoped out of.
- **Follow-up conditions do not exist on this branch.** The ticket brief assumed follow-ups evaluate logic conditions through `apps/web/lib/surveyLogic/utils.ts`; `evaluateFollowUp` actually only looks up a `to` address in `response.data`. Nothing to wire there today.

## Breaking changes

None — both widened schemas accept everything they accepted before. `ZDynamicLogicFieldValue` and `ZDynamicLogicFieldValueDeprecated` gained a union member; no member was narrowed or removed, and `ZSurveyRecallItem.type` gained an enum value. Existing surveys, stored logic, and API payloads parse exactly as before. Both new engine parameters default (`embeddedValues = {}`), so every existing caller compiles and behaves identically.

One behaviour change worth naming even though nothing depended on it: a recall of `url` now renders origin + path rather than the full href. Nothing shipped could have relied on the previous form — this PR is what first makes the value reachable.

## QA / Test Plan

**How to test**

- [ ] Open a survey in the editor → in a question headline, type `@` → the recall dropdown lists a reserved group containing **Url**, **Source**, **Action**, **Language**.
- [ ] In that same dropdown → **Country**, **Duration Seconds**, **Ip Address**, **Browser**, **Os** and **Finished** are **not** offered. (They are server-derived; offering them mid-survey would be the bug this ticket fixes.)
- [ ] Pick **Url** → it inserts as a labelled chip reading `Url`, **not** as raw text `#recall:url/fallback:#`.
- [ ] Publish as a **link survey**, open the link → the headline renders the actual survey URL in place of the chip, **without its query string** (open the link with `?foo=bar` to see the redaction).
- [ ] Add a hidden field named exactly `country` → reopen the recall dropdown → **Country** is no longer offered in the reserved group (the declared field is offered in the Hidden fields group instead), and `#recall:country#` renders the hidden field's value, not the geo-IP country. **This is the critical regression check.**
- [ ] Rename a question's id to exactly `url` (Advanced settings on the question card) → reopen the recall dropdown and the logic left-operand dropdown → **Url** is no longer offered in the reserved group. Before the review fix, both lists offered two rows that stored the same value.
- [ ] Survey editor → block logic → **Add condition** → the left-operand dropdown has a **Survey data** group with the same client-available fields. Choose `Url`, operator `contains`, value a fragment of your link **path** → the survey routes down that branch when opened. (A fragment of the *query* will not match — see the redaction above.)
- [ ] Ending card → set a **redirect URL** containing a recall of `url` or `source` → finish the survey → the redirect target has the value interpolated, and the interpolated `url` carries no query string. **Security check:** open the survey via a single-use link and confirm `suToken` does not reach the redirect target.
- [ ] **Quotas** (Enterprise): survey → Quotas → add a quota condition → the left-operand dropdown has **no** Survey data group (picker opt-out is intentional). If you can post a quota through the v3 API with `{ "type": "reserved", "value": "country" }`, submit a response from a known country and confirm the quota now matches — that path was silently dead before this PR.
- [ ] **Regression, exports:** download a response export → column set is unchanged; no reserved columns appear.
- [ ] **Regression, filters:** response filters offer the same fields as before; no reserved fields appear.

**Preconditions / test data**

- Any workspace; a link survey is the easiest way to see `url` resolve.
- The quota check needs an Enterprise plan/entitlement.
- The grandfather check needs a survey that declares a hidden field named `country` (create it explicitly — new declarations of reserved names are refused on the strict path by ENG-1839 part 2, so use a survey where it already exists, or a hidden field added before that guard applies).
- No feature flag. Cloud and self-host behave identically.

**Risks & regressions**

- **Highest risk: the merge order.** If reserved values ever spread *over* response data, every survey with a declared field named `country`/`url`/`source`/`action`/`language` starts showing metadata instead of the respondent's answer. Re-check recall and logic on any survey declaring one of those names.
- Recall in the **welcome card**, **ending cards** and **redirect URLs** now receives a merged map through the existing `responseData` prop. Both components use that prop *only* for recall (verified), and the prop is documented as such — but any future code reading it for the respondent's actual answers must take its own prop.
- A stored `reserved` operand reaching an **already-deployed SDK bundle** hits that engine's existing `default: return undefined` arm and reads as **unset** — no crash, no exception, the condition simply does not match. Reasoned from the source, not observed against a published `surveys.umd.cjs` (see Open gaps).
- **Quota evaluation now receives an extra argument on every response.** It is the row the caller already holds, so there is no new query, but every `evaluateResponseQuotas` call site was touched — worth a glance that none dropped it. The parameter is optional and defaults to `{}`, so a missed site degrades to "reserved operands read as unset" rather than failing.
- A recall of `url` renders origin + path. If a reviewer expects the full href, that is the redaction described under Security, not a bug.
- Picking a reserved left operand sets the default operator via the survey's first *element*, which may briefly not be a member of the reserved operator set until the author picks one. This is pre-existing behaviour shared with the `hiddenField` path, not introduced here.

**Migrations / env / cutover**

- none. No schema change, no env var, no data migration. `packages/surveys` must be rebuilt for the renderer change to ship — CI does this; local devs need `pnpm build --filter=@formbricks/surveys... --force` plus a hard refresh.


---
_Generated by [Claude Code](https://claude.ai/code)_