### PR TITLE
fix(analysis): stop the pie tooltip showing the internal measure key [ENG-2346]

### DIFF
--- a/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
@@ -307,7 +307,13 @@ const PieChartView = ({
             })}
             <Label position="center" content={<PieCenterLabel total={total} label={centerLabel} />} />
           </Pie>
-          <ChartTooltip content={<PolishedChartTooltip labelFormatter={formatDimensionValue} />} />
+          {/* Measure slices carry the measure label on the row itself, so the header (the same
+              slice name) would only repeat it — suppress it like the pivoted bar chart does. */}
+          <ChartTooltip
+            content={
+              <PolishedChartTooltip labelFormatter={formatDimensionValue} hideLabel={useMeasureSlices} />
+            }
+          />
           <Legend
             verticalAlign="bottom"
             height={36}

--- a/apps/web/modules/ee/analysis/charts/lib/chart-utils.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/chart-utils.test.ts
@@ -27,10 +27,19 @@ describe("chart-utils", () => {
       const rows = [{ "m.joy": 1163, "m.anger": 1050, "m.fear": 3 }];
       const result = prepareMeasureSliceData(rows, ["m.joy", "m.anger", "m.fear"], label);
       expect(result).toEqual([
-        { [PIE_MEASURE_NAME_KEY]: "L:m.joy", [PIE_MEASURE_VALUE_KEY]: 1163 },
-        { [PIE_MEASURE_NAME_KEY]: "L:m.anger", [PIE_MEASURE_VALUE_KEY]: 1050 },
-        { [PIE_MEASURE_NAME_KEY]: "L:m.fear", [PIE_MEASURE_VALUE_KEY]: 3 },
+        { [PIE_MEASURE_NAME_KEY]: "L:m.joy", [PIE_MEASURE_VALUE_KEY]: 1163, tooltipLabel: "L:m.joy" },
+        { [PIE_MEASURE_NAME_KEY]: "L:m.anger", [PIE_MEASURE_VALUE_KEY]: 1050, tooltipLabel: "L:m.anger" },
+        { [PIE_MEASURE_NAME_KEY]: "L:m.fear", [PIE_MEASURE_VALUE_KEY]: 3, tooltipLabel: "L:m.fear" },
       ]);
+    });
+
+    // The tooltip labels each row from its dataKey, which for these slices is the internal
+    // PIE_MEASURE_VALUE_KEY — without tooltipLabel it renders that raw key (ENG-2346).
+    test("labels every slice for the tooltip, never leaving the internal value key exposed", () => {
+      const rows = [{ "m.joy": 10, "m.anger": 2 }];
+      const result = prepareMeasureSliceData(rows, ["m.joy", "m.anger"], label);
+      expect(result.map((row) => row.tooltipLabel)).toEqual(["L:m.joy", "L:m.anger"]);
+      expect(result.every((row) => !String(row.tooltipLabel).includes(PIE_MEASURE_VALUE_KEY))).toBe(true);
     });
 
     test("sums a measure across multiple rows and treats non-numeric as 0", () => {
@@ -40,8 +49,8 @@ describe("chart-utils", () => {
       ];
       const result = prepareMeasureSliceData(rows, ["m.joy", "m.anger"], label);
       expect(result).toEqual([
-        { [PIE_MEASURE_NAME_KEY]: "L:m.joy", [PIE_MEASURE_VALUE_KEY]: 15 },
-        { [PIE_MEASURE_NAME_KEY]: "L:m.anger", [PIE_MEASURE_VALUE_KEY]: 2 },
+        { [PIE_MEASURE_NAME_KEY]: "L:m.joy", [PIE_MEASURE_VALUE_KEY]: 15, tooltipLabel: "L:m.joy" },
+        { [PIE_MEASURE_NAME_KEY]: "L:m.anger", [PIE_MEASURE_VALUE_KEY]: 2, tooltipLabel: "L:m.anger" },
       ]);
     });
   });

--- a/apps/web/modules/ee/analysis/charts/lib/chart-utils.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/chart-utils.ts
@@ -125,6 +125,10 @@ export const PIE_MEASURE_VALUE_KEY = "__measureValue";
  * Pivot several measures (one/few rows, N measure columns) into one row per measure, so a pie
  * chart with multiple measures and no dimension renders a slice per measure instead of only the
  * first one. Each measure is summed across the given rows.
+ *
+ * The measure label is stored a second time as `tooltipLabel` because the tooltip keys its row
+ * label off the dataKey, which here is the internal PIE_MEASURE_VALUE_KEY rather than a Cube
+ * column — without it the tooltip prettifies that key and shows "__measure Value" (ENG-2346).
  */
 export const prepareMeasureSliceData = (
   rows: TChartDataRow[],
@@ -137,6 +141,7 @@ export const prepareMeasureSliceData = (
       (sum, row) => sum + (isNumericValue(row[key]) ? Number(row[key]) : 0),
       0
     ),
+    tooltipLabel: labelFor(key),
   }));
 
 /** Category key for rows produced by {@link pivotMeasuresToCategories}. */


### PR DESCRIPTION
Fixes ENG-2346

## What & why

Hovering a slice of a pie chart built from several measures with no dimension showed `__measure Value` as the row label instead of the measure's name.

That pie shape is produced by `prepareMeasureSliceData`, which pivots each measure column into its own slice and stores the value under the internal key `PIE_MEASURE_VALUE_KEY` (`"__measureValue"`). `PolishedChartTooltip` labels each row from `item.payload?.tooltipLabel ?? formatCubeColumnHeader(dataKey)` — those rows carried no `tooltipLabel`, so the fallback prettified the internal key. `formatCubeColumnHeader` finds no matching field definition, splits camelCase and returns the literal string `"__measure Value"` (verified by calling it directly against the pre-fix code).

