### PR TITLE
fix(responses): bounds-check the response modal index on delete [ENG-2130]

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseCardModal.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseCardModal.tsx
@@ -88,8 +88,19 @@ export const ResponseCardModal = ({
     }
   };
 
-  // If no response is selected or currentIndex is null or invalid, do not render the modal
-  if (selectedResponseId === null || currentIndex === null || currentIndex === -1) return null;
+  // If no response is selected or currentIndex is null or invalid, do not render the modal.
+  // `currentIndex` is only reset in the effect above, so on the render that follows a delete it can
+  // still point past the end of the shortened `responses` array — deleting the survey's only response
+  // leaves it at `0` while `responses` is empty. `responses[currentIndex]` is then `undefined` and
+  // `SingleResponseCard` throws reading `response.finished`, replacing the page with the error screen
+  // instead of the empty state (ENG-2130). Bounds-check rather than testing for `-1` alone.
+  if (
+    selectedResponseId === null ||
+    currentIndex === null ||
+    currentIndex < 0 ||
+    currentIndex >= responses.length
+  )
+    return null;
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>


### PR DESCRIPTION
Fixes ENG-2130
Fixes #8712

## What & why

Deleting the last remaining response from the response detail modal replaced the page with the "Error loading resources" screen instead of returning to the responses table's empty state.

`ResponseCardModal` keeps the selected row's position in `currentIndex` and only resets it in a `useEffect`, so on the render that follows a delete the index can still point past the end of the shortened `responses` array. With the survey's only response deleted, `responses` is `[]` while `currentIndex` is still `0`. The guard tested `currentIndex === null || currentIndex === -1` — neither catches that — so `responses[currentIndex]` was `undefined` and `SingleResponseCard` threw reading `response.finished`.

The guard now bounds-checks the index against `responses.length`:

```diff
-if (selectedResponseId === null || currentIndex === null || currentIndex === -1) return null;
+if (
+  selectedResponseId === null ||
+  currentIndex === null ||
+  currentIndex < 0 ||
+  currentIndex >= responses.length
+)
+  return null;
```

`currentIndex < 0` subsumes the `=== -1` case it replaces (that is the sentinel the effect writes when the selected id is missing from `idToIndexMap`). The single-response case is the reliable reproduction, but the same stale-index window exists whenever deleting the selected response leaves `currentIndex` outside the shortened array, so the fix is a bounds check rather than an empty-array special case.

Nothing else changes: the delete path in `SingleResponseCard` still calls `updateResponseList` and then `setSelectedResponseId(null)`, and the modal still unmounts through the existing effect. This only stops the intermediate render from reading past the end.

Note for whoever picks this up: an external contributor proposed the same one-line direction on the GitHub issue (#8712) and has a branch on their fork that was never opened against this repo. Worth a mention in the issue thread when this merges.

Before:

https://github.com/user-attachments/assets/7ae423ad-d861-4171-a4aa-3165e98eef10


After:

https://github.com/user-attachments/assets/e770d67a-b86a-4407-a119-97aa05893c91

## Breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Deleting the only response from the detail modal returns to the empty state instead of the error screen | manual | **Not performed — see Open gaps.** Traced through the code path instead: after the delete, the modal renders once with `responses === []` and `currentIndex === 0`, which the new bound rejects before `responses[currentIndex]` is read |
| Navigation, guard for an unknown selected id, and the rest of the modal are unchanged | unit (guard) | Nothing under the responses route regressed: `pnpm vitest run "app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses"`, 25 tests green |

```
$ npx tsc --noEmit -p tsconfig.json     # no diagnostics in ResponseCardModal.tsx
$ npx eslint ".../responses/components/ResponseCardModal.tsx"   # clean
$ npx prettier --check ".../responses/components/ResponseCardModal.tsx"
All matched files use Prettier code style!
```

**Open gaps**

- **This is the significant one: the fix has no automated coverage and was not exercised in a browser.** Per `AGENTS.md` this flow belongs in a Playwright spec, not a `.tsx` unit test, and the environment this change was written in has no Docker daemon, so neither the database nor the app could be started (`pnpm db:up` fails at `dial unix /var/run/docker.sock`) and no spec could be run before being pushed. Rather than add an E2E spec whose selectors were never executed, none is included. The reproduction from the ticket is three steps — collect one response on a link survey, open it from the Responses tab, delete it — and should be walked through before this leaves draft.
- The ticket also reports the crash as timing-dependent: `updateResponseList` and `setSelectedResponseId(null)` are batched in the delete handler, and the interleaving that lets the bad render through was not reproduced here. The guard makes the render safe under any interleaving, so the fix does not depend on pinning that down, but it does mean "before" and "after" were not observed side by side.

**Risks**

- If `currentIndex` were ever legitimately out of range while a response should still be shown, the modal would now render nothing instead of crashing. There is no such case in the current code: `currentIndex` is only ever set from `idToIndexMap.get(...) ?? -1`, which is in range by construction for the same `responses` array.
- Bounds-checking against `responses.length` reads the array on every render of the guard; `responses` is already a dependency of the memo above it, so there is no new subscription or re-render.

---

> [!NOTE]
> **AI model used** — written by an AI agent via Claude Code, reasoning effort high.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HgLtqtyygdo1JBkVt73bZ1)_