### PR TITLE
fix(authorization): scope the page surface to the request, not the callback (ENG-2444)

### DIFF
--- a/apps/web/lib/authorization/README.md
+++ b/apps/web/lib/authorization/README.md
@@ -175,7 +175,7 @@ migration; resource-level relationships belong to the later sharing phase.
   `member` role by name, which admitted `billing`; `organization.manage` is what
   its own message always claimed.
 
-### Migrated by ENG-2388 and ENG-2409
+### Migrated by ENG-2388, ENG-2409 and ENG-2444
 
 ENG-2388 added the `page` surface for server-rendered routes. Until then a `can`
 call from a page or layout resolved no rollout target, so the coordinator
@@ -184,6 +184,29 @@ decisions were correct and invisible at the same time. The surface is opened at
 the choke points routes already funnel through (`getWorkspaceAuth`,
 `workspaceIdLayoutChecks`, `getWorkspaceLayoutData`) rather than at one boundary,
 because Next gives no RSC equivalent of the action-client wrapper.
+
+ENG-2444 then fixed how long that surface lasts. `AsyncLocalStorage` closes when
+the awaited callback returns, so the surface used to end with the choke-point
+helper — a page that awaited `getWorkspaceAuth()` and then authorized anything
+else did so outside any surface, back on the unconditional legacy path. That was
+not merely missing evidence: it would have bypassed enforcement invisibly, since
+a check with no surface never compares and so never mismatches. Nine routes were
+affected, two of them issuing one unscoped check _per feedback directory_ or _per
+dashboard widget_.
+
+`page` is now held in a React `cache()` slot, which is scoped to the whole render
+pass, so a layout and its page share one context and it outlives every helper.
+Every other surface keeps its `AsyncLocalStorage` boundary; outside a React
+request scope — scripts, unit tests, any non-RSC caller — `page` falls back to
+that same boundary, which is the pre-ENG-2444 behaviour.
+
+Two things follow. A navigation now records **one** checks-per-request
+observation instead of one per choke point. And **`page:user` is eligible for
+`AUTHZED_ENFORCEMENT_TARGETS`** — before ENG-2444 it had to stay shadow-only.
+
+`formbricks_authzed_authorization_unscoped_checks_total` should stay flat for
+page traffic; it is kept deliberately as the regression detector if this boundary
+is ever narrowed again.
 
 ENG-2409 then routed the organization-side gates, which a surface alone could not
 help because they never called `can` at all:

