### PR TITLE
fix(integrations): await Google Sheets writes instead of throwing in callbacks [ENG-2250]

### DIFF
--- a/apps/web/lib/googleSheet/service.test.ts
+++ b/apps/web/lib/googleSheet/service.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test, vi } from "vitest";
-import { AuthenticationError } from "@formbricks/types/errors";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthenticationError, UnknownError } from "@formbricks/types/errors";
 import { TIntegrationGoogleSheets } from "@formbricks/types/integration/google-sheet";
 import { GOOGLE_SHEET_INTEGRATION_INVALID_GRANT } from "@/lib/googleSheet/constants";
 
@@ -12,7 +12,23 @@ vi.mock("@/lib/constants", () => ({
   GOOGLE_SHEET_MESSAGE_LIMIT: 50000,
 }));
 
-const { getSpreadsheetNameById } = await import("@/lib/googleSheet/service");
+const sheetsMock = vi.hoisted(() => ({
+  update: vi.fn(),
+  append: vi.fn(),
+}));
+
+vi.mock("googleapis", () => ({
+  google: {
+    auth: {
+      OAuth2: class {
+        setCredentials() {}
+      },
+    },
+    sheets: () => ({ spreadsheets: { values: sheetsMock } }),
+  },
+}));
+
+const { getSpreadsheetNameById, writeData } = await import("@/lib/googleSheet/service");
 
 /**
  * The shape the integration has once ENG-2078's redaction has blanked `config.key`: schema-valid,
@@ -44,5 +60,79 @@ describe("getSpreadsheetNameById", () => {
     await expect(getSpreadsheetNameById(redactedIntegration, "sheet1")).rejects.toThrow(
       new AuthenticationError(GOOGLE_SHEET_INTEGRATION_INVALID_GRANT)
     );
+  });
+});
+
+/** An integration whose stored access token is still valid, so `authorize` never has to refresh. */
+const authorizedIntegration = {
+  id: "integration1",
+  type: "googleSheets",
+  workspaceId: "ws1",
+  config: {
+    email: "owner@example.com",
+    data: [],
+    key: {
+      scope: "https://www.googleapis.com/auth/spreadsheets",
+      token_type: "Bearer",
+      expiry_date: Date.now() + 60 * 60 * 1000,
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+    },
+  },
+} as TIntegrationGoogleSheets;
+
+// ENG-2250: both writes used to `throw` from inside the node-style googleapis callback, so the error
+// escaped `writeData`'s own `try/catch` and surfaced as an unhandled rejection while `writeData` itself
+// resolved — the pipeline recorded a success and the customer's sheet quietly stopped filling up.
+describe("writeData", () => {
+  /**
+   * googleapis never calls back on the same tick, and that is the whole bug: a synchronous callback
+   * would carry the old `throw` back into `writeData`'s `try/catch` and hide it. Every mock here defers
+   * like the real client does.
+   */
+  const respondAsync =
+    (err: Error | null, onCall?: () => void) => (_params: unknown, callback: (err: Error | null) => void) => {
+      setTimeout(() => {
+        onCall?.();
+        callback(err);
+      }, 0);
+    };
+
+  beforeEach(() => {
+    sheetsMock.update.mockReset();
+    sheetsMock.append.mockReset();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("rejects with an UnknownError when the append callback reports an error", async () => {
+    sheetsMock.update.mockImplementation(respondAsync(null));
+    sheetsMock.append.mockImplementation(respondAsync(new Error("The caller does not have permission")));
+
+    await expect(writeData(authorizedIntegration, "sheet1", ["answer"], ["question"])).rejects.toThrow(
+      new UnknownError("Error while appending data: The caller does not have permission")
+    );
+  });
+
+  test("rejects with an UnknownError when the header update callback reports an error", async () => {
+    sheetsMock.update.mockImplementation(respondAsync(new Error("Requested entity was not found")));
+
+    await expect(writeData(authorizedIntegration, "sheet1", ["answer"], ["question"])).rejects.toThrow(
+      new UnknownError("Error while appending data: Requested entity was not found")
+    );
+    expect(sheetsMock.append).not.toHaveBeenCalled();
+  });
+
+  test("resolves only after both writes have completed", async () => {
+    const completed: string[] = [];
+    sheetsMock.update.mockImplementation(respondAsync(null, () => completed.push("update")));
+    sheetsMock.append.mockImplementation(respondAsync(null, () => completed.push("append")));
+
+    await writeData(authorizedIntegration, "sheet1", ["answer"], ["question"]);
+
+    expect(completed).toEqual(["update", "append"]);
   });
 });

--- a/apps/web/lib/googleSheet/service.ts
+++ b/apps/web/lib/googleSheet/service.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { google } from "googleapis";
 import { z } from "zod";
 import { Prisma } from "@formbricks/database/prisma";
 import { ZString } from "@formbricks/types/common";
@@ -26,7 +27,23 @@ import { createOrUpdateIntegration } from "@/lib/integration/service";
 import { truncateText } from "../utils/strings";
 import { validateInputs } from "../utils/validate";
 
-const { google } = require("googleapis");
+/**
+ * ENG-2250: `sheets.spreadsheets.values.*` take a node-style callback, so a `throw` inside one escapes
+ * the surrounding `try/catch` and lands as an unhandled rejection — the write fails, the sheet silently
+ * stops receiving responses and the caller is never told. Wrap the call so the error rejects a promise
+ * the caller awaits instead. `invoke` receives the callback rather than the method being detached, to
+ * keep googleapis' own `this` binding intact.
+ */
+const runSheetsWrite = (invoke: (callback: (err: Error | null) => void) => void): Promise<void> =>
+  new Promise((resolve, reject) => {
+    invoke((err) => {
+      if (err) {
+        reject(new UnknownError(`Error while appending data: ${err.message}`));
+        return;
+      }
+      resolve();
+    });
+  });
 
 export const writeData = async (
   integrationData: TIntegrationGoogleSheets,
@@ -55,32 +72,28 @@ export const writeData = async (
     };
 
     const element = { values: [elements] };
-    sheets.spreadsheets.values.update(
-      {
-        spreadsheetId: spreadsheetId,
-        range: "A1",
-        valueInputOption: "RAW",
-        resource: element,
-      },
-      (err: Error) => {
-        if (err) {
-          throw new UnknownError(`Error while appending data: ${err.message}`);
-        }
-      }
+    await runSheetsWrite((callback) =>
+      sheets.spreadsheets.values.update(
+        {
+          spreadsheetId: spreadsheetId,
+          range: "A1",
+          valueInputOption: "RAW",
+          requestBody: element,
+        },
+        callback
+      )
     );
 
-    sheets.spreadsheets.values.append(
-      {
-        spreadsheetId: spreadsheetId,
-        range: "A2",
-        valueInputOption: "RAW",
-        resource: responsesMapped,
-      },
-      (err: Error) => {
-        if (err) {
-          throw new UnknownError(`Error while appending data: ${err.message}`);
-        }
-      }
+    await runSheetsWrite((callback) =>
+      sheets.spreadsheets.values.append(
+        {
+          spreadsheetId: spreadsheetId,
+          range: "A2",
+          valueInputOption: "RAW",
+          requestBody: responsesMapped,
+        },
+        callback
+      )
     );
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -114,7 +127,10 @@ export const getSpreadsheetNameById = async (
     return new Promise((resolve, reject) => {
       sheets.spreadsheets.get(
         { spreadsheetId },
-        (err: Error | null, response: { data: { properties: { title: string } } }) => {
+        (
+          err: Error | null,
+          response?: { data: { properties?: { title?: string | null } | null } } | null
+        ) => {
           if (err) {
             const msg = err.message?.toLowerCase() ?? "";
             const isPermissionError =
@@ -129,7 +145,11 @@ export const getSpreadsheetNameById = async (
             }
             return;
           }
-          const spreadsheetTitle = response.data.properties.title;
+          const spreadsheetTitle = response?.data.properties?.title;
+          if (!spreadsheetTitle) {
+            reject(new UnknownError("Error while fetching spreadsheet data: no title on the response"));
+            return;
+          }
           resolve(spreadsheetTitle);
         }
       );
@@ -196,7 +216,10 @@ const authorize = async (googleSheetIntegrationData: TIntegrationGoogleSheets) =
   try {
     const { credentials } = await oAuth2Client.refreshAccessToken();
     const mergedCredentials = {
-      ...credentials,
+      scope: credentials.scope ?? key.scope,
+      token_type: "Bearer" as const,
+      expiry_date: credentials.expiry_date ?? key.expiry_date,
+      access_token: credentials.access_token ?? key.access_token,
       refresh_token: credentials.refresh_token ?? key.refresh_token,
     };
     await createOrUpdateIntegration(googleSheetIntegrationData.workspaceId, {


### PR DESCRIPTION
Fixes ENG-2250

## What & why

`writeData` handed node-style callbacks to `sheets.spreadsheets.values.update` and `.append` that did `throw new UnknownError(...)`. googleapis invokes those callbacks on a later tick, so the throw never passed through the surrounding `try/catch` — it became an unhandled rejection (`mechanism: auto.node.onunhandledrejection`, 958 events since 2026-03-16) while `writeData` itself had already resolved. `handleGoogleSheetsIntegration` saw a success, logged nothing, and the customer's sheet quietly stopped receiving responses.

- Both writes now go through a small `runSheetsWrite` helper that wraps the call in a promise and **rejects** on error, so the failure reaches `writeData`'s `try/catch` and then `handleGoogleSheetsIntegration`'s error branch, where it is logged like every other integration failure.
- Awaiting them also closes the fire-and-forget window (`writeData` used to resolve before either request had been sent) and orders the header write ahead of the row append, instead of racing them.
- The error message is unchanged (`Error while appending data: …`) so the existing Sentry grouping still applies.

Supporting change: `require("googleapis")` became the ESM `import { google } from "googleapis"` that `app/api/google-sheet/route.ts` already uses. This is what makes the module mockable — Vitest cannot intercept a `require`, and without it the new tests reached the real Google API. The typed client then needed three small adjustments:

- `resource` → `requestBody` on both write calls. `resource` is googleapis' documented back-compat alias, mapped to `requestBody` in `googleapis-common/build/src/apirequest.js:83-88`, so the request body is byte-for-byte the same.
- a nullable-safe read of the spreadsheet title in `getSpreadsheetNameById`, which rejects instead of throwing a `TypeError` inside another node callback (the same failure mode as the bug above).
- an explicitly built credential object on the token-refresh path, replacing a spread of googleapis' nullable `Credentials`. The five fields are exactly what `ZGoogleCredential` accepts, so the persisted value is unchanged (the zod schema already stripped anything else).

## Breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `writeData` rejects with `UnknownError` when the **append** callback reports an error | unit (red on main) | Fails on the pre-fix code (it resolved, and the throw escaped out-of-band); passes now |
| `writeData` rejects when the **header update** callback errors, and does not attempt the append | unit (red on main) | Fails on the pre-fix code (both writes fired regardless); passes now |
| `writeData` resolves only after both writes have completed, header before rows | unit (red on main) | Fails on the pre-fix code (resolved before either callback ran); passes now |
| Blank refresh token still fails as the reconnect case (ENG-2303) | unit (guard) | Existing `getSpreadsheetNameById` test unchanged and still green |
| Google Sheets response pipeline still behaves as before | unit (guard) | `modules/response-pipeline`, green |

**Red/green proof**

All four runs below are the same unchanged spec (`apps/web/lib/googleSheet/service.test.ts`), from a
clean worktree at this branch's head, run from `apps/web`. Only `service.ts` differs between them.

*Run A — spec against `main`'s `service.ts`* (`git show HEAD~1:apps/web/lib/googleSheet/service.ts` restored over the fixed file):

```
$ pnpm vitest run lib/googleSheet --reporter=verbose
 ✓ getSpreadsheetNameById > throws an invalid_grant AuthenticationError when the stored refresh token is blank 4ms
 × writeData > rejects with an UnknownError when the append callback reports an error 15ms
   → promise resolved "undefined" instead of rejecting
 × writeData > rejects with an UnknownError when the header update callback reports an error 1ms
   → promise resolved "undefined" instead of rejecting
 × writeData > resolves only after both writes have completed 2ms
   → expected [] to deeply equal [ 'update', 'append' ]

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

Run A is red but does not isolate the callback bug, because on `main` the mock never lands at all. A
throwaway probe added to the spec — buggy `writeData` awaited, then `sheetsMock.update.mock.calls.length`
asserted — reported `PROBE update calls: 0 append calls: 0` and failed, which is the evidence for the
`require` → ESM claim above: with `require("googleapis")` the spec reaches the real client.

*Run B — pre-fix `writeData` (throwing callbacks, neither write awaited) with the ESM import kept, so the mock does land.* This is the run that isolates the bug:

```
$ pnpm vitest run lib/googleSheet --reporter=verbose
 ✓ getSpreadsheetNameById > throws an invalid_grant AuthenticationError when the stored refresh token is blank 3ms
 × writeData > rejects with an UnknownError when the append callback reports an error 3ms
   → promise resolved "undefined" instead of rejecting
 × writeData > rejects with an UnknownError when the header update callback reports an error 1ms
   → promise resolved "undefined" instead of rejecting
 × writeData > resolves only after both writes have completed 2ms
   → expected [] to deeply equal [ 'update', 'append' ]

⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
UnknownError: Error while appending data: The caller does not have permission
 ❯ lib/googleSheet/service.ts:98:17
 ❯ Timeout._onTimeout lib/googleSheet/service.test.ts:97:9
 ❯ listOnTimeout node:internal/timers:608:17

⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
UnknownError: Error while appending data: Requested entity was not found
 ❯ lib/googleSheet/service.ts:84:17
 ❯ Timeout._onTimeout lib/googleSheet/service.test.ts:97:9

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
     Errors  2 errors
```

That is the production failure reproduced: `writeData` resolves with `undefined` while the
`UnknownError` surfaces out-of-band, past every `try/catch` on the path. It lands as an uncaught
exception here only because the spec's mock defers with `setTimeout`; googleapis calls back from its
own promise chain, which is why Sentry recorded it as `auto.node.onunhandledrejection`. Same escape,
different Node channel.

*Run C — same buggy `service.ts` as Run B, but with the spec's `respondAsync` made synchronous:*

```
 ✓ writeData > rejects with an UnknownError when the append callback reports an error 1ms
 ✓ writeData > rejects with an UnknownError when the header update callback reports an error 1ms
 ✓ writeData > resolves only after both writes have completed 0ms

      Tests  4 passed (4)
```

All three pass on the buggy code. A synchronous mock carries the old `throw` straight back into
`writeData`'s own `try/catch` and hides the bug completely — which is why `respondAsync` uses
`setTimeout` for every mock in this spec.

*Run D — this branch, unmodified, plus the guard suite:*

```
$ pnpm vitest run lib/googleSheet --reporter=verbose
 ✓ getSpreadsheetNameById > throws an invalid_grant AuthenticationError when the stored refresh token is blank 3ms
 ✓ writeData > rejects with an UnknownError when the append callback reports an error 4ms
 ✓ writeData > rejects with an UnknownError when the header update callback reports an error 2ms
 ✓ writeData > resolves only after both writes have completed 2ms

 Test Files  1 passed (1)
      Tests  4 passed (4)

$ pnpm vitest run lib/googleSheet modules/response-pipeline
 Test Files  5 passed (5)
      Tests  79 passed (79)
```

**Open gaps**

- No run against the real Google Sheets API — this environment has no Google OAuth credentials, so the fix is verified against a mocked client only. What is actually being asserted is the promise/callback plumbing, which is where the bug lives; the request payload is unchanged apart from the `resource` → `requestBody` rename, and that equivalence rests on reading `apirequest.js` rather than on a live call.
- The new "no title on the response" rejection in `getSpreadsheetNameById` has no test. It replaces an unguarded property read that would have thrown a `TypeError` inside the callback, and it is only reachable if Google returns a spreadsheet with no `properties.title`.
- The rebuilt credential object on the refresh path is covered by typecheck and the schema, not by a test — the existing spec short-circuits before any refresh.

**Risks**

- Google Sheets failures that were previously invisible now surface as `Error in google sheets integration` in the logs. That is the point of the change, but expect the logged integration-failure rate to rise while the corresponding unhandled-rejection events in Sentry disappear. Nothing becomes fatal: `handleIntegrations` logs each integration's `Result` and carries on with the others.
- The two writes are now sequential rather than concurrent, adding one round-trip to each Google Sheets response delivery. This runs in the response pipeline, not a user-facing request.
- If the header update fails, the row append no longer runs where it previously did. A sheet that only failed on the header write will now skip that response's row instead of appending it under a stale header — the caller is told either way, which it was not before.

---

> [!NOTE]
> **AI model used** — written by an AI agent via Claude Code, reasoning effort high.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HgLtqtyygdo1JBkVt73bZ1)_
