### PR TITLE
feat(surveys): refuse reserved names for newly declared fields [ENG-1839]

### DIFF
--- a/apps/web/app/api/v3/surveys/patch.test.ts
+++ b/apps/web/app/api/v3/surveys/patch.test.ts
@@ -559,6 +559,122 @@ describe("patchV3Survey", () => {
     expect(prisma.survey.update).not.toHaveBeenCalled();
   });
 
+  /**
+   * ENG-1839. `PATCH /api/v3/surveys/*` and the MCP write path reach the survey through here, so the
+   * guard has to sit at this boundary too — before the transaction, so a refusal is a validation
+   * response rather than a rollback.
+   */
+  describe("reserved names for newly declared fields", () => {
+    const documentFor = (overrides: Record<string, unknown>) =>
+      ({
+        name: currentSurvey.name,
+        status: currentSurvey.status,
+        metadata: currentSurvey.metadata,
+        defaultLanguage: "en-US",
+        languages: [{ code: "en-US", enabled: true }],
+        welcomeCard: currentSurvey.welcomeCard,
+        blocks: currentSurvey.blocks,
+        endings: currentSurvey.endings,
+        hiddenFields: currentSurvey.hiddenFields,
+        variables: currentSurvey.variables,
+        ...overrides,
+      }) as unknown as Parameters<typeof executeV3SurveyPatch>[0]["document"];
+
+    test("rejects a patch that ADDS a hidden field named after a reserved field, and does not write", async () => {
+      await expect(
+        executeV3SurveyPatch({
+          currentSurvey: currentSurvey as TSurvey,
+          document: documentFor({ hiddenFields: { enabled: true, fieldIds: ["country"] } }),
+          languageRequests: [{ code: "en-US", default: true, enabled: true }],
+          requestId: "req_1",
+        })
+      ).rejects.toBeInstanceOf(V3SurveyReferenceValidationError);
+
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+      // Runs before `ensureV3WorkspaceLanguages`: a rejected patch must not create a workspace language.
+      expect(prisma.language.upsert).not.toHaveBeenCalled();
+    });
+
+    test("reports the refused name as a forbidden_identifier invalid param", async () => {
+      const error = await executeV3SurveyPatch({
+        currentSurvey: currentSurvey as TSurvey,
+        document: documentFor({ hiddenFields: { enabled: true, fieldIds: ["country"] } }),
+        languageRequests: [{ code: "en-US", default: true, enabled: true }],
+        requestId: "req_1",
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(V3SurveyReferenceValidationError);
+      expect((error as V3SurveyReferenceValidationError).invalidParams).toEqual([
+        expect.objectContaining({ name: "country", code: "forbidden_identifier", identifier: "country" }),
+      ]);
+    });
+
+    test("rejects a variable named after a reserved field", async () => {
+      await expect(
+        executeV3SurveyPatch({
+          currentSurvey: currentSurvey as TSurvey,
+          document: documentFor({
+            variables: [{ id: "clvar123456789012345678901", name: "browser", type: "text", value: "" }],
+          }),
+          languageRequests: [{ code: "en-US", default: true, enabled: true }],
+          requestId: "req_1",
+        })
+      ).rejects.toBeInstanceOf(V3SurveyReferenceValidationError);
+
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    test("GRANDFATHER: a patch on a survey that ALREADY declares `country` succeeds and keeps the field", async () => {
+      const grandfathered = {
+        ...currentSurvey,
+        hiddenFields: { enabled: true, fieldIds: ["country"] },
+      } as TSurvey;
+
+      await executeV3SurveyPatch({
+        currentSurvey: grandfathered,
+        document: documentFor({ hiddenFields: { enabled: true, fieldIds: ["country"] } }),
+        languageRequests: [{ code: "en-US", default: true, enabled: true }],
+        requestId: "req_1",
+      });
+
+      // Nothing is renamed or dropped: the field is written back exactly as it was.
+      expect(prisma.survey.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            hiddenFields: { enabled: true, fieldIds: ["country"] },
+          }),
+        })
+      );
+    });
+
+    test("GRANDFATHER: a grandfathered survey may still not ADD a second reserved name", async () => {
+      await expect(
+        executeV3SurveyPatch({
+          currentSurvey: {
+            ...currentSurvey,
+            hiddenFields: { enabled: true, fieldIds: ["country"] },
+          } as TSurvey,
+          document: documentFor({ hiddenFields: { enabled: true, fieldIds: ["country", "url"] } }),
+          languageRequests: [{ code: "en-US", default: true, enabled: true }],
+          requestId: "req_1",
+        })
+      ).rejects.toBeInstanceOf(V3SurveyReferenceValidationError);
+
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    test("accepts adding an ordinary new hidden field name", async () => {
+      await executeV3SurveyPatch({
+        currentSurvey: currentSurvey as TSurvey,
+        document: documentFor({ hiddenFields: { enabled: true, fieldIds: ["team_size"] } }),
+        languageRequests: [{ code: "en-US", default: true, enabled: true }],
+        requestId: "req_1",
+      });
+
+      expect(prisma.survey.update).toHaveBeenCalled();
+    });
+  });
+
   test("reconciles due survey schedules without refetching when no schedule transition persisted", async () => {
     vi.mocked(isSurveySchedulingDue).mockReturnValue(true);
     vi.mocked(reconcileDueSurveySchedules).mockResolvedValue({

--- a/apps/web/app/api/v3/surveys/patch.ts
+++ b/apps/web/app/api/v3/surveys/patch.ts
@@ -2,6 +2,11 @@ import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import {
+  collectDeclaredFieldNames,
+  describeDeclaredFieldNameError,
+  validateNewDeclaredFieldNames,
+} from "@formbricks/types/surveys/declared-field-guard";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import { getActionClasses } from "@/lib/actionClass/service";
 import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
@@ -188,6 +193,25 @@ export async function executeV3SurveyPatch(params: {
     throw new V3SurveyReferenceValidationError([
       { name: "triggers", reason: APP_SURVEY_TRIGGER_REQUIRED_MESSAGE },
     ]);
+  }
+
+  // ENG-1839: a newly declared field may not take a reserved name. Before the transaction, so a
+  // refusal is a validation response rather than a rollback, and before `ensureV3WorkspaceLanguages`
+  // — which writes workspace languages — so a rejected patch creates nothing. Names `currentSurvey`
+  // already declares are grandfathered and pass untouched.
+  const declaredFieldNameErrors = validateNewDeclaredFieldNames({
+    existing: collectDeclaredFieldNames(currentSurvey),
+    incoming: collectDeclaredFieldNames(document),
+  });
+  if (declaredFieldNameErrors.length > 0) {
+    throw new V3SurveyReferenceValidationError(
+      declaredFieldNameErrors.map((error) => ({
+        name: error.field,
+        reason: describeDeclaredFieldNameError(error),
+        code: "forbidden_identifier" as const,
+        identifier: error.field,
+      }))
+    );
   }
 
   const languages = await ensureV3WorkspaceLanguages(currentSurvey.workspaceId, languageRequests, requestId);

--- a/apps/web/integration/embedded-data-reconcile.integration.test.ts
+++ b/apps/web/integration/embedded-data-reconcile.integration.test.ts
@@ -293,4 +293,66 @@ describe("reconcileEmbeddedData (real Postgres)", () => {
     // storage key, which is exactly why no response migration is needed.
     expect(response.data).toEqual({ plan: "pro" });
   });
+
+  /**
+   * ENG-1839. The reserved-name guard is deliberately NOT in this file's production counterpart:
+   * `reconcileEmbeddedData` must keep accepting a reserved name, because a survey COPY feeds the
+   * whole source survey's fields in as "new" against zero existing rows. A guard here would make
+   * duplicating a grandfathered survey fail — which is why these live at the three input boundaries
+   * (`updateSurveyInternal`, `createSurvey`, the v3 patch) instead.
+   */
+  describe("grandfathered reserved names (ENG-1839)", () => {
+    test("reconciles a survey that declares `country`, creating the row and the link", async () => {
+      const { surveyId, workspaceId } = await seedSurvey();
+
+      await reconcile(surveyId, workspaceId, {
+        hiddenFields: { enabled: true, fieldIds: ["country", "url"] },
+      });
+
+      expect(await readFields(surveyId)).toEqual([
+        expect.objectContaining({ storageKey: "country", name: "country", source: "ingested" }),
+        expect.objectContaining({ storageKey: "url", name: "url", source: "ingested" }),
+      ]);
+    });
+
+    test("DUPLICATING a survey that declares `country` still succeeds", async () => {
+      // The shape of `copySurveyToOtherWorkspace`: the copy is its own `survey.create`, and the
+      // source survey's declared fields are then reconciled onto it with no rows of its own — every
+      // name arrives as "new", reserved ones included.
+      const { surveyId, workspaceId } = await seedSurvey();
+      const declared = { enabled: true, fieldIds: ["country", "team_size"] };
+      await reconcile(surveyId, workspaceId, { hiddenFields: declared });
+
+      const copy = await prisma.survey.create({
+        data: { name: "Survey (copy)", workspaceId, hiddenFields: declared },
+      });
+
+      await expect(reconcile(copy.id, workspaceId, { hiddenFields: declared })).resolves.not.toThrow();
+
+      // The duplicate has its own rows, and the original is untouched.
+      expect(await readFields(copy.id)).toEqual([
+        expect.objectContaining({ storageKey: "country", name: "country" }),
+        expect.objectContaining({ storageKey: "team_size", name: "team_size" }),
+      ]);
+      expect(await readFields(surveyId)).toHaveLength(2);
+    });
+
+    test("a copy into ANOTHER workspace defines `country` there too", async () => {
+      const { surveyId, workspaceId } = await seedSurvey();
+      const declared = { enabled: true, fieldIds: ["country"] };
+      await reconcile(surveyId, workspaceId, { hiddenFields: declared });
+
+      const { workspaceId: otherWorkspaceId } = await seedSurvey();
+      const copy = await prisma.survey.create({
+        data: { name: "Survey (copy)", workspaceId: otherWorkspaceId, hiddenFields: declared },
+      });
+
+      await reconcile(copy.id, otherWorkspaceId, { hiddenFields: declared });
+
+      expect(await readFields(copy.id)).toEqual([
+        expect.objectContaining({ storageKey: "country", name: "country" }),
+      ]);
+      expect(await prisma.embeddedData.count({ where: { workspaceId: otherWorkspaceId } })).toBe(1);
+    });
+  });
 });

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -533,6 +533,97 @@ describe("Tests for updateSurvey", () => {
       expect(prisma.survey.update).not.toHaveBeenCalled();
     });
   });
+
+  /**
+   * ENG-1839. This is the create-time layer `ZSurveyHiddenFields` deliberately cannot be: the same
+   * schema parses surveys loaded from the database, so it has to stay lenient. Without a guard here,
+   * `PUT /api/v1/management/surveys/<id>` creates a hidden field that can never receive a value.
+   *
+   * The grandfather cases are the load-bearing ones: surveys in production already declare
+   * `country`, `url`, `source`, `browser`, and this ticket must not rename or break any of them.
+   */
+  describe("reserved names for newly declared fields", () => {
+    test("rejects a save that ADDS a hidden field named after a reserved field, and does not write", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce({
+        ...mockSurveyOutput,
+        hiddenFields: { enabled: true, fieldIds: [] },
+      } as any);
+
+      await expect(
+        updateSurveyInternal(
+          { ...updateSurveyInput, hiddenFields: { enabled: true, fieldIds: ["country"] } },
+          true
+        )
+      ).rejects.toThrow(InvalidInputError);
+
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    test("GRANDFATHER: a save on a survey that ALREADY has `country` succeeds and keeps the field", async () => {
+      // Draft row: `skipValidation` is restricted to drafts by the ENG-1939 gate, which runs after
+      // this guard. The grandfathering under test is unaffected by the status.
+      const grandfathered = {
+        ...mockSurveyOutput,
+        status: "draft",
+        hiddenFields: { enabled: true, fieldIds: ["country"] },
+      };
+      prisma.survey.findUnique.mockResolvedValueOnce(grandfathered as any);
+      prisma.survey.update.mockResolvedValueOnce(grandfathered as any);
+
+      await expect(
+        updateSurveyInternal(
+          { ...updateSurveyInput, hiddenFields: { enabled: true, fieldIds: ["country"] } },
+          true
+        )
+      ).resolves.toBeDefined();
+
+      const updateArg = vi.mocked(prisma.survey.update).mock.calls.at(-1)?.[0];
+      // Nothing is renamed or dropped: the field is written back exactly as it was.
+      expect(updateArg?.data).toMatchObject({ hiddenFields: { enabled: true, fieldIds: ["country"] } });
+    });
+
+    test("GRANDFATHER: a grandfathered survey may still not ADD a second reserved name", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce({
+        ...mockSurveyOutput,
+        hiddenFields: { enabled: true, fieldIds: ["country"] },
+      } as any);
+
+      await expect(
+        updateSurveyInternal(
+          { ...updateSurveyInput, hiddenFields: { enabled: true, fieldIds: ["country", "browser"] } },
+          true
+        )
+      ).rejects.toThrow(InvalidInputError);
+
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    test("GRANDFATHER: a survey that already declares `country` as a VARIABLE keeps it", async () => {
+      const variable = { id: "wcfy2mkgc1ky2rzq7pcpjrxk", name: "country", type: "text" as const, value: "" };
+      const grandfathered = { ...mockSurveyOutput, status: "draft", variables: [variable] };
+      prisma.survey.findUnique.mockResolvedValueOnce(grandfathered as any);
+      prisma.survey.update.mockResolvedValueOnce(grandfathered as any);
+
+      await expect(
+        updateSurveyInternal({ ...updateSurveyInput, variables: [variable] }, true)
+      ).resolves.toBeDefined();
+    });
+
+    test("accepts adding an ordinary new hidden field name", async () => {
+      const draft = { ...mockSurveyOutput, status: "draft" };
+      prisma.survey.findUnique.mockResolvedValueOnce(draft as any);
+      prisma.survey.update.mockResolvedValueOnce(draft as any);
+
+      await expect(
+        updateSurveyInternal(
+          { ...updateSurveyInput, hiddenFields: { enabled: true, fieldIds: ["team_size"] } },
+          true
+        )
+      ).resolves.toBeDefined();
+
+      expect(prisma.survey.update).toHaveBeenCalled();
+    });
+  });
 });
 
 describe("Tests for getSurveyCount service", () => {
@@ -1227,6 +1318,43 @@ describe("Tests for createSurvey", () => {
       prisma.survey.create.mockRejectedValueOnce(mockError);
 
       await expect(createSurvey(mockWorkspaceId, mockCreateSurveyInput)).rejects.toThrow(DatabaseError);
+    });
+
+    // ENG-1839. A create authors every name fresh, so there is nothing to grandfather.
+    test("rejects a hidden field named after a reserved field, before writing anything", async () => {
+      await expect(
+        createSurvey(mockWorkspaceId, {
+          ...mockCreateSurveyInput,
+          hiddenFields: { enabled: true, fieldIds: ["country"] },
+        })
+      ).rejects.toThrow(InvalidInputError);
+
+      expect(prisma.survey.create).not.toHaveBeenCalled();
+    });
+
+    test("rejects a variable named after a reserved field", async () => {
+      await expect(
+        createSurvey(mockWorkspaceId, {
+          ...mockCreateSurveyInput,
+          variables: [{ id: "wcfy2mkgc1ky2rzq7pcpjrxk", name: "browser", type: "text", value: "" }],
+        })
+      ).rejects.toThrow(InvalidInputError);
+
+      expect(prisma.survey.create).not.toHaveBeenCalled();
+    });
+
+    test("accepts an ordinary new hidden field name", async () => {
+      vi.mocked(getOrganizationByWorkspaceId).mockResolvedValueOnce(mockOrganizationOutput);
+      prisma.survey.create.mockResolvedValueOnce(mockSurveyOutput);
+
+      await expect(
+        createSurvey(mockWorkspaceId, {
+          ...mockCreateSurveyInput,
+          hiddenFields: { enabled: true, fieldIds: ["team_size"] },
+        })
+      ).resolves.toBeDefined();
+
+      expect(prisma.survey.create).toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -13,7 +13,6 @@ import {
 import { TBaseFilters, ZSegmentFilters } from "@formbricks/types/segment";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import {
-  type TDeclaredFieldSource,
   collectDeclaredFieldNames,
   describeDeclaredFieldNameErrors,
   validateNewDeclaredFieldNames,

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -12,6 +12,12 @@ import {
 } from "@formbricks/types/errors";
 import { TBaseFilters, ZSegmentFilters } from "@formbricks/types/segment";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
+import {
+  type TDeclaredFieldSource,
+  collectDeclaredFieldNames,
+  describeDeclaredFieldNameErrors,
+  validateNewDeclaredFieldNames,
+} from "@formbricks/types/surveys/declared-field-guard";
 import { TSurvey, TSurveyCreateInput, ZSurvey, ZSurveyCreateInput } from "@formbricks/types/surveys/types";
 import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
 import { selectSurveyEmbeddedDataLinks, withInlinedEmbeddedFields } from "@/lib/embedded-data/survey-fields";
@@ -38,6 +44,22 @@ import {
   transformPrismaSurvey,
   validateMediaAndPrepareBlocks,
 } from "./utils";
+
+/**
+ * ENG-1839: refuse reserved names for newly declared fields, as an `InvalidInputError` — which
+ * `handleApiError` maps to a 400 carrying this message, and the editor surfaces as a toast. Thrown
+ * before any transaction is opened, so a refusal never fails inside an interactive transaction.
+ *
+ * Deliberately NOT inside `reconcileEmbeddedData`: that runs in the transaction, and the survey copy
+ * flow feeds a whole survey's fields to it as "new" against zero existing rows — guarding there
+ * would make duplicating a grandfathered survey fail.
+ */
+const assertNoReservedNewDeclaredFieldNames = (params: { existing: string[]; incoming: string[] }): void => {
+  const errors = validateNewDeclaredFieldNames(params);
+  if (errors.length > 0) {
+    throw new InvalidInputError(describeDeclaredFieldNameErrors(errors));
+  }
+};
 
 export const selectSurvey = {
   id: true,
@@ -350,6 +372,18 @@ export const updateSurveyInternal = async (
     // referenced language belongs to this survey's workspace so a caller cannot attach another
     // tenant's language. Mirrors the create path guard (covers drafts too — runs before validation).
     await assertSurveyLanguagesBelongToWorkspace(currentSurvey.workspaceId, languages);
+
+    // ENG-1839: a newly declared field may not take a reserved name. Runs here — before the
+    // transaction, and regardless of `skipValidation` — because this is an input-boundary check, not
+    // schema validation: `ZSurveyHiddenFields` stays lenient by design (the same schema parses
+    // surveys loaded from the database), so without this `PUT /api/v1/management/surveys/<id>` can
+    // still create a hidden field named `country` or `lang` that can never receive a value.
+    // Grandfathering is what makes it safe: `existing` carries everything this survey already
+    // declares, and any name in it passes untouched.
+    assertNoReservedNewDeclaredFieldNames({
+      existing: collectDeclaredFieldNames(currentSurvey),
+      incoming: collectDeclaredFieldNames(updatedSurvey),
+    });
 
     // ENG-1939: validation may only be skipped while the survey is still a draft. Gate on the
     // PERSISTED status, not the payload's — the lenient draft schema (ZSurveyDraft) does not validate
@@ -809,6 +843,15 @@ export const createSurvey = async (
     const { createdBy, languages, segment, followUps, styling, ...restSurveyBody } = parsedSurveyBody;
     await assertSurveyLanguagesBelongToWorkspace(parsedWorkspaceId, languages);
     await assertSurveySegmentBelongsToWorkspace(parsedWorkspaceId, segment);
+
+    // ENG-1839: `existing` is empty because a create authors every name fresh — there is nothing to
+    // grandfather yet. Covers templates, `POST /api/v1/management/surveys` and the v3 create route.
+    // The survey COPY flow does its own `tx.survey.create` and never reaches here, which is what
+    // keeps duplicating a survey that already declares `country` working.
+    assertNoReservedNewDeclaredFieldNames({
+      existing: [],
+      incoming: collectDeclaredFieldNames(restSurveyBody),
+    });
 
     // An app survey can never be shown without a trigger, so block creating one directly in a
     // non-draft status with zero triggers (mirrors the editor's publish guard).

--- a/apps/web/modules/survey/editor/components/survey-variables-card-item.tsx
+++ b/apps/web/modules/survey/editor/components/survey-variables-card-item.tsx
@@ -7,9 +7,10 @@ import { useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TSurveyQuota } from "@formbricks/types/quota";
-import { isSafeIdentifier } from "@formbricks/types/safe-identifier";
 import { TSurvey, TSurveyVariable } from "@formbricks/types/surveys/types";
+import { validateId } from "@formbricks/types/surveys/validation";
 import { findVariableUsedInLogic, isUsedInQuota, isUsedInRecall } from "@/modules/survey/editor/lib/utils";
+import { getValidateIdErrorMessage } from "@/modules/survey/editor/lib/validation";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { Button } from "@/modules/ui/components/button";
 import { FormControl, FormField, FormItem, FormProvider } from "@/modules/ui/components/form";
@@ -161,14 +162,32 @@ export const SurveyVariablesCardItem = ({
               name="name"
               rules={{
                 validate: (value) => {
-                  // Single shared naming rule for new variable names: the charset check and the
-                  // leading-letter check together are exactly `isSafeIdentifier`. Kept first so the
-                  // name-rule message still wins over the duplicate messages, as `pattern` did.
-                  // Shares the strict gate's message because it states both halves of the rule.
-                  if (!isSafeIdentifier(value)) {
-                    return t("workspace.surveys.edit.validate_id_not_safe_identifier", {
-                      type: t("common.variable"),
+                  /*
+                   * The same strict gate the server applies (ENG-1839), so an author learns here rather
+                   * than from an untranslated save error. `isSafeIdentifier` alone was not enough:
+                   * `country` satisfies it, so a variable named after an auto-captured system field was
+                   * accepted by the editor and only refused by `validateNewDeclaredFieldNames` at save
+                   * time. Same call shape as `hidden-fields-card.tsx`, so the two cards cannot drift.
+                   *
+                   * Empty id lists on purpose: `validateId`'s duplicate check would pre-empt this
+                   * card's own duplicate messages, which are more specific ("already taken",
+                   * "conflicts with a hidden field") and are applied just below.
+                   *
+                   * Skipped when an edit leaves the name untouched — that is the grandfather rule in
+                   * the editor. A survey that already declares a variable called `country` must stay
+                   * editable, or the author could no longer change its type or value.
+                   */
+                  const isUnchangedName =
+                    mode === "edit" && variable?.name.toLowerCase() === value.toLowerCase();
+
+                  if (!isUnchangedName) {
+                    const validateIdError = validateId(value, [], [], [], [], {
+                      requireSafeIdentifier: true,
                     });
+
+                    if (validateIdError) {
+                      return getValidateIdErrorMessage(validateIdError, "variable", t);
+                    }
                   }
                   if (mode === "create" && localSurvey.variables.find((v) => v.name === value)) {
                     return t("workspace.surveys.edit.variable_name_is_already_taken_please_choose_another");

--- a/apps/web/modules/survey/editor/lib/validation.ts
+++ b/apps/web/modules/survey/editor/lib/validation.ts
@@ -317,11 +317,14 @@ export const isSurveyValid = (
 
 export const getValidateIdErrorMessage = (
   error: TValidateIdError,
-  type: "hiddenField" | "question",
+  type: "hiddenField" | "question" | "variable",
   t: TFunction
 ): string => {
-  const localizedType =
-    type === "hiddenField" ? t("common.hidden_field") : t("workspace.surveys.edit.question");
+  const localizedType = {
+    hiddenField: () => t("common.hidden_field"),
+    question: () => t("workspace.surveys.edit.question"),
+    variable: () => t("common.variable"),
+  }[type]();
 
   switch (error.code) {
     case TValidateIdErrorCode.Empty:

--- a/apps/web/playwright/survey-editor-embedded-fields.spec.ts
+++ b/apps/web/playwright/survey-editor-embedded-fields.spec.ts
@@ -415,10 +415,14 @@ test.describe("Survey editor Embedded Data definitions @slow", () => {
     );
 
     await saveDraft(page);
+    // Asserted on the definition, not on the link's `storageKey`: a variable is addressed by its cuid
+    // everywhere, so `toDesiredEmbeddedFields` stores that id as the storage key while the name — the
+    // only thing this gate reads — lives on the definition. A hidden field's two happen to be equal,
+    // which is why the sibling test above can compare storage keys directly.
     const stored = await prisma.surveyEmbeddedData.findMany({
       where: { surveyId },
-      select: { storageKey: true },
+      select: { embeddedData: { select: { name: true, source: true } } },
     });
-    expect(stored.map((field) => field.storageKey)).toEqual([allowedName]);
+    expect(stored.map((link) => link.embeddedData)).toEqual([{ name: allowedName, source: "computed" }]);
   });
 });

--- a/apps/web/playwright/survey-editor-embedded-fields.spec.ts
+++ b/apps/web/playwright/survey-editor-embedded-fields.spec.ts
@@ -335,7 +335,9 @@ test.describe("Survey editor Embedded Data definitions @slow", () => {
 
     // The error names the field, and the field is NOT added to the card.
     await expect(
-      page.getByText('Hidden field ID "country" is not allowed. It is a reserved keyword.')
+      page.getByText('Hidden field ID "country" is not allowed. It is a reserved keyword.', {
+        exact: true,
+      })
     ).toBeVisible();
     await expect(
       editorPanel(page).getByText("country", { exact: true }),
@@ -347,7 +349,9 @@ test.describe("Survey editor Embedded Data definitions @slow", () => {
     await input.fill("Country");
     await addButton.click();
     await expect(
-      page.getByText('Hidden field ID "Country" is not allowed. It is a reserved keyword.')
+      page.getByText('Hidden field ID "Country" is not allowed. It is a reserved keyword.', {
+        exact: true,
+      })
     ).toBeVisible();
 
     // An ordinary name still works, so the guard rejects the reserved name rather than the card.

--- a/apps/web/playwright/survey-editor-embedded-fields.spec.ts
+++ b/apps/web/playwright/survey-editor-embedded-fields.spec.ts
@@ -308,4 +308,59 @@ test.describe("Survey editor Embedded Data definitions @slow", () => {
     await expect(page.locator("#action-0-variableId")).toContainText(renamedVariableName);
     await expect(page.locator("#action-0-value-input")).toHaveAttribute("type", "number");
   });
+
+  /**
+   * ENG-1839. `country` is a Tier-1 reserved field, read off every response. A newly declared hidden
+   * field may not take that name — the two would collide in the recall/logic namespace, and
+   * `getHiddenFieldsFromSearchParams` would refuse to fill it, leaving it silently empty forever.
+   *
+   * Surveys that ALREADY declare `country` are grandfathered and keep working; that half is covered
+   * below the browser boundary (service, v3 patch and reconcile suites), because reaching it here
+   * would mean authoring a state the editor now refuses to create.
+   */
+  test("refuses a hidden field named after a reserved field", async ({ page, users }) => {
+    const allowedName = uniqueName("plan_tier");
+
+    const user = await users.create();
+    await user.login();
+    await page.waitForURL(/\/workspaces\/[^/]+\/surveys/);
+    const surveyId = await createSurveyFromScratch(page);
+
+    await openCard(page, "Hidden fields");
+    const input = editorPanel(page).locator("#hiddenField");
+    const addButton = editorPanel(page).getByRole("button", { name: "Add hidden field ID", exact: true });
+
+    await input.fill("country");
+    await addButton.click();
+
+    // The error names the field, and the field is NOT added to the card.
+    await expect(
+      page.getByText('Hidden field ID "country" is not allowed. It is a reserved keyword.')
+    ).toBeVisible();
+    await expect(
+      editorPanel(page).getByText("country", { exact: true }),
+      "the refused name must not be added to the hidden fields card"
+    ).toHaveCount(0);
+
+    // Uppercase is refused too: the reserved match is case-insensitive, and a survey declaring
+    // `Country` would collide with the same reserved read.
+    await input.fill("Country");
+    await addButton.click();
+    await expect(
+      page.getByText('Hidden field ID "Country" is not allowed. It is a reserved keyword.')
+    ).toBeVisible();
+
+    // An ordinary name still works, so the guard rejects the reserved name rather than the card.
+    await input.fill(allowedName);
+    await addButton.click();
+    await expect(editorPanel(page).getByText(allowedName, { exact: true })).toBeVisible();
+
+    // And the refusal really did not reach the database: the save writes one field, not three.
+    await saveDraft(page);
+    const stored = await prisma.surveyEmbeddedData.findMany({
+      where: { surveyId },
+      select: { storageKey: true },
+    });
+    expect(stored.map((field) => field.storageKey)).toEqual([allowedName]);
+  });
 });

--- a/apps/web/playwright/survey-editor-embedded-fields.spec.ts
+++ b/apps/web/playwright/survey-editor-embedded-fields.spec.ts
@@ -367,4 +367,58 @@ test.describe("Survey editor Embedded Data definitions @slow", () => {
     });
     expect(stored.map((field) => field.storageKey)).toEqual([allowedName]);
   });
+
+  /**
+   * The variables half of the same guard. `isSafeIdentifier("country")` passes — it is lowercase with
+   * no separators — so this card accepted the name and the author only found out at save time, from
+   * the server guard's untranslated message. The card now applies the same `validateId` strict gate
+   * the hidden-fields card does, so the refusal is translated and immediate.
+   */
+  test("refuses a variable named after a reserved field", async ({ page, users }) => {
+    const allowedName = uniqueName("score");
+
+    const user = await users.create();
+    await user.login();
+    await page.waitForURL(/\/workspaces\/[^/]+\/surveys/);
+    const surveyId = await createSurveyFromScratch(page);
+
+    await openCard(page, "Variables");
+    const createForm = variableForms(page).last();
+    const nameInput = createForm.getByPlaceholder(VARIABLE_NAME_PLACEHOLDER);
+
+    await nameInput.fill("country");
+    await selectVariableType(page, createForm, "Text");
+    await createForm.getByRole("button", { name: "Add variable", exact: true }).click();
+
+    // Inline under the field rather than a toast — that is how this card reports name errors.
+    await expect(
+      createForm.getByText('Variable ID "country" is not allowed. It is a reserved keyword.', {
+        exact: true,
+      })
+    ).toBeVisible();
+
+    // Case-insensitive, matching the server guard and the hidden-fields card.
+    await nameInput.fill("Country");
+    await createForm.getByRole("button", { name: "Add variable", exact: true }).click();
+    await expect(
+      createForm.getByText('Variable ID "Country" is not allowed. It is a reserved keyword.', {
+        exact: true,
+      })
+    ).toBeVisible();
+
+    // An ordinary name still works, so the gate refuses the name rather than the card.
+    await nameInput.fill(allowedName);
+    await selectVariableType(page, createForm, "Text");
+    await createForm.getByRole("button", { name: "Add variable", exact: true }).click();
+    await expect(variableForms(page).first().getByPlaceholder(VARIABLE_NAME_PLACEHOLDER)).toHaveValue(
+      allowedName
+    );
+
+    await saveDraft(page);
+    const stored = await prisma.surveyEmbeddedData.findMany({
+      where: { surveyId },
+      select: { storageKey: true },
+    });
+    expect(stored.map((field) => field.storageKey)).toEqual([allowedName]);
+  });
 });

--- a/packages/types/surveys/declared-field-guard.test.ts
+++ b/packages/types/surveys/declared-field-guard.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "vitest";
+import {
+  collectDeclaredFieldNames,
+  describeDeclaredFieldNameErrors,
+  validateNewDeclaredFieldNames,
+} from "./declared-field-guard";
+import { TValidateIdErrorCode } from "./validation";
+
+const refusedNames = (params: { existing: string[]; incoming: string[] }): string[] =>
+  validateNewDeclaredFieldNames(params).map((error) => error.field);
+
+describe("validateNewDeclaredFieldNames", () => {
+  describe("grandfathering", () => {
+    test("a reserved name already in `existing` passes", () => {
+      // The whole point of the ticket: surveys in production already declare these, their values
+      // live at response.data["country"], and nothing may be renamed.
+      expect(refusedNames({ existing: ["country"], incoming: ["country"] })).toEqual([]);
+      expect(
+        refusedNames({
+          existing: ["country", "url", "source", "browser"],
+          incoming: ["country", "url", "source", "browser"],
+        })
+      ).toEqual([]);
+    });
+
+    test("the same name absent from `existing` is refused", () => {
+      expect(refusedNames({ existing: [], incoming: ["country"] })).toEqual(["country"]);
+      expect(refusedNames({ existing: ["other_field"], incoming: ["country"] })).toEqual(["country"]);
+    });
+
+    test("a grandfathered survey may still not add a *different* reserved name", () => {
+      expect(refusedNames({ existing: ["country"], incoming: ["country", "browser"] })).toEqual(["browser"]);
+    });
+
+    test("grandfathering is per name, not a blanket exemption for the payload", () => {
+      expect(refusedNames({ existing: ["country"], incoming: ["country", "team_size", "url"] })).toEqual([
+        "url",
+      ]);
+    });
+  });
+
+  describe("case-insensitivity", () => {
+    test("a reserved name is refused under any casing", () => {
+      expect(refusedNames({ existing: [], incoming: ["Country"] })).toEqual(["Country"]);
+      expect(refusedNames({ existing: [], incoming: ["COUNTRY"] })).toEqual(["COUNTRY"]);
+      // camelCase catalog entries are stored lowercased in the reserved set.
+      expect(refusedNames({ existing: [], incoming: ["deviceType"] })).toEqual(["deviceType"]);
+    });
+
+    test("`existing` grandfathers across casing too", () => {
+      expect(refusedNames({ existing: ["Country"], incoming: ["country"] })).toEqual([]);
+      expect(refusedNames({ existing: ["country"], incoming: ["Country"] })).toEqual([]);
+    });
+
+    test("a duplicated incoming name yields at most one error", () => {
+      expect(refusedNames({ existing: [], incoming: ["country", "Country"] })).toEqual(["country"]);
+    });
+  });
+
+  describe("which names are refused", () => {
+    test("refuses Tier-1 reserved field names (RESERVED_FIELD_NAMES)", () => {
+      for (const name of ["source", "url", "country", "browser", "os", "finished", "language"]) {
+        expect(refusedNames({ existing: [], incoming: [name] })).toEqual([name]);
+      }
+    });
+
+    test("refuses link-survey system params and forbidden ids (RESERVED_DECLARED_FIELD_NAMES)", () => {
+      for (const name of ["userid", "lang", "suid"]) {
+        expect(refusedNames({ existing: [], incoming: [name] })).toEqual([name]);
+      }
+    });
+
+    test("refuses names that are not safe identifiers", () => {
+      const errors = validateNewDeclaredFieldNames({ existing: [], incoming: ["Team Size"] });
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).not.toBe(TValidateIdErrorCode.Reserved);
+    });
+
+    test("allows an ordinary new name", () => {
+      expect(refusedNames({ existing: [], incoming: ["team_size", "plan", "signup_source"] })).toEqual([]);
+    });
+
+    test("reports a reserved name with the Reserved code", () => {
+      const errors = validateNewDeclaredFieldNames({ existing: [], incoming: ["country"] });
+      expect(errors).toEqual([{ code: TValidateIdErrorCode.Reserved, field: "country" }]);
+    });
+
+    test("a name colliding with an existing one is not reported as a duplicate", () => {
+      // Duplicate detection belongs to the reconcile and the v3 reference validation; reporting it
+      // here would turn every grandfathered name into an error.
+      expect(refusedNames({ existing: ["team_size"], incoming: ["team_size"] })).toEqual([]);
+    });
+  });
+});
+
+describe("collectDeclaredFieldNames", () => {
+  test("collects variable names and hidden field ids", () => {
+    expect(
+      collectDeclaredFieldNames({
+        variables: [{ id: "v1", name: "score", type: "number", value: 0 }],
+        hiddenFields: { fieldIds: ["team_size", "plan"] },
+      })
+    ).toEqual(["score", "team_size", "plan"]);
+  });
+
+  test("a payload omitting `hiddenFields` declares nothing from it", () => {
+    // Presence is `!== undefined`, not `in` — mirroring `resolveDesiredEmbeddedFields`. A patch that
+    // never mentioned hiddenFields must not read as declaring the empty set, and must not be
+    // validated as if it had re-declared the survey's stored fields either.
+    expect(collectDeclaredFieldNames({ variables: [], hiddenFields: undefined })).toEqual([]);
+    expect(collectDeclaredFieldNames({})).toEqual([]);
+  });
+
+  test("an object literal with both keys spelled out but undefined declares nothing", () => {
+    // The exact shape every write seam builds.
+    const payload = { variables: undefined, hiddenFields: undefined };
+    expect("hiddenFields" in payload).toBe(true);
+    expect(collectDeclaredFieldNames(payload)).toEqual([]);
+  });
+
+  test("a null carrier declares nothing", () => {
+    expect(collectDeclaredFieldNames({ variables: null, hiddenFields: null })).toEqual([]);
+  });
+
+  test("hiddenFields present with no fieldIds declares nothing", () => {
+    expect(collectDeclaredFieldNames({ hiddenFields: {} })).toEqual([]);
+  });
+
+  test("a payload that omits hiddenFields validates no hidden field name", () => {
+    expect(
+      validateNewDeclaredFieldNames({
+        existing: [],
+        incoming: collectDeclaredFieldNames({ variables: [], hiddenFields: undefined }),
+      })
+    ).toEqual([]);
+  });
+});
+
+describe("describeDeclaredFieldNameErrors", () => {
+  test("names every refused field and says existing fields keep working", () => {
+    const message = describeDeclaredFieldNameErrors(
+      validateNewDeclaredFieldNames({ existing: [], incoming: ["country", "url"] })
+    );
+
+    expect(message).toContain('"country"');
+    expect(message).toContain('"url"');
+    expect(message).toContain("newly added names only");
+  });
+});

--- a/packages/types/surveys/declared-field-guard.test.ts
+++ b/packages/types/surveys/declared-field-guard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   collectDeclaredFieldNames,
+  describeDeclaredFieldNameError,
   describeDeclaredFieldNameErrors,
   validateNewDeclaredFieldNames,
 } from "./declared-field-guard";
@@ -35,6 +36,23 @@ describe("validateNewDeclaredFieldNames", () => {
     test("grandfathering is per name, not a blanket exemption for the payload", () => {
       expect(refusedNames({ existing: ["country"], incoming: ["country", "team_size", "url"] })).toEqual([
         "url",
+      ]);
+    });
+
+    test("the reprieve is spent by deleting the field: re-adding it afterwards is refused", () => {
+      // `existing` is the survey's CURRENT names, so grandfathering lasts as long as the field does.
+      // Pinned because it is a decision, not an accident: remembering every name a survey ever had
+      // would need storage this layer has no access to, and a survey that gives up its declared
+      // `country` gains the auto-captured one in exchange.
+      const survey = { existing: ["country", "team_size"] };
+
+      // Still there, still fine — the save that keeps it, and the save that drops it, both pass.
+      expect(refusedNames({ ...survey, incoming: ["country", "team_size"] })).toEqual([]);
+      expect(refusedNames({ ...survey, incoming: ["team_size"] })).toEqual([]);
+
+      // After that save the survey no longer declares it, so the name is new again.
+      expect(refusedNames({ existing: ["team_size"], incoming: ["team_size", "country"] })).toEqual([
+        "country",
       ]);
     });
   });
@@ -133,6 +151,43 @@ describe("collectDeclaredFieldNames", () => {
         incoming: collectDeclaredFieldNames({ variables: [], hiddenFields: undefined }),
       })
     ).toEqual([]);
+  });
+});
+
+describe("describeDeclaredFieldNameError", () => {
+  const reasonFor = (name: string): string =>
+    describeDeclaredFieldNameError(validateNewDeclaredFieldNames({ existing: [], incoming: [name] })[0]);
+
+  test("a Tier-1 catalog name is not described as unfillable", () => {
+    // `RESERVED_FIELD_NAMES` is deliberately absent from the capture-refusal list, so `?country=DE`
+    // DOES fill a survey's declared `country`. Telling an integrator otherwise could send them off to
+    // remove URL params that work.
+    const reason = reasonFor("country");
+
+    expect(reason).toContain("auto-captured system field");
+    expect(reason).not.toContain("never filled from the URL");
+  });
+
+  test("a link-survey system param is described as unfillable, because it is", () => {
+    // `getHiddenFieldsFromSearchParams` skips these, so a field declared under one stays empty.
+    const reason = reasonFor("lang");
+
+    expect(reason).toContain("never filled from the URL");
+  });
+
+  test("a name in both lists takes the capture-refusal reason", () => {
+    // `source` is the one Tier-1 field that is also a link-survey system param. Both statements are
+    // true of it; the stronger one wins.
+    const reason = reasonFor("source");
+
+    expect(reason).toContain("never filled from the URL");
+  });
+
+  test("a name that is merely not a safe identifier keeps the naming-rule reason", () => {
+    const reason = reasonFor("Team Size");
+
+    expect(reason).toContain("lowercase letter");
+    expect(reason).not.toContain("reserved");
   });
 });
 

--- a/packages/types/surveys/declared-field-guard.ts
+++ b/packages/types/surveys/declared-field-guard.ts
@@ -1,4 +1,5 @@
-import type { TSurveyHiddenFields, TSurveyVariables } from "./types";
+import type { z } from "zod";
+import { type TSurveyHiddenFields, ZSurveyVariables } from "./types";
 import { type TValidateIdError, TValidateIdErrorCode, validateId } from "./validation";
 
 /**
@@ -7,7 +8,15 @@ import { type TValidateIdError, TValidateIdErrorCode, validateId } from "./valid
  */
 export interface TDeclaredFieldSource {
   hiddenFields?: Pick<TSurveyHiddenFields, "fieldIds"> | null;
-  variables?: TSurveyVariables | null;
+  /**
+   * Only `name` is required, deliberately: this reads nothing else, and the write seams hand it both
+   * sides of the survey schema. `ZSurveyVariable` gives `value` a `prefault`, so a *create* payload
+   * (`ZSurveyCreateInput`) types `value` as optional while a parsed survey types it as required -
+   * demanding the *parsed* `TSurveyVariables` here made `createSurvey` fail to type check against
+   * its own input, so this is the schema's input side: `value` optional, which a parsed survey
+   * (value required) also satisfies.
+   */
+  variables?: z.input<typeof ZSurveyVariables> | null;
 }
 
 /**

--- a/packages/types/surveys/declared-field-guard.ts
+++ b/packages/types/surveys/declared-field-guard.ts
@@ -1,6 +1,12 @@
 import type { z } from "zod";
+import { RESERVED_FIELD_NAMES } from "../reserved-field-names";
 import { type TSurveyHiddenFields, ZSurveyVariables } from "./types";
-import { type TValidateIdError, TValidateIdErrorCode, validateId } from "./validation";
+import {
+  RESERVED_DECLARED_FIELD_NAMES,
+  type TValidateIdError,
+  TValidateIdErrorCode,
+  validateId,
+} from "./validation";
 
 /**
  * The legacy declared-field carriers of a survey write payload, as every write seam spells them:
@@ -61,6 +67,25 @@ export const collectDeclaredFieldNames = (source: TDeclaredFieldSource): string[
  *
  * Duplicate incoming names yield one error each at most — the caller sees one error per bad name.
  *
+ * ## Grandfathering is per-save, not permanent — and that is deliberate
+ *
+ * `existing` is the survey's *current* names, so the reprieve lasts exactly as long as the field does.
+ * Delete a grandfathered `country` field, save, and it can no longer be added back: the next write
+ * sees an `existing` set without it and refuses the name like any other new declaration. Editing the
+ * field, renaming other fields around it, or saving the survey untouched all keep it — only removing
+ * it spends the reprieve.
+ *
+ * That is the intended reading of "already declared". The alternative — remembering every name a
+ * survey ever had — would need storage this layer does not have, and would keep a name reserved for a
+ * survey that no longer uses it. A survey that gives up its declared `country` gains the auto-captured
+ * one in exchange, which is the field the name is supposed to mean from here on.
+ *
+ * The client-facing message says "fields a survey already has keep working", which is true of the
+ * survey as it stands and is what an integrator hitting this on a *different* survey needs to hear.
+ * Someone who deleted the field yesterday and is re-adding it today is the one case where that
+ * sentence reads as contradicting them; pinned by a test so the behaviour is a decision rather than an
+ * accident.
+ *
  * @param existing - Every declared field name the survey already has (variables + hidden fields).
  *   Pass `[]` on a create, which authors every name fresh.
  * @param incoming - The declared field names the payload carries, from
@@ -101,10 +126,32 @@ export const validateNewDeclaredFieldNames = ({
  * of this layer; the editor refuses these names client-side with a translated toast long before a
  * request is made.
  */
+const describeReservedReason = (field: string): string => {
+  // Order matters: a name in BOTH lists (`source` is the one Tier-1 field that is also a link-survey
+  // system param) gets the capture-refusal reason, which is the stronger and still-true statement.
+  //
+  // The two halves fail for genuinely different reasons, and saying "could never receive a value" for
+  // the catalog half would be actively misleading: `RESERVED_FIELD_NAMES` is deliberately kept OUT of
+  // the capture-refusal list read by `getHiddenFieldsFromSearchParams`, precisely so `?country=DE`
+  // keeps filling the field of a survey that already declares `country`. An integrator told the wrong
+  // reason here could go and remove URL params that work.
+  if (RESERVED_DECLARED_FIELD_NAMES.has(field.toLowerCase())) {
+    return "it is reserved by the link-survey URL contract, so a field declared under it is never filled from the URL and would stay empty";
+  }
+
+  if (RESERVED_FIELD_NAMES.has(field.toLowerCase())) {
+    return "it names an auto-captured system field that every survey can already read by name, so a second field under that name would be ambiguous in recall and logic";
+  }
+
+  // `validateId` classified this Reserved, so one of the two sets matched at the time. Reaching here
+  // means the sets and this description have drifted; say something true rather than guess which.
+  return "it is a reserved name";
+};
+
 export const describeDeclaredFieldNameError = (error: TValidateIdError): string => {
   const reason =
     error.code === TValidateIdErrorCode.Reserved
-      ? "it is a reserved name, read from every response, and a field declared under it could never receive a value"
+      ? describeReservedReason(error.field)
       : "it must start with a lowercase letter and contain only lowercase letters, numbers and underscores";
 
   return `Field name "${error.field}" cannot be used: ${reason}.`;

--- a/packages/types/surveys/declared-field-guard.ts
+++ b/packages/types/surveys/declared-field-guard.ts
@@ -1,0 +1,110 @@
+import type { TSurveyHiddenFields, TSurveyVariables } from "./types";
+import { type TValidateIdError, TValidateIdErrorCode, validateId } from "./validation";
+
+/**
+ * The legacy declared-field carriers of a survey write payload, as every write seam spells them:
+ * one object literal with both keys present, each either populated or `undefined`.
+ */
+export interface TDeclaredFieldSource {
+  hiddenFields?: Pick<TSurveyHiddenFields, "fieldIds"> | null;
+  variables?: TSurveyVariables | null;
+}
+
+/**
+ * The declared field names a payload actually *declares*.
+ *
+ * Presence is `!== undefined`, deliberately **not** the `in` operator — the same test
+ * `resolveDesiredEmbeddedFields` (apps/web/lib/embedded-data/reconcile.ts) uses, and for the same
+ * reason: every write seam builds one object literal with both keys spelled out and lets Prisma (or
+ * the reconcile) ignore the undefined ones. Under `in`, a patch that never mentioned `hiddenFields`
+ * would read as declaring the empty set, and the two modules would disagree about what a payload
+ * said — the reconcile carrying the current rows over while the guard treated them as absent.
+ *
+ * A `null` carrier is treated as absent for the same reason: it declares nothing to validate.
+ */
+export const collectDeclaredFieldNames = (source: TDeclaredFieldSource): string[] => [
+  ...(source.variables !== undefined && source.variables !== null
+    ? source.variables.map((variable) => variable.name)
+    : []),
+  ...(source.hiddenFields !== undefined && source.hiddenFields !== null
+    ? (source.hiddenFields.fieldIds ?? [])
+    : []),
+];
+
+/**
+ * Refuses reserved names for **newly declared** field names, and only for those.
+ *
+ * This is the create-time layer the lenient load-time schemas cannot be: `ZSurveyHiddenFields` and
+ * `ZSurveyVariables` also parse surveys read back out of the database, so they must keep accepting
+ * whatever is already stored. `validateId`'s strict mode is the same rule, but until now it was
+ * passed from exactly one place (the hidden-fields editor card) — so
+ * `PUT /api/v1/management/surveys/<id>` could still create a hidden field named `lang` or `country`
+ * that `getHiddenFieldsFromSearchParams` then refuses to fill, leaving it silently empty forever.
+ *
+ * ## Grandfathering is the whole point
+ *
+ * Surveys in production already declare `country`, `url`, `source`, `browser`. Their values live at
+ * `response.data["country"]`, `#recall:country#` resolves from there, and nothing may be renamed. So
+ * a name already in `existing` returns **no error**, whatever it is — the blocklist applies to names
+ * this write is *authoring*. Matching is case-insensitive in both directions, because
+ * `getHiddenFieldsFromSearchParams` refuses to capture a reserved param under any casing, and
+ * because `Country` and `country` would collide in the recall namespace all the same.
+ *
+ * Duplicate incoming names yield one error each at most — the caller sees one error per bad name.
+ *
+ * @param existing - Every declared field name the survey already has (variables + hidden fields).
+ *   Pass `[]` on a create, which authors every name fresh.
+ * @param incoming - The declared field names the payload carries, from
+ *   {@link collectDeclaredFieldNames}.
+ * @returns One error per refused new name, or `[]` when everything is allowed.
+ */
+export const validateNewDeclaredFieldNames = ({
+  existing,
+  incoming,
+}: {
+  existing: string[];
+  incoming: string[];
+}): TValidateIdError[] => {
+  const grandfathered = new Set(existing.map((name) => name.toLowerCase()));
+  const seen = new Set<string>();
+  const errors: TValidateIdError[] = [];
+
+  for (const name of incoming) {
+    const lowered = name.toLowerCase();
+    if (grandfathered.has(lowered) || seen.has(lowered)) continue;
+    seen.add(lowered);
+
+    // Delegated rather than reimplemented so this guard and the editor card can never drift apart:
+    // `validateId`'s strict branch is the single definition of what a new declared name may be. The
+    // id lists are empty on purpose — a collision with an existing name is a *duplicate*, which the
+    // reconcile's `assertNoDuplicateStorageKeys` and the v3 reference validation already own, and
+    // reporting it here would turn a grandfathered name into an error.
+    const error = validateId(name, [], [], [], [], { requireSafeIdentifier: true });
+    if (error) errors.push(error);
+  }
+
+  return errors;
+};
+
+/**
+ * One human-readable sentence for a set of refusals, for the error a write path returns to its
+ * client. Server-side and non-localized, matching `APP_SURVEY_TRIGGER_REQUIRED_MESSAGE` and the rest
+ * of this layer; the editor refuses these names client-side with a translated toast long before a
+ * request is made.
+ */
+export const describeDeclaredFieldNameError = (error: TValidateIdError): string => {
+  const reason =
+    error.code === TValidateIdErrorCode.Reserved
+      ? "it is a reserved name, read from every response, and a field declared under it could never receive a value"
+      : "it must start with a lowercase letter and contain only lowercase letters, numbers and underscores";
+
+  return `Field name "${error.field}" cannot be used: ${reason}.`;
+};
+
+/**
+ * The full client-facing message for a set of refusals. Names a survey already declares are never in
+ * here — they are grandfathered — so the trailing sentence is what tells an integrator why their
+ * *other* survey with the same field name keeps working.
+ */
+export const describeDeclaredFieldNameErrors = (errors: TValidateIdError[]): string =>
+  `${errors.map(describeDeclaredFieldNameError).join(" ")} Fields a survey already has keep working; this applies to newly added names only.`;

--- a/packages/types/surveys/validation.test.ts
+++ b/packages/types/surveys/validation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { RESERVED_FIELD_NAMES } from "../reserved-field-names";
 import {
   LINK_SURVEY_SYSTEM_PARAMS,
   RESERVED_DECLARED_FIELD_NAMES,
@@ -91,12 +92,37 @@ describe("validateId", () => {
 
     test("still accepts names that merely contain a reserved word", () => {
       expect(validateId("user_id_ref", ...noExistingIds, strict)).toBeNull();
-      expect(validateId("language", ...noExistingIds, strict)).toBeNull();
       expect(validateId("verified", ...noExistingIds, strict)).toBeNull();
       expect(validateId("started_at", ...noExistingIds, strict)).toBeNull();
+      expect(validateId("country_code", ...noExistingIds, strict)).toBeNull();
+    });
+
+    /**
+     * ENG-1839. The Tier-1 Embedded Data catalog is a second blocklist on the strict path only:
+     * a field named `country` would be permanently shadowed by the reserved read of the same name.
+     * `language` moved from the accepted list above to here for exactly that reason.
+     */
+    test("rejects the Tier-1 reserved field names in any casing", () => {
+      for (const reserved of RESERVED_FIELD_NAMES) {
+        for (const candidate of [reserved, reserved.toUpperCase()]) {
+          expect(validateId(candidate, ...noExistingIds, strict)).toEqual({
+            code: TValidateIdErrorCode.Reserved,
+            field: candidate,
+          });
+        }
+      }
+      // The camelCase spelling of a catalog entry is refused too — the set stores them lowercased.
+      expect(validateId("deviceType", ...noExistingIds, strict)?.code).toBe(TValidateIdErrorCode.Reserved);
     });
 
     test("leaves the lenient path alone so element and question ids keep parsing", () => {
+      // ENG-1839: the Tier-1 catalog must NOT reach the lenient path. `ZSurveyHiddenFields` parses
+      // surveys loaded from the database through it, so a survey that already declares `country`
+      // has to keep loading.
+      expect(validateId("country", ...noExistingIds)).toBeNull();
+      expect(validateId("browser", ...noExistingIds)).toBeNull();
+      expect(validateId("language", ...noExistingIds)).toBeNull();
+
       // Element/question id renames must not start failing: only the exact-case FORBIDDEN_IDS entry
       // is reserved there, exactly as before this change.
       expect(validateId("userid", ...noExistingIds)).toBeNull();

--- a/packages/types/surveys/validation.ts
+++ b/packages/types/surveys/validation.ts
@@ -1,6 +1,7 @@
 import { parse } from "node-html-parser";
 import { type z } from "zod";
 import type { TI18nString } from "../i18n";
+import { RESERVED_FIELD_NAMES } from "../reserved-field-names";
 import { isLegacyIdCharset, isSafeIdentifier } from "../safe-identifier";
 import type { TConditionGroup, TSingleCondition } from "./logic";
 import type {
@@ -395,8 +396,14 @@ export const validateId = (
   // behaving exactly as before. New declared field names are matched case-insensitively and against
   // the link-survey system params too, because `getHiddenFieldsFromSearchParams` refuses to capture
   // any of those under any casing - a name that could never receive a value must not be creatable.
+  //
+  // `RESERVED_FIELD_NAMES` (the Tier-1 Embedded Data catalog: country, url, browser, ...) joins them
+  // on the strict path ONLY. It must never move into `RESERVED_DECLARED_FIELD_NAMES`, which is also
+  // the capture-refusal list read by `getHiddenFieldsFromSearchParams` — putting `country` there
+  // would stop `?country=DE` from filling the hidden field of a survey that legitimately declares
+  // `country` today. Refused at authoring time; whatever a survey already declares keeps working.
   const isReserved = requireSafeIdentifier
-    ? RESERVED_DECLARED_FIELD_NAMES.has(field.toLowerCase())
+    ? RESERVED_DECLARED_FIELD_NAMES.has(field.toLowerCase()) || RESERVED_FIELD_NAMES.has(field.toLowerCase())
     : FORBIDDEN_IDS.includes(field);
 
   if (isReserved) {


### PR DESCRIPTION
> **Stacked on #8892** (the Tier-1 reserved field catalog) — please merge that one first. This PR's base is `javier/eng-1839-reserved-field-catalog-tier-1-name-collision-rules`; GitHub will retarget it to `epic/embedded-data-v1` automatically once #8892 merges. The repo merges with merge commits, so no rebase is needed.

## What & why

Embedded Data **reserved** fields (`country`, `url`, `browser`, `duration…`) are system metadata readable by name on every response. If an author declares a field with one of those names, the two collide in the recall/logic namespace and the new field can never receive a value — `getHiddenFieldsFromSearchParams` refuses to capture a reserved param, so the field stays silently empty forever.

That guard was missing at the create path. ENG-1834 gave `validateId` an opt-in `requireSafeIdentifier` that rejects reserved names, but it is passed from **exactly one** place — the hidden-fields editor card. `ZSurveyHiddenFields` stays lenient by design, because the same schema parses surveys loaded from the database. So `PUT /api/v1/management/surveys/{id}` could still create a hidden field named `lang` or `country`, bypassing the editor guard entirely.

This adds the one create-time validation layer that the lenient load-time schema cannot be:

- **New** `packages/types/surveys/declared-field-guard.ts` — `validateNewDeclaredFieldNames({ existing, incoming })`. It delegates each new name to `validateId`'s strict branch, so the guard and the editor card cannot drift apart.
- **`validateId`'s strict branch now also consults `RESERVED_FIELD_NAMES`** (the Tier-1 catalog from #8892). The lenient branch is untouched.
- **Called at exactly three input boundaries, before the transaction in each case:**

  | Boundary | Covers | `existing` |
  | --- | --- | --- |
  | `updateSurveyInternal` | editor save, `PUT /api/v1/management/surveys/[surveyId]` | the survey's current variable names + `hiddenFields.fieldIds` |
  | `createSurvey` | templates, `POST /api/v1/management/surveys`, v3 create | `[]` — a create authors every name fresh |
  | `executeV3SurveyPatch` | `PATCH /api/v3/surveys/*`, the MCP write path | the loaded `currentSurvey`'s declared names |

### Grandfathering is the whole point

Surveys in production already have hidden fields named `country`, `url`, `source`, `browser`. Their values live at `response.data["country"]`, `#recall:country#` resolves from there, and **nothing is renamed**. A name already present in `existing` returns no error, whatever it is — the blocklist applies to names a write is *authoring*. Matching is case-insensitive in both directions.

Two deliberate non-changes, both load-bearing:

- `RESERVED_DECLARED_FIELD_NAMES` is **not** grown. It is also the capture-refusal list read by `getHiddenFieldsFromSearchParams`, so adding `country` there would stop `?country=DE` from filling the hidden field of a survey that legitimately declares `country` today.
- The guard is **not** inside `reconcileEmbeddedData`. It must return a validation error to the client rather than fail inside an interactive transaction, and the survey copy flow feeds a whole survey's fields in as "new" against zero existing rows — a guard there would make duplicating a grandfathered survey fail.

Payload presence is tested with `!== undefined`, not the `in` operator, mirroring `resolveDesiredEmbeddedFields`: every write seam builds one object literal with both keys spelled out, so a patch that never mentioned `hiddenFields` must not read as declaring the empty set.

## Linear ticket

Fixes ENG-1839 — https://linear.app/formbricks/issue/ENG-1839/reserved-field-catalog-tier-1-name-collision-rules

## How this was tested

| Behavior | Coverage | Result |
| --- | --- | --- |
| Reserved name refused for a **new** hidden field / variable | unit — `declared-field-guard.test.ts`, `service.test.ts`, `patch.test.ts` | ✅ |
| **Grandfather**: a survey that already declares `country` still saves, field left in place | **unit (red on main)** — see command below | ✅ |
| Grandfathered survey may still not add a *second* reserved name | unit — `service.test.ts`, `patch.test.ts` | ✅ |
| Case-insensitive matching (`Country`, `COUNTRY`, `deviceType`) | unit — `declared-field-guard.test.ts`, `validation.test.ts` | ✅ |
| `!== undefined` presence rule (payload omitting `hiddenFields` validates nothing) | unit — `declared-field-guard.test.ts` | ✅ |
| Lenient path unchanged, so stored surveys keep loading | unit — `validation.test.ts` | ✅ |
| **Duplicating** a survey that declares `country` still succeeds | integration (real Postgres) — `embedded-data-reconcile.integration.test.ts` | ✅ |
| Editor shows an error and does not save `country` | e2e — spec added, **not executed** (see Open gaps) | ⚠️ |
| **Variables card** refuses `country` before the save, with translated copy | e2e — spec added, **not executed** (see Open gaps) | ⚠️ |
| The refusal reason matches the list that refused the name | unit — `declared-field-guard.test.ts` | ✅ |
| Grandfathering is per-save: deleting the field makes the name refusable again | unit — `declared-field-guard.test.ts` | ✅ |

Commands actually run, with results:

```
# packages/types — 6 files, 263 tests
cd packages/types && npx vitest run                                   ✅ 263 passed

# apps/web unit — service, v3 patch, v3 create
cd apps/web && npx vitest run lib/survey/service.test.ts \
  app/api/v3/surveys/patch.test.ts app/api/v3/surveys/create.test.ts  ✅ 130 passed

# integration against real Postgres (18 tests, incl. the 3 new duplicate/grandfather cases)
cd apps/web && TEST_DB_PROVISIONED=1 TEST_DATABASE_URL={test db} \
  npx dotenv -e ../../.env -- npx vitest run \
  --config vitest.integration.config.mts \
  integration/embedded-data-reconcile.integration.test.ts             ✅ 18 passed

npx tsc --noEmit -p apps/web/tsconfig.json                            ✅ exit 0
npx tsc --noEmit -p packages/types/tsconfig.json                      ✅ exit 0
npx eslint {the 9 touched .ts files}                                  ✅ 0 errors
npx prettier --check {the 10 touched files}                           ✅ clean
```

**The grandfather row is red on main.** Delete the `existing` short-circuit in `packages/types/surveys/declared-field-guard.ts` — the line

```ts
if (grandfathered.has(lowered) || seen.has(lowered)) continue;
```

changed to `if (seen.has(lowered)) continue;` — then run:

```
cd packages/types && npx vitest run surveys/declared-field-guard.test.ts
```

Verified: **4 failed | 16 passed** — `a reserved name already in "existing" passes`, `a grandfathered survey may still not add a *different* reserved name`, `grandfathering is per name, not a blanket exemption for the payload`, and `"existing" grandfathers across casing too`. Restored, it is 20/20 green.

### Review round (pandeymangg)

Three findings, all addressed in `d5fdf0826`:

1. **The refusal reason was wrong for half the names it covered.** It said a reserved name "could never receive a value", which is true only of `RESERVED_DECLARED_FIELD_NAMES` — `getHiddenFieldsFromSearchParams` skips those. `RESERVED_FIELD_NAMES` is deliberately **not** in that list, so `?country=DE` does still fill a survey's declared `country`, and an integrator given the wrong reason could have removed URL params that work. `describeReservedReason` now branches on which set matched, with the capture-refusal reason winning for `source` (the one name in both).
2. **Variable names were not gated in the editor.** `isSafeIdentifier("country")` passes, so the variables card accepted the name and the author's first signal was the untranslated server message. The card now calls `validateId(..., { requireSafeIdentifier: true })` and reports through `getValidateIdErrorMessage(error, "variable", t)`, reusing `validate_id_reserved`. The check is skipped when an edit leaves the name unchanged — without that, a survey already declaring a variable called `country` would have become uneditable, breaking the grandfather rule in the editor by way of the change meant to enforce it.
3. **Grandfathering is per-save, and that was undocumented.** Deleting a grandfathered field spends the reprieve: the name is refusable again on the next write. Intended (remembering every name a survey ever had needs storage this layer has none of, and the survey gains the auto-captured field in exchange), now stated in the doc comment and walked by a test.

`packages/types` is 280 passed / 7 files after the round; `apps/web` `modules/survey/editor/lib/validation.test.ts` is 105 passed, covering the widened `getValidateIdErrorMessage` union.

**Blast radius, measured in production** (from the review, not by me): **8 surveys** declare a colliding name. That closes the optional read-only report ENG-1839 asked for, which I could not run from this sandbox.

One pre-existing test changed meaning rather than being deleted: `validation.test.ts` asserted `language` was accepted in strict mode. `language` is a Tier-1 reserved name, so it moved from the accepted list into the new rejected-in-strict-mode case, and the lenient path gained explicit assertions that `country` / `browser` / `language` still parse (which is what keeps stored surveys loading).

### Open gaps

- **The Playwright spec was not executed to completion.** `apps/web/playwright/survey-editor-embedded-fields.spec.ts` gained a `refuses a hidden field named after a reserved field` test (written, formatted, lint-clean). In this sandbox it reached the browser — Chromium launched, the user fixture was created, login succeeded — but the run then stalled on environment plumbing (the box exports a `DATABASE_URL` that overrides the repo `.env`, and the shared dev database is stuck on a failed migration unrelated to this branch). **No editor screenshot is attached for that row**, and the e2e row above is marked ⚠️ rather than ✅ for that reason. The equivalent behaviour is covered below the browser boundary by the service, v3-patch and integration suites; the editor toast copy asserted by the spec is the existing `validate_id_reserved` string, which this PR routes `country` into. Please run that spec (or the manual QA step below) before this leaves draft.
- **The edit-mode grandfather skip in the variables card is not covered.** Reaching that state through the editor is impossible by construction now (the card refuses to create the name), and seeding a survey that declares `country` means hand-building its `SurveyEmbeddedData` rows through Prisma — a fixture likely to fail for reasons unrelated to what it would test. Same boundary the hidden-field grandfather case documents. The skip fails *open* toward the author keeping their field, so the worst case if it were wrong is the refusal it prevents.
- No new i18n string was added. The editor refusal reuses the existing translated `workspace.surveys.edit.validate_id_reserved` copy (`Hidden field ID "country" is not allowed. It is a reserved keyword.`, and `Variable ID "country" …` for the variables card), which now covers reserved catalog names too; the server-side messages follow the existing non-localized `APP_SURVEY_TRIGGER_REQUIRED_MESSAGE` precedent for this layer. `pnpm i18n` was therefore not run — adding a key nothing reads would be dead copy. Happy to add a dedicated string if reviewers prefer distinct wording for system fields vs. other reserved keywords.

## Breaking changes

None for API/SDK request or response **shapes** — no field renamed, removed, retyped, or revalued; no endpoint or webhook payload changed.

One **behavioral** change worth calling out for integrators, which is the point of the ticket: a create or update that previously **accepted** a reserved field name is now **rejected**.

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| Declaring a hidden field or variable named after a reserved field (`country`, `url`, `source`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`, `action`) | Accepted; the field was created and then never received a value | `POST`/`PUT /api/v1/management/surveys` → **400**; `POST`/`PATCH /api/v3/surveys` → **422** with a `forbidden_identifier` invalid param | API/MCP clients that create surveys with one of those names | Rename the field to a non-reserved name. **Surveys that already declare one keep working unchanged** — the refusal applies only to names being newly added |

## QA / Test Plan

**How to test**

- [ ] Editor → open a survey → **Hidden fields** card → type `country` → **Add hidden field ID** → an error toast reads `Hidden field ID "country" is not allowed. It is a reserved keyword.` and the field is **not** added to the card.
- [ ] Same card, type `Country` (capital C) → same refusal — matching is case-insensitive.
- [ ] Same card, type `team_size` → the field is added normally, and **Save** persists it. Confirms the card still works.
- [ ] Repeat the first step in the **Variables** card with the name `browser` → refused the same way.
- [ ] API: `PUT /api/v1/management/surveys/{id}` with `"hiddenFields": {"enabled": true, "fieldIds": ["country"]}` → **400**, body message names the field, and the survey is unchanged when you re-fetch it.
- [ ] API: `POST /api/v1/management/surveys` with the same `hiddenFields` → **400**, and no survey is created.
- [ ] API: `PATCH /api/v3/surveys/{id}` with the same `hiddenFields` → **422**, `invalid_params` contains a `country` entry with code `forbidden_identifier`, and the survey is unchanged.
- [ ] **Grandfather (the critical one)**: take a survey that ALREADY has a hidden field named `country` (create it on `epic/embedded-data-v1` before this PR, or insert one directly). Open it in the editor, change something unrelated (e.g. the survey name), **Save** → saves successfully, and the `country` field is still listed in the Hidden fields card afterwards.
- [ ] On that same grandfathered survey, submit a response with `?country=DE` on the link → the response still stores `country: "DE"` in `response.data`, and a `#recall:country#` token in a question still resolves from it.
- [ ] On that same grandfathered survey, try to add a **second** reserved name (`browser`) → refused, while `country` stays untouched.
- [ ] **Duplicate** a survey that declares `country` (survey list → ⋯ → Duplicate) → the copy is created successfully and also has the `country` field.
- [ ] Create a survey from a **template** (any template) → still creates normally, no name is refused.

**Preconditions / test data**

- A workspace with at least one survey, and one survey that already declares a hidden field named `country` (this is the grandfathered case — it has to be created before this PR's guard exists, or inserted directly).
- An API key for the v1 management endpoints, and one for v3.
- No feature flag, plan, or entitlement gates this. Applies equally to Cloud and self-hosted.

**Risks & regressions**

- **Grandfathered surveys must not break.** The blocklist applies to newly added names only; nothing is renamed and no stored value moves. Re-check that an existing survey with `country`/`url`/`source`/`browser` still saves, still captures `?country=…`, and still resolves `#recall:country#`.
- **Link-survey capture must not narrow.** `RESERVED_DECLARED_FIELD_NAMES` was deliberately **not** grown with the catalog names — it is also the capture-refusal list in `apps/web/modules/survey/link/lib/hidden-fields.ts`, so adding `country` there would stop `?country=DE` from filling a grandfathered survey's hidden field. Re-check link-survey URL param capture.
- **Survey duplication must not fail.** The guard is deliberately **not** inside `reconcileEmbeddedData` / `resolveDesiredEmbeddedFields`, and the copy flow at `apps/web/modules/survey/list/lib/survey.ts` is deliberately **not** guarded (it does its own `tx.survey.create` and never calls `createSurvey`). A duplicate of a grandfathered survey must keep succeeding — covered by the integration test.
- Templates: `apps/web/app/lib/templates.ts` declares `fieldIds: []` / `variables: []` and `minimal-survey.ts` declares `variables: []`, so no template carries a reserved name and guarding `createSurvey` cannot break template creation. Re-verify if templates change.
- Element and question **ids** are unaffected — only the strict (`requireSafeIdentifier`) path changed, so renaming a question to `Q1` still works.

**Migrations / env / cutover**

- none


---
_Generated by [Claude Code](https://claude.ai/code)_