--- a/apps/web/lib/authorization/context.rsc.test.ts
+++ b/apps/web/lib/authorization/context.rsc.test.ts
@@ -1,0 +1,133 @@
+import { after } from "next/server";
+import * as React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  getAuthorizationSurface,
+  getIssuedAuthorizationCheckCount,
+  recordAuthorizationCheckIssued,
+  withAuthorizationSurface,
+} from "./context";
+import { recordAuthorizationChecksPerRequest } from "./metrics";
+
+/**
+ * ENG-2444 — the `page` surface under a real React request scope.
+ *
+ * This file exists because the `unit` project cannot cover the fix at all: the default build of React
+ * ships `cache` as a permanent no-op (`return fn.apply(null, arguments)`), so the slot the `page`
+ * surface lives in never memoizes there and the surface silently falls back to the old async-scoped
+ * boundary. Only the react-server build implements `cache`, which is why these run in the `rsc`
+ * Vitest project (see vite.config.mts).
+ *
+ * The request scope is installed directly rather than by running a renderer: React's `cache` reads
+ * `ReactSharedInternals.A` and calls `getCacheForType` on it, and that is the entire contract Next.js
+ * satisfies per request. Installing it here exercises React's REAL `cache` implementation — what is
+ * substituted is the request boundary Next would provide, not the behaviour under test.
+ */
+const reactServerInternals = (
+  React as unknown as {
+    __SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE: { A: unknown };
+  }
+).__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+
+/** One React request scope, the shape Next.js establishes around a render. */
+const enterRequestScope = (): void => {
+  const roots = new Map<() => unknown, unknown>();
+  reactServerInternals.A = {
+    getCacheForType<T>(resourceType: () => T): T {
+      if (!roots.has(resourceType)) roots.set(resourceType, resourceType());
+      return roots.get(resourceType) as T;
+    },
+  };
+};
+
+const leaveRequestScope = (): void => {
+  reactServerInternals.A = null;
+};
+
+const afterCallbacks = vi.hoisted(() => [] as Array<() => Promise<void> | void>);
+
+vi.mock("next/server", () => ({
+  after: vi.fn((callback: () => Promise<void> | void) => afterCallbacks.push(callback)),
+}));
+vi.mock("./metrics", () => ({ recordAuthorizationChecksPerRequest: vi.fn() }));
+
+beforeEach(() => {
+  afterCallbacks.length = 0;
+  leaveRequestScope();
+  vi.mocked(recordAuthorizationChecksPerRequest).mockReset();
+  vi.mocked(after)
+    .mockReset()
+    .mockImplementation((callback) => afterCallbacks.push(callback));
+});
+
+describe("the react-server build is what makes this testable", () => {
+  test("React here implements cache for real, and only memoizes inside a request scope", () => {
+    const slot = React.cache(() => ({}));
+
+    expect(slot()).not.toBe(slot());
+    enterRequestScope();
+    expect(slot()).toBe(slot());
+  });
+});
+
+describe("page surface — request-scoped boundary (ENG-2444)", () => {
+  test("a check issued AFTER the choke-point helper returns is still attributed to the page surface", async () => {
+    enterRequestScope();
+
+    // Exactly the shape of a real page: await the choke point, then keep authorizing. Before this
+    // change the surface closed with the helper and this check answered from the legacy evaluator
+    // with no rollout target at all — correct, invisible, and unenforceable.
+    await withAuthorizationSurface("page", async () => "workspace-auth");
+
+    expect(getAuthorizationSurface()).toBe("page");
+  });
+
+  test("a layout and its page share ONE context, so the request records one observation", async () => {
+    enterRequestScope();
+
+    // Two choke points in one render — a layout's and its page's.
+    await withAuthorizationSurface("page", async () => recordAuthorizationCheckIssued());
+    await withAuthorizationSurface("page", async () => recordAuthorizationCheckIssued());
+    // ...plus a check the page makes on its own, outside both.
+    recordAuthorizationCheckIssued();
+
+    expect(getIssuedAuthorizationCheckCount()).toBe(3);
+    expect(afterCallbacks).toHaveLength(1);
+
+    await afterCallbacks[0]();
+    expect(recordAuthorizationChecksPerRequest).toHaveBeenCalledTimes(1);
+    expect(recordAuthorizationChecksPerRequest).toHaveBeenCalledWith(3, "page");
+  });
+
+  test("two requests never share a context", async () => {
+    enterRequestScope();
+    await withAuthorizationSurface("page", async () => recordAuthorizationCheckIssued());
+    expect(getIssuedAuthorizationCheckCount()).toBe(1);
+
+    enterRequestScope();
+    expect(getAuthorizationSurface()).toBe("unscoped");
+    await withAuthorizationSurface("page", async () => undefined);
+    expect(getIssuedAuthorizationCheckCount()).toBe(0);
+  });
+
+  test("an enclosing server-action surface keeps precedence over the page slot", async () => {
+    enterRequestScope();
+
+    await withAuthorizationSurface("server_action", async () => {
+      await withAuthorizationSurface("page", async () => undefined);
+      // The action opened first and owns the request: a page choke point inside it must not
+      // re-attribute the request to `the page surface`.
+      expect(getAuthorizationSurface()).toBe("server_action");
+    });
+  });
+
+  test("outside a request scope it falls back to the async-scoped boundary", async () => {
+    // Scripts and non-RSC callers have no scope to hang the slot on. The surface must still work
+    // within the callback — that is the pre-ENG-2444 behaviour — and must not leak past it.
+    await withAuthorizationSurface("page", async () => {
+      expect(getAuthorizationSurface()).toBe("page");
+    });
+
+    expect(getAuthorizationSurface()).toBe("unscoped");
+  });
+});