- `prepareMeasureSliceData` now carries the translated measure label on each slice as `tooltipLabel`, the same field `pivotMeasuresToCategories` already sets for the pivoted bar chart.
- `PieChartView` passes `hideLabel={useMeasureSlices}` to the tooltip. The header for these pies is the slice name, which is now the row label too, so it would only repeat it — this mirrors the `tooltipHideLabel` that `CartesianChart` already applies to the pivoted bar chart.

Dimension-based pies take neither path: `useMeasureSlices` is false for them, so they keep their dimension-value header and measure-name row label unchanged.

## Before / after

Beffore:
<img width="514" height="413" alt="Screenshot 2026-08-19 at 12 35 55 PM" src="https://github.com/user-attachments/assets/d9431cae-f1f0-4316-a753-c2a85c2a2bd2" />

After:
<img width="501" height="358" alt="Screenshot 2026-08-19 at 12 36 37 PM" src="https://github.com/user-attachments/assets/8b6b77a9-6f27-4863-97c8-6c27db0eafc8" />


Verified on a live dashboard against Cube-backed data — a pie built from three measures (`promoterCount`, `passiveCount`, `detractorCount`) with no dimension, i.e. the `prepareMeasureSliceData` shape, hovering the promoters slice:

| | Tooltip header | Tooltip row |
| --- | --- | --- |
| Before | `NPS: Promoters` | `__measure Value` &nbsp; 37 |
| After | *(suppressed — it only repeated the row)* | `NPS: Promoters` &nbsp; 37 |

**Before**

<!-- drop before.png here -->

**After**

<!-- drop after.png here -->

<details>
<summary>How to reproduce either state locally</summary>

Chart config — pie, no dimension, three measures:

```json
{
  "measures": [
    "FeedbackRecords.promoterCount",
    "FeedbackRecords.passiveCount",
    "FeedbackRecords.detractorCount"
  ]
}
```

Add it to a dashboard and hover any slice. To see the pre-fix tooltip, drop the two lines this PR adds:

- remove `tooltipLabel: labelFor(key),` from `prepareMeasureSliceData` in `apps/web/modules/ee/analysis/charts/lib/chart-utils.ts`
- remove `hideLabel={useMeasureSlices}` from `PieChartView` in `apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx`

</details>

## Breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Every pivoted pie slice carries the measure label for the tooltip, so the internal value key is never what gets rendered | unit (red on main) | New test `labels every slice for the tooltip, never leaving the internal value key exposed` in `apps/web/modules/ee/analysis/charts/lib/chart-utils.test.ts`. Reverted `chart-utils.ts` to its pre-fix state (`git checkout HEAD~1 -- apps/web/modules/ee/analysis/charts/lib/chart-utils.ts`) and reran `npx vitest run modules/ee/analysis/charts/lib/chart-utils.test.ts` from `apps/web`: 3 failed / 34 passed — the new test plus the two existing `prepareMeasureSliceData` shape assertions. Restored, all 37 pass. |
| The label leaking into the tooltip is exactly the reported string | manual | Called `formatCubeColumnHeader("__measureValue")` in a throwaway spec against the pre-fix code; it returned `"__measure Value"`, confirming the fallback prettifier — not some other code path — produced the text in the ticket screenshot. Spec deleted, not committed. |
| Dimension-based pies keep their tooltip header and row label | unit (guard) | `useMeasureSlices` gates both `tooltipLabel` (only set on rows this function builds) and `hideLabel`, so no other chart shape is reachable from this diff. The existing `preparePieData` and `pivotMeasuresToCategories` suites still pass unchanged. |

**Open gaps**

- ~~No screenshot of the fixed tooltip.~~ Now observed on a real chart — see **Before / after** above. Both halves were verified by hovering the same slice with and without the diff applied: the row label changes from `__measure Value` to `NPS: Promoters`, and the duplicated header disappears. The header-suppression half no longer rests only on it matching the `hideLabel` wiring `CartesianChart` already ships (`cartesian-chart.tsx:197-203`).
- No unit test for the `hideLabel` prop itself — `AGENTS.md` rules out component unit tests for `.tsx`, and no Playwright spec covers chart tooltips today.

**Risks**

- If a reviewer would rather keep the slice name as the tooltip header, dropping `hideLabel={useMeasureSlices}` still fixes the reported bug; the tooltip would then show the measure name twice.
- `tooltipLabel` is now a third key on these rows. It flows into `preparePieData` (which spreads rows and only reads the value/name keys) and into recharts as inert row data, so nothing else consumes it.

**Verification output**

```
$ pnpm lint
✖ 40 problems (0 errors, 40 warnings)
 Tasks:    21 successful, 21 total
(all 40 warnings are pre-existing react-hooks/exhaustive-deps warnings in files this diff does not touch)

$ pnpm typecheck
 Tasks:    27 successful, 27 total

$ pnpm test
 Test Files  612 passed (612)
      Tests  8063 passed (8063)
 Tasks:    26 successful, 26 total

$ pnpm format:check
Checking formatting...
All matched files use Prettier code style!
```

`pnpm install` reported no change to `pnpm-lock.yaml`. The suite needs a populated `.env` (created with `pnpm dev:setup`, as `test.yml` does); without it 69 tests fail on env validation alone, unrelated to this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfseXRewPu6FAneLZNTctF)_