--- a/apps/web/lib/authorization/context.rsc.test.ts
+++ b/apps/web/lib/authorization/context.rsc.test.ts
@@ -121,6 +121,22 @@ describe("page surface — request-scoped boundary (ENG-2444)", () => {
     });
   });
 
+  test("an established page surface keeps precedence over a nested non-page wrapper", async () => {
+    enterRequestScope();
+
+    await withAuthorizationSurface("page", async () => {
+      await withAuthorizationSurface("server_action", async () => {
+        recordAuthorizationCheckIssued();
+        expect(getAuthorizationSurface()).toBe("page");
+      });
+    });
+
+    expect(afterCallbacks).toHaveLength(1);
+    await afterCallbacks[0]();
+    expect(recordAuthorizationChecksPerRequest).toHaveBeenCalledOnce();
+    expect(recordAuthorizationChecksPerRequest).toHaveBeenCalledWith(1, "page");
+  });
+
   test("outside a request scope it falls back to the async-scoped boundary", async () => {
     // Scripts and non-RSC callers have no scope to hang the slot on. The surface must still work
     // within the callback — that is the pre-ENG-2444 behaviour — and must not leak past it.

--- a/apps/web/lib/authorization/context.test.ts
+++ b/apps/web/lib/authorization/context.test.ts
@@ -51,6 +51,22 @@ describe("authorization request context", () => {
     expect(afterCallbacks).toHaveLength(2);
   });
 
+  // ENG-2444 made `page` request-scoped via a React `cache()` slot. Nothing in this project has such a
+  // scope — the shared vitestSetup mocks `cache` to identity, and the non-server React build ships it
+  // as a no-op anyway — so `page` here exercises the async-scoped fallback, which is what scripts and
+  // any non-RSC caller get. It must still work inside the callback and must not leak past it. The
+  // request-scoped behaviour is covered in context.rsc.test.ts, which runs React's real `cache`.
+  test("page falls back to the async-scoped boundary when there is no request scope", async () => {
+    await withAuthorizationSurface("page", async () => {
+      expect(getAuthorizationSurface()).toBe("page");
+      recordAuthorizationCheckIssued();
+      expect(getIssuedAuthorizationCheckCount()).toBe(1);
+    });
+
+    expect(getAuthorizationSurface()).toBe("unscoped");
+    expect(getIssuedAuthorizationCheckCount()).toBeNull();
+  });
+
   test("is unscoped outside a request context", () => {
     expect(getAuthorizationSurface()).toBe("unscoped");
   });

--- a/apps/web/lib/authorization/context.ts
+++ b/apps/web/lib/authorization/context.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { after } from "next/server";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { cache as reactCache } from "react";
 import { recordAuthorizationChecksPerRequest } from "./metrics";
 
 /**
@@ -9,22 +10,30 @@ import { recordAuthorizationChecksPerRequest } from "./metrics";
  * Unlike every other surface, it is not established at a single request boundary: Next.js gives no RSC
  * equivalent of the action-client or API wrapper, and a layout's render and its page's render are
  * separate async contexts. It is therefore opened at the authorization choke points every product
- * route already funnels through. `withAuthorizationSurface` returns early when a surface is already
- * open, so opening it at more than one choke point is idempotent rather than nesting.
+ * route already funnels through, and opening it more than once is idempotent rather than nesting.
  *
- * Two consequences follow, and the second is a real coverage limit rather than a reporting quirk.
+ * **`page` is request-scoped; every other surface is callback-scoped.** That difference is ENG-2444.
+ * `AsyncLocalStorage` closes when the awaited callback returns, so the surface used to end with the
+ * choke-point helper: a page that awaited `getWorkspaceAuth()` and then authorized anything else did
+ * so with no surface, and those decisions were labelled `unscoped` in the authoritative decision
+ * telemetry the direct-authority rollout is monitored on. Nine routes were affected, two of them
+ * issuing one such check *per feedback directory* or *per dashboard widget*.
  *
- * The histogram splits: one navigation that runs both a layout check and a page check records two
- * observations rather than one. That weakens the N+1 signal slightly; it does not make it wrong.
+ * `page` is now held in a React `cache()` slot, which is scoped to the whole render pass, so a layout
+ * and its page share one context and it outlives every helper. Two consequences, both improvements on
+ * what this comment used to record:
  *
- * **The surface does not span the whole page.** `AsyncLocalStorage` scopes to the awaited callback,
- * so it closes when the choke-point helper returns — a page that calls `getWorkspaceAuth()` and then
- * issues further central checks makes those checks without a page label. They still use authoritative
- * SpiceDB, but are tagged `unscoped` in decision telemetry.
+ * A navigation records ONE checks-per-request observation rather than one per choke point, which is
+ * the N+1 signal that histogram exists for.
  *
- * Closing it needs a boundary that survives past the helper — a request-scoped store (React `cache`)
- * rather than an async-scoped one. That telemetry attribution improvement is separate from evaluator
- * authority and requires a render harness or E2E proof.
+ * `getAuthorizationSurface()` reports `page` for the whole render instead of `unscoped` after the first
+ * helper returns, so `formbricks_authzed_authorization_decisions_total` attributes page traffic
+ * correctly.
+ *
+ * Outside a React request scope — scripts, unit tests, any non-RSC caller — `cache()` does not
+ * memoize, so there is no slot to hold. `page` then falls back to the `AsyncLocalStorage` boundary,
+ * which is the pre-ENG-2444 behaviour: narrower than a render scope, but correct for a caller with no
+ * render to scope to.
  */
 export type TAuthorizationSurface =
   | "server_action"
@@ -49,6 +58,58 @@ const authorizationContext =
 
 globalForAuthorization.formbricksAuthorizationContext = authorizationContext;
 
+type TPageSurfaceSlot = { context: TAuthorizationContext | null };
+
+/**
+ * One slot per React request scope. In an RSC render that is the whole render pass, so a layout and
+ * its page resolve the same slot — which is what lets the `page` surface outlive the choke-point
+ * helper that opened it.
+ *
+ * `reactCache` is already this codebase's memoization idiom (resolvers.ts, and both choke-point
+ * modules); here it is used for its scope rather than to cache a value.
+ */
+const getPageSurfaceSlot = reactCache((): TPageSurfaceSlot => ({ context: null }));
+
+/**
+ * Whether React is holding a request scope we can hang the `page` surface on.
+ *
+ * `cache()` only memoizes inside one — outside it (scripts, unit tests, the non-RSC bundle, where the
+ * client build's `cache` is a permanent no-op) every call returns a fresh object, so identity is a
+ * direct, dependency-free probe. Deliberately not named "is rendering": Next also establishes a scope
+ * outside component rendering, and `page` is only ever *selected* by the caller — the ALS store is
+ * consulted first, so an enclosing server-action or API surface always keeps precedence.
+ */
+const hasReactRequestScope = (slot: TPageSurfaceSlot): boolean => slot === getPageSurfaceSlot();
+
+const createSurfaceContext = (surface: TAuthorizationSurface): TAuthorizationContext => ({
+  checksIssued: 0,
+  surface,
+});
+
+/**
+ * Register the one post-response observation for a surface. Shared by both boundaries so they cannot
+ * drift, and fail-safe: an unavailable `after()` costs the histogram observation, never the decision.
+ */
+const scheduleChecksPerRequestObservation = (context: TAuthorizationContext): void => {
+  try {
+    after(() => {
+      try {
+        recordAuthorizationChecksPerRequest(context.checksIssued, context.surface);
+      } catch {
+        // Telemetry must never alter an authoritative response.
+      }
+    });
+  } catch {
+    // A wrapper can be invoked outside a Next.js request in scripts/tests — `after()` is unavailable
+    // there. The authorization decision remains authoritative; only the request histogram observation
+    // is omitted.
+  }
+};
+
+/** The surface answering for the current caller: an explicit ALS boundary first, else the page slot. */
+const getActiveContext = (): TAuthorizationContext | null =>
+  authorizationContext.getStore() ?? getPageSurfaceSlot().context;
+
 export const withAuthorizationSurface = async <T>(
   surface: TAuthorizationSurface,
   callback: () => T | Promise<T>
@@ -57,23 +118,25 @@ export const withAuthorizationSurface = async <T>(
     return callback();
   }
 
-  const context: TAuthorizationContext = { checksIssued: 0, surface };
+  if (surface === "page") {
+    const slot = getPageSurfaceSlot();
+    if (hasReactRequestScope(slot)) {
+      // Opened once per render, then left open: every later check in the same render — including the
+      // ones a page issues long after this helper returned — resolves through this slot.
+      if (!slot.context) {
+        slot.context = createSurfaceContext(surface);
+        scheduleChecksPerRequestObservation(slot.context);
+      }
+      return callback();
+    }
+    // No render to scope to: fall through to the async-scoped boundary, which is what this surface did
+    // before ENG-2444. Narrower, but correct for a caller with no request scope.
+  }
+
+  const context = createSurfaceContext(surface);
 
   return authorizationContext.run(context, async () => {
-    try {
-      after(() => {
-        try {
-          recordAuthorizationChecksPerRequest(context.checksIssued, surface);
-        } catch {
-          // Telemetry must never alter an authoritative response.
-        }
-      });
-    } catch {
-      // A wrapper can be invoked outside a Next.js request in scripts/tests — `after()` is
-      // unavailable there. The authorization decision remains authoritative; only the request
-      // histogram observation is omitted.
-    }
-
+    scheduleChecksPerRequestObservation(context);
     return callback();
   });
 };
@@ -85,14 +148,13 @@ export const withAuthorizationSurface = async <T>(
  * that never establish a surface are simply not counted rather than throwing.
  */
 export const recordAuthorizationCheckIssued = (): void => {
-  const context = authorizationContext.getStore();
+  const context = getActiveContext();
   if (context) context.checksIssued += 1;
 };
 
 /** The number of central authorization operations in the current surface, or `null` outside one. */
-export const getIssuedAuthorizationCheckCount = (): number | null =>
-  authorizationContext.getStore()?.checksIssued ?? null;
+export const getIssuedAuthorizationCheckCount = (): number | null => getActiveContext()?.checksIssued ?? null;
 
 /** The current bounded request surface, or `unscoped` for scripts and non-request authorization calls. */
 export const getAuthorizationSurface = (): TAuthorizationSurface | "unscoped" =>
-  authorizationContext.getStore()?.surface ?? "unscoped";
+  getActiveContext()?.surface ?? "unscoped";

--- a/apps/web/lib/authorization/context.ts
+++ b/apps/web/lib/authorization/context.ts
@@ -49,8 +49,11 @@ type TAuthorizationContext = {
   surface: TAuthorizationSurface;
 };
 
+type TPageSurfaceSlot = { context: TAuthorizationContext | null };
+
 const globalForAuthorization = globalThis as unknown as {
   formbricksAuthorizationContext: AsyncLocalStorage<TAuthorizationContext> | undefined;
+  formbricksAuthorizationPageSurfaceSlot: (() => TPageSurfaceSlot) | undefined;
 };
 
 const authorizationContext =
@@ -58,17 +61,20 @@ const authorizationContext =
 
 globalForAuthorization.formbricksAuthorizationContext = authorizationContext;
 
-type TPageSurfaceSlot = { context: TAuthorizationContext | null };
-
 /**
  * One slot per React request scope. In an RSC render that is the whole render pass, so a layout and
  * its page resolve the same slot — which is what lets the `page` surface outlive the choke-point
  * helper that opened it.
  *
  * `reactCache` is already this codebase's memoization idiom (resolvers.ts, and both choke-point
- * modules); here it is used for its scope rather than to cache a value.
+ * modules); here it is used for its scope rather than to cache a value. The wrapper itself is pinned
+ * to `globalThis` so duplicated Next.js server bundles still use the same React cache key.
  */
-const getPageSurfaceSlot = reactCache((): TPageSurfaceSlot => ({ context: null }));
+const getPageSurfaceSlot =
+  globalForAuthorization.formbricksAuthorizationPageSurfaceSlot ??
+  reactCache((): TPageSurfaceSlot => ({ context: null }));
+
+globalForAuthorization.formbricksAuthorizationPageSurfaceSlot = getPageSurfaceSlot;
 
 /**
  * Whether React is holding a request scope we can hang the `page` surface on.
@@ -118,14 +124,21 @@ export const withAuthorizationSurface = async <T>(
     return callback();
   }
 
+  const pageSlot = getPageSurfaceSlot();
+  if (hasReactRequestScope(pageSlot) && pageSlot.context) {
+    // A request has one outer surface. Before `page` moved from ALS to React cache, a nested wrapper
+    // inherited the page context through the early return above. Preserve that behavior so one render
+    // cannot split its check count across multiple telemetry observations.
+    return callback();
+  }
+
   if (surface === "page") {
-    const slot = getPageSurfaceSlot();
-    if (hasReactRequestScope(slot)) {
+    if (hasReactRequestScope(pageSlot)) {
       // Opened once per render, then left open: every later check in the same render — including the
       // ones a page issues long after this helper returned — resolves through this slot.
-      if (!slot.context) {
-        slot.context = createSurfaceContext(surface);
-        scheduleChecksPerRequestObservation(slot.context);
+      if (!pageSlot.context) {
+        pageSlot.context = createSurfaceContext(surface);
+        scheduleChecksPerRequestObservation(pageSlot.context);
       }
       return callback();
     }

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -26,6 +26,7 @@ export default defineConfig({
             ".next/**",
             "**/*.integration.test.ts",
             "**/*.test.tsx",
+            "**/*.rsc.test.ts",
           ],
         },
       },
@@ -35,6 +36,27 @@ export default defineConfig({
           name: "components",
           environment: "jsdom",
           include: ["**/*.test.tsx"],
+        },
+      },
+      {
+        // ENG-2444: the `page` authorization surface lives in a React `cache()` slot, and `cache` only
+        // does anything in the react-server build — the default build ships it as a permanent no-op,
+        // and the shared vitestSetup mocks it to identity on top of that. So the `unit` project cannot
+        // exercise this surface at all. Here React resolves the way Next.js resolves it for RSC, so
+        // the real implementation runs. `ssr.resolve.conditions` is the knob that works: Vitest loads
+        // test modules through the SSR environment, so a top-level `resolve.conditions` is ignored.
+        //
+        // Deliberately NOT `extends: true`: that merges the root `setupFiles`, which import
+        // react-dom/client (forbidden under the react-server condition) and mock `cache` away.
+        plugins: [tsconfigPaths()],
+        resolve: { conditions: ["react-server", "node", "import", "default"] },
+        ssr: { resolve: { conditions: ["react-server", "node", "import", "default"] } },
+        test: {
+          name: "rsc",
+          environment: "node",
+          include: ["**/*.rsc.test.ts"],
+          env: loadEnv("", process.cwd(), ""),
+          setupFiles: ["./vitestSetup.rsc.ts"],
         },
       },
     ],

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -49,7 +49,6 @@ export default defineConfig({
         // Deliberately NOT `extends: true`: that merges the root `setupFiles`, which import
         // react-dom/client (forbidden under the react-server condition) and mock `cache` away.
         plugins: [tsconfigPaths()],
-        resolve: { conditions: ["react-server", "node", "import", "default"] },
         ssr: { resolve: { conditions: ["react-server", "node", "import", "default"] } },
         test: {
           name: "rsc",

--- a/apps/web/vitestSetup.rsc.ts
+++ b/apps/web/vitestSetup.rsc.ts
@@ -1,0 +1,16 @@
+import { vi } from "vitest";
+
+/**
+ * Setup for the `rsc` Vitest project (ENG-2444), deliberately NOT the shared `vitestSetup.ts`.
+ *
+ * That file is unusable here for two reasons, and the second is the important one:
+ *
+ * 1. It imports `@testing-library/react`, which pulls `react-dom/client` — React refuses to load it
+ *    under the `react-server` condition.
+ * 2. **It mocks React's `cache` to the identity function** (`const testCache = (func) => func`). That
+ *    is a sensible default for unit tests, and it is exactly what makes the `page` authorization
+ *    surface untestable there: with `cache` stubbed out there is no request scope to hold the slot,
+ *    so the surface always falls back to the async-scoped boundary and the ENG-2444 behaviour never
+ *    runs. Keep this file free of a `react` mock.
+ */
+vi.mock("server-only", () => ({}));


### PR DESCRIPTION
Fixes ENG-2444

## What & why

The `page` authorization surface previously lived only for the awaited choke-point callback. Later authorization checks in the same React server render therefore appeared as `unscoped`, splitting checks-per-request telemetry and hiding the true page-level request boundary.

This PR stores the page context in a real React `cache()` request slot while retaining `AsyncLocalStorage` for API, MCP, gateway, and server-action surfaces.

- Layouts and pages in the same render share one page context and one checks-per-request observation.
- An enclosing non-page surface keeps precedence, including when another wrapper is nested inside the page callback.
- The cached slot factory is pinned on `globalThis`, so duplicated Next.js server bundles share the same React cache key.
- Callers outside a React request scope retain the previous async-scoped fallback.
- The dedicated Vitest RSC project resolves React with the `react-server` condition; the redundant top-level resolver condition has been removed.

The PR is stacked on #8936 because it depends on the direct-authority telemetry introduced by that stack. Merge #8936 first, then retarget this PR to `epic/authzed`.

## Breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Page context survives the choke-point callback for the rest of the React request | unit (mutation): `context.rsc.test.ts` | A later check remains attributed to `page` and is included in the same observation |
| Layout and page checks share one request observation | unit (mutation): `context.rsc.test.ts` | Multiple page scopes produce one callback and the combined check count |
| Nested non-page wrappers cannot split an established page observation | unit (mutation): `context.rsc.test.ts` | The page surface keeps precedence and emits exactly one page metric |
| Concurrent and sequential requests do not leak context | unit (guard): `context.rsc.test.ts` | Each request starts with an independent cached slot |
| API/server-action precedence and non-RSC fallback remain unchanged | unit (guard): `context.test.ts` and `context.rsc.test.ts` | All boundary and fallback cases passed |
| Broader authorization helpers remain compatible | unit (guard): `pnpm --filter @formbricks/web exec vitest run lib/authorization modules/organization/lib modules/workspaces/lib` | 20 files and 156 tests passed |
| AuthZed runtime remains operational after the stacked change | integration: `pnpm authzed:smoke` | Schema lifecycle, projections, user/API-key decisions, revocations, outages, migrations, and persistence passed |
| Schema, types, and formatting remain valid | integration: `pnpm authzed:validate`, web typecheck, and Prettier | All passed; schema validation ran 157 assertions and 6 expected relations |

**Open gaps**

- Browser-level authoritative UI coverage remains owned by ENG-2457 because the shared Playwright workflow does not currently provision SpiceDB.
- Live sandbox validation follows after both stack PRs merge and does not belong to this request-context implementation PR.

**Risks**

- The RSC Vitest project intentionally does not inherit the shared setup that mocks React `cache()` to an identity function; future shared test setup changes may need an explicit RSC equivalent.
- The `globalThis` slot stores only the cache factory, not request data. Request data remains scoped by React's cache dispatcher.

---

> [!NOTE]
> **AI model used** — `GPT-5.6`, reasoning effort `high`.

### Restack status

Rebased cleanly onto reviewed #8936 head `75293099f`; the stacked head is now `43b7c8680`. The authorization-focused suite still passes (20 files, 156 tests). Merge #8936 first, then retarget this PR to `epic/authzed`.