### PR TITLE
feat: make AuthZed relationship delivery durable

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -142,6 +142,10 @@ jobs:
           echo "S3_FORCE_PATH_STYLE=1" >> .env
         shell: bash
 
+      - name: Start AuthZed CI fixture
+        run: bash scripts/start-authzed-ci.sh
+        shell: bash
+
       - name: Start RustFS Server
         run: |
           set -euo pipefail
@@ -382,3 +386,8 @@ jobs:
           else
             echo "app.log not found because the Run App step did not execute or failed before log creation."
           fi
+
+      - name: Output AuthZed logs
+        if: failure()
+        run: docker logs formbricks-authzed-ci 2>&1 || true
+        shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -123,6 +123,11 @@ jobs:
           sed -i "s|PASSWORD_RESET_DISABLED=.*|PASSWORD_RESET_DISABLED=0|" .env
         shell: bash
 
+      - name: Start AuthZed CI fixture
+        if: steps.harness.outputs.present == 'true'
+        run: bash scripts/start-authzed-ci.sh
+        shell: bash
+
       # Build the workspace packages the tests import (@formbricks/logger, cache, types, email, …) so
       # vite can resolve their package.json `exports` → dist. Deps only (`^...`), not the Next app.
       - name: Build workspace package dependencies
@@ -165,4 +170,9 @@ jobs:
         run: cd apps/web && pnpm test:integration
         env:
           TEST_DB_PROVISIONED: "1"
+        shell: bash
+
+      - name: Output AuthZed logs
+        if: failure() && steps.harness.outputs.present == 'true'
+        run: docker logs formbricks-authzed-ci 2>&1 || true
         shell: bash

--- a/apps/web/instrumentation-jobs.test.ts
+++ b/apps/web/instrumentation-jobs.test.ts
@@ -7,6 +7,8 @@ const mockRemoveSurveyArchivePurge = vi.fn();
 const mockUpsertSurveyArchivePurge = vi.fn();
 const mockRemoveWorkflowRunReconcile = vi.fn();
 const mockUpsertWorkflowRunReconcile = vi.fn();
+const mockUpsertAuthzedProjectionDelivery = vi.fn();
+const mockUpsertAuthzedReconciliationAudit = vi.fn();
 const mockDebug = vi.fn();
 const mockError = vi.fn();
 const mockWarn = vi.fn();
@@ -17,6 +19,8 @@ const mockProcessSurveySchedulingJob = vi.fn();
 const mockProcessSurveyArchivePurgeJob = vi.fn();
 const mockProcessWorkflowRunJob = vi.fn();
 const mockProcessWorkflowRunReconcileJob = vi.fn();
+const mockProcessAuthzedProjectionDeliveryJob = vi.fn();
+const mockProcessAuthzedScheduledReconciliationJob = vi.fn();
 const TEST_TIMEOUT_MS = 15_000;
 
 const slowTest = (name: string, fn: () => Promise<void>): void => {
@@ -31,6 +35,18 @@ vi.mock("@formbricks/jobs", () => ({
     workflowRun: "workflow-run.process",
   },
   recurringJobs: {
+    authzedProjectionDelivery: {
+      name: "authzed-projection.deliver",
+      scheduleId: "authzed-projection-delivery",
+      scope: "global",
+      upsert: mockUpsertAuthzedProjectionDelivery,
+    },
+    authzedReconciliationAudit: {
+      name: "authzed-reconciliation.audit",
+      scheduleId: "authzed-reconciliation-audit",
+      scope: "global",
+      upsert: mockUpsertAuthzedReconciliationAudit,
+    },
     surveyArchivePurge: {
       name: "survey-archive-purge.process",
       remove: mockRemoveSurveyArchivePurge,
@@ -88,6 +104,14 @@ vi.mock("@/modules/ee/workflows/lib/runner/process-workflow-run-job", () => ({
 
 vi.mock("@/modules/ee/workflows/lib/runner/process-workflow-run-reconcile-job", () => ({
   processWorkflowRunReconcileJob: mockProcessWorkflowRunReconcileJob,
+}));
+
+vi.mock("@/lib/authzed/outbox-processor", () => ({
+  processAuthzedProjectionDeliveryJob: mockProcessAuthzedProjectionDeliveryJob,
+}));
+
+vi.mock("@/lib/authzed/scheduled-reconciliation", () => ({
+  processAuthzedScheduledReconciliationJob: mockProcessAuthzedScheduledReconciliationJob,
 }));
 
 describe("instrumentation-jobs", () => {
@@ -176,6 +200,8 @@ describe("instrumentation-jobs", () => {
     expect(mockStartJobsRuntime).toHaveBeenCalledWith({
       concurrency: 4,
       jobHandlerOverrides: {
+        "authzed-projection.deliver": expect.any(Function),
+        "authzed-reconciliation.audit": expect.any(Function),
         "response-pipeline.process": expect.any(Function),
         "survey-scheduling.reconcile": expect.any(Function),
         "survey-archive-purge.process": expect.any(Function),
@@ -416,6 +442,16 @@ describe("instrumentation-jobs", () => {
       // The schedule identity and payload now belong to the job declaration in @formbricks/jobs (and are
       // asserted there); what this app owns, and what is asserted here, is the timing per job.
       expect(mockStartJobsRuntime).not.toHaveBeenCalled();
+      expect(mockUpsertAuthzedProjectionDelivery).toHaveBeenCalledOnce();
+      expect(mockUpsertAuthzedProjectionDelivery).toHaveBeenCalledWith({
+        everyMs: 5_000,
+        kind: "every",
+      });
+      expect(mockUpsertAuthzedReconciliationAudit).toHaveBeenCalledOnce();
+      expect(mockUpsertAuthzedReconciliationAudit).toHaveBeenCalledWith({
+        everyMs: 6 * 60 * 60 * 1_000,
+        kind: "every",
+      });
       expect(mockUpsertSurveyScheduling).toHaveBeenCalledTimes(1);
       expect(mockUpsertSurveyScheduling).toHaveBeenCalledWith({
         cronPattern: SURVEY_SCHEDULING_DAILY_CRON_PATTERN,

--- a/apps/web/integration/reset-db.ts
+++ b/apps/web/integration/reset-db.ts
@@ -15,6 +15,13 @@ import { prisma } from "@formbricks/database";
  * INVARIANT: this relies on every table a flow writes being FK-cascade-reachable from one of these
  * three roots. A future flow that writes a non-descendant table (or one with `onDelete: SetNull` /
  * `Restrict`) must be added here, or its rows will bleed across tests.
+ *
+ * `AuthzedProjectionOutbox` is the first table to hit that invariant. It has no foreign keys at all —
+ * the durable projection queue records identifiers by value so a row survives the deletion it
+ * describes — so nothing above cascades to it, and database triggers write to it on every mutation
+ * the three roots cascade through.
  */
 export const resetDb = (): Promise<unknown> =>
-  prisma.$executeRawUnsafe('TRUNCATE "User", "Organization", "Team" RESTART IDENTITY CASCADE;');
+  prisma.$executeRawUnsafe(
+    'TRUNCATE "User", "Organization", "Team", "AuthzedProjectionOutbox" RESTART IDENTITY CASCADE;'
+  );

--- a/apps/web/lib/authorization/resource-inventory.ts
+++ b/apps/web/lib/authorization/resource-inventory.ts
@@ -24,6 +24,7 @@ export const PRISMA_AUTHORIZATION_RESOURCE_INVENTORY = {
   ActionClass: "workspace_inherited_resource",
   ApiKey: "relationship_or_grant_source",
   ApiKeyWorkspace: "relationship_or_grant_source",
+  AuthzedProjectionOutbox: "authentication_or_application",
   Chart: "workspace_inherited_resource",
   Contact: "workspace_inherited_resource",
   ContactAttribute: "parent_derived_or_data_integrity",

--- a/apps/web/lib/authorization/spicedb-evaluator.test.ts
+++ b/apps/web/lib/authorization/spicedb-evaluator.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/lib/constants", () => ({
   },
 }));
 vi.mock("@/lib/authzed/client", () => ({ getAuthzedClient: vi.fn() }));
+vi.mock("@/lib/authzed/outbox-freshness", () => ({ assertAuthzedProjectionFreshness: vi.fn() }));
 vi.mock("./source-scope", () => ({ resolveAuthorizationScope: vi.fn() }));
 
 const checkPermission = vi.fn();

--- a/apps/web/lib/authorization/spicedb-evaluator.ts
+++ b/apps/web/lib/authorization/spicedb-evaluator.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { getAuthzedClient } from "@/lib/authzed/client";
+import { assertAuthzedProjectionFreshness } from "@/lib/authzed/outbox-freshness";
 import { USER_MANAGEMENT_MINIMUM_ROLE } from "@/lib/constants";
 import {
   AUTHORIZATION_PERMISSION_MAP,
@@ -78,6 +79,8 @@ export const checkSpicedbPermissionAtScope = async <TAction extends TAuthorizati
   scope: TResolvedAuthorizationScope
 ): Promise<boolean> => {
   if (!scope.actorValid) return false;
+
+  await assertAuthzedProjectionFreshness();
 
   const permission = getPermission(actor, action, resource.type);
   if (!permission) return false;

--- a/apps/web/lib/authzed/backfill-apply.ts
+++ b/apps/web/lib/authzed/backfill-apply.ts
@@ -1,0 +1,29 @@
+import "server-only";
+import { reconcileApiKeyRelationships } from "./api-key";
+import type { TAuthzedBackfillApply } from "./backfill";
+import {
+  deleteFeedbackDirectoryAssignmentRelationships,
+  reconcileFeedbackDirectoryRelationships,
+} from "./feedback-directory";
+import { reconcileOrganizationMemberships } from "./organization-membership";
+import { reconcileTeamWorkspaceRelationships } from "./team-workspace";
+
+const INERT_RESULT = { passes: 0, status: "projected" } as const;
+
+/** No-op write capability used when the shared orchestrator runs in dry-run mode. */
+export const createAuthzedBackfillNoopApply = (): TAuthzedBackfillApply => ({
+  deleteFeedbackDirectoryAssignmentResources: async () => INERT_RESULT,
+  reconcileApiKeys: async () => INERT_RESULT,
+  reconcileFeedbackDirectories: async () => INERT_RESULT,
+  reconcileMemberships: async () => INERT_RESULT,
+  reconcileTeamWorkspace: async () => INERT_RESULT,
+});
+
+/** Internal write capability shared by the operator CLI and the scheduled attributable repair. */
+export const createAuthzedBackfillApply = (): TAuthzedBackfillApply => ({
+  deleteFeedbackDirectoryAssignmentResources: deleteFeedbackDirectoryAssignmentRelationships,
+  reconcileApiKeys: reconcileApiKeyRelationships,
+  reconcileFeedbackDirectories: reconcileFeedbackDirectoryRelationships,
+  reconcileMemberships: reconcileOrganizationMemberships,
+  reconcileTeamWorkspace: reconcileTeamWorkspaceRelationships,
+});

--- a/apps/web/lib/authzed/backfill-cli.ts
+++ b/apps/web/lib/authzed/backfill-cli.ts
@@ -1,22 +1,16 @@
 import "server-only";
 import { env } from "@/lib/env";
-import { reconcileApiKeyRelationships } from "./api-key";
 import {
   type TAuthzedBackfillApply,
   type TAuthzedBackfillRequest,
   type TAuthzedBackfillResult,
   runAuthzedBackfill,
 } from "./backfill";
+import { createAuthzedBackfillApply, createAuthzedBackfillNoopApply } from "./backfill-apply";
 import type { TAuthzedBackfillCliCommand } from "./backfill-cli-command";
 import { closeAuthzedClient, configureAuthzedClientForBulkWork, getAuthzedClient } from "./client";
 import { isAuthzedEnabled } from "./config";
 import { AUTHZED_ERROR_CODES, AuthzedError, type TAuthzedErrorCode, mapAuthzedError } from "./errors";
-import {
-  deleteFeedbackDirectoryAssignmentRelationships,
-  reconcileFeedbackDirectoryRelationships,
-} from "./feedback-directory";
-import { reconcileOrganizationMemberships } from "./organization-membership";
-import { reconcileTeamWorkspaceRelationships } from "./team-workspace";
 
 export { parseAuthzedBackfillCommand } from "./backfill-cli-command";
 export type { TAuthzedBackfillCliCommand } from "./backfill-cli-command";
@@ -50,25 +44,6 @@ type TAuthzedBackfillCliDependencies = Readonly<{
  * The orchestrator can reach a mutation only through this object, so a dry run supplying
  * `createInertApply()` cannot write regardless of any flag it is passed.
  */
-const createWritableApply = (): TAuthzedBackfillApply => ({
-  deleteFeedbackDirectoryAssignmentResources: deleteFeedbackDirectoryAssignmentRelationships,
-  reconcileApiKeys: reconcileApiKeyRelationships,
-  reconcileFeedbackDirectories: reconcileFeedbackDirectoryRelationships,
-  reconcileMemberships: reconcileOrganizationMemberships,
-  reconcileTeamWorkspace: reconcileTeamWorkspaceRelationships,
-});
-
-const INERT_RESULT = { passes: 0, status: "projected" } as const;
-
-/** No-op reconcilers for a dry run. */
-const createInertApply = (): TAuthzedBackfillApply => ({
-  deleteFeedbackDirectoryAssignmentResources: async () => INERT_RESULT,
-  reconcileApiKeys: async () => INERT_RESULT,
-  reconcileFeedbackDirectories: async () => INERT_RESULT,
-  reconcileMemberships: async () => INERT_RESULT,
-  reconcileTeamWorkspace: async () => INERT_RESULT,
-});
-
 const defaultDependencies: TAuthzedBackfillCliDependencies = {
   closeClient: closeAuthzedClient,
   isEnabled: isAuthzedEnabled,
@@ -159,7 +134,7 @@ export const runAuthzedBackfillCli = async (
           prune: command.prune,
           scope: resolveScope(command),
         },
-        command.mode === "apply" ? createWritableApply() : createInertApply()
+        command.mode === "apply" ? createAuthzedBackfillApply() : createAuthzedBackfillNoopApply()
       );
       exitCode = toExitCode(result.status);
     }

--- a/apps/web/lib/authzed/backfill-source.test.ts
+++ b/apps/web/lib/authzed/backfill-source.test.ts
@@ -9,7 +9,7 @@ import {
   readOrganizationSource,
   readWorkspaceSource,
 } from "./backfill-source";
-import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE } from "./constants";
+import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE, AUTHZED_TARGET_CHUNK_SIZE } from "./constants";
 import { getFeedbackDirectoryAssignmentObjectId } from "./feedback-directory-assignment-id";
 
 vi.mock("node:crypto", async (importOriginal) => importOriginal());
@@ -565,7 +565,7 @@ describe("findMissingSourceRefs", () => {
   test("chunks a large request so the query cannot approach the bind-parameter ceiling", async () => {
     // The composite-key kinds contribute two bind parameters per record, so an unchunked list would build
     // exactly the unbounded OR that the chunk size exists to prevent.
-    const refs = Array.from({ length: AUTHZED_BACKFILL_TARGET_CHUNK_SIZE + 1 }, (_unused, index) => ({
+    const refs = Array.from({ length: AUTHZED_TARGET_CHUNK_SIZE + 1 }, (_unused, index) => ({
       kind: "teamMembership" as const,
       teamId: "team-1",
       userId: `user-${index}`,

--- a/apps/web/lib/authzed/backfill-source.ts
+++ b/apps/web/lib/authzed/backfill-source.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { prisma } from "@formbricks/database";
 import type { TAuthzedParentEdge, TAuthzedSourceRef } from "./backfill-diff";
 import type { TAuthzedRelationship } from "./client";
-import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE } from "./constants";
+import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE, AUTHZED_TARGET_CHUNK_SIZE } from "./constants";
 import { getFeedbackDirectoryAssignmentObjectId } from "./feedback-directory-assignment-id";
 import {
   ORGANIZATION_ACCESS_RELATIONS,
@@ -560,8 +560,8 @@ const inChunks = async <TItem>(
   read: (chunk: ReadonlyArray<TItem>) => Promise<ReadonlyArray<TItem>>
 ): Promise<ReadonlyArray<TItem>> => {
   const collected: TItem[] = [];
-  for (let start = 0; start < items.length; start += AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
-    collected.push(...(await read(items.slice(start, start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE))));
+  for (let start = 0; start < items.length; start += AUTHZED_TARGET_CHUNK_SIZE) {
+    collected.push(...(await read(items.slice(start, start + AUTHZED_TARGET_CHUNK_SIZE))));
   }
 
   return collected;
@@ -581,7 +581,7 @@ const inChunks = async <TItem>(
 export const findMismatchedParentEdges = async (
   edges: ReadonlyArray<TAuthzedParentEdge>
 ): Promise<ReadonlyArray<TAuthzedParentEdge>> => {
-  if (edges.length > AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
+  if (edges.length > AUTHZED_TARGET_CHUNK_SIZE) {
     return inChunks(edges, findMismatchedParentEdges);
   }
 
@@ -661,7 +661,7 @@ export const findMissingSourceRefs = async (
   // parameters per record, so an unchunked list would approach PostgreSQL's parameter ceiling and give
   // the planner an `OR` list it cannot use an index for. One query per kind *per chunk* still keeps the
   // cost proportional to the number of kinds rather than the number of records.
-  if (refs.length > AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
+  if (refs.length > AUTHZED_TARGET_CHUNK_SIZE) {
     return inChunks(refs, findMissingSourceRefs);
   }
 

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -4,9 +4,9 @@ import { type TAuthzedBackfillRequest, runAuthzedBackfill } from "./backfill";
 import * as source from "./backfill-source";
 import type { TAuthzedOrganizationSource } from "./backfill-source";
 import {
-  AUTHZED_BACKFILL_TARGET_CHUNK_SIZE,
   AUTHZED_MAX_RELATIONSHIP_READS,
   AUTHZED_MAX_TRACKED_ORPHAN_REFS,
+  AUTHZED_TARGET_CHUNK_SIZE,
 } from "./constants";
 import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
 
@@ -1080,7 +1080,7 @@ describe("full-scope orphan sweep", () => {
 
 describe("chunking", () => {
   test("splits a large target list so no reconciler receives an unbounded query", async () => {
-    const memberships = Array.from({ length: AUTHZED_BACKFILL_TARGET_CHUNK_SIZE + 1 }, (_unused, index) => ({
+    const memberships = Array.from({ length: AUTHZED_TARGET_CHUNK_SIZE + 1 }, (_unused, index) => ({
       organizationId: "org-1",
       userId: `user-${index}`,
     }));
@@ -1089,9 +1089,7 @@ describe("chunking", () => {
     await runAuthzedBackfill(request(), dependencies);
 
     expect(apply.reconcileMemberships).toHaveBeenCalledTimes(2);
-    expect(apply.reconcileMemberships.mock.calls[0][0].memberships).toHaveLength(
-      AUTHZED_BACKFILL_TARGET_CHUNK_SIZE
-    );
+    expect(apply.reconcileMemberships.mock.calls[0][0].memberships).toHaveLength(AUTHZED_TARGET_CHUNK_SIZE);
     expect(apply.reconcileMemberships.mock.calls[1][0].memberships).toHaveLength(1);
   });
 
@@ -1153,10 +1151,10 @@ describe("chunking", () => {
   });
 
   test("bounds each list independently, so call count follows the longest list", async () => {
-    const teamMemberships = Array.from(
-      { length: AUTHZED_BACKFILL_TARGET_CHUNK_SIZE + 1 },
-      (_unused, index) => ({ teamId: "team-1", userId: `user-${index}` })
-    );
+    const teamMemberships = Array.from({ length: AUTHZED_TARGET_CHUNK_SIZE + 1 }, (_unused, index) => ({
+      teamId: "team-1",
+      userId: `user-${index}`,
+    }));
     vi.mocked(source.readOrganizationSource).mockResolvedValue({
       ...emptySource,
       teamIds: ["team-1"],
@@ -1169,12 +1167,12 @@ describe("chunking", () => {
     // The short list is exhausted by the first call and must not be resent.
     expect(apply.reconcileTeamWorkspace.mock.calls[0][0]).toMatchObject({
       teamIds: ["team-1"],
-      teamMemberships: teamMemberships.slice(0, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE),
+      teamMemberships: teamMemberships.slice(0, AUTHZED_TARGET_CHUNK_SIZE),
     });
     // The short list is exhausted by the first call, so the second must not resend it.
     expect(apply.reconcileTeamWorkspace.mock.calls[1][0]).toMatchObject({
       teamIds: [],
-      teamMemberships: teamMemberships.slice(AUTHZED_BACKFILL_TARGET_CHUNK_SIZE),
+      teamMemberships: teamMemberships.slice(AUTHZED_TARGET_CHUNK_SIZE),
     });
   });
 });

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -29,7 +29,6 @@ import {
 import type { TAuthzedClient, TAuthzedRelationship } from "./client";
 import {
   AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
-  AUTHZED_BACKFILL_TARGET_CHUNK_SIZE,
   AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES,
   AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN,
   AUTHZED_MAX_TRACKED_ORPHAN_REFS,
@@ -39,6 +38,7 @@ import type { TFeedbackDirectoryProjectionTargets } from "./feedback-directory";
 import { getFeedbackDirectoryAssignmentObjectId } from "./feedback-directory-assignment-id";
 import type { TOrganizationMembershipProjectionTargets } from "./organization-membership";
 import type { TAuthzedProjectionResult } from "./projection";
+import { runChunked } from "./projection-chunks";
 import { forEachRelationshipPage, readAllRelationships } from "./relationship-reads";
 import type { TTeamWorkspaceProjectionTargets } from "./team-workspace";
 
@@ -403,56 +403,6 @@ const mergeTargets = (left: TReconcileTargets, right: TReconcileTargets): TRecon
   workspaceIds: [...left.workspaceIds, ...right.workspaceIds],
   workspaceTeamGrants: [...left.workspaceTeamGrants, ...right.workspaceTeamGrants],
 });
-
-/**
- * Run one reconciler over chunked targets, stopping at the first chunk that does not project.
- *
- * A reconciler accepts several target lists at once and reads one PostgreSQL snapshot covering all of
- * them, so every list it understands is passed in a single call. Splitting them would multiply the
- * snapshot reads and the verification passes for no benefit.
- *
- * Chunking bounds each list independently, because each becomes its own `OR` clause in the snapshot
- * query. Call *i* takes chunk *i* of every list, so the number of calls is set by the longest list
- * rather than by their total.
- *
- * Returns `null` when every list was empty, so nothing reaches a reconciler — the write facade rejects
- * an empty update batch.
- */
-const runChunked = async <TTargets extends Readonly<Record<string, ReadonlyArray<unknown>>>>(
-  reconcile: (targets: TTargets) => Promise<TAuthzedProjectionResult>,
-  targets: TTargets
-): Promise<TAuthzedProjectionResult | null> => {
-  type TEntry = readonly [keyof TTargets & string, ReadonlyArray<unknown>];
-  const entries = (Object.entries(targets) as ReadonlyArray<TEntry>).filter(([, items]) => items.length > 0);
-  if (entries.length === 0) {
-    return null;
-  }
-
-  const chunkCount = Math.max(
-    ...entries.map(([, items]) => Math.ceil(items.length / AUTHZED_BACKFILL_TARGET_CHUNK_SIZE))
-  );
-
-  for (let index = 0; index < chunkCount; index++) {
-    const start = index * AUTHZED_BACKFILL_TARGET_CHUNK_SIZE;
-    // Built by narrowing a full target object rather than assembling a partial one and asserting the
-    // type. Every field of the reconcilers' target types is optional, so an assertion would silently
-    // keep compiling if one ever became required — and the missing list would only surface at runtime.
-    const chunkTargets: TTargets = { ...targets };
-    for (const [key, items] of entries) {
-      (chunkTargets as Record<string, ReadonlyArray<unknown>>)[key] = items.slice(
-        start,
-        start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE
-      );
-    }
-
-    const result = await reconcile(chunkTargets);
-    if (result.status !== "projected") {
-      return result;
-    }
-  }
-
-  return { passes: 1, status: "projected" };
-};
 
 /**
  * Reconcile every target list, reporting the first reconciler that did not project.

--- a/apps/web/lib/authzed/constants.ts
+++ b/apps/web/lib/authzed/constants.ts
@@ -66,7 +66,7 @@ export const AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE = 100;
  * PostgreSQL's bound-parameter ceiling. 200 targets also keeps the widest fan-out (4 updates per
  * membership) under `AUTHZED_MAX_RELATIONSHIP_UPDATES`.
  */
-export const AUTHZED_BACKFILL_TARGET_CHUNK_SIZE = 200;
+export const AUTHZED_TARGET_CHUNK_SIZE = 200;
 
 /**
  * Orphaned resources a single run may prune.

--- a/apps/web/lib/authzed/errors.ts
+++ b/apps/web/lib/authzed/errors.ts
@@ -13,6 +13,7 @@ export const AUTHZED_ERROR_CODES = {
   NOT_FOUND: "authzed_not_found",
   OVERLOADED: "authzed_overloaded",
   PERMISSION_DENIED: "authzed_permission_denied",
+  PROJECTION_STALE: "authzed_projection_stale",
   SCHEMA_CHANGED: "authzed_schema_changed",
   SCHEMA_VERIFICATION_FAILED: "authzed_schema_verification_failed",
   TIMEOUT: "authzed_timeout",

--- a/apps/web/lib/authzed/metrics.test.ts
+++ b/apps/web/lib/authzed/metrics.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { AUTHZED_ERROR_CODES } from "./errors";
 
 const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
+const gauges = new Map<string, { record: ReturnType<typeof vi.fn> }>();
 const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
 
 vi.mock("@opentelemetry/api", () => ({
@@ -10,6 +11,11 @@ vi.mock("@opentelemetry/api", () => ({
       createCounter: vi.fn((name: string) => {
         const instrument = { add: vi.fn() };
         counters.set(name, instrument);
+        return instrument;
+      }),
+      createGauge: vi.fn((name: string) => {
+        const instrument = { record: vi.fn() };
+        gauges.set(name, instrument);
         return instrument;
       }),
       createHistogram: vi.fn((name: string) => {
@@ -21,8 +27,12 @@ vi.mock("@opentelemetry/api", () => ({
   },
 }));
 
-const { recordAuthzedProjection, recordAuthzedRequestFailure, recordAuthzedRequestRetry } =
-  await import("./metrics");
+const {
+  recordAuthzedOutboxStatus,
+  recordAuthzedProjection,
+  recordAuthzedRequestFailure,
+  recordAuthzedRequestRetry,
+} = await import("./metrics");
 
 const counter = (name: string) => counters.get(name)!;
 const histogram = (name: string) => histograms.get(name)!;
@@ -32,6 +42,9 @@ beforeEach(() => {
     instrument.add.mockClear();
   }
   for (const instrument of histograms.values()) {
+    instrument.record.mockClear();
+  }
+  for (const instrument of gauges.values()) {
     instrument.record.mockClear();
   }
 });
@@ -116,6 +129,29 @@ describe("recordAuthzedRequestRetry", () => {
   });
 });
 
+describe("recordAuthzedOutboxStatus", () => {
+  test("records point-in-time queue state without identifier attributes", () => {
+    recordAuthzedOutboxStatus({
+      deadLettered: 2,
+      oldestPendingAgeSeconds: 47,
+      pending: 11,
+      revocationsPastCritical: 1,
+      revocationsPastWarning: 3,
+    });
+
+    const status = gauges.get("formbricks_authzed_projection_outbox_status")!;
+    expect(status.record.mock.calls).toEqual([
+      [11, { state: "pending" }],
+      [2, { state: "dead_lettered" }],
+      [3, { state: "revocation_warning" }],
+      [1, { state: "revocation_critical" }],
+    ]);
+    expect(
+      gauges.get("formbricks_authzed_projection_outbox_oldest_pending_age_seconds")!.record
+    ).toHaveBeenCalledWith(47);
+  });
+});
+
 describe("attribute cardinality", () => {
   test("never carries an identifier", () => {
     // These attributes leave the deployment when an OTLP endpoint is configured. An organization or
@@ -132,10 +168,18 @@ describe("attribute cardinality", () => {
       operation: "write_relationships",
       retryable: false,
     });
+    recordAuthzedOutboxStatus({
+      deadLettered: 0,
+      oldestPendingAgeSeconds: null,
+      pending: 1,
+      revocationsPastCritical: 0,
+      revocationsPastWarning: 0,
+    });
 
     const recordedAttributes = [
       ...counter("formbricks_authzed_projection_total").add.mock.calls,
       ...counter("formbricks_authzed_request_failures_total").add.mock.calls,
+      ...gauges.get("formbricks_authzed_projection_outbox_status")!.record.mock.calls,
     ].flatMap(([, attributes]) => Object.keys(attributes as object));
 
     expect([...new Set(recordedAttributes)].sort()).toEqual([
@@ -143,6 +187,7 @@ describe("attribute cardinality", () => {
       "operation",
       "projection",
       "retryable",
+      "state",
       "status",
     ]);
   });

--- a/apps/web/lib/authzed/metrics.ts
+++ b/apps/web/lib/authzed/metrics.ts
@@ -80,6 +80,42 @@ const requestRetriesTotal = meter.createCounter("formbricks_authzed_request_retr
   description: "AuthZed requests retried after a retryable failure",
 });
 
+const outboxDeliveryTotal = meter.createCounter("formbricks_authzed_projection_outbox_delivery_total", {
+  description: "Authorization projection outbox events processed by outcome",
+});
+
+const outboxDeliveryDuration = meter.createHistogram(
+  "formbricks_authzed_projection_outbox_delivery_duration_seconds",
+  {
+    advice: {
+      explicitBucketBoundaries: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+    },
+    description: "Duration of an authorization projection outbox delivery batch",
+    unit: "s",
+  }
+);
+
+const reconciliationAuditTotal = meter.createCounter("formbricks_authzed_reconciliation_audit_total", {
+  description: "Scheduled authorization relationship audits by outcome",
+});
+
+const reconciliationDriftTotal = meter.createCounter("formbricks_authzed_reconciliation_drift_total", {
+  description: "Attributable relationship differences observed by scheduled audits",
+});
+
+const outboxStatus = meter.createGauge("formbricks_authzed_projection_outbox_status", {
+  description: "Point-in-time authorization projection outbox counts by bounded state",
+  unit: "{event}",
+});
+
+const outboxOldestPendingAge = meter.createGauge(
+  "formbricks_authzed_projection_outbox_oldest_pending_age_seconds",
+  {
+    description: "Point-in-time age of the oldest pending authorization projection event",
+    unit: "s",
+  }
+);
+
 export type TAuthzedProjectionMetric = Readonly<{
   durationMs: number;
   operation: string;
@@ -123,4 +159,51 @@ export const recordAuthzedRequestRetry = ({
   operation,
 }: Readonly<{ code: string; operation: string }>): void => {
   requestRetriesTotal.add(1, { code, operation });
+};
+
+export const recordAuthzedOutboxDelivery = ({
+  count,
+  durationMs,
+  status,
+}: Readonly<{
+  count: number;
+  durationMs: number;
+  status: "delivered" | "failed";
+}>): void => {
+  outboxDeliveryTotal.add(count, { status });
+  outboxDeliveryDuration.record(durationMs / 1000, { status });
+};
+
+export const recordAuthzedOutboxStatus = ({
+  deadLettered,
+  oldestPendingAgeSeconds,
+  pending,
+  revocationsPastCritical,
+  revocationsPastWarning,
+}: Readonly<{
+  deadLettered: number;
+  oldestPendingAgeSeconds: number | null;
+  pending: number;
+  revocationsPastCritical: number;
+  revocationsPastWarning: number;
+}>): void => {
+  outboxStatus.record(pending, { state: "pending" });
+  outboxStatus.record(deadLettered, { state: "dead_lettered" });
+  outboxStatus.record(revocationsPastWarning, { state: "revocation_warning" });
+  outboxStatus.record(revocationsPastCritical, { state: "revocation_critical" });
+  outboxOldestPendingAge.record(oldestPendingAgeSeconds ?? 0);
+};
+
+export const recordAuthzedReconciliationAudit = ({
+  drift,
+  failures,
+  status,
+}: Readonly<{
+  drift: number;
+  failures: number;
+  status: "drifted" | "failed" | "reconciled";
+}>): void => {
+  reconciliationAuditTotal.add(1, { status });
+  if (drift > 0) reconciliationDriftTotal.add(drift, { kind: "attributable" });
+  if (failures > 0) reconciliationDriftTotal.add(failures, { kind: "failure" });
 };

--- a/apps/web/lib/authzed/outbox-cli-command.test.ts
+++ b/apps/web/lib/authzed/outbox-cli-command.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { parseAuthzedOutboxCliCommand } from "./outbox-cli-command";
+
+describe("AuthZed outbox CLI command", () => {
+  test.each([
+    [["status"], { action: "status" }],
+    [["replay"], { action: "replay" }],
+    [["drain"], { action: "drain", maxBatches: 100 }],
+    [["drain", "--max-batches=1"], { action: "drain", maxBatches: 1 }],
+    [["drain", "--max-batches=1000"], { action: "drain", maxBatches: 1000 }],
+  ])("parses %j", (args, expected) => {
+    expect(parseAuthzedOutboxCliCommand(args as string[])).toEqual(expected);
+  });
+
+  test.each([
+    [[]],
+    [["unknown"]],
+    [["status", "extra"]],
+    [["replay", "extra"]],
+    [["drain", "--max-batches=0"]],
+    [["drain", "--max-batches=1001"]],
+    [["drain", "--max-batches=1", "--max-batches=2"]],
+  ])("rejects %j", (args) => {
+    expect(parseAuthzedOutboxCliCommand(args)).toBeUndefined();
+  });
+});

--- a/apps/web/lib/authzed/outbox-cli-command.ts
+++ b/apps/web/lib/authzed/outbox-cli-command.ts
@@ -1,0 +1,25 @@
+import "server-only";
+
+export type TAuthzedOutboxCliCommand =
+  | Readonly<{ action: "drain"; maxBatches: number }>
+  | Readonly<{ action: "replay" }>
+  | Readonly<{ action: "status" }>;
+
+const MAX_BATCHES = 1_000;
+
+export const parseAuthzedOutboxCliCommand = (
+  args: ReadonlyArray<string>
+): TAuthzedOutboxCliCommand | undefined => {
+  const [action, ...flags] = args;
+  if (action === "status" || action === "replay") {
+    return flags.length === 0 ? { action } : undefined;
+  }
+  if (action !== "drain") return undefined;
+  if (flags.length === 0) return { action, maxBatches: 100 };
+  if (flags.length !== 1 || !flags[0].startsWith("--max-batches=")) return undefined;
+
+  const value = flags[0].slice("--max-batches=".length);
+  if (!/^[1-9]\d{0,3}$/.test(value)) return undefined;
+  const maxBatches = Number(value);
+  return maxBatches <= MAX_BATCHES ? { action, maxBatches } : undefined;
+};

--- a/apps/web/lib/authzed/outbox-cli.test.ts
+++ b/apps/web/lib/authzed/outbox-cli.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { runAuthzedOutboxCli } from "./outbox-cli";
+
+const dependencies = {
+  closeClient: vi.fn(),
+  drain: vi.fn(),
+  replay: vi.fn(),
+  status: vi.fn(),
+  writeOutput: vi.fn(),
+};
+
+describe("AuthZed outbox CLI", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("prints a healthy identifier-free status", async () => {
+    dependencies.status.mockResolvedValue({
+      deadLettered: 0,
+      oldestPendingAgeSeconds: 4,
+      overdueRevocations: 0,
+      pending: 2,
+      revocationsPastCritical: 0,
+      revocationsPastWarning: 0,
+    });
+
+    await expect(runAuthzedOutboxCli({ action: "status" }, dependencies)).resolves.toBe(0);
+    expect(dependencies.writeOutput).toHaveBeenCalledWith(
+      '{"deadLettered":0,"oldestPendingAgeSeconds":4,"overdueRevocations":0,"pending":2,"revocationsPastCritical":0,"revocationsPastWarning":0,"status":"healthy"}\n'
+    );
+    expect(dependencies.closeClient).toHaveBeenCalledOnce();
+  });
+
+  test("uses exit 2 for stale revocations without exposing rows", async () => {
+    dependencies.status.mockResolvedValue({
+      deadLettered: 1,
+      oldestPendingAgeSeconds: 61,
+      overdueRevocations: 1,
+      pending: 1,
+      revocationsPastCritical: 1,
+      revocationsPastWarning: 1,
+    });
+
+    await expect(runAuthzedOutboxCli({ action: "status" }, dependencies)).resolves.toBe(2);
+    const output = dependencies.writeOutput.mock.calls[0][0] as string;
+    expect(JSON.parse(output)).toEqual({
+      deadLettered: 1,
+      oldestPendingAgeSeconds: 61,
+      overdueRevocations: 1,
+      pending: 1,
+      revocationsPastCritical: 1,
+      revocationsPastWarning: 1,
+      status: "critical",
+    });
+    expect(output).not.toContain("primaryId");
+    expect(output).not.toContain("secondaryId");
+  });
+
+  test("drains and replays with stable exit codes", async () => {
+    dependencies.drain.mockResolvedValue({
+      claimed: 2,
+      deadLettered: 0,
+      delivered: 2,
+      failed: 0,
+      remaining: 0,
+      status: "drained",
+    });
+    dependencies.replay.mockResolvedValue(3);
+
+    await expect(runAuthzedOutboxCli({ action: "drain", maxBatches: 4 }, dependencies)).resolves.toBe(0);
+    expect(dependencies.drain).toHaveBeenCalledWith(4);
+
+    await expect(runAuthzedOutboxCli({ action: "replay" }, dependencies)).resolves.toBe(0);
+    expect(dependencies.writeOutput).toHaveBeenLastCalledWith('{"replayed":3,"status":"replayed"}\n');
+  });
+
+  test("sanitizes unexpected failures", async () => {
+    dependencies.status.mockRejectedValue(new Error("token and row identifier"));
+
+    await expect(runAuthzedOutboxCli({ action: "status" }, dependencies)).resolves.toBe(1);
+    expect(dependencies.writeOutput).toHaveBeenCalledWith(
+      '{"code":"authzed_internal","retryable":false,"status":"failed"}\n'
+    );
+  });
+});

--- a/apps/web/lib/authzed/outbox-cli.ts
+++ b/apps/web/lib/authzed/outbox-cli.ts
@@ -1,0 +1,66 @@
+import "server-only";
+import { closeAuthzedClient } from "./client";
+import type { TAuthzedOutboxCliCommand } from "./outbox-cli-command";
+import { drainAuthzedOutbox } from "./outbox-processor";
+import { getAuthzedOutboxStatus, replayAuthzedOutboxDeadLetters } from "./outbox-repository";
+
+type TOutboxCliDependencies = Readonly<{
+  closeClient: () => void;
+  drain: typeof drainAuthzedOutbox;
+  replay: typeof replayAuthzedOutboxDeadLetters;
+  status: typeof getAuthzedOutboxStatus;
+  writeOutput: (output: string) => void;
+}>;
+
+const defaultDependencies: TOutboxCliDependencies = {
+  closeClient: closeAuthzedClient,
+  drain: drainAuthzedOutbox,
+  replay: replayAuthzedOutboxDeadLetters,
+  status: getAuthzedOutboxStatus,
+  writeOutput: (output) => process.stdout.write(output),
+};
+
+export const runAuthzedOutboxCli = async (
+  command: TAuthzedOutboxCliCommand,
+  overrides: Partial<TOutboxCliDependencies> = {}
+): Promise<number> => {
+  const dependencies = { ...defaultDependencies, ...overrides };
+  let result: object;
+  let exitCode = 1;
+
+  try {
+    switch (command.action) {
+      case "status": {
+        const status = await dependencies.status();
+        const health =
+          status.deadLettered > 0 || status.revocationsPastCritical > 0
+            ? "critical"
+            : status.revocationsPastWarning > 0
+              ? "warning"
+              : "healthy";
+        result = { ...status, status: health };
+        exitCode = health === "healthy" ? 0 : 2;
+        break;
+      }
+      case "drain": {
+        const drainResult = await dependencies.drain(command.maxBatches);
+        result = drainResult;
+        exitCode = drainResult.status === "drained" ? 0 : 2;
+        break;
+      }
+      case "replay": {
+        result = { replayed: await dependencies.replay(), status: "replayed" };
+        exitCode = 0;
+        break;
+      }
+    }
+  } catch {
+    result = { code: "authzed_internal", retryable: false, status: "failed" };
+    exitCode = 1;
+  } finally {
+    dependencies.closeClient();
+  }
+
+  dependencies.writeOutput(`${JSON.stringify(result)}\n`);
+  return exitCode;
+};

--- a/apps/web/lib/authzed/outbox-freshness.test.ts
+++ b/apps/web/lib/authzed/outbox-freshness.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { hasStaleAuthzedRevocation } from "./outbox-repository";
+
+vi.mock("react", () => ({ cache: <T extends (...args: never[]) => unknown>(fn: T) => fn }));
+vi.mock("./outbox-repository", () => ({ hasStaleAuthzedRevocation: vi.fn() }));
+
+describe("AuthZed projection freshness guard", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("allows a fresh graph", async () => {
+    vi.mocked(hasStaleAuthzedRevocation).mockResolvedValue(false);
+    const { assertAuthzedProjectionFreshness } = await import("./outbox-freshness");
+    await expect(assertAuthzedProjectionFreshness()).resolves.toBeUndefined();
+  });
+
+  test("fails closed for an overdue or dead-letter revocation", async () => {
+    vi.mocked(hasStaleAuthzedRevocation).mockResolvedValue(true);
+    const { assertAuthzedProjectionFreshness } = await import("./outbox-freshness");
+    await expect(assertAuthzedProjectionFreshness()).rejects.toMatchObject({
+      code: "authzed_projection_stale",
+      retryable: false,
+    });
+  });
+});

--- a/apps/web/lib/authzed/outbox-freshness.test.ts
+++ b/apps/web/lib/authzed/outbox-freshness.test.ts
@@ -1,24 +1,80 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { hasStaleAuthzedRevocation } from "./outbox-repository";
 
-vi.mock("react", () => ({ cache: <T extends (...args: never[]) => unknown>(fn: T) => fn }));
 vi.mock("./outbox-repository", () => ({ hasStaleAuthzedRevocation: vi.fn() }));
+
+/**
+ * Each test imports the module fresh, because the memo is module state on purpose: React's `cache()`
+ * used to sit here and silently did nothing in Route Handlers, which is where nine of the eleven
+ * rollout targets live.
+ */
+const loadGuard = async () => {
+  vi.resetModules();
+  return import("./outbox-freshness");
+};
 
 describe("AuthZed projection freshness guard", () => {
   beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
 
   test("allows a fresh graph", async () => {
     vi.mocked(hasStaleAuthzedRevocation).mockResolvedValue(false);
-    const { assertAuthzedProjectionFreshness } = await import("./outbox-freshness");
+    const { assertAuthzedProjectionFreshness } = await loadGuard();
+
     await expect(assertAuthzedProjectionFreshness()).resolves.toBeUndefined();
   });
 
   test("fails closed for an overdue or dead-letter revocation", async () => {
     vi.mocked(hasStaleAuthzedRevocation).mockResolvedValue(true);
-    const { assertAuthzedProjectionFreshness } = await import("./outbox-freshness");
+    const { assertAuthzedProjectionFreshness } = await loadGuard();
+
     await expect(assertAuthzedProjectionFreshness()).rejects.toMatchObject({
       code: "authzed_projection_stale",
       retryable: false,
     });
+  });
+
+  test("collapses a fan-out of concurrent checks into one query", async () => {
+    // A request makes many checks — three for workspace navigation, one per directory in the
+    // feedback-directory fan-out — and they all start before any of them finishes.
+    let release: (stale: boolean) => void = () => undefined;
+    vi.mocked(hasStaleAuthzedRevocation).mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        release = resolve;
+      })
+    );
+    const { assertAuthzedProjectionFreshness } = await loadGuard();
+
+    const checks = Promise.all(Array.from({ length: 5 }, () => assertAuthzedProjectionFreshness()));
+    release(false);
+
+    await expect(checks).resolves.toHaveLength(5);
+    expect(hasStaleAuthzedRevocation).toHaveBeenCalledOnce();
+  });
+
+  test("re-reads once the memo window has elapsed", async () => {
+    vi.useFakeTimers();
+    vi.mocked(hasStaleAuthzedRevocation).mockResolvedValue(false);
+    const { AUTHZED_FRESHNESS_MEMO_TTL_MS, assertAuthzedProjectionFreshness } = await loadGuard();
+
+    await assertAuthzedProjectionFreshness();
+    await assertAuthzedProjectionFreshness();
+    expect(hasStaleAuthzedRevocation).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(AUTHZED_FRESHNESS_MEMO_TTL_MS);
+    await assertAuthzedProjectionFreshness();
+    expect(hasStaleAuthzedRevocation).toHaveBeenCalledTimes(2);
+  });
+
+  test("keeps denying rather than memoizing a failed read", async () => {
+    vi.mocked(hasStaleAuthzedRevocation)
+      .mockRejectedValueOnce(new Error("connection terminated"))
+      .mockResolvedValue(false);
+    const { assertAuthzedProjectionFreshness } = await loadGuard();
+
+    await expect(assertAuthzedProjectionFreshness()).rejects.toThrow("connection terminated");
+    // The rejection is not an answer, so the next check must ask again rather than reuse it.
+    await expect(assertAuthzedProjectionFreshness()).resolves.toBeUndefined();
+    expect(hasStaleAuthzedRevocation).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/lib/authzed/outbox-freshness.test.ts
+++ b/apps/web/lib/authzed/outbox-freshness.test.ts
@@ -53,7 +53,9 @@ describe("AuthZed projection freshness guard", () => {
   });
 
   test("re-reads once the memo window has elapsed", async () => {
-    vi.useFakeTimers();
+    // `performance` is not in vitest's default `toFake` set, and the memo reads it rather than
+    // `Date.now()` so a backwards clock step cannot freeze the guard.
+    vi.useFakeTimers({ toFake: ["performance"] });
     vi.mocked(hasStaleAuthzedRevocation).mockResolvedValue(false);
     const { AUTHZED_FRESHNESS_MEMO_TTL_MS, assertAuthzedProjectionFreshness } = await loadGuard();
 

--- a/apps/web/lib/authzed/outbox-freshness.ts
+++ b/apps/web/lib/authzed/outbox-freshness.ts
@@ -18,19 +18,23 @@ import { hasStaleAuthzedRevocation } from "./outbox-repository";
  */
 export const AUTHZED_FRESHNESS_MEMO_TTL_MS = 1_000;
 
+// Monotonic on purpose. `Date.now()` steps backwards on an NTP correction, a VM resume, or a host
+// booting from a bad RTC, and a negative elapsed time is always under the TTL — which would freeze
+// this answer, in whichever direction it happened to hold, for the entire duration of the step. That
+// is the one way the bound below could be exceeded without limit, on every process sharing the clock.
 let memoizedAt = Number.NEGATIVE_INFINITY;
 let memoizedValue = false;
 let inFlight: Promise<boolean> | null = null;
 
 const readStaleness = (): Promise<boolean> => {
-  if (Date.now() - memoizedAt < AUTHZED_FRESHNESS_MEMO_TTL_MS) return Promise.resolve(memoizedValue);
+  if (performance.now() - memoizedAt < AUTHZED_FRESHNESS_MEMO_TTL_MS) return Promise.resolve(memoizedValue);
 
   // Concurrent checks share one read. A value-only memo would not collapse a fan-out, because every
   // check in it starts before any of them has finished.
   inFlight ??= hasStaleAuthzedRevocation()
     .then((stale) => {
       memoizedValue = stale;
-      memoizedAt = Date.now();
+      memoizedAt = performance.now();
       return stale;
     })
     // Deliberately not memoized on rejection: a failed read must keep denying, not be cached as an

--- a/apps/web/lib/authzed/outbox-freshness.ts
+++ b/apps/web/lib/authzed/outbox-freshness.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import { cache } from "react";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+import { hasStaleAuthzedRevocation } from "./outbox-repository";
+
+const getRequestCachedStaleness = cache(hasStaleAuthzedRevocation);
+
+/**
+ * Refuse to authorize from a graph that may still contain access revoked in PostgreSQL.
+ *
+ * This is deliberately called only by the SpiceDB evaluator. The bridge release keeps the legacy
+ * evaluator authoritative while the durable queue is populated and drained; direct authority fails
+ * closed once a revocation is older than the bounded delivery window or has entered dead letter.
+ */
+export const assertAuthzedProjectionFreshness = async (): Promise<void> => {
+  if (!(await getRequestCachedStaleness())) return;
+
+  throw new AuthzedError({
+    attempts: 0,
+    code: AUTHZED_ERROR_CODES.PROJECTION_STALE,
+    operation: "authorization_projection_freshness",
+    retryable: false,
+  });
+};

--- a/apps/web/lib/authzed/outbox-freshness.ts
+++ b/apps/web/lib/authzed/outbox-freshness.ts
@@ -1,9 +1,46 @@
 import "server-only";
-import { cache } from "react";
 import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
 import { hasStaleAuthzedRevocation } from "./outbox-repository";
 
-const getRequestCachedStaleness = cache(hasStaleAuthzedRevocation);
+/**
+ * How long one staleness answer is reused across authorization checks.
+ *
+ * React's `cache()` was here and did almost nothing: the Route Handler runtime carries no cache
+ * dispatcher, so `cache` falls through to a plain call there — and nine of the eleven rollout targets
+ * are Route-Handler-only. Every authorization check therefore paid its own PostgreSQL round trip, and
+ * a request makes many checks: three for workspace navigation, one per access item in the action
+ * client, one per directory in the feedback-directory fan-out.
+ *
+ * A short process-wide memo dedupes across all of them, including the surfaces that open no
+ * authorization context at all and the shadow comparisons that run after the response. The cost is
+ * bounded and explicit: the guard can arm up to this much later than the sixty-second window it
+ * enforces.
+ */
+export const AUTHZED_FRESHNESS_MEMO_TTL_MS = 1_000;
+
+let memoizedAt = Number.NEGATIVE_INFINITY;
+let memoizedValue = false;
+let inFlight: Promise<boolean> | null = null;
+
+const readStaleness = (): Promise<boolean> => {
+  if (Date.now() - memoizedAt < AUTHZED_FRESHNESS_MEMO_TTL_MS) return Promise.resolve(memoizedValue);
+
+  // Concurrent checks share one read. A value-only memo would not collapse a fan-out, because every
+  // check in it starts before any of them has finished.
+  inFlight ??= hasStaleAuthzedRevocation()
+    .then((stale) => {
+      memoizedValue = stale;
+      memoizedAt = Date.now();
+      return stale;
+    })
+    // Deliberately not memoized on rejection: a failed read must keep denying, not be cached as an
+    // answer. Clearing the slot here also lets the next check retry rather than reuse the rejection.
+    .finally(() => {
+      inFlight = null;
+    });
+
+  return inFlight;
+};
 
 /**
  * Refuse to authorize from a graph that may still contain access revoked in PostgreSQL.
@@ -13,7 +50,7 @@ const getRequestCachedStaleness = cache(hasStaleAuthzedRevocation);
  * closed once a revocation is older than the bounded delivery window or has entered dead letter.
  */
 export const assertAuthzedProjectionFreshness = async (): Promise<void> => {
-  if (!(await getRequestCachedStaleness())) return;
+  if (!(await readStaleness())) return;
 
   throw new AuthzedError({
     attempts: 0,

--- a/apps/web/lib/authzed/outbox-migration.test.ts
+++ b/apps/web/lib/authzed/outbox-migration.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+const migration = readFileSync(
+  new URL(
+    "../../../../packages/database/migration/20260818120000_add_authzed_projection_outbox/migration.sql",
+    import.meta.url
+  ),
+  "utf8"
+);
+
+describe("AuthZed projection outbox migration contract", () => {
+  test("covers every authorization relationship source table", () => {
+    const sourceTables = [
+      "ApiKey",
+      "ApiKeyWorkspace",
+      "FeedbackDirectory",
+      "FeedbackDirectoryWorkspace",
+      "Membership",
+      "Organization",
+      "Team",
+      "TeamUser",
+      "User",
+      "Workspace",
+      "WorkspaceTeam",
+    ];
+
+    for (const sourceTable of sourceTables) {
+      expect(migration).toContain(` ON "${sourceTable}"`);
+    }
+    expect(migration.match(/CREATE TRIGGER/g)).toHaveLength(sourceTables.length);
+  });
+
+  test("enqueues the previous relationship key as a revocation when a source pair moves", () => {
+    expect(migration).toContain(
+      "previous_source ->> primary_field IS DISTINCT FROM source ->> primary_field"
+    );
+    expect(migration).toContain(
+      "previous_source ->> secondary_field IS DISTINCT FROM source ->> secondary_field"
+    );
+    expect(migration).toContain("previous_source ->> primary_field");
+    expect(migration).toMatch(/previous_source[\s\S]*?true,[\s\S]*?NOW\(\)/);
+  });
+
+  test("marks all updates and deletes as revocations and ignores non-authorization updates", () => {
+    expect(migration).toContain("TG_OP <> 'INSERT'");
+    expect(migration).toContain('UPDATE OF "role", "accepted", "organizationId", "userId"');
+    expect(migration).toContain('UPDATE OF "permission", "workspaceId", "teamId"');
+    expect(migration).toContain('UPDATE OF "permission", "apiKeyId", "workspaceId"');
+    expect(migration).not.toContain('UPDATE OF "lastUsedAt"');
+  });
+
+  test("is safe to rerun after a development schema push", () => {
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS "AuthzedProjectionOutbox"');
+    expect(migration.match(/DROP TRIGGER IF EXISTS/g)).toHaveLength(11);
+    expect(migration).toContain("CREATE OR REPLACE FUNCTION enqueue_authzed_projection()");
+  });
+});

--- a/apps/web/lib/authzed/outbox-migration.test.ts
+++ b/apps/web/lib/authzed/outbox-migration.test.ts
@@ -42,17 +42,36 @@ describe("AuthZed projection outbox migration contract", () => {
     expect(migration).toMatch(/previous_source[\s\S]*?true,[\s\S]*?NOW\(\)/);
   });
 
-  test("marks all updates and deletes as revocations and ignores non-authorization updates", () => {
-    expect(migration).toContain("TG_OP <> 'INSERT'");
+  test("watches only the columns that can change a projected relationship", () => {
     expect(migration).toContain('UPDATE OF "role", "accepted", "organizationId", "userId"');
     expect(migration).toContain('UPDATE OF "permission", "workspaceId", "teamId"');
     expect(migration).toContain('UPDATE OF "permission", "apiKeyId", "workspaceId"');
     expect(migration).not.toContain('UPDATE OF "lastUsedAt"');
   });
 
+  // Whether the classifier is *correct* is only observable against a real PostgreSQL, so the
+  // transition table lives in outbox-trigger.integration.test.ts. What a text assertion can see, and
+  // a runtime one cannot, is that no future target type is added without a deliberate decision:
+  // the CASE has no catch-all beyond `ELSE false`, so an unmapped type is a revocation.
+  test("classifies updates through a deny-by-default grant predicate", () => {
+    expect(migration).toContain("CREATE OR REPLACE FUNCTION authzed_projection_is_grant(");
+    expect(migration).toContain("ELSE NOT authzed_projection_is_grant(target_type, previous_source, source)");
+    expect(migration).toContain("ELSE false");
+    expect(migration).not.toContain("TG_OP <> 'INSERT'");
+  });
+
+  test("keeps every hot-path index off the seven days of retained history", () => {
+    const createIndexStatements = migration.match(/CREATE INDEX IF NOT EXISTS[\s\S]*?;/g) ?? [];
+    expect(createIndexStatements).not.toHaveLength(0);
+    for (const statement of createIndexStatements) {
+      expect(statement).toMatch(/WHERE "processedAt" IS (NULL|NOT NULL)/);
+    }
+  });
+
   test("is safe to rerun after a development schema push", () => {
     expect(migration).toContain('CREATE TABLE IF NOT EXISTS "AuthzedProjectionOutbox"');
     expect(migration.match(/DROP TRIGGER IF EXISTS/g)).toHaveLength(11);
     expect(migration).toContain("CREATE OR REPLACE FUNCTION enqueue_authzed_projection()");
+    expect(migration).toContain('ADD COLUMN IF NOT EXISTS "permanentFailures"');
   });
 });

--- a/apps/web/lib/authzed/outbox-processor.test.ts
+++ b/apps/web/lib/authzed/outbox-processor.test.ts
@@ -8,7 +8,11 @@ import {
   deleteUserOrganizationRelationships,
   reconcileOrganizationMemberships,
 } from "./organization-membership";
-import { processAuthzedOutboxBatch, processAuthzedProjectionDeliveryJob } from "./outbox-processor";
+import {
+  drainAuthzedOutbox,
+  processAuthzedOutboxBatch,
+  processAuthzedProjectionDeliveryJob,
+} from "./outbox-processor";
 import {
   claimAuthzedOutboxEvents,
   getAuthzedOutboxStatus,
@@ -21,7 +25,7 @@ import { deleteUserTeamRelationships, reconcileTeamWorkspaceRelationships } from
 vi.mock("@formbricks/database", () => ({
   prisma: {
     organization: { findMany: vi.fn() },
-    user: { findUnique: vi.fn() },
+    user: { findMany: vi.fn() },
   },
 }));
 vi.mock("@formbricks/logger", () => ({ logger: { warn: vi.fn() } }));
@@ -51,6 +55,10 @@ vi.mock("./team-workspace", () => ({
 }));
 
 const projected = { passes: 1, status: "projected" } as const;
+
+const failed = (code: string, retryable: boolean) =>
+  ({ attempts: 3, code, retryable, status: "failed" }) as const;
+
 const event = (
   targetType: TAuthzedOutboxTargetType,
   primaryId: string,
@@ -65,6 +73,28 @@ const event = (
   targetType,
 });
 
+/** Every target type, one event each, in the order `buildDeliveryGroups` consumes them. */
+const everyTarget = (): ReadonlyArray<TAuthzedOutboxEvent> => [
+  event("organization", "org"),
+  event("membership", "org", "user"),
+  event("user", "deleted-user"),
+  event("team", "team"),
+  event("team_membership", "team", "user"),
+  event("workspace", "workspace"),
+  event("workspace_team", "workspace", "team"),
+  event("api_key", "key"),
+  event("api_key_workspace", "key", "workspace"),
+  event("feedback_directory", "directory"),
+  event("feedback_directory_assignment", "directory", "workspace"),
+];
+
+const sorted = (ids: ReadonlyArray<string>): ReadonlyArray<string> =>
+  [...ids].sort((left, right) => left.localeCompare(right));
+
+/** Sorted because delivery reports in group order, which is not the order events were claimed in. */
+const deliveredIds = (): ReadonlyArray<string> =>
+  sorted(vi.mocked(markAuthzedOutboxEventsDelivered).mock.calls.flatMap(([, ids]) => [...ids]));
+
 describe("AuthZed projection outbox processor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -77,7 +107,7 @@ describe("AuthZed projection outbox processor", () => {
     vi.mocked(reconcileApiKeyRelationships).mockResolvedValue(projected);
     vi.mocked(reconcileFeedbackDirectoryRelationships).mockResolvedValue(projected);
     vi.mocked(prisma.organization.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.user.findMany).mockResolvedValue([]);
     vi.mocked(markAuthzedOutboxEventsFailed).mockResolvedValue(0);
     vi.mocked(getAuthzedOutboxStatus).mockResolvedValue({
       deadLettered: 0,
@@ -90,19 +120,7 @@ describe("AuthZed projection outbox processor", () => {
   });
 
   test("maps every durable target to the existing idempotent reconcilers", async () => {
-    const events = [
-      event("organization", "org"),
-      event("membership", "org", "user"),
-      event("user", "deleted-user"),
-      event("team", "team"),
-      event("team_membership", "team", "user"),
-      event("workspace", "workspace"),
-      event("workspace_team", "workspace", "team"),
-      event("api_key", "key"),
-      event("api_key_workspace", "key", "workspace"),
-      event("feedback_directory", "directory"),
-      event("feedback_directory_assignment", "directory", "workspace"),
-    ];
+    const events = everyTarget();
     vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue(events);
 
     await expect(processAuthzedOutboxBatch("lease")).resolves.toEqual({
@@ -132,24 +150,177 @@ describe("AuthZed projection outbox processor", () => {
       assignments: [{ feedbackDirectoryId: "directory", workspaceId: "workspace" }],
       feedbackDirectoryIds: ["directory"],
     });
-    expect(markAuthzedOutboxEventsDelivered).toHaveBeenCalledWith(
+    expect(deliveredIds()).toEqual(sorted(events.map(({ id }) => id)));
+  });
+
+  test("delivers every healthy group when one of them fails", async () => {
+    const events = everyTarget();
+    vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue(events);
+    vi.mocked(reconcileApiKeyRelationships).mockResolvedValue(failed("authzed_internal", false));
+
+    await expect(processAuthzedOutboxBatch("lease")).resolves.toMatchObject({
+      delivered: 9,
+      failed: 2,
+    });
+
+    const apiKeyIds = events
+      .filter(({ targetType }) => targetType === "api_key" || targetType === "api_key_workspace")
+      .map(({ id }) => id);
+    expect(deliveredIds()).toEqual(
+      sorted(events.filter(({ id }) => !apiKeyIds.includes(id)).map(({ id }) => id))
+    );
+    expect(markAuthzedOutboxEventsFailed).toHaveBeenCalledWith("lease", apiKeyIds, "authzed_internal", {
+      isolated: false,
+      retryable: false,
+    });
+  });
+
+  test("stops spending retry budget once a fault is known to be transient", async () => {
+    vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue(everyTarget());
+    // The membership group runs first, so a retryable failure there must release the rest untried.
+    vi.mocked(reconcileOrganizationMemberships).mockResolvedValue(failed("authzed_unavailable", true));
+
+    await expect(processAuthzedOutboxBatch("lease")).resolves.toMatchObject({ delivered: 0, failed: 11 });
+
+    expect(reconcileTeamWorkspaceRelationships).not.toHaveBeenCalled();
+    expect(reconcileApiKeyRelationships).not.toHaveBeenCalled();
+    expect(reconcileFeedbackDirectoryRelationships).not.toHaveBeenCalled();
+    // Nothing here earned a permanent failure: dead-lettering needs `!retryable && isolated`, and a
+    // transient fault never satisfies the first half however the events happened to be grouped.
+    for (const [, , , attribution] of vi.mocked(markAuthzedOutboxEventsFailed).mock.calls) {
+      expect(attribution).toMatchObject({ retryable: true });
+    }
+  });
+
+  test("keeps going when a failure is local to one group", async () => {
+    vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue(everyTarget());
+    vi.mocked(reconcileOrganizationMemberships).mockResolvedValue(failed("authzed_internal", false));
+
+    await processAuthzedOutboxBatch("lease");
+
+    expect(reconcileTeamWorkspaceRelationships).toHaveBeenCalled();
+    expect(reconcileApiKeyRelationships).toHaveBeenCalled();
+    expect(reconcileFeedbackDirectoryRelationships).toHaveBeenCalled();
+  });
+
+  test("treats an unstable source snapshot as transient rather than as a poison event", async () => {
+    vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue([event("membership", "org", "user")]);
+    // The projector reports this as non-retryable, but it means the row moved under the reconciler.
+    vi.mocked(reconcileOrganizationMemberships).mockResolvedValue(
+      failed("authzed_projection_unstable", false)
+    );
+
+    await processAuthzedOutboxBatch("lease");
+
+    expect(markAuthzedOutboxEventsFailed).toHaveBeenCalledWith(
       "lease",
-      events.map(({ id }) => id)
+      ["membership-org-user"],
+      "authzed_projection_unstable",
+      // Retryable is what matters: it is what keeps the event out of the dead-letter budget.
+      { isolated: true, retryable: true }
     );
   });
 
-  test("releases a failed lease for retry without logging identifiers", async () => {
-    const events = [event("membership", "private-org", "private-user")];
+  test("isolates the one event a per-event failure is attributable to", async () => {
+    const events = ["a", "b", "c", "d"].map((suffix) =>
+      event("feedback_directory_assignment", `directory-${suffix}`, "workspace")
+    );
+    const poison = events[2];
     vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue(events);
-    vi.mocked(reconcileOrganizationMemberships).mockResolvedValue({
-      attempts: 3,
-      code: "authzed_unavailable",
-      retryable: true,
-      status: "failed",
-    });
+    vi.mocked(reconcileFeedbackDirectoryRelationships).mockImplementation(({ assignments }) =>
+      Promise.resolve(
+        (assignments ?? []).some(({ feedbackDirectoryId }) => feedbackDirectoryId === poison.primaryId)
+          ? failed("authzed_projection_invalid_source", false)
+          : projected
+      )
+    );
 
-    await expect(processAuthzedOutboxBatch("lease")).resolves.toMatchObject({ failed: 1 });
-    expect(markAuthzedOutboxEventsFailed).toHaveBeenCalledWith("lease", events, "authzed_unavailable");
+    await expect(processAuthzedOutboxBatch("lease")).resolves.toMatchObject({ delivered: 3, failed: 1 });
+
+    expect(deliveredIds()).toEqual(sorted(events.filter(({ id }) => id !== poison.id).map(({ id }) => id)));
+    expect(markAuthzedOutboxEventsFailed).toHaveBeenCalledWith(
+      "lease",
+      [poison.id],
+      "authzed_projection_invalid_source",
+      { isolated: true, retryable: false }
+    );
+  });
+
+  test("does not split a group for a failure that describes the instance", async () => {
+    const events = ["a", "b", "c", "d"].map((suffix) =>
+      event("feedback_directory_assignment", `directory-${suffix}`, "workspace")
+    );
+    vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue(events);
+    vi.mocked(reconcileFeedbackDirectoryRelationships).mockResolvedValue(failed("authzed_internal", false));
+
+    await processAuthzedOutboxBatch("lease");
+
+    // One call, not the 2N a blind split would spend every five seconds against a broken instance.
+    expect(reconcileFeedbackDirectoryRelationships).toHaveBeenCalledOnce();
+    expect(markAuthzedOutboxEventsFailed).toHaveBeenCalledWith(
+      "lease",
+      events.map(({ id }) => id),
+      "authzed_internal",
+      { isolated: false, retryable: false }
+    );
+  });
+
+  test("reads every claimed user once and treats a missing row as inactive", async () => {
+    vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue([
+      event("user", "active-one"),
+      event("user", "active-two"),
+      event("user", "active-two"),
+      event("user", "gone"),
+    ]);
+    vi.mocked(prisma.user.findMany).mockResolvedValue([
+      {
+        id: "active-one",
+        isActive: true,
+        memberships: [{ organizationId: "org-1" }],
+        teamUsers: [{ teamId: "team-1" }],
+      },
+      {
+        id: "active-two",
+        isActive: true,
+        memberships: [{ organizationId: "org-2" }],
+        teamUsers: [],
+      },
+    ] as never);
+
+    await processAuthzedOutboxBatch("lease");
+
+    expect(prisma.user.findMany).toHaveBeenCalledOnce();
+    expect(vi.mocked(prisma.user.findMany).mock.calls[0][0]).toMatchObject({
+      where: { id: { in: ["active-one", "active-two", "gone"] } },
+    });
+    expect(deleteUserOrganizationRelationships).toHaveBeenCalledExactlyOnceWith("gone");
+    expect(deleteUserTeamRelationships).toHaveBeenCalledExactlyOnceWith("gone");
+    expect(reconcileOrganizationMemberships).toHaveBeenCalledExactlyOnceWith({
+      memberships: [
+        { organizationId: "org-1", userId: "active-one" },
+        { organizationId: "org-2", userId: "active-two" },
+      ],
+    });
+    expect(reconcileTeamWorkspaceRelationships).toHaveBeenCalledExactlyOnceWith({
+      teamMemberships: [{ teamId: "team-1", userId: "active-one" }],
+    });
+  });
+
+  test("keeps draining while batches make progress and stops when one makes none", async () => {
+    const events = [event("membership", "org", "user")];
+    vi.mocked(claimAuthzedOutboxEvents)
+      .mockResolvedValueOnce(events)
+      .mockResolvedValueOnce(events)
+      .mockResolvedValueOnce([]);
+
+    await drainAuthzedOutbox(10);
+    expect(claimAuthzedOutboxEvents).toHaveBeenCalledTimes(3);
+
+    vi.mocked(claimAuthzedOutboxEvents).mockReset().mockResolvedValue(events);
+    vi.mocked(reconcileOrganizationMemberships).mockResolvedValue(failed("authzed_unavailable", true));
+
+    await drainAuthzedOutbox(10);
+    expect(claimAuthzedOutboxEvents).toHaveBeenCalledOnce();
   });
 
   test("does not touch PostgreSQL when AuthZed is disabled", async () => {

--- a/apps/web/lib/authzed/outbox-processor.test.ts
+++ b/apps/web/lib/authzed/outbox-processor.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { reconcileApiKeyRelationships } from "./api-key";
+import { isAuthzedEnabled } from "./config";
+import { reconcileFeedbackDirectoryRelationships } from "./feedback-directory";
+import {
+  deleteOrganizationRelationships,
+  deleteUserOrganizationRelationships,
+  reconcileOrganizationMemberships,
+} from "./organization-membership";
+import { processAuthzedOutboxBatch, processAuthzedProjectionDeliveryJob } from "./outbox-processor";
+import {
+  claimAuthzedOutboxEvents,
+  getAuthzedOutboxStatus,
+  markAuthzedOutboxEventsDelivered,
+  markAuthzedOutboxEventsFailed,
+} from "./outbox-repository";
+import type { TAuthzedOutboxEvent, TAuthzedOutboxTargetType } from "./outbox-types";
+import { deleteUserTeamRelationships, reconcileTeamWorkspaceRelationships } from "./team-workspace";
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    organization: { findMany: vi.fn() },
+    user: { findUnique: vi.fn() },
+  },
+}));
+vi.mock("@formbricks/logger", () => ({ logger: { warn: vi.fn() } }));
+vi.mock("./api-key", () => ({ reconcileApiKeyRelationships: vi.fn() }));
+vi.mock("./config", () => ({ isAuthzedEnabled: vi.fn() }));
+vi.mock("./feedback-directory", () => ({ reconcileFeedbackDirectoryRelationships: vi.fn() }));
+vi.mock("./metrics", () => ({
+  recordAuthzedOutboxDelivery: vi.fn(),
+  recordAuthzedOutboxStatus: vi.fn(),
+}));
+vi.mock("./organization-membership", () => ({
+  deleteOrganizationRelationships: vi.fn(),
+  deleteUserOrganizationRelationships: vi.fn(),
+  reconcileOrganizationMemberships: vi.fn(),
+}));
+vi.mock("./outbox-repository", () => ({
+  AUTHZED_OUTBOX_BATCH_SIZE: 200,
+  claimAuthzedOutboxEvents: vi.fn(),
+  createAuthzedOutboxLeaseOwner: vi.fn(() => "lease"),
+  getAuthzedOutboxStatus: vi.fn(),
+  markAuthzedOutboxEventsDelivered: vi.fn(),
+  markAuthzedOutboxEventsFailed: vi.fn(),
+}));
+vi.mock("./team-workspace", () => ({
+  deleteUserTeamRelationships: vi.fn(),
+  reconcileTeamWorkspaceRelationships: vi.fn(),
+}));
+
+const projected = { passes: 1, status: "projected" } as const;
+const event = (
+  targetType: TAuthzedOutboxTargetType,
+  primaryId: string,
+  secondaryId: string | null = null
+): TAuthzedOutboxEvent => ({
+  attempts: 1,
+  createdAt: new Date(0),
+  id: `${targetType}-${primaryId}-${secondaryId ?? ""}`,
+  isRevocation: false,
+  primaryId,
+  secondaryId,
+  targetType,
+});
+
+describe("AuthZed projection outbox processor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isAuthzedEnabled).mockReturnValue(true);
+    vi.mocked(reconcileOrganizationMemberships).mockResolvedValue(projected);
+    vi.mocked(deleteOrganizationRelationships).mockResolvedValue(projected);
+    vi.mocked(deleteUserOrganizationRelationships).mockResolvedValue(projected);
+    vi.mocked(deleteUserTeamRelationships).mockResolvedValue(projected);
+    vi.mocked(reconcileTeamWorkspaceRelationships).mockResolvedValue(projected);
+    vi.mocked(reconcileApiKeyRelationships).mockResolvedValue(projected);
+    vi.mocked(reconcileFeedbackDirectoryRelationships).mockResolvedValue(projected);
+    vi.mocked(prisma.organization.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    vi.mocked(markAuthzedOutboxEventsFailed).mockResolvedValue(0);
+    vi.mocked(getAuthzedOutboxStatus).mockResolvedValue({
+      deadLettered: 0,
+      oldestPendingAgeSeconds: null,
+      overdueRevocations: 0,
+      pending: 0,
+      revocationsPastCritical: 0,
+      revocationsPastWarning: 0,
+    });
+  });
+
+  test("maps every durable target to the existing idempotent reconcilers", async () => {
+    const events = [
+      event("organization", "org"),
+      event("membership", "org", "user"),
+      event("user", "deleted-user"),
+      event("team", "team"),
+      event("team_membership", "team", "user"),
+      event("workspace", "workspace"),
+      event("workspace_team", "workspace", "team"),
+      event("api_key", "key"),
+      event("api_key_workspace", "key", "workspace"),
+      event("feedback_directory", "directory"),
+      event("feedback_directory_assignment", "directory", "workspace"),
+    ];
+    vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue(events);
+
+    await expect(processAuthzedOutboxBatch("lease")).resolves.toEqual({
+      claimed: 11,
+      deadLettered: 0,
+      delivered: 11,
+      failed: 0,
+    });
+
+    expect(reconcileOrganizationMemberships).toHaveBeenCalledWith({
+      memberships: [{ organizationId: "org", userId: "user" }],
+    });
+    expect(deleteOrganizationRelationships).toHaveBeenCalledWith("org");
+    expect(deleteUserOrganizationRelationships).toHaveBeenCalledWith("deleted-user");
+    expect(deleteUserTeamRelationships).toHaveBeenCalledWith("deleted-user");
+    expect(reconcileTeamWorkspaceRelationships).toHaveBeenCalledWith({
+      teamIds: ["team"],
+      teamMemberships: [{ teamId: "team", userId: "user" }],
+      workspaceIds: ["workspace"],
+      workspaceTeamGrants: [{ teamId: "team", workspaceId: "workspace" }],
+    });
+    expect(reconcileApiKeyRelationships).toHaveBeenCalledWith({
+      apiKeyIds: ["key"],
+      apiKeyWorkspaceGrants: [{ apiKeyId: "key", workspaceId: "workspace" }],
+    });
+    expect(reconcileFeedbackDirectoryRelationships).toHaveBeenCalledWith({
+      assignments: [{ feedbackDirectoryId: "directory", workspaceId: "workspace" }],
+      feedbackDirectoryIds: ["directory"],
+    });
+    expect(markAuthzedOutboxEventsDelivered).toHaveBeenCalledWith(
+      "lease",
+      events.map(({ id }) => id)
+    );
+  });
+
+  test("releases a failed lease for retry without logging identifiers", async () => {
+    const events = [event("membership", "private-org", "private-user")];
+    vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue(events);
+    vi.mocked(reconcileOrganizationMemberships).mockResolvedValue({
+      attempts: 3,
+      code: "authzed_unavailable",
+      retryable: true,
+      status: "failed",
+    });
+
+    await expect(processAuthzedOutboxBatch("lease")).resolves.toMatchObject({ failed: 1 });
+    expect(markAuthzedOutboxEventsFailed).toHaveBeenCalledWith("lease", events, "authzed_unavailable");
+  });
+
+  test("does not touch PostgreSQL when AuthZed is disabled", async () => {
+    vi.mocked(isAuthzedEnabled).mockReturnValue(false);
+    await processAuthzedProjectionDeliveryJob();
+    expect(claimAuthzedOutboxEvents).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/authzed/outbox-processor.test.ts
+++ b/apps/web/lib/authzed/outbox-processor.test.ts
@@ -170,7 +170,7 @@ describe("AuthZed projection outbox processor", () => {
       sorted(events.filter(({ id }) => !apiKeyIds.includes(id)).map(({ id }) => id))
     );
     expect(markAuthzedOutboxEventsFailed).toHaveBeenCalledWith("lease", apiKeyIds, "authzed_internal", {
-      isolated: false,
+      attributable: false,
       retryable: false,
     });
   });
@@ -217,8 +217,28 @@ describe("AuthZed projection outbox processor", () => {
       ["membership-org-user"],
       "authzed_projection_unstable",
       // Retryable is what matters: it is what keeps the event out of the dead-letter budget.
-      { isolated: true, retryable: true }
+      { attributable: false, retryable: true }
     );
+  });
+
+  test("does not blame a lone event for a failure that describes the instance", async () => {
+    // A five-second cadence means most groups hold exactly one event, so "the attempt covered one
+    // event" is nearly always true and says nothing about fault. If size alone drove attribution, a
+    // rotated SpiceDB credential would dead-letter whichever revocations happened to be travelling
+    // alone — and a dead-lettered revocation denies the whole deployment until something replays it.
+    for (const code of ["authzed_unauthenticated", "authzed_internal", "authzed_permission_denied"]) {
+      vi.clearAllMocks();
+      vi.mocked(markAuthzedOutboxEventsFailed).mockResolvedValue(0);
+      vi.mocked(claimAuthzedOutboxEvents).mockResolvedValue([event("membership", "org", "user")]);
+      vi.mocked(reconcileOrganizationMemberships).mockResolvedValue(failed(code, false));
+
+      await processAuthzedOutboxBatch("lease");
+
+      expect(markAuthzedOutboxEventsFailed).toHaveBeenCalledWith("lease", ["membership-org-user"], code, {
+        attributable: false,
+        retryable: false,
+      });
+    }
   });
 
   test("isolates the one event a per-event failure is attributable to", async () => {
@@ -242,7 +262,7 @@ describe("AuthZed projection outbox processor", () => {
       "lease",
       [poison.id],
       "authzed_projection_invalid_source",
-      { isolated: true, retryable: false }
+      { attributable: true, retryable: false }
     );
   });
 
@@ -261,7 +281,7 @@ describe("AuthZed projection outbox processor", () => {
       "lease",
       events.map(({ id }) => id),
       "authzed_internal",
-      { isolated: false, retryable: false }
+      { attributable: false, retryable: false }
     );
   });
 

--- a/apps/web/lib/authzed/outbox-processor.ts
+++ b/apps/web/lib/authzed/outbox-processor.ts
@@ -1,0 +1,225 @@
+import "server-only";
+import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
+import { reconcileApiKeyRelationships } from "./api-key";
+import { isAuthzedEnabled } from "./config";
+import { reconcileFeedbackDirectoryRelationships } from "./feedback-directory";
+import { recordAuthzedOutboxDelivery, recordAuthzedOutboxStatus } from "./metrics";
+import {
+  deleteOrganizationRelationships,
+  deleteUserOrganizationRelationships,
+  reconcileOrganizationMemberships,
+} from "./organization-membership";
+import {
+  AUTHZED_OUTBOX_BATCH_SIZE,
+  claimAuthzedOutboxEvents,
+  createAuthzedOutboxLeaseOwner,
+  getAuthzedOutboxStatus,
+  markAuthzedOutboxEventsDelivered,
+  markAuthzedOutboxEventsFailed,
+} from "./outbox-repository";
+import type {
+  TAuthzedOutboxDrainResult,
+  TAuthzedOutboxEvent,
+  TAuthzedOutboxTargetType,
+} from "./outbox-types";
+import type { TAuthzedProjectionResult } from "./projection";
+import { deleteUserTeamRelationships, reconcileTeamWorkspaceRelationships } from "./team-workspace";
+
+const DELIVERY_ERROR_CODE = "authzed_projection_delivery_failed";
+const DISABLED_ERROR_CODE = "authzed_disabled";
+
+type TGroupedEvents = ReadonlyMap<TAuthzedOutboxTargetType, ReadonlyArray<TAuthzedOutboxEvent>>;
+
+const groupEvents = (events: ReadonlyArray<TAuthzedOutboxEvent>): TGroupedEvents => {
+  const grouped = new Map<TAuthzedOutboxTargetType, TAuthzedOutboxEvent[]>();
+  for (const event of events) {
+    const targetEvents = grouped.get(event.targetType) ?? [];
+    targetEvents.push(event);
+    grouped.set(event.targetType, targetEvents);
+  }
+  return grouped;
+};
+
+const requireProjected = (result: TAuthzedProjectionResult): void => {
+  if (result.status === "projected") return;
+  throw new Error(result.status === "disabled" ? DISABLED_ERROR_CODE : result.code);
+};
+
+const secondaryTargets = (
+  events: ReadonlyArray<TAuthzedOutboxEvent> | undefined
+): ReadonlyArray<Readonly<{ primaryId: string; secondaryId: string }>> =>
+  (events ?? []).flatMap((event) =>
+    event.secondaryId ? [{ primaryId: event.primaryId, secondaryId: event.secondaryId }] : []
+  );
+
+const reconcileUser = async (userId: string): Promise<void> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      isActive: true,
+      memberships: { select: { organizationId: true } },
+      teamUsers: { select: { teamId: true } },
+    },
+  });
+
+  if (!user?.isActive) {
+    requireProjected(await deleteUserOrganizationRelationships(userId));
+    requireProjected(await deleteUserTeamRelationships(userId));
+    return;
+  }
+
+  requireProjected(
+    await reconcileOrganizationMemberships({
+      memberships: user.memberships.map(({ organizationId }) => ({ organizationId, userId })),
+    })
+  );
+  requireProjected(
+    await reconcileTeamWorkspaceRelationships({
+      teamMemberships: user.teamUsers.map(({ teamId }) => ({ teamId, userId })),
+    })
+  );
+};
+
+const reconcileEventGroups = async (grouped: TGroupedEvents): Promise<void> => {
+  const membershipTargets = secondaryTargets(grouped.get("membership"));
+  requireProjected(
+    await reconcileOrganizationMemberships({
+      memberships: membershipTargets.map(({ primaryId, secondaryId }) => ({
+        organizationId: primaryId,
+        userId: secondaryId,
+      })),
+    })
+  );
+
+  const organizations = grouped.get("organization") ?? [];
+  if (organizations.length > 0) {
+    const existing = new Set(
+      (
+        await prisma.organization.findMany({
+          where: { id: { in: organizations.map(({ primaryId }) => primaryId) } },
+          select: { id: true },
+        })
+      ).map(({ id }) => id)
+    );
+    for (const event of organizations) {
+      if (!existing.has(event.primaryId))
+        requireProjected(await deleteOrganizationRelationships(event.primaryId));
+    }
+  }
+
+  for (const event of grouped.get("user") ?? []) await reconcileUser(event.primaryId);
+
+  const teamMemberships = secondaryTargets(grouped.get("team_membership"));
+  const workspaceTeamGrants = secondaryTargets(grouped.get("workspace_team"));
+  requireProjected(
+    await reconcileTeamWorkspaceRelationships({
+      teamIds: (grouped.get("team") ?? []).map(({ primaryId }) => primaryId),
+      teamMemberships: teamMemberships.map(({ primaryId, secondaryId }) => ({
+        teamId: primaryId,
+        userId: secondaryId,
+      })),
+      workspaceIds: (grouped.get("workspace") ?? []).map(({ primaryId }) => primaryId),
+      workspaceTeamGrants: workspaceTeamGrants.map(({ primaryId, secondaryId }) => ({
+        teamId: secondaryId,
+        workspaceId: primaryId,
+      })),
+    })
+  );
+
+  const apiKeyWorkspaceGrants = secondaryTargets(grouped.get("api_key_workspace"));
+  requireProjected(
+    await reconcileApiKeyRelationships({
+      apiKeyIds: (grouped.get("api_key") ?? []).map(({ primaryId }) => primaryId),
+      apiKeyWorkspaceGrants: apiKeyWorkspaceGrants.map(({ primaryId, secondaryId }) => ({
+        apiKeyId: primaryId,
+        workspaceId: secondaryId,
+      })),
+    })
+  );
+
+  const assignments = secondaryTargets(grouped.get("feedback_directory_assignment"));
+  requireProjected(
+    await reconcileFeedbackDirectoryRelationships({
+      assignments: assignments.map(({ primaryId, secondaryId }) => ({
+        feedbackDirectoryId: primaryId,
+        workspaceId: secondaryId,
+      })),
+      feedbackDirectoryIds: (grouped.get("feedback_directory") ?? []).map(({ primaryId }) => primaryId),
+    })
+  );
+};
+
+const sanitizeDeliveryError = (error: unknown): string => {
+  if (error instanceof Error) {
+    if (error.message === DISABLED_ERROR_CODE) return DISABLED_ERROR_CODE;
+    if (error.message.startsWith("authzed_")) return error.message;
+  }
+  return DELIVERY_ERROR_CODE;
+};
+
+export const processAuthzedOutboxBatch = async (
+  leaseOwner = createAuthzedOutboxLeaseOwner(),
+  batchSize = AUTHZED_OUTBOX_BATCH_SIZE
+): Promise<Readonly<{ claimed: number; deadLettered: number; delivered: number; failed: number }>> => {
+  const events = await claimAuthzedOutboxEvents(leaseOwner, batchSize);
+  if (events.length === 0) return { claimed: 0, deadLettered: 0, delivered: 0, failed: 0 };
+
+  const startedAt = performance.now();
+  try {
+    await reconcileEventGroups(groupEvents(events));
+    await markAuthzedOutboxEventsDelivered(
+      leaseOwner,
+      events.map(({ id }) => id)
+    );
+    recordAuthzedOutboxDelivery({
+      count: events.length,
+      durationMs: performance.now() - startedAt,
+      status: "delivered",
+    });
+    return { claimed: events.length, deadLettered: 0, delivered: events.length, failed: 0 };
+  } catch (error) {
+    const errorCode = sanitizeDeliveryError(error);
+    const deadLettered = await markAuthzedOutboxEventsFailed(leaseOwner, events, errorCode);
+    logger.warn(
+      {
+        component: "authzed",
+        count: events.length,
+        deadLettered,
+        errorCode,
+        operation: "projection_outbox_delivery",
+        status: "failed",
+      },
+      "AuthZed projection outbox delivery failed"
+    );
+    recordAuthzedOutboxDelivery({
+      count: events.length,
+      durationMs: performance.now() - startedAt,
+      status: "failed",
+    });
+    return { claimed: events.length, deadLettered, delivered: 0, failed: events.length };
+  }
+};
+
+export const drainAuthzedOutbox = async (maxBatches = 100): Promise<TAuthzedOutboxDrainResult> => {
+  const totals = { claimed: 0, deadLettered: 0, delivered: 0, failed: 0 };
+  const leaseOwner = createAuthzedOutboxLeaseOwner();
+
+  for (let batch = 0; batch < maxBatches; batch++) {
+    const result = await processAuthzedOutboxBatch(leaseOwner);
+    totals.claimed += result.claimed;
+    totals.deadLettered += result.deadLettered;
+    totals.delivered += result.delivered;
+    totals.failed += result.failed;
+    if (result.claimed === 0 || result.failed > 0) break;
+  }
+
+  const status = await getAuthzedOutboxStatus();
+  recordAuthzedOutboxStatus(status);
+  return { ...totals, remaining: status.pending, status: status.pending === 0 ? "drained" : "partial" };
+};
+
+export const processAuthzedProjectionDeliveryJob = async (): Promise<void> => {
+  if (!isAuthzedEnabled()) return;
+  await drainAuthzedOutbox(10);
+};

--- a/apps/web/lib/authzed/outbox-processor.ts
+++ b/apps/web/lib/authzed/outbox-processor.ts
@@ -288,10 +288,18 @@ const runGroup = async (
 };
 
 type TFailure = Readonly<{
+  /**
+   * The failure names THIS event: the attempt covered it alone, AND the code is one an event can
+   * actually cause.
+   *
+   * Both halves are load-bearing. A single-event group is the normal case on a five-second cadence,
+   * so size alone would charge a permanent failure to whichever events happened to be travelling
+   * alone when SpiceDB rejected the credential — the same codes this module already refuses to split
+   * on precisely because they describe the instance rather than an event.
+   */
+  attributable: boolean;
   code: string;
   eventIds: ReadonlyArray<string>;
-  /** The attempt covered this event and nothing else, so its failure is attributable to it. */
-  isolated: boolean;
   retryable: boolean;
 }>;
 
@@ -309,9 +317,9 @@ const failureOutcome = (
   delivered: [],
   failures: [
     {
+      attributable: events.length === 1 && PER_EVENT_ERROR_CODES.has(outcome.code),
       code: outcome.code,
       eventIds: events.map(({ id }) => id),
-      isolated: events.length === 1,
       retryable: outcome.retryable,
     },
   ],
@@ -351,7 +359,7 @@ const deliverGroup = async (
       failures: [
         ...left.failures,
         ...(untried.length > 0
-          ? [{ code: left.haltCode, eventIds: untried, isolated: false, retryable: true }]
+          ? [{ attributable: false, code: left.haltCode, eventIds: untried, retryable: true }]
           : []),
       ],
       haltCode: left.haltCode,
@@ -381,7 +389,7 @@ const deliverEventGroups = async (grouped: TGroupedEvents): Promise<TDeliveryOut
       // instance already known to be unreachable. Release the rest untried and unblamed.
       const untried = groups.slice(index + 1).flatMap(({ events }) => events.map(({ id }) => id));
       if (untried.length > 0) {
-        failures.push({ code: outcome.haltCode, eventIds: untried, isolated: false, retryable: true });
+        failures.push({ attributable: false, code: outcome.haltCode, eventIds: untried, retryable: true });
       }
       return { delivered, failures, haltCode: outcome.haltCode };
     }
@@ -394,7 +402,7 @@ const deliverEventGroups = async (grouped: TGroupedEvents): Promise<TDeliveryOut
 const mergeFailures = (failures: ReadonlyArray<TFailure>): ReadonlyArray<TFailure> => {
   const merged = new Map<string, TFailure & { eventIds: string[] }>();
   for (const failure of failures) {
-    const key = `${failure.code}:${String(failure.isolated)}:${String(failure.retryable)}`;
+    const key = `${failure.code}:${String(failure.attributable)}:${String(failure.retryable)}`;
     const existing = merged.get(key);
     if (existing) existing.eventIds.push(...failure.eventIds);
     else merged.set(key, { ...failure, eventIds: [...failure.eventIds] });
@@ -420,7 +428,7 @@ export const processAuthzedOutboxBatch = async (
   for (const failure of mergeFailures(outcome.failures)) {
     failed += failure.eventIds.length;
     deadLettered += await markAuthzedOutboxEventsFailed(leaseOwner, failure.eventIds, failure.code, {
-      isolated: failure.isolated,
+      attributable: failure.attributable,
       retryable: failure.retryable,
     });
   }

--- a/apps/web/lib/authzed/outbox-processor.ts
+++ b/apps/web/lib/authzed/outbox-processor.ts
@@ -3,6 +3,8 @@ import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import { reconcileApiKeyRelationships } from "./api-key";
 import { isAuthzedEnabled } from "./config";
+import { AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES } from "./constants";
+import { AUTHZED_ERROR_CODES } from "./errors";
 import { reconcileFeedbackDirectoryRelationships } from "./feedback-directory";
 import { recordAuthzedOutboxDelivery, recordAuthzedOutboxStatus } from "./metrics";
 import {
@@ -24,10 +26,27 @@ import type {
   TAuthzedOutboxTargetType,
 } from "./outbox-types";
 import type { TAuthzedProjectionResult } from "./projection";
+import { runChunked } from "./projection-chunks";
 import { deleteUserTeamRelationships, reconcileTeamWorkspaceRelationships } from "./team-workspace";
 
 const DELIVERY_ERROR_CODE = "authzed_projection_delivery_failed";
 const DISABLED_ERROR_CODE = "authzed_disabled";
+const UNSTABLE_ERROR_CODE = "authzed_projection_unstable";
+
+/**
+ * Error codes that can plausibly be caused by one event rather than by the batch it travelled in.
+ *
+ * Only these justify splitting a failed group to find the culprit. Every other non-retryable code —
+ * `authzed_unauthenticated`, `authzed_internal` — describes the instance, not an event, so splitting
+ * would spend 2xN gRPC calls every five seconds to learn what a single call already reported.
+ */
+const PER_EVENT_ERROR_CODES: ReadonlySet<string> = new Set<string>([
+  "authzed_projection_invalid_source",
+  AUTHZED_ERROR_CODES.INVALID_REQUEST,
+]);
+
+/** 2^8 exceeds the claim batch size, so a split always reaches singletons before this bites. */
+const MAX_QUARANTINE_DEPTH = 8;
 
 type TGroupedEvents = ReadonlyMap<TAuthzedOutboxTargetType, ReadonlyArray<TAuthzedOutboxEvent>>;
 
@@ -41,121 +60,346 @@ const groupEvents = (events: ReadonlyArray<TAuthzedOutboxEvent>): TGroupedEvents
   return grouped;
 };
 
-const requireProjected = (result: TAuthzedProjectionResult): void => {
-  if (result.status === "projected") return;
-  throw new Error(result.status === "disabled" ? DISABLED_ERROR_CODE : result.code);
-};
+const byType = (
+  events: ReadonlyArray<TAuthzedOutboxEvent>,
+  targetType: TAuthzedOutboxTargetType
+): ReadonlyArray<TAuthzedOutboxEvent> => events.filter((event) => event.targetType === targetType);
 
 const secondaryTargets = (
-  events: ReadonlyArray<TAuthzedOutboxEvent> | undefined
+  events: ReadonlyArray<TAuthzedOutboxEvent>
 ): ReadonlyArray<Readonly<{ primaryId: string; secondaryId: string }>> =>
-  (events ?? []).flatMap((event) =>
+  events.flatMap((event) =>
     event.secondaryId ? [{ primaryId: event.primaryId, secondaryId: event.secondaryId }] : []
   );
 
-const reconcileUser = async (userId: string): Promise<void> => {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
+const PROJECTED_WITHOUT_WORK: TAuthzedProjectionResult = { passes: 0, status: "projected" };
+
+/**
+ * Hand targets to a reconciler in bounded chunks.
+ *
+ * A claimed batch is bounded, but the targets it expands into are not — one `user` event can carry an
+ * unbounded number of memberships, and every list becomes its own `OR` clause in the reconciler's
+ * snapshot query. `runChunked` returns `null` when every list was empty, which here means the group
+ * had nothing to project rather than that it failed.
+ */
+const runChunkedProjection = async <TTargets extends Readonly<Record<string, ReadonlyArray<unknown>>>>(
+  reconcile: (targets: TTargets) => Promise<TAuthzedProjectionResult>,
+  targets: TTargets
+): Promise<TAuthzedProjectionResult> => (await runChunked(reconcile, targets)) ?? PROJECTED_WITHOUT_WORK;
+
+/**
+ * Run per-subject projections with a bounded fan-out, stopping at the first that does not project.
+ *
+ * Used only for deletes, which address a whole subject through a relationship filter and so cannot be
+ * packed into a shared write the way reconciler updates are. `runBestEffortProjection` never throws,
+ * so `Promise.all` cannot reject here.
+ */
+const runBoundedConcurrently = async (
+  operations: ReadonlyArray<() => Promise<TAuthzedProjectionResult>>
+): Promise<TAuthzedProjectionResult> => {
+  for (let start = 0; start < operations.length; start += AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES) {
+    const results = await Promise.all(
+      operations.slice(start, start + AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES).map((run) => run())
+    );
+    const failure = results.find((result) => result.status !== "projected");
+    if (failure) return failure;
+  }
+  return PROJECTED_WITHOUT_WORK;
+};
+
+/**
+ * Reconcile every named user in one pass.
+ *
+ * One `findMany` for the whole group rather than a `findUnique` per event: the delivery job runs on a
+ * five-second cadence, and a claimed batch can carry two hundred user events. A user missing from the
+ * result is treated exactly as an inactive one — `findMany` omits rows that a per-id `findUnique`
+ * would have returned as `null`, and both mean there is no active user left to hold relationships.
+ */
+const reconcileUsers = async (
+  events: ReadonlyArray<TAuthzedOutboxEvent>
+): Promise<TAuthzedProjectionResult> => {
+  const userIds = [...new Set(events.map(({ primaryId }) => primaryId))];
+  if (userIds.length === 0) return PROJECTED_WITHOUT_WORK;
+
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
     select: {
+      id: true,
       isActive: true,
       memberships: { select: { organizationId: true } },
       teamUsers: { select: { teamId: true } },
     },
   });
 
-  if (!user?.isActive) {
-    requireProjected(await deleteUserOrganizationRelationships(userId));
-    requireProjected(await deleteUserTeamRelationships(userId));
-    return;
-  }
+  const active = users.filter(({ isActive }) => isActive);
+  const activeIds = new Set(active.map(({ id }) => id));
 
-  requireProjected(
-    await reconcileOrganizationMemberships({
-      memberships: user.memberships.map(({ organizationId }) => ({ organizationId, userId })),
-    })
+  const removal = await runBoundedConcurrently(
+    userIds
+      .filter((userId) => !activeIds.has(userId))
+      .flatMap((userId) => [
+        () => deleteUserOrganizationRelationships(userId),
+        () => deleteUserTeamRelationships(userId),
+      ])
   );
-  requireProjected(
-    await reconcileTeamWorkspaceRelationships({
-      teamMemberships: user.teamUsers.map(({ teamId }) => ({ teamId, userId })),
-    })
+  if (removal.status !== "projected") return removal;
+
+  const memberships = await runChunkedProjection(reconcileOrganizationMemberships, {
+    memberships: active.flatMap((user) =>
+      user.memberships.map(({ organizationId }) => ({ organizationId, userId: user.id }))
+    ),
+  });
+  if (memberships.status !== "projected") return memberships;
+
+  return runChunkedProjection(reconcileTeamWorkspaceRelationships, {
+    teamMemberships: active.flatMap((user) =>
+      user.teamUsers.map(({ teamId }) => ({ teamId, userId: user.id }))
+    ),
+  });
+};
+
+/** Organization events are inserts and deletes only; a row that is gone must lose its relationships. */
+const reconcileOrganizations = async (
+  events: ReadonlyArray<TAuthzedOutboxEvent>
+): Promise<TAuthzedProjectionResult> => {
+  const organizationIds = [...new Set(events.map(({ primaryId }) => primaryId))];
+  if (organizationIds.length === 0) return PROJECTED_WITHOUT_WORK;
+
+  const existing = new Set(
+    (
+      await prisma.organization.findMany({
+        where: { id: { in: organizationIds } },
+        select: { id: true },
+      })
+    ).map(({ id }) => id)
+  );
+
+  return runBoundedConcurrently(
+    organizationIds
+      .filter((organizationId) => !existing.has(organizationId))
+      .map((organizationId) => () => deleteOrganizationRelationships(organizationId))
   );
 };
 
-const reconcileEventGroups = async (grouped: TGroupedEvents): Promise<void> => {
-  const membershipTargets = secondaryTargets(grouped.get("membership"));
-  requireProjected(
-    await reconcileOrganizationMemberships({
-      memberships: membershipTargets.map(({ primaryId, secondaryId }) => ({
-        organizationId: primaryId,
-        userId: secondaryId,
-      })),
-    })
-  );
+/**
+ * One delivery group per reconciler call.
+ *
+ * The grouping is the attribution boundary: a failure is charged to the events that were in flight
+ * with it and to nothing else. `run` rebuilds its targets from the events it is handed rather than
+ * from the surrounding batch, which is what lets a failed group be re-run over a subset.
+ */
+type TDeliveryGroup = Readonly<{
+  events: ReadonlyArray<TAuthzedOutboxEvent>;
+  run: (events: ReadonlyArray<TAuthzedOutboxEvent>) => Promise<TAuthzedProjectionResult>;
+}>;
 
-  const organizations = grouped.get("organization") ?? [];
-  if (organizations.length > 0) {
-    const existing = new Set(
-      (
-        await prisma.organization.findMany({
-          where: { id: { in: organizations.map(({ primaryId }) => primaryId) } },
-          select: { id: true },
-        })
-      ).map(({ id }) => id)
-    );
-    for (const event of organizations) {
-      if (!existing.has(event.primaryId))
-        requireProjected(await deleteOrganizationRelationships(event.primaryId));
-    }
-  }
+const buildDeliveryGroups = (grouped: TGroupedEvents): ReadonlyArray<TDeliveryGroup> => {
+  const collect = (
+    ...targetTypes: ReadonlyArray<TAuthzedOutboxTargetType>
+  ): ReadonlyArray<TAuthzedOutboxEvent> => targetTypes.flatMap((type) => [...(grouped.get(type) ?? [])]);
 
-  for (const event of grouped.get("user") ?? []) await reconcileUser(event.primaryId);
+  const groups: ReadonlyArray<TDeliveryGroup> = [
+    {
+      events: collect("membership"),
+      run: (events) =>
+        runChunkedProjection(reconcileOrganizationMemberships, {
+          memberships: secondaryTargets(events).map(({ primaryId, secondaryId }) => ({
+            organizationId: primaryId,
+            userId: secondaryId,
+          })),
+        }),
+    },
+    { events: collect("organization"), run: reconcileOrganizations },
+    { events: collect("user"), run: reconcileUsers },
+    {
+      events: collect("team", "team_membership", "workspace", "workspace_team"),
+      run: (events) =>
+        runChunkedProjection(reconcileTeamWorkspaceRelationships, {
+          teamIds: byType(events, "team").map(({ primaryId }) => primaryId),
+          teamMemberships: secondaryTargets(byType(events, "team_membership")).map(
+            ({ primaryId, secondaryId }) => ({ teamId: primaryId, userId: secondaryId })
+          ),
+          workspaceIds: byType(events, "workspace").map(({ primaryId }) => primaryId),
+          workspaceTeamGrants: secondaryTargets(byType(events, "workspace_team")).map(
+            ({ primaryId, secondaryId }) => ({ teamId: secondaryId, workspaceId: primaryId })
+          ),
+        }),
+    },
+    {
+      events: collect("api_key", "api_key_workspace"),
+      run: (events) =>
+        runChunkedProjection(reconcileApiKeyRelationships, {
+          apiKeyIds: byType(events, "api_key").map(({ primaryId }) => primaryId),
+          apiKeyWorkspaceGrants: secondaryTargets(byType(events, "api_key_workspace")).map(
+            ({ primaryId, secondaryId }) => ({ apiKeyId: primaryId, workspaceId: secondaryId })
+          ),
+        }),
+    },
+    {
+      events: collect("feedback_directory", "feedback_directory_assignment"),
+      run: (events) =>
+        runChunkedProjection(reconcileFeedbackDirectoryRelationships, {
+          assignments: secondaryTargets(byType(events, "feedback_directory_assignment")).map(
+            ({ primaryId, secondaryId }) => ({ feedbackDirectoryId: primaryId, workspaceId: secondaryId })
+          ),
+          feedbackDirectoryIds: byType(events, "feedback_directory").map(({ primaryId }) => primaryId),
+        }),
+    },
+  ];
 
-  const teamMemberships = secondaryTargets(grouped.get("team_membership"));
-  const workspaceTeamGrants = secondaryTargets(grouped.get("workspace_team"));
-  requireProjected(
-    await reconcileTeamWorkspaceRelationships({
-      teamIds: (grouped.get("team") ?? []).map(({ primaryId }) => primaryId),
-      teamMemberships: teamMemberships.map(({ primaryId, secondaryId }) => ({
-        teamId: primaryId,
-        userId: secondaryId,
-      })),
-      workspaceIds: (grouped.get("workspace") ?? []).map(({ primaryId }) => primaryId),
-      workspaceTeamGrants: workspaceTeamGrants.map(({ primaryId, secondaryId }) => ({
-        teamId: secondaryId,
-        workspaceId: primaryId,
-      })),
-    })
-  );
-
-  const apiKeyWorkspaceGrants = secondaryTargets(grouped.get("api_key_workspace"));
-  requireProjected(
-    await reconcileApiKeyRelationships({
-      apiKeyIds: (grouped.get("api_key") ?? []).map(({ primaryId }) => primaryId),
-      apiKeyWorkspaceGrants: apiKeyWorkspaceGrants.map(({ primaryId, secondaryId }) => ({
-        apiKeyId: primaryId,
-        workspaceId: secondaryId,
-      })),
-    })
-  );
-
-  const assignments = secondaryTargets(grouped.get("feedback_directory_assignment"));
-  requireProjected(
-    await reconcileFeedbackDirectoryRelationships({
-      assignments: assignments.map(({ primaryId, secondaryId }) => ({
-        feedbackDirectoryId: primaryId,
-        workspaceId: secondaryId,
-      })),
-      feedbackDirectoryIds: (grouped.get("feedback_directory") ?? []).map(({ primaryId }) => primaryId),
-    })
-  );
+  return groups.filter(({ events }) => events.length > 0);
 };
 
 const sanitizeDeliveryError = (error: unknown): string => {
-  if (error instanceof Error) {
-    if (error.message === DISABLED_ERROR_CODE) return DISABLED_ERROR_CODE;
-    if (error.message.startsWith("authzed_")) return error.message;
-  }
+  if (error instanceof Error && error.message.startsWith("authzed_")) return error.message;
   return DELIVERY_ERROR_CODE;
+};
+
+type TGroupOutcome =
+  | Readonly<{ status: "projected" }>
+  | Readonly<{ code: string; retryable: boolean; status: "failed" }>;
+
+const runGroup = async (
+  group: TDeliveryGroup,
+  events: ReadonlyArray<TAuthzedOutboxEvent>
+): Promise<TGroupOutcome> => {
+  let result: TAuthzedProjectionResult;
+  try {
+    result = await group.run(events);
+  } catch (error) {
+    // Reconcilers never throw — `runBestEffortProjection` converts failures into a result — but the
+    // PostgreSQL reads this module makes around them can. Treat that as transient rather than as a
+    // fault attributable to any single event.
+    return { code: sanitizeDeliveryError(error), retryable: true, status: "failed" };
+  }
+
+  if (result.status === "projected") return { status: "projected" };
+  // AuthZed switched off mid-batch: nothing was attempted, so nothing is anyone's fault.
+  if (result.status === "disabled") return { code: DISABLED_ERROR_CODE, retryable: true, status: "failed" };
+
+  return {
+    code: result.code,
+    // A source row that kept moving under the reconciler will settle. That is a retry, not a poison —
+    // and it is likeliest on exactly the hot rows the outbox carries. Overridden here rather than on
+    // `AuthzedProjectionUnstableError`, whose `retryable: false` is part of the projector contract.
+    retryable: result.retryable || result.code === UNSTABLE_ERROR_CODE,
+    status: "failed",
+  };
+};
+
+type TFailure = Readonly<{
+  code: string;
+  eventIds: ReadonlyArray<string>;
+  /** The attempt covered this event and nothing else, so its failure is attributable to it. */
+  isolated: boolean;
+  retryable: boolean;
+}>;
+
+type TDeliveryOutcome = Readonly<{
+  delivered: ReadonlyArray<string>;
+  failures: ReadonlyArray<TFailure>;
+  /** Set when delivery hit a transient fault: stop spending retry budget against it this tick. */
+  haltCode: string | null;
+}>;
+
+const failureOutcome = (
+  events: ReadonlyArray<TAuthzedOutboxEvent>,
+  outcome: Extract<TGroupOutcome, { status: "failed" }>
+): TDeliveryOutcome => ({
+  delivered: [],
+  failures: [
+    {
+      code: outcome.code,
+      eventIds: events.map(({ id }) => id),
+      isolated: events.length === 1,
+      retryable: outcome.retryable,
+    },
+  ],
+  haltCode: outcome.retryable ? outcome.code : null,
+});
+
+/**
+ * Deliver one group, halving it to isolate the culprit when the failure could be a single event's.
+ *
+ * Without this, one cross-tenant assignment row fails every feedback-directory event in every batch
+ * for as long as it exists. With it, the poison event is alone by the time it is charged a permanent
+ * failure — which is the precondition for dead-lettering ever being attributable.
+ */
+const deliverGroup = async (
+  group: TDeliveryGroup,
+  events: ReadonlyArray<TAuthzedOutboxEvent>,
+  depth: number
+): Promise<TDeliveryOutcome> => {
+  const outcome = await runGroup(group, events);
+  if (outcome.status === "projected") {
+    return { delivered: events.map(({ id }) => id), failures: [], haltCode: null };
+  }
+
+  const splittable =
+    events.length > 1 &&
+    !outcome.retryable &&
+    PER_EVENT_ERROR_CODES.has(outcome.code) &&
+    depth < MAX_QUARANTINE_DEPTH;
+  if (!splittable) return failureOutcome(events, outcome);
+
+  const middle = Math.ceil(events.length / 2);
+  const left = await deliverGroup(group, events.slice(0, middle), depth + 1);
+  if (left.haltCode) {
+    const untried = events.slice(middle).map(({ id }) => id);
+    return {
+      delivered: left.delivered,
+      failures: [
+        ...left.failures,
+        ...(untried.length > 0
+          ? [{ code: left.haltCode, eventIds: untried, isolated: false, retryable: true }]
+          : []),
+      ],
+      haltCode: left.haltCode,
+    };
+  }
+
+  const right = await deliverGroup(group, events.slice(middle), depth + 1);
+  return {
+    delivered: [...left.delivered, ...right.delivered],
+    failures: [...left.failures, ...right.failures],
+    haltCode: right.haltCode,
+  };
+};
+
+const deliverEventGroups = async (grouped: TGroupedEvents): Promise<TDeliveryOutcome> => {
+  const groups = buildDeliveryGroups(grouped);
+  const delivered: string[] = [];
+  const failures: TFailure[] = [];
+
+  for (const [index, group] of groups.entries()) {
+    const outcome = await deliverGroup(group, group.events, 0);
+    delivered.push(...outcome.delivered);
+    failures.push(...outcome.failures);
+
+    if (outcome.haltCode) {
+      // Continuing would spend another three-attempt retry budget per remaining group against an
+      // instance already known to be unreachable. Release the rest untried and unblamed.
+      const untried = groups.slice(index + 1).flatMap(({ events }) => events.map(({ id }) => id));
+      if (untried.length > 0) {
+        failures.push({ code: outcome.haltCode, eventIds: untried, isolated: false, retryable: true });
+      }
+      return { delivered, failures, haltCode: outcome.haltCode };
+    }
+  }
+
+  return { delivered, failures, haltCode: null };
+};
+
+/** One release statement per distinct verdict rather than per failure record. */
+const mergeFailures = (failures: ReadonlyArray<TFailure>): ReadonlyArray<TFailure> => {
+  const merged = new Map<string, TFailure & { eventIds: string[] }>();
+  for (const failure of failures) {
+    const key = `${failure.code}:${String(failure.isolated)}:${String(failure.retryable)}`;
+    const existing = merged.get(key);
+    if (existing) existing.eventIds.push(...failure.eventIds);
+    else merged.set(key, { ...failure, eventIds: [...failure.eventIds] });
+  }
+  return [...merged.values()];
 };
 
 export const processAuthzedOutboxBatch = async (
@@ -166,39 +410,44 @@ export const processAuthzedOutboxBatch = async (
   if (events.length === 0) return { claimed: 0, deadLettered: 0, delivered: 0, failed: 0 };
 
   const startedAt = performance.now();
-  try {
-    await reconcileEventGroups(groupEvents(events));
-    await markAuthzedOutboxEventsDelivered(
-      leaseOwner,
-      events.map(({ id }) => id)
-    );
-    recordAuthzedOutboxDelivery({
-      count: events.length,
-      durationMs: performance.now() - startedAt,
-      status: "delivered",
+  const outcome = await deliverEventGroups(groupEvents(events));
+  const durationMs = performance.now() - startedAt;
+
+  await markAuthzedOutboxEventsDelivered(leaseOwner, outcome.delivered);
+
+  let deadLettered = 0;
+  let failed = 0;
+  for (const failure of mergeFailures(outcome.failures)) {
+    failed += failure.eventIds.length;
+    deadLettered += await markAuthzedOutboxEventsFailed(leaseOwner, failure.eventIds, failure.code, {
+      isolated: failure.isolated,
+      retryable: failure.retryable,
     });
-    return { claimed: events.length, deadLettered: 0, delivered: events.length, failed: 0 };
-  } catch (error) {
-    const errorCode = sanitizeDeliveryError(error);
-    const deadLettered = await markAuthzedOutboxEventsFailed(leaseOwner, events, errorCode);
+  }
+
+  if (outcome.delivered.length > 0) {
+    recordAuthzedOutboxDelivery({ count: outcome.delivered.length, durationMs, status: "delivered" });
+  }
+
+  if (failed > 0) {
     logger.warn(
       {
         component: "authzed",
-        count: events.length,
+        count: failed,
         deadLettered,
-        errorCode,
+        // Stable enumerable codes only — never an event, target, or tenant identifier.
+        errorCodes: [...new Set(outcome.failures.map(({ code }) => code))].sort((left, right) =>
+          left.localeCompare(right)
+        ),
         operation: "projection_outbox_delivery",
         status: "failed",
       },
       "AuthZed projection outbox delivery failed"
     );
-    recordAuthzedOutboxDelivery({
-      count: events.length,
-      durationMs: performance.now() - startedAt,
-      status: "failed",
-    });
-    return { claimed: events.length, deadLettered, delivered: 0, failed: events.length };
+    recordAuthzedOutboxDelivery({ count: failed, durationMs, status: "failed" });
   }
+
+  return { claimed: events.length, deadLettered, delivered: outcome.delivered.length, failed };
 };
 
 export const drainAuthzedOutbox = async (maxBatches = 100): Promise<TAuthzedOutboxDrainResult> => {
@@ -211,7 +460,10 @@ export const drainAuthzedOutbox = async (maxBatches = 100): Promise<TAuthzedOutb
     totals.deadLettered += result.deadLettered;
     totals.delivered += result.delivered;
     totals.failed += result.failed;
-    if (result.claimed === 0 || result.failed > 0) break;
+    // A partial batch is the normal outcome once failures are attributed per group, so draining stops
+    // on no progress rather than on any failure. Delivered rows get `processedAt` and failed rows a
+    // future `availableAt`, so every iteration strictly shrinks the claimable set.
+    if (result.claimed === 0 || result.delivered === 0) break;
   }
 
   const status = await getAuthzedOutboxStatus();

--- a/apps/web/lib/authzed/outbox-repository.test.ts
+++ b/apps/web/lib/authzed/outbox-repository.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import {
+  AUTHZED_OUTBOX_MAX_ATTEMPTS,
+  claimAuthzedOutboxEvents,
+  getAuthzedOutboxStatus,
+  hasStaleAuthzedRevocation,
+  markAuthzedOutboxEventsDelivered,
+  markAuthzedOutboxEventsFailed,
+  pruneAuthzedOutboxHistory,
+  replayAuthzedOutboxDeadLetters,
+} from "./outbox-repository";
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+    $executeRaw: vi.fn(),
+    authzedProjectionOutbox: { updateMany: vi.fn() },
+  },
+}));
+
+const row = (targetType: string) => ({
+  attempts: 1,
+  createdAt: new Date(0),
+  id: `${targetType}-event`,
+  isRevocation: true,
+  primaryId: "private-primary",
+  secondaryId: "private-secondary",
+  targetType,
+});
+
+describe("AuthZed projection outbox repository", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  test("dead-letters an unknown target instead of leaving it leased forever", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([row("membership"), row("future_unknown_target")]);
+
+    await expect(claimAuthzedOutboxEvents("lease-owner")).resolves.toEqual([row("membership")]);
+    expect(prisma.authzedProjectionOutbox.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["future_unknown_target-event"] },
+        leaseOwner: "lease-owner",
+        processedAt: null,
+      },
+      data: {
+        deadLetteredAt: expect.any(Date),
+        lastErrorCode: "authzed_projection_invalid_event",
+        leaseExpiresAt: null,
+        leasedAt: null,
+        leaseOwner: null,
+      },
+    });
+  });
+
+  test("marks only events owned by the active lease as delivered", async () => {
+    vi.mocked(prisma.authzedProjectionOutbox.updateMany).mockResolvedValue({ count: 1 });
+
+    await markAuthzedOutboxEventsDelivered("lease-owner", ["event-1", "event-2"]);
+
+    expect(prisma.authzedProjectionOutbox.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["event-1", "event-2"] },
+        leaseOwner: "lease-owner",
+        processedAt: null,
+      },
+      data: {
+        lastErrorCode: null,
+        leaseExpiresAt: null,
+        leasedAt: null,
+        leaseOwner: null,
+        processedAt: expect.any(Date),
+      },
+    });
+  });
+
+  test("releases retryable work with bounded exponential backoff before attempt twenty", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-18T00:00:00.000Z"));
+    const event = { ...row("membership"), attempts: 3 };
+    vi.mocked(prisma.authzedProjectionOutbox.updateMany).mockResolvedValue({ count: 1 });
+
+    await expect(markAuthzedOutboxEventsFailed("lease-owner", [event], "authzed_unavailable")).resolves.toBe(
+      0
+    );
+
+    expect(prisma.authzedProjectionOutbox.updateMany).toHaveBeenCalledWith({
+      where: { id: event.id, leaseOwner: "lease-owner", processedAt: null },
+      data: {
+        availableAt: new Date("2026-08-18T00:00:04.000Z"),
+        deadLetteredAt: null,
+        lastErrorCode: "authzed_unavailable",
+        leaseExpiresAt: null,
+        leasedAt: null,
+        leaseOwner: null,
+      },
+    });
+  });
+
+  test("dead-letters the twentieth failed delivery", async () => {
+    const event = { ...row("membership"), attempts: AUTHZED_OUTBOX_MAX_ATTEMPTS };
+    vi.mocked(prisma.authzedProjectionOutbox.updateMany).mockResolvedValue({ count: 1 });
+
+    await expect(markAuthzedOutboxEventsFailed("lease-owner", [event], "authzed_unavailable")).resolves.toBe(
+      1
+    );
+
+    expect(prisma.authzedProjectionOutbox.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ deadLetteredAt: expect.any(Date) }),
+      })
+    );
+  });
+
+  test("normalizes aggregate status values without exposing source rows", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([
+      {
+        dead_lettered: 2n,
+        oldest_pending_age_seconds: 47.9,
+        overdue_revocations: 1n,
+        pending: 11n,
+        revocations_past_critical: 3n,
+        revocations_past_warning: 5n,
+      },
+    ]);
+
+    await expect(getAuthzedOutboxStatus()).resolves.toEqual({
+      deadLettered: 2,
+      oldestPendingAgeSeconds: 47,
+      overdueRevocations: 1,
+      pending: 11,
+      revocationsPastCritical: 3,
+      revocationsPastWarning: 5,
+    });
+  });
+
+  test("uses a boolean result for the authorization freshness guard", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ stale: true }]);
+
+    await expect(hasStaleAuthzedRevocation()).resolves.toBe(true);
+  });
+
+  test("returns the bounded delivered-history cleanup count", async () => {
+    vi.mocked(prisma.$executeRaw).mockResolvedValue(17);
+
+    await expect(pruneAuthzedOutboxHistory()).resolves.toBe(17);
+  });
+
+  test("replays only undelivered dead letters from attempt zero", async () => {
+    vi.mocked(prisma.authzedProjectionOutbox.updateMany).mockResolvedValue({ count: 4 });
+
+    await expect(replayAuthzedOutboxDeadLetters()).resolves.toBe(4);
+
+    expect(prisma.authzedProjectionOutbox.updateMany).toHaveBeenCalledWith({
+      where: { deadLetteredAt: { not: null }, processedAt: null },
+      data: {
+        attempts: 0,
+        availableAt: expect.any(Date),
+        deadLetteredAt: null,
+        lastErrorCode: null,
+        leaseExpiresAt: null,
+        leasedAt: null,
+        leaseOwner: null,
+      },
+    });
+  });
+});

--- a/apps/web/lib/authzed/outbox-repository.test.ts
+++ b/apps/web/lib/authzed/outbox-repository.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import {
-  AUTHZED_OUTBOX_MAX_ATTEMPTS,
   claimAuthzedOutboxEvents,
   getAuthzedOutboxStatus,
   hasStaleAuthzedRevocation,
@@ -28,6 +27,15 @@ const row = (targetType: string) => ({
   secondaryId: "private-secondary",
   targetType,
 });
+
+/**
+ * The release statement binds exactly one boolean: "this failure is attributable to one event".
+ * Located by type rather than by position so reordering the SQL cannot silently invert the check.
+ */
+const boundPermanentFlag = (): unknown =>
+  (vi.mocked(prisma.$queryRaw).mock.calls.at(-1) ?? [])
+    .slice(1)
+    .find((value: unknown) => typeof value === "boolean");
 
 describe("AuthZed projection outbox repository", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -74,42 +82,66 @@ describe("AuthZed projection outbox repository", () => {
     });
   });
 
-  test("releases retryable work with bounded exponential backoff before attempt twenty", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-18T00:00:00.000Z"));
-    const event = { ...row("membership"), attempts: 3 };
-    vi.mocked(prisma.authzedProjectionOutbox.updateMany).mockResolvedValue({ count: 1 });
+  // The backoff schedule and the dead-letter threshold are computed in SQL from each row's own
+  // `attempts`, so they are only observable against a real PostgreSQL — see
+  // outbox-trigger.integration.test.ts. What matters here is the attribution rule that decides
+  // whether a failure is allowed to count towards dead-lettering at all.
+  test("charges a permanent failure only when one event failed on its own", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ dead_lettered: 1n }]);
 
-    await expect(markAuthzedOutboxEventsFailed("lease-owner", [event], "authzed_unavailable")).resolves.toBe(
-      0
-    );
+    await expect(
+      markAuthzedOutboxEventsFailed("lease-owner", ["event-1"], "authzed_invalid_request", {
+        isolated: true,
+        retryable: false,
+      })
+    ).resolves.toBe(1);
 
-    expect(prisma.authzedProjectionOutbox.updateMany).toHaveBeenCalledWith({
-      where: { id: event.id, leaseOwner: "lease-owner", processedAt: null },
-      data: {
-        availableAt: new Date("2026-08-18T00:00:04.000Z"),
-        deadLetteredAt: null,
-        lastErrorCode: "authzed_unavailable",
-        leaseExpiresAt: null,
-        leasedAt: null,
-        leaseOwner: null,
-      },
-    });
+    expect(boundPermanentFlag()).toBe(true);
   });
 
-  test("dead-letters the twentieth failed delivery", async () => {
-    const event = { ...row("membership"), attempts: AUTHZED_OUTBOX_MAX_ATTEMPTS };
-    vi.mocked(prisma.authzedProjectionOutbox.updateMany).mockResolvedValue({ count: 1 });
+  test("never charges a permanent failure for a retryable fault or an unattributed group", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ dead_lettered: 0n }]);
 
-    await expect(markAuthzedOutboxEventsFailed("lease-owner", [event], "authzed_unavailable")).resolves.toBe(
-      1
+    for (const attribution of [
+      { isolated: true, retryable: true },
+      { isolated: false, retryable: false },
+      { isolated: false, retryable: true },
+    ]) {
+      await expect(
+        markAuthzedOutboxEventsFailed(
+          "lease-owner",
+          ["event-1", "event-2"],
+          "authzed_unavailable",
+          attribution
+        )
+      ).resolves.toBe(0);
+
+      expect(boundPermanentFlag()).toBe(false);
+    }
+  });
+
+  test("releases a whole failed batch in one statement", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ dead_lettered: 0n }]);
+
+    await markAuthzedOutboxEventsFailed(
+      "lease-owner",
+      Array.from({ length: 200 }, (_unused, index) => `event-${String(index)}`),
+      "authzed_unavailable",
+      { isolated: false, retryable: true }
     );
 
-    expect(prisma.authzedProjectionOutbox.updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ deadLetteredAt: expect.any(Date) }),
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not reach the database when nothing failed", async () => {
+    await expect(
+      markAuthzedOutboxEventsFailed("lease-owner", [], "authzed_unavailable", {
+        isolated: false,
+        retryable: true,
       })
-    );
+    ).resolves.toBe(0);
+
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
   });
 
   test("normalizes aggregate status values without exposing source rows", async () => {
@@ -161,6 +193,7 @@ describe("AuthZed projection outbox repository", () => {
         leaseExpiresAt: null,
         leasedAt: null,
         leaseOwner: null,
+        permanentFailures: 0,
       },
     });
   });

--- a/apps/web/lib/authzed/outbox-repository.test.ts
+++ b/apps/web/lib/authzed/outbox-repository.test.ts
@@ -91,7 +91,7 @@ describe("AuthZed projection outbox repository", () => {
 
     await expect(
       markAuthzedOutboxEventsFailed("lease-owner", ["event-1"], "authzed_invalid_request", {
-        isolated: true,
+        attributable: true,
         retryable: false,
       })
     ).resolves.toBe(1);
@@ -103,9 +103,9 @@ describe("AuthZed projection outbox repository", () => {
     vi.mocked(prisma.$queryRaw).mockResolvedValue([{ dead_lettered: 0n }]);
 
     for (const attribution of [
-      { isolated: true, retryable: true },
-      { isolated: false, retryable: false },
-      { isolated: false, retryable: true },
+      { attributable: true, retryable: true },
+      { attributable: false, retryable: false },
+      { attributable: false, retryable: true },
     ]) {
       await expect(
         markAuthzedOutboxEventsFailed(
@@ -127,7 +127,7 @@ describe("AuthZed projection outbox repository", () => {
       "lease-owner",
       Array.from({ length: 200 }, (_unused, index) => `event-${String(index)}`),
       "authzed_unavailable",
-      { isolated: false, retryable: true }
+      { attributable: false, retryable: true }
     );
 
     expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
@@ -136,7 +136,7 @@ describe("AuthZed projection outbox repository", () => {
   test("does not reach the database when nothing failed", async () => {
     await expect(
       markAuthzedOutboxEventsFailed("lease-owner", [], "authzed_unavailable", {
-        isolated: false,
+        attributable: false,
         retryable: true,
       })
     ).resolves.toBe(0);

--- a/apps/web/lib/authzed/outbox-repository.ts
+++ b/apps/web/lib/authzed/outbox-repository.ts
@@ -7,7 +7,26 @@ import {
   type TAuthzedOutboxStatus,
 } from "./outbox-types";
 
-export const AUTHZED_OUTBOX_MAX_ATTEMPTS = 20;
+/**
+ * Attempts after which the retry backoff stops growing.
+ *
+ * This is a bound on the exponent, not a dead-letter budget: `attempts` keeps climbing while SpiceDB
+ * is unreachable, and `2 ^ attempts` would overflow long before anyone noticed.
+ */
+export const AUTHZED_OUTBOX_MAX_BACKOFF_ATTEMPTS = 20;
+export const AUTHZED_OUTBOX_MAX_RETRY_DELAY_MS = 5 * 60_000;
+
+/**
+ * Non-retryable failures, attributable to one event alone, before it dead-letters.
+ *
+ * Deliberately separate from `attempts`. A dead-lettered revocation arms the fail-closed freshness
+ * guard for the whole deployment, so reaching it must mean "PostgreSQL removed access and we cannot
+ * make SpiceDB agree" — never "SpiceDB was down for an hour". Retryable failures and group failures
+ * therefore leave this untouched; only an event that failed on its own has earned a permanent mark.
+ * With the backoff below that is roughly 17 minutes of solitary failure, well past the 45-second
+ * critical alarm.
+ */
+export const AUTHZED_OUTBOX_MAX_PERMANENT_FAILURES = 10;
 export const AUTHZED_OUTBOX_LEASE_MS = 60_000;
 export const AUTHZED_OUTBOX_REVOCATION_MAX_AGE_MS = 60_000;
 export const AUTHZED_OUTBOX_BATCH_SIZE = 200;
@@ -89,30 +108,58 @@ export const markAuthzedOutboxEventsDelivered = async (
   });
 };
 
-const getRetryDelayMs = (attempts: number): number => Math.min(5 * 60_000, 1_000 * 2 ** (attempts - 1));
-
+/**
+ * Release a failed lease, and dead-letter only what the failure actually attributes.
+ *
+ * `isolated` says the attempt covered this event and nothing else. A group failure reports that the
+ * group did not deliver, not which member broke it, so it must never spend a permanent failure —
+ * otherwise one poison event walks its whole batch to dead letter, and a dead-lettered revocation is
+ * a deployment-wide authorization outage.
+ *
+ * One statement rather than one per event: this path runs when delivery is already failing, which is
+ * exactly when the database is least likely to have headroom for 200 sequential round trips. The
+ * backoff is computed from each row's own `attempts` so nothing has to be grouped by attempt count.
+ */
 export const markAuthzedOutboxEventsFailed = async (
   leaseOwner: string,
-  events: ReadonlyArray<TAuthzedOutboxEvent>,
-  errorCode: string
+  eventIds: ReadonlyArray<string>,
+  errorCode: string,
+  { isolated, retryable }: Readonly<{ isolated: boolean; retryable: boolean }>
 ): Promise<number> => {
-  let deadLettered = 0;
-  for (const event of events) {
-    const shouldDeadLetter = event.attempts >= AUTHZED_OUTBOX_MAX_ATTEMPTS;
-    deadLettered += shouldDeadLetter ? 1 : 0;
-    await prisma.authzedProjectionOutbox.updateMany({
-      where: { id: event.id, leaseOwner, processedAt: null },
-      data: {
-        availableAt: new Date(Date.now() + getRetryDelayMs(event.attempts)),
-        deadLetteredAt: shouldDeadLetter ? new Date() : null,
-        lastErrorCode: errorCode,
-        leaseExpiresAt: null,
-        leasedAt: null,
-        leaseOwner: null,
-      },
-    });
-  }
-  return deadLettered;
+  if (eventIds.length === 0) return 0;
+  const permanent = !retryable && isolated;
+
+  const [row] = await prisma.$queryRaw<ReadonlyArray<{ dead_lettered: bigint }>>`
+    WITH released AS (
+      UPDATE "AuthzedProjectionOutbox"
+      SET "availableAt" = NOW() + (
+            LEAST(
+              ${AUTHZED_OUTBOX_MAX_RETRY_DELAY_MS}::double precision,
+              1000 * 2 ^ (LEAST("attempts", ${AUTHZED_OUTBOX_MAX_BACKOFF_ATTEMPTS}) - 1)
+            ) * INTERVAL '1 millisecond'
+          ),
+          "permanentFailures" = "permanentFailures" + ${permanent ? 1 : 0},
+          "deadLetteredAt" = CASE
+            WHEN ${permanent}::boolean
+             AND "permanentFailures" + 1 >= ${AUTHZED_OUTBOX_MAX_PERMANENT_FAILURES}
+            THEN NOW()
+            ELSE NULL
+          END,
+          "lastErrorCode" = ${errorCode},
+          "leaseExpiresAt" = NULL,
+          "leasedAt" = NULL,
+          "leaseOwner" = NULL,
+          -- Raw SQL bypasses Prisma's @updatedAt, which the previous per-event updateMany got free.
+          "updatedAt" = NOW()
+      WHERE "id" = ANY(${[...eventIds]}::text[])
+        AND "leaseOwner" = ${leaseOwner}
+        AND "processedAt" IS NULL
+      RETURNING "deadLetteredAt"
+    )
+    SELECT COUNT(*) FILTER (WHERE "deadLetteredAt" IS NOT NULL) AS dead_lettered FROM released
+  `;
+
+  return Number(row?.dead_lettered ?? 0);
 };
 
 type TStatusRow = Readonly<{
@@ -126,42 +173,69 @@ type TStatusRow = Readonly<{
 
 type TStaleRevocationRow = Readonly<{ stale: boolean }>;
 
-/** Indexed fail-closed check for the authorization hot path; avoid aggregating retained history. */
+/**
+ * Indexed fail-closed check for the authorization hot path; avoid aggregating retained history.
+ *
+ * Two `EXISTS` rather than one with an `OR`, because the two halves live in different partial
+ * indexes: `_claim_idx` covers `deadLetteredAt IS NULL` and `_dead_letter_idx` covers the complement,
+ * and no single index can serve both sides of that disjunction. Split, each branch is an index probe
+ * and the second is skipped whenever the first already answered.
+ */
 export const hasStaleAuthzedRevocation = async (): Promise<boolean> => {
   const [row] = await prisma.$queryRaw<TStaleRevocationRow[]>`
-    SELECT EXISTS (
-      SELECT 1
-      FROM "AuthzedProjectionOutbox"
-      WHERE "isRevocation" = true
-        AND "processedAt" IS NULL
-        AND ("deadLetteredAt" IS NOT NULL OR "createdAt" <= NOW() - INTERVAL '60 seconds')
+    SELECT (
+      EXISTS (
+        SELECT 1
+        FROM "AuthzedProjectionOutbox"
+        WHERE "isRevocation" = true
+          AND "processedAt" IS NULL
+          AND "deadLetteredAt" IS NULL
+          AND "createdAt" <= NOW() - INTERVAL '60 seconds'
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM "AuthzedProjectionOutbox"
+        WHERE "isRevocation" = true
+          AND "processedAt" IS NULL
+          AND "deadLetteredAt" IS NOT NULL
+      )
     ) AS stale
   `;
 
   return row?.stale ?? false;
 };
 
+/**
+ * Aggregate outbox health.
+ *
+ * Scoped to undelivered rows by the outer `WHERE`, which is what keeps this off the seven days of
+ * retained history: the delivery job calls it every five seconds, so an unscoped aggregate is a
+ * full-table scan twelve times a minute. `dead_lettered` is unaffected by the scoping — a
+ * dead-lettered row always has a NULL `processedAt`, because the claim skips dead letters and
+ * `replayAuthzedOutboxDeadLetters` clears `deadLetteredAt` before delivery is possible again.
+ */
 export const getAuthzedOutboxStatus = async (): Promise<TAuthzedOutboxStatus> => {
   const [row] = await prisma.$queryRaw<TStatusRow[]>`
     SELECT
-      COUNT(*) FILTER (WHERE "processedAt" IS NULL AND "deadLetteredAt" IS NULL) AS pending,
+      COUNT(*) FILTER (WHERE "deadLetteredAt" IS NULL) AS pending,
       COUNT(*) FILTER (WHERE "deadLetteredAt" IS NOT NULL) AS dead_lettered,
       COUNT(*) FILTER (
-        WHERE "processedAt" IS NULL AND "isRevocation" = true
+        WHERE "isRevocation" = true
           AND ("deadLetteredAt" IS NOT NULL OR "createdAt" <= NOW() - INTERVAL '60 seconds')
       ) AS overdue_revocations,
       COUNT(*) FILTER (
-        WHERE "processedAt" IS NULL AND "isRevocation" = true
+        WHERE "isRevocation" = true
           AND ("deadLetteredAt" IS NOT NULL OR "createdAt" <= NOW() - INTERVAL '45 seconds')
       ) AS revocations_past_critical,
       COUNT(*) FILTER (
-        WHERE "processedAt" IS NULL AND "isRevocation" = true
+        WHERE "isRevocation" = true
           AND ("deadLetteredAt" IS NOT NULL OR "createdAt" <= NOW() - INTERVAL '15 seconds')
       ) AS revocations_past_warning,
       EXTRACT(EPOCH FROM NOW() - MIN("createdAt") FILTER (
-        WHERE "processedAt" IS NULL AND "deadLetteredAt" IS NULL
+        WHERE "deadLetteredAt" IS NULL
       ))::double precision AS oldest_pending_age_seconds
     FROM "AuthzedProjectionOutbox"
+    WHERE "processedAt" IS NULL
   `;
 
   return {
@@ -188,6 +262,9 @@ export const replayAuthzedOutboxDeadLetters = async (): Promise<number> => {
       leaseExpiresAt: null,
       leasedAt: null,
       leaseOwner: null,
+      // Reset alongside `attempts`: a replay is a decision that the cause was addressed, so the event
+      // gets the full permanent-failure budget again rather than dead-lettering on its next failure.
+      permanentFailures: 0,
     },
   });
   return result.count;

--- a/apps/web/lib/authzed/outbox-repository.ts
+++ b/apps/web/lib/authzed/outbox-repository.ts
@@ -17,12 +17,13 @@ export const AUTHZED_OUTBOX_MAX_BACKOFF_ATTEMPTS = 20;
 export const AUTHZED_OUTBOX_MAX_RETRY_DELAY_MS = 5 * 60_000;
 
 /**
- * Non-retryable failures, attributable to one event alone, before it dead-letters.
+ * Failures attributable to one event alone before it dead-letters.
  *
  * Deliberately separate from `attempts`. A dead-lettered revocation arms the fail-closed freshness
  * guard for the whole deployment, so reaching it must mean "PostgreSQL removed access and we cannot
- * make SpiceDB agree" — never "SpiceDB was down for an hour". Retryable failures and group failures
- * therefore leave this untouched; only an event that failed on its own has earned a permanent mark.
+ * make SpiceDB agree" — never "SpiceDB was unreachable, or rejected our credential, for a while".
+ * Only a failure that named a single event AND carried a code an event can cause increments this;
+ * retryable failures, group failures and instance-scoped failures all leave it untouched.
  * With the backoff below that is roughly 17 minutes of solitary failure, well past the 45-second
  * critical alarm.
  */
@@ -111,10 +112,13 @@ export const markAuthzedOutboxEventsDelivered = async (
 /**
  * Release a failed lease, and dead-letter only what the failure actually attributes.
  *
- * `isolated` says the attempt covered this event and nothing else. A group failure reports that the
- * group did not deliver, not which member broke it, so it must never spend a permanent failure —
- * otherwise one poison event walks its whole batch to dead letter, and a dead-lettered revocation is
- * a deployment-wide authorization outage.
+ * `attributable` says the failure names these events: the attempt covered one event, AND the code is
+ * one an event can actually cause. Anything else must never spend a permanent failure. A group
+ * failure reports that the group did not deliver, not which member broke it. An instance-scoped code
+ * (a rejected credential, an unmapped internal error) reports that SpiceDB is unhappy — the event
+ * that happened to be travelling alone when it happened did not cause it, and charging it would
+ * dead-letter a bystander mid-outage. Either mistake ends the same way: a dead-lettered revocation
+ * is a deployment-wide authorization outage until something replays it.
  *
  * One statement rather than one per event: this path runs when delivery is already failing, which is
  * exactly when the database is least likely to have headroom for 200 sequential round trips. The
@@ -124,10 +128,10 @@ export const markAuthzedOutboxEventsFailed = async (
   leaseOwner: string,
   eventIds: ReadonlyArray<string>,
   errorCode: string,
-  { isolated, retryable }: Readonly<{ isolated: boolean; retryable: boolean }>
+  { attributable, retryable }: Readonly<{ attributable: boolean; retryable: boolean }>
 ): Promise<number> => {
   if (eventIds.length === 0) return 0;
-  const permanent = !retryable && isolated;
+  const permanent = !retryable && attributable;
 
   const [row] = await prisma.$queryRaw<ReadonlyArray<{ dead_lettered: bigint }>>`
     WITH released AS (
@@ -177,7 +181,7 @@ type TStaleRevocationRow = Readonly<{ stale: boolean }>;
  * Indexed fail-closed check for the authorization hot path; avoid aggregating retained history.
  *
  * Two `EXISTS` rather than one with an `OR`, because the two halves live in different partial
- * indexes: `_claim_idx` covers `deadLetteredAt IS NULL` and `_dead_letter_idx` covers the complement,
+ * indexes: `_claim_idx` covers `deadLetteredAt IS NULL` and `_undelivered_idx` covers the complement,
  * and no single index can serve both sides of that disjunction. Split, each branch is an index probe
  * and the second is skipped whenever the first already answered.
  */

--- a/apps/web/lib/authzed/outbox-repository.ts
+++ b/apps/web/lib/authzed/outbox-repository.ts
@@ -1,0 +1,209 @@
+import "server-only";
+import { randomUUID } from "node:crypto";
+import { prisma } from "@formbricks/database";
+import {
+  AUTHZED_OUTBOX_TARGET_TYPES,
+  type TAuthzedOutboxEvent,
+  type TAuthzedOutboxStatus,
+} from "./outbox-types";
+
+export const AUTHZED_OUTBOX_MAX_ATTEMPTS = 20;
+export const AUTHZED_OUTBOX_LEASE_MS = 60_000;
+export const AUTHZED_OUTBOX_REVOCATION_MAX_AGE_MS = 60_000;
+export const AUTHZED_OUTBOX_BATCH_SIZE = 200;
+export const AUTHZED_OUTBOX_HISTORY_RETENTION_DAYS = 7;
+export const AUTHZED_OUTBOX_HISTORY_DELETE_BATCH_SIZE = 10_000;
+const INVALID_EVENT_ERROR_CODE = "authzed_projection_invalid_event";
+
+type TClaimedRow = Omit<TAuthzedOutboxEvent, "targetType"> & { targetType: string };
+
+const isTargetType = (value: string): value is TAuthzedOutboxEvent["targetType"] =>
+  (AUTHZED_OUTBOX_TARGET_TYPES as readonly string[]).includes(value);
+
+export const createAuthzedOutboxLeaseOwner = (): string => randomUUID();
+
+export const claimAuthzedOutboxEvents = async (
+  leaseOwner: string,
+  limit = AUTHZED_OUTBOX_BATCH_SIZE
+): Promise<ReadonlyArray<TAuthzedOutboxEvent>> => {
+  const rows = await prisma.$queryRaw<TClaimedRow[]>`
+    WITH claimable AS (
+      SELECT "id"
+      FROM "AuthzedProjectionOutbox"
+      WHERE "processedAt" IS NULL
+        AND "deadLetteredAt" IS NULL
+        AND "availableAt" <= NOW()
+        AND ("leaseExpiresAt" IS NULL OR "leaseExpiresAt" <= NOW())
+      ORDER BY "isRevocation" DESC, "createdAt" ASC
+      LIMIT ${limit}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE "AuthzedProjectionOutbox" AS outbox
+    SET "attempts" = outbox."attempts" + 1,
+        "lastAttemptAt" = NOW(),
+        "leasedAt" = NOW(),
+        "leaseExpiresAt" = NOW() + (${AUTHZED_OUTBOX_LEASE_MS} * INTERVAL '1 millisecond'),
+        "leaseOwner" = ${leaseOwner},
+        "updatedAt" = NOW()
+    FROM claimable
+    WHERE outbox."id" = claimable."id"
+    RETURNING outbox."id", outbox."targetType", outbox."primaryId", outbox."secondaryId",
+              outbox."isRevocation", outbox."attempts", outbox."createdAt"
+  `;
+
+  const invalidIds = rows.filter(({ targetType }) => !isTargetType(targetType)).map(({ id }) => id);
+  if (invalidIds.length > 0) {
+    // A manually inserted or corrupted event must not remain silently leased forever. Dead-letter it
+    // without logging its identifiers; an invalid revocation will then activate the freshness guard.
+    await prisma.authzedProjectionOutbox.updateMany({
+      where: { id: { in: invalidIds }, leaseOwner, processedAt: null },
+      data: {
+        deadLetteredAt: new Date(),
+        lastErrorCode: INVALID_EVENT_ERROR_CODE,
+        leaseExpiresAt: null,
+        leasedAt: null,
+        leaseOwner: null,
+      },
+    });
+  }
+
+  return rows.flatMap((row) =>
+    isTargetType(row.targetType) ? [{ ...row, targetType: row.targetType }] : []
+  );
+};
+
+export const markAuthzedOutboxEventsDelivered = async (
+  leaseOwner: string,
+  eventIds: ReadonlyArray<string>
+): Promise<void> => {
+  if (eventIds.length === 0) return;
+  await prisma.authzedProjectionOutbox.updateMany({
+    where: { id: { in: [...eventIds] }, leaseOwner, processedAt: null },
+    data: {
+      lastErrorCode: null,
+      leaseExpiresAt: null,
+      leasedAt: null,
+      leaseOwner: null,
+      processedAt: new Date(),
+    },
+  });
+};
+
+const getRetryDelayMs = (attempts: number): number => Math.min(5 * 60_000, 1_000 * 2 ** (attempts - 1));
+
+export const markAuthzedOutboxEventsFailed = async (
+  leaseOwner: string,
+  events: ReadonlyArray<TAuthzedOutboxEvent>,
+  errorCode: string
+): Promise<number> => {
+  let deadLettered = 0;
+  for (const event of events) {
+    const shouldDeadLetter = event.attempts >= AUTHZED_OUTBOX_MAX_ATTEMPTS;
+    deadLettered += shouldDeadLetter ? 1 : 0;
+    await prisma.authzedProjectionOutbox.updateMany({
+      where: { id: event.id, leaseOwner, processedAt: null },
+      data: {
+        availableAt: new Date(Date.now() + getRetryDelayMs(event.attempts)),
+        deadLetteredAt: shouldDeadLetter ? new Date() : null,
+        lastErrorCode: errorCode,
+        leaseExpiresAt: null,
+        leasedAt: null,
+        leaseOwner: null,
+      },
+    });
+  }
+  return deadLettered;
+};
+
+type TStatusRow = Readonly<{
+  dead_lettered: bigint;
+  oldest_pending_age_seconds: number | null;
+  overdue_revocations: bigint;
+  pending: bigint;
+  revocations_past_critical: bigint;
+  revocations_past_warning: bigint;
+}>;
+
+type TStaleRevocationRow = Readonly<{ stale: boolean }>;
+
+/** Indexed fail-closed check for the authorization hot path; avoid aggregating retained history. */
+export const hasStaleAuthzedRevocation = async (): Promise<boolean> => {
+  const [row] = await prisma.$queryRaw<TStaleRevocationRow[]>`
+    SELECT EXISTS (
+      SELECT 1
+      FROM "AuthzedProjectionOutbox"
+      WHERE "isRevocation" = true
+        AND "processedAt" IS NULL
+        AND ("deadLetteredAt" IS NOT NULL OR "createdAt" <= NOW() - INTERVAL '60 seconds')
+    ) AS stale
+  `;
+
+  return row?.stale ?? false;
+};
+
+export const getAuthzedOutboxStatus = async (): Promise<TAuthzedOutboxStatus> => {
+  const [row] = await prisma.$queryRaw<TStatusRow[]>`
+    SELECT
+      COUNT(*) FILTER (WHERE "processedAt" IS NULL AND "deadLetteredAt" IS NULL) AS pending,
+      COUNT(*) FILTER (WHERE "deadLetteredAt" IS NOT NULL) AS dead_lettered,
+      COUNT(*) FILTER (
+        WHERE "processedAt" IS NULL AND "isRevocation" = true
+          AND ("deadLetteredAt" IS NOT NULL OR "createdAt" <= NOW() - INTERVAL '60 seconds')
+      ) AS overdue_revocations,
+      COUNT(*) FILTER (
+        WHERE "processedAt" IS NULL AND "isRevocation" = true
+          AND ("deadLetteredAt" IS NOT NULL OR "createdAt" <= NOW() - INTERVAL '45 seconds')
+      ) AS revocations_past_critical,
+      COUNT(*) FILTER (
+        WHERE "processedAt" IS NULL AND "isRevocation" = true
+          AND ("deadLetteredAt" IS NOT NULL OR "createdAt" <= NOW() - INTERVAL '15 seconds')
+      ) AS revocations_past_warning,
+      EXTRACT(EPOCH FROM NOW() - MIN("createdAt") FILTER (
+        WHERE "processedAt" IS NULL AND "deadLetteredAt" IS NULL
+      ))::double precision AS oldest_pending_age_seconds
+    FROM "AuthzedProjectionOutbox"
+  `;
+
+  return {
+    deadLettered: Number(row?.dead_lettered ?? 0),
+    oldestPendingAgeSeconds:
+      row?.oldest_pending_age_seconds === null || row?.oldest_pending_age_seconds === undefined
+        ? null
+        : Math.max(0, Math.floor(row.oldest_pending_age_seconds)),
+    overdueRevocations: Number(row?.overdue_revocations ?? 0),
+    pending: Number(row?.pending ?? 0),
+    revocationsPastCritical: Number(row?.revocations_past_critical ?? 0),
+    revocationsPastWarning: Number(row?.revocations_past_warning ?? 0),
+  };
+};
+
+export const replayAuthzedOutboxDeadLetters = async (): Promise<number> => {
+  const result = await prisma.authzedProjectionOutbox.updateMany({
+    where: { deadLetteredAt: { not: null }, processedAt: null },
+    data: {
+      attempts: 0,
+      availableAt: new Date(),
+      deadLetteredAt: null,
+      lastErrorCode: null,
+      leaseExpiresAt: null,
+      leasedAt: null,
+      leaseOwner: null,
+    },
+  });
+  return result.count;
+};
+
+/** Bound table growth without deleting pending or dead-letter evidence. */
+export const pruneAuthzedOutboxHistory = async (): Promise<number> =>
+  prisma.$executeRaw`
+    WITH expired AS (
+      SELECT "id"
+      FROM "AuthzedProjectionOutbox"
+      WHERE "processedAt" < NOW() - (${AUTHZED_OUTBOX_HISTORY_RETENTION_DAYS} * INTERVAL '1 day')
+      ORDER BY "processedAt" ASC
+      LIMIT ${AUTHZED_OUTBOX_HISTORY_DELETE_BATCH_SIZE}
+    )
+    DELETE FROM "AuthzedProjectionOutbox" AS outbox
+    USING expired
+    WHERE outbox."id" = expired."id"
+  `;

--- a/apps/web/lib/authzed/outbox-trigger.integration.test.ts
+++ b/apps/web/lib/authzed/outbox-trigger.integration.test.ts
@@ -151,11 +151,12 @@ describe("AuthZed projection outbox triggers", () => {
       { isRevocation: false, primaryId: directory.id, secondaryId: null, targetType: "feedback_directory" },
     ]);
 
+    await prisma.feedbackDirectory.update({ where: { id: directory.id }, data: { isArchived: true } });
+    // Cleared AFTER the re-archive, not before: that setup step enqueues a revocation of its own, and
+    // `outboxRows` sorts revocations first, so asserting on `.at(0)` would have read the setup row and
+    // passed even with the organizationId clause deleted from the classifier.
     await clearOutbox();
-    await prisma.feedbackDirectory.update({
-      where: { id: directory.id },
-      data: { isArchived: true },
-    });
+
     await prisma.feedbackDirectory.update({
       where: { id: directory.id },
       data: { isArchived: false, organizationId: other.id },
@@ -163,7 +164,9 @@ describe("AuthZed projection outbox triggers", () => {
 
     // The parent edge is only ever touched, never re-pointed, so the old organization's administrators
     // keep access until reconciliation. A widening that moves tenants is still a revocation.
-    expect((await outboxRows()).at(0)?.isRevocation).toBe(true);
+    expect(await outboxRows()).toEqual([
+      { isRevocation: true, primaryId: directory.id, secondaryId: null, targetType: "feedback_directory" },
+    ]);
   });
 
   test("classifies an unmapped enum move as a revocation", async () => {
@@ -209,14 +212,21 @@ type TReleaseState = Readonly<{ availableAt: Date; deadLetteredAt: Date | null; 
 
 const insertClaimedEvent = async (
   id: string,
-  overrides: Readonly<{ attempts?: number; isRevocation?: boolean; permanentFailures?: number }> = {}
+  overrides: Readonly<{
+    attempts?: number;
+    isRevocation?: boolean;
+    permanentFailures?: number;
+    processedAt?: Date;
+  }> = {}
 ): Promise<void> => {
   await prisma.$executeRaw`
     INSERT INTO "AuthzedProjectionOutbox"
-      ("id", "targetType", "primaryId", "isRevocation", "attempts", "permanentFailures", "leaseOwner", "updatedAt")
+      ("id", "targetType", "primaryId", "isRevocation", "attempts", "permanentFailures", "processedAt",
+       "leaseOwner", "updatedAt")
     VALUES (
       ${id}, 'membership', 'organization-id', ${overrides.isRevocation ?? false},
-      ${overrides.attempts ?? 1}, ${overrides.permanentFailures ?? 0}, 'lease', NOW()
+      ${overrides.attempts ?? 1}, ${overrides.permanentFailures ?? 0}, ${overrides.processedAt ?? null},
+      'lease', NOW()
     )
   `;
 };
@@ -239,7 +249,7 @@ describe("AuthZed projection outbox failure release", () => {
 
     await expect(
       markAuthzedOutboxEventsFailed("lease", ["solo"], "authzed_invalid_request", {
-        isolated: true,
+        attributable: true,
         retryable: false,
       })
     ).resolves.toBe(0);
@@ -248,7 +258,7 @@ describe("AuthZed projection outbox failure release", () => {
     await reclaim("solo");
     await expect(
       markAuthzedOutboxEventsFailed("lease", ["solo"], "authzed_invalid_request", {
-        isolated: true,
+        attributable: true,
         retryable: false,
       })
     ).resolves.toBe(1);
@@ -264,7 +274,7 @@ describe("AuthZed projection outbox failure release", () => {
       await reclaim("outage");
       await expect(
         markAuthzedOutboxEventsFailed("lease", ["outage"], "authzed_unavailable", {
-          isolated: true,
+          attributable: true,
           retryable: true,
         })
       ).resolves.toBe(0);
@@ -278,7 +288,7 @@ describe("AuthZed projection outbox failure release", () => {
 
     await expect(
       markAuthzedOutboxEventsFailed("lease", ["bystander", "other"], "authzed_projection_invalid_source", {
-        isolated: false,
+        attributable: false,
         retryable: false,
       })
     ).resolves.toBe(0);
@@ -296,7 +306,7 @@ describe("AuthZed projection outbox failure release", () => {
     ]);
 
     await markAuthzedOutboxEventsFailed("lease", ["early", "late"], "authzed_unavailable", {
-      isolated: false,
+      attributable: false,
       retryable: true,
     });
 
@@ -312,7 +322,7 @@ describe("AuthZed projection outbox failure release", () => {
 
     await expect(
       markAuthzedOutboxEventsFailed("lease", ["stolen"], "authzed_internal", {
-        isolated: true,
+        attributable: true,
         retryable: false,
       })
     ).resolves.toBe(0);
@@ -326,6 +336,17 @@ describe("AuthZed projection freshness guard", () => {
     // The whole point of the classifier: a bulk invite acceptance must not deny the deployment.
     await insertClaimedEvent("aged-grant", { isRevocation: false });
     await prisma.$executeRaw`UPDATE "AuthzedProjectionOutbox" SET "createdAt" = NOW() - INTERVAL '1 hour' WHERE "id" = 'aged-grant'`;
+
+    await expect(hasStaleAuthzedRevocation()).resolves.toBe(false);
+  });
+
+  test("stays disarmed for a revocation that was actually delivered", async () => {
+    // Delivered rows are retained for seven days, so a healthy deployment permanently holds thousands
+    // of processed revocations far older than the window. Dropping `processedAt IS NULL` from either
+    // EXISTS would therefore deny the whole deployment forever, and nothing else in the suite writes a
+    // delivered row to notice.
+    await insertClaimedEvent("delivered-revocation", { isRevocation: true, processedAt: new Date() });
+    await prisma.$executeRaw`UPDATE "AuthzedProjectionOutbox" SET "createdAt" = NOW() - INTERVAL '1 hour' WHERE "id" = 'delivered-revocation'`;
 
     await expect(hasStaleAuthzedRevocation()).resolves.toBe(false);
   });
@@ -353,8 +374,8 @@ describe("AuthZed projection outbox indexes", () => {
 
     expect(indexes.map(({ indexname }) => indexname)).toEqual([
       "AuthzedProjectionOutbox_claim_idx",
-      "AuthzedProjectionOutbox_dead_letter_idx",
       "AuthzedProjectionOutbox_processed_idx",
+      "AuthzedProjectionOutbox_undelivered_idx",
     ]);
     for (const { indexdef } of indexes) {
       expect(indexdef).toMatch(/WHERE /);

--- a/apps/web/lib/authzed/outbox-trigger.integration.test.ts
+++ b/apps/web/lib/authzed/outbox-trigger.integration.test.ts
@@ -1,0 +1,389 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { resetDb } from "@/integration/reset-db";
+import {
+  AUTHZED_OUTBOX_MAX_PERMANENT_FAILURES,
+  hasStaleAuthzedRevocation,
+  markAuthzedOutboxEventsFailed,
+} from "@/lib/authzed/outbox-repository";
+
+/**
+ * The durable outbox against a real PostgreSQL (ENG-2408).
+ *
+ * Three things in this feature are implemented in SQL and are therefore invisible to a unit test: the
+ * trigger's grant/revocation classifier, the backoff and dead-letter arithmetic in the failure
+ * release, and whether the indexes are actually the partial ones the hot paths need. The
+ * string-matching contract test next door can see that the SQL *says* something; only this can see
+ * that it *does* it.
+ *
+ * The classifier is the load-bearing one. `isRevocation` has a single reader — the fail-closed
+ * freshness guard — and a guard armed by a pure grant denies every enforced authorization check in
+ * the deployment, so a mass invite acceptance would be an outage. The transition table below is the
+ * evidence that it is not.
+ */
+
+type TOutboxRow = Readonly<{
+  isRevocation: boolean;
+  primaryId: string;
+  secondaryId: string | null;
+  targetType: string;
+}>;
+
+const outboxRows = (): Promise<ReadonlyArray<TOutboxRow>> =>
+  prisma.$queryRaw<TOutboxRow[]>`
+    SELECT "targetType", "primaryId", "secondaryId", "isRevocation"
+    FROM "AuthzedProjectionOutbox"
+    ORDER BY "isRevocation" DESC, "createdAt" ASC
+  `;
+
+/** Source setup fires the triggers too, so clear what it produced before the mutation under test. */
+const clearOutbox = (): Promise<unknown> => prisma.$executeRawUnsafe('TRUNCATE "AuthzedProjectionOutbox";');
+
+const seedUser = (email: string, isActive = true) =>
+  prisma.user.create({ data: { email, name: email, isActive } });
+
+const seedOrganization = (name: string) => prisma.organization.create({ data: { name } });
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("AuthZed projection outbox triggers", () => {
+  test("does not classify an accepted invite as a revocation", async () => {
+    const [user, organization] = await Promise.all([
+      seedUser("accept@integration.test"),
+      seedOrganization("Accept"),
+    ]);
+    await prisma.membership.create({
+      data: { organizationId: organization.id, userId: user.id, accepted: false, role: "member" },
+    });
+    await clearOutbox();
+
+    await prisma.membership.update({
+      where: { userId_organizationId: { organizationId: organization.id, userId: user.id } },
+      data: { accepted: true },
+    });
+
+    // The projected snapshot ignores `accepted` entirely, so this writes byte-identical relationships.
+    expect(await outboxRows()).toEqual([
+      {
+        isRevocation: false,
+        primaryId: organization.id,
+        secondaryId: user.id,
+        targetType: "membership",
+      },
+    ]);
+  });
+
+  test("classifies any role move as a revocation, promotions included", async () => {
+    const [user, organization] = await Promise.all([
+      seedUser("promote@integration.test"),
+      seedOrganization("Promote"),
+    ]);
+    await prisma.membership.create({
+      data: { organizationId: organization.id, userId: user.id, accepted: true, role: "member" },
+    });
+    await clearOutbox();
+
+    await prisma.membership.update({
+      where: { userId_organizationId: { organizationId: organization.id, userId: user.id } },
+      data: { role: "owner" },
+    });
+
+    // Deny by default: a role move deletes the relation for the old role, and the permission ladder is
+    // deliberately not encoded in SQL where nothing would catch it drifting from authzed/schema.zed.
+    expect(await outboxRows()).toEqual([
+      { isRevocation: true, primaryId: organization.id, secondaryId: user.id, targetType: "membership" },
+    ]);
+  });
+
+  test("enqueues the abandoned pair as a revocation when a membership moves organization", async () => {
+    const [user, from, to] = await Promise.all([
+      seedUser("move@integration.test"),
+      seedOrganization("Move from"),
+      seedOrganization("Move to"),
+    ]);
+    await prisma.membership.create({
+      data: { organizationId: from.id, userId: user.id, accepted: true, role: "member" },
+    });
+    await clearOutbox();
+
+    await prisma.$executeRaw`
+      UPDATE "Membership" SET "organizationId" = ${to.id}
+      WHERE "userId" = ${user.id} AND "organizationId" = ${from.id}
+    `;
+
+    expect(await outboxRows()).toEqual([
+      { isRevocation: true, primaryId: from.id, secondaryId: user.id, targetType: "membership" },
+      { isRevocation: false, primaryId: to.id, secondaryId: user.id, targetType: "membership" },
+    ]);
+  });
+
+  test("classifies reactivation as a grant and deactivation as a revocation", async () => {
+    const user = await seedUser("toggle@integration.test", false);
+    await clearOutbox();
+
+    await prisma.user.update({ where: { id: user.id }, data: { isActive: true } });
+    // Every relationship is deleted while a user is inactive, so the pre-state is empty by construction.
+    expect(await outboxRows()).toEqual([
+      { isRevocation: false, primaryId: user.id, secondaryId: null, targetType: "user" },
+    ]);
+
+    await clearOutbox();
+    await prisma.user.update({ where: { id: user.id }, data: { isActive: false } });
+    expect(await outboxRows()).toEqual([
+      { isRevocation: true, primaryId: user.id, secondaryId: null, targetType: "user" },
+    ]);
+  });
+
+  test("classifies unarchiving a directory as a grant unless it also changes organization", async () => {
+    const [organization, other] = await Promise.all([
+      seedOrganization("Directory home"),
+      seedOrganization("Directory elsewhere"),
+    ]);
+    const directory = await prisma.feedbackDirectory.create({
+      data: { name: "Archived", organizationId: organization.id, isArchived: true },
+    });
+    await clearOutbox();
+
+    await prisma.feedbackDirectory.update({ where: { id: directory.id }, data: { isArchived: false } });
+    expect(await outboxRows()).toEqual([
+      { isRevocation: false, primaryId: directory.id, secondaryId: null, targetType: "feedback_directory" },
+    ]);
+
+    await clearOutbox();
+    await prisma.feedbackDirectory.update({
+      where: { id: directory.id },
+      data: { isArchived: true },
+    });
+    await prisma.feedbackDirectory.update({
+      where: { id: directory.id },
+      data: { isArchived: false, organizationId: other.id },
+    });
+
+    // The parent edge is only ever touched, never re-pointed, so the old organization's administrators
+    // keep access until reconciliation. A widening that moves tenants is still a revocation.
+    expect((await outboxRows()).at(0)?.isRevocation).toBe(true);
+  });
+
+  test("classifies an unmapped enum move as a revocation", async () => {
+    const [user, organization] = await Promise.all([
+      seedUser("team@integration.test"),
+      seedOrganization("Team owner"),
+    ]);
+    const team = await prisma.team.create({ data: { name: "Team", organizationId: organization.id } });
+    await prisma.teamUser.create({ data: { teamId: team.id, userId: user.id, role: "contributor" } });
+    await clearOutbox();
+
+    await prisma.teamUser.update({
+      where: { teamId_userId: { teamId: team.id, userId: user.id } },
+      data: { role: "admin" },
+    });
+
+    expect(await outboxRows()).toEqual([
+      { isRevocation: true, primaryId: team.id, secondaryId: user.id, targetType: "team_membership" },
+    ]);
+  });
+
+  test("classifies a delete as a revocation", async () => {
+    const [user, organization] = await Promise.all([
+      seedUser("delete@integration.test"),
+      seedOrganization("Delete"),
+    ]);
+    await prisma.membership.create({
+      data: { organizationId: organization.id, userId: user.id, accepted: true, role: "member" },
+    });
+    await clearOutbox();
+
+    await prisma.membership.delete({
+      where: { userId_organizationId: { organizationId: organization.id, userId: user.id } },
+    });
+
+    expect(await outboxRows()).toEqual([
+      { isRevocation: true, primaryId: organization.id, secondaryId: user.id, targetType: "membership" },
+    ]);
+  });
+});
+
+type TReleaseState = Readonly<{ availableAt: Date; deadLetteredAt: Date | null; permanentFailures: number }>;
+
+const insertClaimedEvent = async (
+  id: string,
+  overrides: Readonly<{ attempts?: number; isRevocation?: boolean; permanentFailures?: number }> = {}
+): Promise<void> => {
+  await prisma.$executeRaw`
+    INSERT INTO "AuthzedProjectionOutbox"
+      ("id", "targetType", "primaryId", "isRevocation", "attempts", "permanentFailures", "leaseOwner", "updatedAt")
+    VALUES (
+      ${id}, 'membership', 'organization-id', ${overrides.isRevocation ?? false},
+      ${overrides.attempts ?? 1}, ${overrides.permanentFailures ?? 0}, 'lease', NOW()
+    )
+  `;
+};
+
+/** Releasing clears the lease, so the next failure has to be preceded by a fresh claim. */
+const reclaim = (id: string): Promise<unknown> =>
+  prisma.$executeRaw`UPDATE "AuthzedProjectionOutbox" SET "leaseOwner" = 'lease' WHERE "id" = ${id}`;
+
+const releaseState = async (id: string): Promise<TReleaseState> => {
+  const [row] = await prisma.$queryRaw<TReleaseState[]>`
+    SELECT "availableAt", "deadLetteredAt", "permanentFailures"
+    FROM "AuthzedProjectionOutbox" WHERE "id" = ${id}
+  `;
+  return row;
+};
+
+describe("AuthZed projection outbox failure release", () => {
+  test("dead-letters only after enough failures attributable to one event", async () => {
+    await insertClaimedEvent("solo", { permanentFailures: AUTHZED_OUTBOX_MAX_PERMANENT_FAILURES - 2 });
+
+    await expect(
+      markAuthzedOutboxEventsFailed("lease", ["solo"], "authzed_invalid_request", {
+        isolated: true,
+        retryable: false,
+      })
+    ).resolves.toBe(0);
+    expect((await releaseState("solo")).permanentFailures).toBe(AUTHZED_OUTBOX_MAX_PERMANENT_FAILURES - 1);
+
+    await reclaim("solo");
+    await expect(
+      markAuthzedOutboxEventsFailed("lease", ["solo"], "authzed_invalid_request", {
+        isolated: true,
+        retryable: false,
+      })
+    ).resolves.toBe(1);
+    expect((await releaseState("solo")).deadLetteredAt).toBeInstanceOf(Date);
+  });
+
+  test("never dead-letters a retryable failure, however long the outage runs", async () => {
+    // The reported failure mode: SpiceDB down for an hour dead-letters two hundred healthy events, and
+    // a dead-lettered revocation denies every enforced check until an operator replays it by hand.
+    await insertClaimedEvent("outage", { attempts: 60, permanentFailures: 0 });
+
+    for (let attempt = 0; attempt < AUTHZED_OUTBOX_MAX_PERMANENT_FAILURES + 5; attempt++) {
+      await reclaim("outage");
+      await expect(
+        markAuthzedOutboxEventsFailed("lease", ["outage"], "authzed_unavailable", {
+          isolated: true,
+          retryable: true,
+        })
+      ).resolves.toBe(0);
+    }
+
+    expect(await releaseState("outage")).toMatchObject({ deadLetteredAt: null, permanentFailures: 0 });
+  });
+
+  test("never dead-letters an event a group failure could not attribute", async () => {
+    await insertClaimedEvent("bystander", { permanentFailures: AUTHZED_OUTBOX_MAX_PERMANENT_FAILURES - 1 });
+
+    await expect(
+      markAuthzedOutboxEventsFailed("lease", ["bystander", "other"], "authzed_projection_invalid_source", {
+        isolated: false,
+        retryable: false,
+      })
+    ).resolves.toBe(0);
+
+    expect(await releaseState("bystander")).toMatchObject({
+      deadLetteredAt: null,
+      permanentFailures: AUTHZED_OUTBOX_MAX_PERMANENT_FAILURES - 1,
+    });
+  });
+
+  test("backs off further for a later attempt and stops growing at the ceiling", async () => {
+    await Promise.all([
+      insertClaimedEvent("early", { attempts: 3 }),
+      insertClaimedEvent("late", { attempts: 40 }),
+    ]);
+
+    await markAuthzedOutboxEventsFailed("lease", ["early", "late"], "authzed_unavailable", {
+      isolated: false,
+      retryable: true,
+    });
+
+    const [early, late] = await Promise.all([releaseState("early"), releaseState("late")]);
+    expect(early.availableAt.getTime()).toBeLessThan(late.availableAt.getTime());
+    // Capped rather than overflowed: 2 ^ 40 milliseconds is thirty-five thousand years.
+    expect(late.availableAt.getTime() - Date.now()).toBeLessThanOrEqual(5 * 60_000 + 5_000);
+  });
+
+  test("leaves an event released by a lease it no longer owns untouched", async () => {
+    await insertClaimedEvent("stolen");
+    await prisma.$executeRaw`UPDATE "AuthzedProjectionOutbox" SET "leaseOwner" = 'other' WHERE "id" = 'stolen'`;
+
+    await expect(
+      markAuthzedOutboxEventsFailed("lease", ["stolen"], "authzed_internal", {
+        isolated: true,
+        retryable: false,
+      })
+    ).resolves.toBe(0);
+
+    expect((await releaseState("stolen")).permanentFailures).toBe(0);
+  });
+});
+
+describe("AuthZed projection freshness guard", () => {
+  test("stays disarmed for a grant that has been pending far past the window", async () => {
+    // The whole point of the classifier: a bulk invite acceptance must not deny the deployment.
+    await insertClaimedEvent("aged-grant", { isRevocation: false });
+    await prisma.$executeRaw`UPDATE "AuthzedProjectionOutbox" SET "createdAt" = NOW() - INTERVAL '1 hour' WHERE "id" = 'aged-grant'`;
+
+    await expect(hasStaleAuthzedRevocation()).resolves.toBe(false);
+  });
+
+  test("arms for an overdue revocation and for a dead-lettered one of any age", async () => {
+    await insertClaimedEvent("aged-revocation", { isRevocation: true });
+    await prisma.$executeRaw`UPDATE "AuthzedProjectionOutbox" SET "createdAt" = NOW() - INTERVAL '1 hour' WHERE "id" = 'aged-revocation'`;
+    await expect(hasStaleAuthzedRevocation()).resolves.toBe(true);
+
+    await prisma.$executeRaw`TRUNCATE "AuthzedProjectionOutbox"`;
+    await insertClaimedEvent("fresh-dead-letter", { isRevocation: true });
+    await prisma.$executeRaw`UPDATE "AuthzedProjectionOutbox" SET "deadLetteredAt" = NOW() WHERE "id" = 'fresh-dead-letter'`;
+    // No age bound on dead letters is deliberate: an old one is more dangerous than a fresh one.
+    await expect(hasStaleAuthzedRevocation()).resolves.toBe(true);
+  });
+});
+
+describe("AuthZed projection outbox indexes", () => {
+  test("keeps every hot-path index off the retained delivery history", async () => {
+    const indexes = await prisma.$queryRaw<ReadonlyArray<{ indexdef: string; indexname: string }>>`
+      SELECT "indexname", "indexdef" FROM pg_indexes
+      WHERE "tablename" = 'AuthzedProjectionOutbox' AND "indexname" <> 'AuthzedProjectionOutbox_pkey'
+      ORDER BY "indexname"
+    `;
+
+    expect(indexes.map(({ indexname }) => indexname)).toEqual([
+      "AuthzedProjectionOutbox_claim_idx",
+      "AuthzedProjectionOutbox_dead_letter_idx",
+      "AuthzedProjectionOutbox_processed_idx",
+    ]);
+    for (const { indexdef } of indexes) {
+      expect(indexdef).toMatch(/WHERE /);
+    }
+  });
+
+  test("serves the claim in index order rather than sorting the backlog", async () => {
+    // Seeded and analyzed on purpose: on an empty table the planner prefers a sequential scan whatever
+    // indexes exist, so asserting the plan without a backlog and real statistics measures nothing.
+    await prisma.$executeRaw`
+      INSERT INTO "AuthzedProjectionOutbox"
+        ("id", "targetType", "primaryId", "isRevocation", "createdAt", "updatedAt")
+      SELECT
+        'plan-' || generated::text, 'membership', 'organization-id', generated % 2 = 0,
+        NOW() - (generated * INTERVAL '1 second'), NOW()
+      FROM generate_series(1, 2000) AS generated
+    `;
+    await prisma.$executeRawUnsafe('ANALYZE "AuthzedProjectionOutbox";');
+
+    const plan = await prisma.$queryRaw<ReadonlyArray<{ "QUERY PLAN": string }>>`
+      EXPLAIN SELECT "id" FROM "AuthzedProjectionOutbox"
+      WHERE "processedAt" IS NULL AND "deadLetteredAt" IS NULL AND "availableAt" <= NOW()
+        AND ("leaseExpiresAt" IS NULL OR "leaseExpiresAt" <= NOW())
+      ORDER BY "isRevocation" DESC, "createdAt" ASC
+      LIMIT 200
+    `;
+    const rendered = plan.map((line) => line["QUERY PLAN"]).join("\n");
+
+    expect(rendered).toContain("AuthzedProjectionOutbox_claim_idx");
+    expect(rendered).not.toContain("Sort");
+  });
+});

--- a/apps/web/lib/authzed/outbox-types.ts
+++ b/apps/web/lib/authzed/outbox-types.ts
@@ -1,0 +1,45 @@
+import "server-only";
+
+export const AUTHZED_OUTBOX_TARGET_TYPES = [
+  "api_key",
+  "api_key_workspace",
+  "feedback_directory",
+  "feedback_directory_assignment",
+  "membership",
+  "organization",
+  "team",
+  "team_membership",
+  "user",
+  "workspace",
+  "workspace_team",
+] as const;
+
+export type TAuthzedOutboxTargetType = (typeof AUTHZED_OUTBOX_TARGET_TYPES)[number];
+
+export type TAuthzedOutboxEvent = Readonly<{
+  attempts: number;
+  createdAt: Date;
+  id: string;
+  isRevocation: boolean;
+  primaryId: string;
+  secondaryId: string | null;
+  targetType: TAuthzedOutboxTargetType;
+}>;
+
+export type TAuthzedOutboxStatus = Readonly<{
+  deadLettered: number;
+  oldestPendingAgeSeconds: number | null;
+  overdueRevocations: number;
+  pending: number;
+  revocationsPastCritical: number;
+  revocationsPastWarning: number;
+}>;
+
+export type TAuthzedOutboxDrainResult = Readonly<{
+  claimed: number;
+  deadLettered: number;
+  delivered: number;
+  failed: number;
+  remaining: number;
+  status: "drained" | "partial";
+}>;

--- a/apps/web/lib/authzed/projection-chunks.ts
+++ b/apps/web/lib/authzed/projection-chunks.ts
@@ -1,0 +1,57 @@
+import "server-only";
+import { AUTHZED_TARGET_CHUNK_SIZE } from "./constants";
+import type { TAuthzedProjectionResult } from "./projection";
+
+/**
+ * Run one reconciler over chunked targets, stopping at the first chunk that does not project.
+ *
+ * A reconciler accepts several target lists at once and reads one PostgreSQL snapshot covering all of
+ * them, so every list it understands is passed in a single call. Splitting them would multiply the
+ * snapshot reads and the verification passes for no benefit.
+ *
+ * Chunking bounds each list independently, because each becomes its own `OR` clause in the snapshot
+ * query. Call *i* takes chunk *i* of every list, so the number of calls is set by the longest list
+ * rather than by their total.
+ *
+ * Returns `null` when every list was empty, so nothing reaches a reconciler — the write facade rejects
+ * an empty update batch.
+ *
+ * Shared by the backfill sweep and the durable outbox: the outbox claims a bounded batch of events,
+ * but a batch of user events expands into an unbounded number of membership targets, so it needs the
+ * same bound.
+ */
+export const runChunked = async <TTargets extends Readonly<Record<string, ReadonlyArray<unknown>>>>(
+  reconcile: (targets: TTargets) => Promise<TAuthzedProjectionResult>,
+  targets: TTargets
+): Promise<TAuthzedProjectionResult | null> => {
+  type TEntry = readonly [keyof TTargets & string, ReadonlyArray<unknown>];
+  const entries = (Object.entries(targets) as ReadonlyArray<TEntry>).filter(([, items]) => items.length > 0);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const chunkCount = Math.max(
+    ...entries.map(([, items]) => Math.ceil(items.length / AUTHZED_TARGET_CHUNK_SIZE))
+  );
+
+  for (let index = 0; index < chunkCount; index++) {
+    const start = index * AUTHZED_TARGET_CHUNK_SIZE;
+    // Built by narrowing a full target object rather than assembling a partial one and asserting the
+    // type. Every field of the reconcilers' target types is optional, so an assertion would silently
+    // keep compiling if one ever became required — and the missing list would only surface at runtime.
+    const chunkTargets: TTargets = { ...targets };
+    for (const [key, items] of entries) {
+      (chunkTargets as Record<string, ReadonlyArray<unknown>>)[key] = items.slice(
+        start,
+        start + AUTHZED_TARGET_CHUNK_SIZE
+      );
+    }
+
+    const result = await reconcile(chunkTargets);
+    if (result.status !== "projected") {
+      return result;
+    }
+  }
+
+  return { passes: 1, status: "projected" };
+};

--- a/apps/web/lib/authzed/scheduled-reconciliation.test.ts
+++ b/apps/web/lib/authzed/scheduled-reconciliation.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { runAuthzedBackfill } from "./backfill";
 import { isAuthzedEnabled } from "./config";
 import { recordAuthzedReconciliationAudit } from "./metrics";
-import { pruneAuthzedOutboxHistory } from "./outbox-repository";
+import { pruneAuthzedOutboxHistory, replayAuthzedOutboxDeadLetters } from "./outbox-repository";
 import { processAuthzedScheduledReconciliationJob } from "./scheduled-reconciliation";
 
 vi.mock("@formbricks/logger", () => ({ logger: { warn: vi.fn() } }));
@@ -14,7 +14,10 @@ vi.mock("./backfill-apply", () => ({
 vi.mock("./client", () => ({ getAuthzedClient: vi.fn(() => ({ client: true })) }));
 vi.mock("./config", () => ({ isAuthzedEnabled: vi.fn() }));
 vi.mock("./metrics", () => ({ recordAuthzedReconciliationAudit: vi.fn() }));
-vi.mock("./outbox-repository", () => ({ pruneAuthzedOutboxHistory: vi.fn() }));
+vi.mock("./outbox-repository", () => ({
+  pruneAuthzedOutboxHistory: vi.fn(),
+  replayAuthzedOutboxDeadLetters: vi.fn(),
+}));
 
 const result = (status: "drifted" | "failed" | "reconciled", missing = 0, mismatchedPermissions = 0) =>
   ({
@@ -52,6 +55,29 @@ describe("scheduled AuthZed reconciliation", () => {
       status: "reconciled",
     });
     expect(pruneAuthzedOutboxHistory).toHaveBeenCalledOnce();
+  });
+
+  // A dead-lettered revocation denies every enforced authorization check with no age bound, so the
+  // audit is the only thing standing between one poison event and an indefinite outage.
+  test("returns dead letters to the delivery loop once an audit comes back clean", async () => {
+    vi.mocked(runAuthzedBackfill).mockResolvedValue(result("reconciled"));
+
+    await processAuthzedScheduledReconciliationJob();
+
+    expect(replayAuthzedOutboxDeadLetters).toHaveBeenCalledOnce();
+  });
+
+  test("leaves dead letters alone while PostgreSQL and SpiceDB still disagree", async () => {
+    for (const status of ["drifted", "failed"] as const) {
+      vi.clearAllMocks();
+      vi.mocked(isAuthzedEnabled).mockReturnValue(true);
+      vi.mocked(runAuthzedBackfill).mockResolvedValue(result(status));
+
+      await processAuthzedScheduledReconciliationJob();
+
+      expect(replayAuthzedOutboxDeadLetters).not.toHaveBeenCalled();
+      expect(pruneAuthzedOutboxHistory).toHaveBeenCalledOnce();
+    }
   });
 
   test("repairs attributable drift and verifies it with a second dry run", async () => {

--- a/apps/web/lib/authzed/scheduled-reconciliation.test.ts
+++ b/apps/web/lib/authzed/scheduled-reconciliation.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { runAuthzedBackfill } from "./backfill";
+import { isAuthzedEnabled } from "./config";
+import { recordAuthzedReconciliationAudit } from "./metrics";
+import { pruneAuthzedOutboxHistory } from "./outbox-repository";
+import { processAuthzedScheduledReconciliationJob } from "./scheduled-reconciliation";
+
+vi.mock("@formbricks/logger", () => ({ logger: { warn: vi.fn() } }));
+vi.mock("./backfill", () => ({ runAuthzedBackfill: vi.fn() }));
+vi.mock("./backfill-apply", () => ({
+  createAuthzedBackfillApply: vi.fn(() => ({ mode: "apply" })),
+  createAuthzedBackfillNoopApply: vi.fn(() => ({ mode: "dry_run" })),
+}));
+vi.mock("./client", () => ({ getAuthzedClient: vi.fn(() => ({ client: true })) }));
+vi.mock("./config", () => ({ isAuthzedEnabled: vi.fn() }));
+vi.mock("./metrics", () => ({ recordAuthzedReconciliationAudit: vi.fn() }));
+vi.mock("./outbox-repository", () => ({ pruneAuthzedOutboxHistory: vi.fn() }));
+
+const result = (status: "drifted" | "failed" | "reconciled", missing = 0, mismatchedPermissions = 0) =>
+  ({
+    counters: { failed: status === "failed" ? 1 : 0, mismatchedPermissions, missing },
+    status,
+  }) as Awaited<ReturnType<typeof runAuthzedBackfill>>;
+
+describe("scheduled AuthZed reconciliation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isAuthzedEnabled).mockReturnValue(true);
+  });
+
+  test("does no database or AuthZed work when disabled", async () => {
+    vi.mocked(isAuthzedEnabled).mockReturnValue(false);
+
+    await processAuthzedScheduledReconciliationJob();
+
+    expect(runAuthzedBackfill).not.toHaveBeenCalled();
+  });
+
+  test("stops after one clean dry-run audit", async () => {
+    vi.mocked(runAuthzedBackfill).mockResolvedValue(result("reconciled"));
+
+    await processAuthzedScheduledReconciliationJob();
+
+    expect(runAuthzedBackfill).toHaveBeenCalledOnce();
+    expect(runAuthzedBackfill).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "dry_run", prune: false, scope: { kind: "all" } }),
+      expect.any(Object)
+    );
+    expect(recordAuthzedReconciliationAudit).toHaveBeenCalledWith({
+      drift: 0,
+      failures: 0,
+      status: "reconciled",
+    });
+    expect(pruneAuthzedOutboxHistory).toHaveBeenCalledOnce();
+  });
+
+  test("repairs attributable drift and verifies it with a second dry run", async () => {
+    vi.mocked(runAuthzedBackfill)
+      .mockResolvedValueOnce(result("drifted", 2, 1))
+      .mockResolvedValueOnce(result("drifted"))
+      .mockResolvedValueOnce(result("reconciled"));
+
+    await processAuthzedScheduledReconciliationJob();
+
+    expect(vi.mocked(runAuthzedBackfill).mock.calls.map(([request]) => request.mode)).toEqual([
+      "dry_run",
+      "apply",
+      "dry_run",
+    ]);
+    expect(recordAuthzedReconciliationAudit).toHaveBeenCalledWith({
+      drift: 3,
+      failures: 0,
+      status: "reconciled",
+    });
+  });
+});

--- a/apps/web/lib/authzed/scheduled-reconciliation.ts
+++ b/apps/web/lib/authzed/scheduled-reconciliation.ts
@@ -1,0 +1,54 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { runAuthzedBackfill } from "./backfill";
+import { createAuthzedBackfillApply, createAuthzedBackfillNoopApply } from "./backfill-apply";
+import { getAuthzedClient } from "./client";
+import { isAuthzedEnabled } from "./config";
+import { AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN } from "./constants";
+import { recordAuthzedReconciliationAudit } from "./metrics";
+import { pruneAuthzedOutboxHistory } from "./outbox-repository";
+
+/** Six-hour full audit. It repairs attributable missing/mismatched edges and never prunes unknown data. */
+export const processAuthzedScheduledReconciliationJob = async (): Promise<void> => {
+  if (!isAuthzedEnabled()) return;
+  const client = getAuthzedClient();
+  const request = {
+    maxPrune: AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN,
+    prune: false,
+    scope: { kind: "all" },
+  } as const;
+  const observed = await runAuthzedBackfill(
+    { ...request, mode: "dry_run" },
+    { apply: createAuthzedBackfillNoopApply(), client }
+  );
+  let result = observed;
+
+  if (observed.status === "drifted") {
+    await runAuthzedBackfill({ ...request, mode: "apply" }, { apply: createAuthzedBackfillApply(), client });
+    result = await runAuthzedBackfill(
+      { ...request, mode: "dry_run" },
+      { apply: createAuthzedBackfillNoopApply(), client }
+    );
+  }
+
+  recordAuthzedReconciliationAudit({
+    drift: observed.counters.missing + observed.counters.mismatchedPermissions,
+    failures: result.counters.failed,
+    status: result.status,
+  });
+
+  if (result.status !== "reconciled") {
+    logger.warn(
+      {
+        component: "authzed",
+        drift: result.counters.missing + result.counters.mismatchedPermissions,
+        failures: result.counters.failed,
+        operation: "scheduled_reconciliation",
+        status: result.status,
+      },
+      "Scheduled AuthZed relationship reconciliation did not finish cleanly"
+    );
+  }
+
+  await pruneAuthzedOutboxHistory();
+};

--- a/apps/web/lib/authzed/scheduled-reconciliation.ts
+++ b/apps/web/lib/authzed/scheduled-reconciliation.ts
@@ -6,7 +6,7 @@ import { getAuthzedClient } from "./client";
 import { isAuthzedEnabled } from "./config";
 import { AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN } from "./constants";
 import { recordAuthzedReconciliationAudit } from "./metrics";
-import { pruneAuthzedOutboxHistory } from "./outbox-repository";
+import { pruneAuthzedOutboxHistory, replayAuthzedOutboxDeadLetters } from "./outbox-repository";
 
 /** Six-hour full audit. It repairs attributable missing/mismatched edges and never prunes unknown data. */
 export const processAuthzedScheduledReconciliationJob = async (): Promise<void> => {
@@ -50,5 +50,16 @@ export const processAuthzedScheduledReconciliationJob = async (): Promise<void> 
     );
   }
 
+  // Runs whatever the audit concluded: it only deletes rows delivered more than a week ago, so it is
+  // never the thing standing between an operator and evidence.
   await pruneAuthzedOutboxHistory();
+
+  // A clean full audit means PostgreSQL and SpiceDB already agree everywhere, so whatever a dead
+  // letter was trying to say has since been said by other means. Hand it back to the delivery loop
+  // rather than leaving the freshness guard denying every authorization check until someone runs
+  // `outbox replay` by hand — a dead-lettered revocation has no age bound in that guard on purpose.
+  // A still-poisoned event simply re-dead-letters, so this is a six-hourly retry, not a loop. The
+  // audit sweeps organizations, so an event for a deleted user or a cross-tenant pair may not be
+  // covered by `reconciled`; replaying it anyway is idempotent and strictly better than denying.
+  if (result.status === "reconciled") await replayAuthzedOutboxDeadLetters();
 };

--- a/apps/web/lib/jobs/recurring-registrations.ts
+++ b/apps/web/lib/jobs/recurring-registrations.ts
@@ -10,6 +10,8 @@ import {
   type TWorkflowRunJobData,
   recurringJobs,
 } from "@formbricks/jobs";
+import { processAuthzedProjectionDeliveryJob } from "@/lib/authzed/outbox-processor";
+import { processAuthzedScheduledReconciliationJob } from "@/lib/authzed/scheduled-reconciliation";
 import { processWorkflowRunJob } from "@/modules/ee/workflows/lib/runner/process-workflow-run-job";
 import { processWorkflowRunReconcileJob } from "@/modules/ee/workflows/lib/runner/process-workflow-run-reconcile-job";
 import { WORKFLOW_RUN_RECONCILE_INTERVAL_MS } from "@/modules/ee/workflows/lib/runner/reconcile-constants";
@@ -56,6 +58,22 @@ interface RecurringJobRegistration {
  * registered at all). A test pins the pairing instead.
  */
 export const RECURRING_JOB_REGISTRATIONS_BY_KEY: Record<TRecurringJobKey, RecurringJobRegistration> = {
+  authzedProjectionDelivery: {
+    handler: processAuthzedProjectionDeliveryJob,
+    job: recurringJobs.authzedProjectionDelivery,
+    schedule: {
+      everyMs: 5_000,
+      kind: "every",
+    },
+  },
+  authzedReconciliationAudit: {
+    handler: processAuthzedScheduledReconciliationJob,
+    job: recurringJobs.authzedReconciliationAudit,
+    schedule: {
+      everyMs: 6 * 60 * 60 * 1_000,
+      kind: "every",
+    },
+  },
   surveyArchivePurge: {
     handler: processSurveyArchivePurgeJob,
     job: recurringJobs.surveyArchivePurge,

--- a/apps/web/scripts/docker/authzed-cli.ts
+++ b/apps/web/scripts/docker/authzed-cli.ts
@@ -85,6 +85,23 @@ const run = async (): Promise<void> => {
         process.exitCode = await runAuthzedBackfillCli(backfillCommand);
         return;
       }
+      case "outbox": {
+        const { parseAuthzedOutboxCliCommand } = await import("../../lib/authzed/outbox-cli-command");
+        const outboxCommand = parseAuthzedOutboxCliCommand(args);
+
+        if (!outboxCommand) {
+          console.error = originalConsoleError;
+          writeResult(INVALID_REQUEST_RESULT);
+          process.exitCode = 1;
+          return;
+        }
+
+        shouldCloseDatabase = true;
+        const { runAuthzedOutboxCli } = await import("../../lib/authzed/outbox-cli");
+        console.error = originalConsoleError;
+        process.exitCode = await runAuthzedOutboxCli(outboxCommand);
+        return;
+      }
       default:
         console.error = originalConsoleError;
         writeResult(INVALID_REQUEST_RESULT);

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -143,13 +143,22 @@ idempotent reconcilers deliver each claimed batch as six independent groups.
 Failure is attributed rather than shared. A group that fails takes only its own
 events; the rest of the batch is still delivered. A retryable failure releases
 every remaining group untried, because spending another three-attempt budget per
-group against an unreachable instance buys nothing. Only a failure that is both
-non-retryable and attributable to a single event counts towards dead-lettering,
-so no SpiceDB outage — of any duration — can dead-letter an event that was never
-the problem. When a failure code could plausibly belong to one event
-(`authzed_projection_invalid_source`, `authzed_invalid_request`), the group is
-halved until the culprit is alone; codes that describe the instance are not
-split. Ten such solitary failures dead-letter the event.
+group against an unreachable instance buys nothing.
+
+Dead-lettering requires the failure to _name_ an event, which takes three things
+together: the code is non-retryable, the attempt covered exactly one event, and
+the code is one an event can actually cause
+(`authzed_projection_invalid_source`, `authzed_invalid_request`). The third
+condition is not redundant. On a five-second cadence most groups hold a single
+event, so size alone would charge whichever revocations happened to be
+travelling alone when SpiceDB rejected a credential — dead-lettering bystanders
+mid-outage, which is the opposite of the intent. Those same event-attributable
+codes are the ones that trigger halving the group until the culprit is alone;
+codes describing the instance are neither split nor charged. Ten solitary,
+attributable failures dead-letter the event.
+
+The consequence is the property worth remembering: **no SpiceDB outage, of any
+duration or kind, can dead-letter an event that was never the problem.**
 
 AuthZed being disabled performs no delivery work. An AuthZed outage never
 changes a successful PostgreSQL mutation into an application error; committed

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -138,7 +138,18 @@ projection event in the same transaction as the source mutation. The existing
 post-commit projector remains as a low-latency fast path, but the PostgreSQL
 outbox is the durable delivery contract: BullMQ wakes a worker every five
 seconds, the worker claims rows with leases and `FOR UPDATE SKIP LOCKED`, and the
-idempotent reconcilers retry failures up to 20 times before dead-lettering.
+idempotent reconcilers deliver each claimed batch as six independent groups.
+
+Failure is attributed rather than shared. A group that fails takes only its own
+events; the rest of the batch is still delivered. A retryable failure releases
+every remaining group untried, because spending another three-attempt budget per
+group against an unreachable instance buys nothing. Only a failure that is both
+non-retryable and attributable to a single event counts towards dead-lettering,
+so no SpiceDB outage — of any duration — can dead-letter an event that was never
+the problem. When a failure code could plausibly belong to one event
+(`authzed_projection_invalid_source`, `authzed_invalid_request`), the group is
+halved until the culprit is alone; codes that describe the instance are not
+split. Ten such solitary failures dead-letter the event.
 
 AuthZed being disabled performs no delivery work. An AuthZed outage never
 changes a successful PostgreSQL mutation into an application error; committed
@@ -147,11 +158,32 @@ records and independent drift are reconciled by the six-hour applying audit and
 by `pnpm authzed:backfill` (see [Backfill and repair](#backfill-and-repair)). A
 clean graph and drained outbox are mandatory before direct authority.
 
-Updates and deletes are conservatively classified as revocations. If a source
-pair moves, the trigger enqueues both the previous pair as a revocation and the
-current pair, preventing a stale old edge from becoming undiscoverable. Direct
-authority refuses protected operations with `authzed_projection_stale` when an
-unresolved revocation reaches 60 seconds or enters dead letter.
+Deletes, and updates that are not provably grants, are classified as revocations.
+The classifier is deny-by-default: an unmapped target type, an unmapped column,
+or any enum move is a revocation. Only three transitions are treated as grants,
+each because the projectors' own write shape proves the relationship set can only
+grow — reactivating a user, unarchiving a feedback directory that stays in its
+organization, and any membership update that leaves `role` unchanged (the
+projected snapshot ignores `accepted`, so accepting an invite writes identical
+relationships).
+
+The permission ladder is deliberately not encoded in the trigger. It is rankable,
+but a rank table in SQL has no compile-time backstop the way
+`relationship-map.ts` does, so a change to `authzed/schema.zed` would silently
+make it wrong in the fail-open direction — the one direction this guard must
+never be wrong in. Role changes are one-at-a-time admin actions rather than the
+bulk operations the classifier exists to keep off the guard. Revisit only if a
+bulk re-roling path appears.
+
+This matters because the guard is global and unscoped. Direct authority refuses
+protected operations with `authzed_projection_stale` when an unresolved
+revocation reaches 60 seconds or enters dead letter, so an undelivered event
+classified as a revocation denies every enforced check in the deployment. A mass
+invite acceptance or reactivation sweep must therefore not arm it.
+
+If a source pair moves, the trigger enqueues both the previous pair as a
+revocation and the current pair, preventing a stale old edge from becoming
+undiscoverable.
 
 The organization-membership projection boundary covers:
 
@@ -567,10 +599,18 @@ formbricks-authzed outbox replay
 
 `status` reports aggregate pending, dead-letter, oldest-age, and revocation-age
 counts. `drain` claims revocations first and stops after the requested number of
-batches or the first failed batch. `replay` resets all unresolved dead letters
-to attempt zero; it does not bypass normal reconciliation, retry, or freshness
-checks. These commands never print target IDs, relationships, credentials, or
-raw errors.
+batches or the first batch that delivers nothing at all — a partially delivered
+batch is the normal outcome once failures are attributed per group, so draining
+stops on no progress rather than on any failure. `replay` resets all unresolved
+dead letters to attempt zero and returns their full permanent-failure budget; it
+does not bypass normal reconciliation, retry, or freshness checks. These commands
+never print target IDs, relationships, credentials, or raw errors.
+
+Dead letters also clear themselves. A dead-lettered revocation has no age bound
+in the freshness guard on purpose — an old one is more dangerous than a fresh one
+— so the six-hour audit replays every unresolved dead letter whenever it comes
+back `reconciled`, bounding a global denial at six hours rather than at whenever
+an operator notices. A still-poisoned event simply dead-letters again.
 
 The recurring six-hour audit runs the normal full-deployment applying backfill
 without prune. It can repair attributable missing and mismatched-permission

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -133,15 +133,25 @@ The current legacy evaluator authorizes every `Membership` row without checking
 behavior: accepted and pending membership rows project identically. An
 `Invite` alone is not projected.
 
-Projection runs after the source transaction commits and is best-effort.
-AuthZed being disabled performs no projection work. An AuthZed outage never
-changes a successful PostgreSQL mutation into an application error; it produces
-only a sanitized operational result and warning. Existing records and any drift
-an outage leaves behind are reconciled by `pnpm authzed:backfill` (see
-[Backfill and repair](#backfill-and-repair)), which must report a clean run
-before direct authority. ENG-2408 replaces this temporary bridge behavior with
-the transactional outbox required by the [direct cutover
-contract](./CUTOVER.md); the best-effort projector is not eligible for cutover.
+Every authorization-bearing source table has a PostgreSQL trigger that inserts a
+projection event in the same transaction as the source mutation. The existing
+post-commit projector remains as a low-latency fast path, but the PostgreSQL
+outbox is the durable delivery contract: BullMQ wakes a worker every five
+seconds, the worker claims rows with leases and `FOR UPDATE SKIP LOCKED`, and the
+idempotent reconcilers retry failures up to 20 times before dead-lettering.
+
+AuthZed being disabled performs no delivery work. An AuthZed outage never
+changes a successful PostgreSQL mutation into an application error; committed
+outbox rows remain recoverable and are replayed when SpiceDB returns. Existing
+records and independent drift are reconciled by the six-hour applying audit and
+by `pnpm authzed:backfill` (see [Backfill and repair](#backfill-and-repair)). A
+clean graph and drained outbox are mandatory before direct authority.
+
+Updates and deletes are conservatively classified as revocations. If a source
+pair moves, the trigger enqueues both the previous pair as a revocation and the
+current pair, preventing a stale old edge from becoming undiscoverable. Direct
+authority refuses protected operations with `authzed_projection_stale` when an
+unresolved revocation reaches 60 seconds or enters dead letter.
 
 The organization-membership projection boundary covers:
 
@@ -543,6 +553,32 @@ it rewrites is not necessarily the one a local dev server talks to. Always pass
 Released Formbricks images include the equivalent `formbricks-authzed backfill`
 command for self-hosted operators. Repository development retains
 `pnpm authzed:backfill`.
+
+## Durable projection outbox
+
+Release images expose bounded, identifier-free outbox operations:
+
+```bash
+formbricks-authzed outbox status
+formbricks-authzed outbox drain
+formbricks-authzed outbox drain --max-batches=500
+formbricks-authzed outbox replay
+```
+
+`status` reports aggregate pending, dead-letter, oldest-age, and revocation-age
+counts. `drain` claims revocations first and stops after the requested number of
+batches or the first failed batch. `replay` resets all unresolved dead letters
+to attempt zero; it does not bypass normal reconciliation, retry, or freshness
+checks. These commands never print target IDs, relationships, credentials, or
+raw errors.
+
+The recurring six-hour audit runs the normal full-deployment applying backfill
+without prune. It can repair attributable missing and mismatched-permission
+edges, but it never automatically deletes orphaned or unmanaged relationships or
+changes a mismatched parent. Those categories still require the guarded operator
+workflow above. Successfully delivered outbox rows are retained for seven days;
+the scheduled audit removes at most 10,000 expired rows per run. Pending and
+dead-letter rows are never removed by retention cleanup.
 
 ## Deliberately not modeled (stays in application code)
 

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -20,13 +20,13 @@ contract.
 
 ## 1. Symptoms
 
-| What you see                           | What it usually means                             |
-| -------------------------------------- | ------------------------------------------------- |
-| Outbox warning count is non-zero       | A revocation has been pending for 15 seconds.     |
-| Outbox critical count is non-zero      | A revocation has been pending for 45 seconds.     |
-| `authzed_projection_stale`             | Revocation is 60 seconds old or dead-lettered.    |
-| Scheduled reconciliation reports drift | Attributable graph drift was found or repaired.   |
-| A dead letter is present               | Ten solitary non-retryable failures; investigate. |
+| What you see                           | What it usually means                                   |
+| -------------------------------------- | ------------------------------------------------------- |
+| Outbox warning count is non-zero       | A revocation has been pending for 15 seconds.           |
+| Outbox critical count is non-zero      | A revocation has been pending for 45 seconds.           |
+| `authzed_projection_stale`             | Revocation is 60 seconds old or dead-lettered.          |
+| Scheduled reconciliation reports drift | Attributable graph drift was found or repaired.         |
+| A dead letter is present               | Ten solitary, event-attributable failures; investigate. |
 
 On the bridge artifact, legacy authorization is unaffected while durable delivery retries or repair converges
 the graph. On the direct-authority artifact, operational AuthZed failures fail protected operations closed.
@@ -298,9 +298,11 @@ the service recovers:
 1. Run `formbricks-authzed health` and verify datastore migrations.
 2. Inspect `formbricks-authzed outbox status` and correct the operational cause.
 3. Run `formbricks-authzed outbox replay` when dead letters are understood, then
-   `formbricks-authzed outbox drain`. A dead letter can only be reached by an event that failed on its own,
-   non-retryably, ten times — a SpiceDB outage never produces one, however long it lasts, so treat any dead
-   letter as a real disagreement between PostgreSQL and SpiceDB rather than as fallout from the outage.
+   `formbricks-authzed outbox drain`. A dead letter can only be reached by an event that failed ten times on
+   its own, non-retryably, with a code an event can actually cause (`authzed_projection_invalid_source`,
+   `authzed_invalid_request`). An unreachable SpiceDB, a rejected credential and an unmapped internal error
+   all fail to qualify, so no outage produces a dead letter however long it lasts — treat any dead letter as
+   a real disagreement between PostgreSQL and SpiceDB rather than as fallout from the outage.
    The six-hour audit also replays dead letters by itself whenever it comes back `reconciled`, so a global
    `authzed_projection_stale` denial clears within six hours even if nobody intervenes.
 4. Run the complete dry-run audit, apply attributable repair, and require two consecutive clean audits.

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -20,13 +20,13 @@ contract.
 
 ## 1. Symptoms
 
-| What you see                           | What it usually means                           |
-| -------------------------------------- | ----------------------------------------------- |
-| Outbox warning count is non-zero       | A revocation has been pending for 15 seconds.   |
-| Outbox critical count is non-zero      | A revocation has been pending for 45 seconds.   |
-| `authzed_projection_stale`             | Revocation is 60 seconds old or dead-lettered.  |
-| Scheduled reconciliation reports drift | Attributable graph drift was found or repaired. |
-| A dead letter is present               | Delivery exhausted 20 attempts; investigate.    |
+| What you see                           | What it usually means                             |
+| -------------------------------------- | ------------------------------------------------- |
+| Outbox warning count is non-zero       | A revocation has been pending for 15 seconds.     |
+| Outbox critical count is non-zero      | A revocation has been pending for 45 seconds.     |
+| `authzed_projection_stale`             | Revocation is 60 seconds old or dead-lettered.    |
+| Scheduled reconciliation reports drift | Attributable graph drift was found or repaired.   |
+| A dead letter is present               | Ten solitary non-retryable failures; investigate. |
 
 On the bridge artifact, legacy authorization is unaffected while durable delivery retries or repair converges
 the graph. On the direct-authority artifact, operational AuthZed failures fail protected operations closed.
@@ -298,7 +298,11 @@ the service recovers:
 1. Run `formbricks-authzed health` and verify datastore migrations.
 2. Inspect `formbricks-authzed outbox status` and correct the operational cause.
 3. Run `formbricks-authzed outbox replay` when dead letters are understood, then
-   `formbricks-authzed outbox drain`.
+   `formbricks-authzed outbox drain`. A dead letter can only be reached by an event that failed on its own,
+   non-retryably, ten times — a SpiceDB outage never produces one, however long it lasts, so treat any dead
+   letter as a real disagreement between PostgreSQL and SpiceDB rather than as fallout from the outage.
+   The six-hour audit also replays dead letters by itself whenever it comes back `reconciled`, so a global
+   `authzed_projection_stale` denial clears within six hours even if nobody intervenes.
 4. Run the complete dry-run audit, apply attributable repair, and require two consecutive clean audits.
 5. Keep direct-authority cutover blocked while a revocation is pending, dead-lettered, or older than its SLA.
 

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -3,9 +3,9 @@
 PostgreSQL is the source of truth for authorization facts. SpiceDB holds their relationship projection and
 becomes the sole decision engine in the direct-authority artifact.
 
-The currently checked-in bridge still performs post-commit best-effort projection. ENG-2408 replaces that
-temporary behavior with a transactional PostgreSQL outbox before any direct-authority deployment is allowed.
-Until that lands, treat every failed projection as potentially lost and prohibit cutover.
+The durable bridge inserts a PostgreSQL outbox row in the same transaction as every authorization-bearing
+source mutation. Existing post-commit projection remains a low-latency fast path, while the outbox is the
+recoverable delivery contract. BullMQ only wakes the worker; queue state and leases remain in PostgreSQL.
 
 > **Direct authority requires durable delivery.** A committed authorization mutation must enqueue its
 > relationship reconciliation atomically, and a revocation that cannot be delivered within 60 seconds must make
@@ -20,13 +20,13 @@ contract.
 
 ## 1. Symptoms
 
-| What you see                                                       | What it usually means                          |
-| ------------------------------------------------------------------ | ---------------------------------------------- |
-| Historical comparison telemetry reports mismatches                 | Drift. Run the backfill.                       |
-| A new member, team, or API key lacks access _in SpiceDB only_      | A dropped projection for that record.          |
-| A removed member still resolves in SpiceDB                         | A stale relationship. Only pruning removes it. |
-| `formbricks_authzed_projection_total{status="failed"}` is non-zero | Projections are failing now.                   |
-| Nothing at all, but AuthZed was recently unavailable               | On the pre-outbox bridge, assume drift.        |
+| What you see                           | What it usually means                           |
+| -------------------------------------- | ----------------------------------------------- |
+| Outbox warning count is non-zero       | A revocation has been pending for 15 seconds.   |
+| Outbox critical count is non-zero      | A revocation has been pending for 45 seconds.   |
+| `authzed_projection_stale`             | Revocation is 60 seconds old or dead-lettered.  |
+| Scheduled reconciliation reports drift | Attributable graph drift was found or repaired. |
+| A dead letter is present               | Delivery exhausted 20 attempts; investigate.    |
 
 On the bridge artifact, legacy authorization is unaffected while durable delivery retries or repair converges
 the graph. On the direct-authority artifact, operational AuthZed failures fail protected operations closed.
@@ -38,6 +38,7 @@ the graph. On the direct-authority artifact, operational AuthZed failures fail p
 ```bash
 pnpm authzed:health     # 0 healthy, 1 otherwise
 pnpm authzed:schema check   # 0 matched, 2 drifted, 1 failed
+formbricks-authzed outbox status  # 0 healthy, 2 warning/critical, 1 failed
 ```
 
 Note `status: "disabled"` from the health command exits **1**. A deployment that believes AuthZed is on
@@ -46,15 +47,21 @@ records `disabled` as its own outcome rather than skipping.
 
 ### Metrics
 
-All five carry only bounded attributes — never an organization, user, or relationship identifier.
+All metrics carry only bounded attributes — never an organization, user, or relationship identifier.
 
-| Metric                                                | Attributes                          | Read it as                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ----------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `formbricks_authzed_projection_total`                 | `operation`, `projection`, `status` | Projection outcomes. `status` is `projected` / `failed` / `disabled`.                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `formbricks_authzed_projection_duration_seconds`      | same                                | Projection latency. It sits on the request path, so a rise here is user-visible. `disabled` outcomes are deliberately excluded — their duration is a structural zero, not a measurement.                                                                                                                                                                                                                                                                                                                                         |
-| `formbricks_authzed_request_failures_total`           | `operation`, `code`, `retryable`    | Requests that exhausted their retry budget — _any_ facade call, including schema operations and reads, and one failed write can carry a whole batch. So a sample is one terminal request failure, **not** one dropped relationship. For "did projection drift get introduced?", use `formbricks_authzed_projection_total{status="failed"}`.                                                                                                                                                                                      |
-| `formbricks_authzed_request_retries_total`            | `operation`, `code`                 | Retries scheduled. Elevated but not failing = degraded, not down.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `formbricks_authzed_authorization_checks_per_request` | `surface`                           | How many central authorization operations one request made. Scalar `can()`/`assertCan()` calls and narrow list observations each count once. Watch the upper percentiles for a page regressing into one operation per row; a rising p99 on a list surface is the N+1 signal. Buckets start at 0.5 so "made no decisions" stays distinct from "made exactly one" — most healthy requests sit in the second bucket. No threshold is suggested yet: it needs a production baseline first. See [`PERFORMANCE.md`](./PERFORMANCE.md). |
+| Metric                                                            | Attributes                          | Read it as                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ----------------------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `formbricks_authzed_projection_total`                             | `operation`, `projection`, `status` | Projection outcomes. `status` is `projected` / `failed` / `disabled`.                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `formbricks_authzed_projection_duration_seconds`                  | same                                | Projection latency. It sits on the request path, so a rise here is user-visible. `disabled` outcomes are deliberately excluded — their duration is a structural zero, not a measurement.                                                                                                                                                                                                                                                                                                                                         |
+| `formbricks_authzed_request_failures_total`                       | `operation`, `code`, `retryable`    | Requests that exhausted their retry budget — _any_ facade call, including schema operations and reads, and one failed write can carry a whole batch. So a sample is one terminal request failure, **not** one dropped relationship. For "did projection drift get introduced?", use `formbricks_authzed_projection_total{status="failed"}`.                                                                                                                                                                                      |
+| `formbricks_authzed_request_retries_total`                        | `operation`, `code`                 | Retries scheduled. Elevated but not failing = degraded, not down.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `formbricks_authzed_authorization_checks_per_request`             | `surface`                           | How many central authorization operations one request made. Scalar `can()`/`assertCan()` calls and narrow list observations each count once. Watch the upper percentiles for a page regressing into one operation per row; a rising p99 on a list surface is the N+1 signal. Buckets start at 0.5 so "made no decisions" stays distinct from "made exactly one" — most healthy requests sit in the second bucket. No threshold is suggested yet: it needs a production baseline first. See [`PERFORMANCE.md`](./PERFORMANCE.md). |
+| `formbricks_authzed_projection_outbox_delivery_total`             | `status`                            | Durable outbox events delivered or failed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `formbricks_authzed_projection_outbox_delivery_duration_seconds`  | `status`                            | Duration of one claimed delivery batch.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `formbricks_authzed_projection_outbox_status`                     | `state`                             | Current pending, dead-letter, 15-second warning, and 45-second critical counts.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `formbricks_authzed_projection_outbox_oldest_pending_age_seconds` | none                                | Current age of the oldest pending event.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `formbricks_authzed_reconciliation_audit_total`                   | `status`                            | Six-hour applying audit outcomes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `formbricks_authzed_reconciliation_drift_total`                   | `kind`                              | Attributable drift and operational failures observed by scheduled audits.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 
 Exported through the readers already configured in `instrumentation-node.ts`: Prometheus when
 `PROMETHEUS_ENABLED=1` (scraped by the chart's ServiceMonitor), OTLP when
@@ -284,14 +291,16 @@ accumulates for the whole period, so a full backfill is required before re-enabl
 
 ### Durable bridge and direct authority
 
-After ENG-2408, source mutations commit a PostgreSQL outbox item atomically. SpiceDB outage does not roll back a
+Source mutations commit a PostgreSQL outbox item atomically. SpiceDB outage does not roll back a
 successful business mutation; delivery retries from PostgreSQL and BullMQ is only the recurring trigger. When
 the service recovers:
 
 1. Run `formbricks-authzed health` and verify datastore migrations.
-2. Drain the outbox and replay any dead letters.
-3. Run the complete dry-run audit, apply attributable repair, and require two consecutive clean audits.
-4. Keep direct-authority cutover blocked while a revocation is pending, dead-lettered, or older than its SLA.
+2. Inspect `formbricks-authzed outbox status` and correct the operational cause.
+3. Run `formbricks-authzed outbox replay` when dead letters are understood, then
+   `formbricks-authzed outbox drain`.
+4. Run the complete dry-run audit, apply attributable repair, and require two consecutive clean audits.
+5. Keep direct-authority cutover blocked while a revocation is pending, dead-lettered, or older than its SLA.
 
 In the direct-authority artifact, a SpiceDB, datastore, resolver, configuration, freshness, or unsupported-result
 failure is not an ordinary denial and never falls back. The protected operation receives a sanitized operational

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -316,6 +316,32 @@ AuthZed Cloud owns datastore backup and restore guarantees. You still need Formb
 recoverable client credentials, release configuration, schema verification, and the relationship repair
 procedure.
 
+## Inspect and drain durable delivery
+
+The v6 bridge writes projection intent in the same PostgreSQL transaction as an authorization source change.
+BullMQ wakes the delivery worker, but PostgreSQL remains the durable queue. Updates and deletes are treated as
+revocations; direct authority fails closed when a revocation remains unresolved for 60 seconds or enters dead
+letter.
+
+```bash
+formbricks-authzed outbox status
+formbricks-authzed outbox drain
+formbricks-authzed outbox drain --max-batches=500
+formbricks-authzed outbox replay
+```
+
+`status` prints aggregate queue counts and ages only. It exits `0` when healthy, `2` at the 15-second warning or
+45-second critical thresholds (and for any dead letter), and `1` for an operational failure. `drain` processes
+revocations first. `replay` resets unresolved dead letters so the normal idempotent reconcilers can retry them;
+investigate the cause before replaying.
+
+These results contain no source IDs, relationship strings, credentials, or raw errors. This is different from
+the detailed backfill report below, which intentionally contains operational identifiers.
+
+Every six hours Formbricks also runs a full applying audit without prune. It automatically repairs attributable
+missing and mismatched-permission relationships. It never deletes orphaned or unmanaged data and never repairs
+a mismatched parent automatically.
+
 ## Audit and repair relationships
 
 The command prints one JSON result. It never prints credentials, database passwords, raw SDK errors, schema
@@ -463,7 +489,8 @@ restore, or shared SpiceDB before proceeding.
 | `authzed_unavailable`                                                                    | SpiceDB or its network path is unavailable            | Restore the service, verify health, then run a full relationship audit                      |
 | `authzed_internal`                                                                       | Unexpected client or runtime failure                  | Check sanitized Formbricks and SpiceDB logs and the deployed version                        |
 | Schema status `drifted`                                                                  | Connected schema differs from this Formbricks release | Back up first, review the diff counts and digest, then perform a guarded schema apply       |
-| Projection status `failed`                                                               | A committed PostgreSQL change may not be in SpiceDB   | Restore connectivity and run backfill; projections are not retried automatically            |
+| Projection status `failed`                                                               | A fast-path or outbox reconciliation attempt failed   | Restore connectivity, inspect outbox status, and drain or replay durable delivery             |
+| `authzed_projection_stale`                                                               | A revocation exceeded 60 seconds or entered dead letter | Investigate immediately, restore delivery, replay, drain, and require a clean audit          |
 
 Formbricks AuthZed logs use `component="authzed"`, stable `errorCode` values, and bounded fields such as
 `operation`, `projection`, `status`, `retryable`, `attemptCount`, `grpcStatus`, and `durationMs`. They must not
@@ -481,6 +508,12 @@ Enable the existing Formbricks Prometheus or OTLP metrics exporter. Current v5 b
 | `formbricks_authzed_request_retries_total`           | Retry attempts caused by transient failures                                 |
 | `formbricks_authzed_authorization_comparisons_total` | Match, mismatch, and operational-error outcomes where comparison is enabled |
 | `formbricks_authzed_authorization_duration_seconds`  | Authorization comparison latency where comparison is enabled                |
+| `formbricks_authzed_projection_outbox_delivery_total` | Durable outbox events delivered or failed                                   |
+| `formbricks_authzed_projection_outbox_delivery_duration_seconds` | Durable delivery batch latency                                    |
+| `formbricks_authzed_projection_outbox_status`        | Point-in-time pending, dead-letter, warning, and critical counts             |
+| `formbricks_authzed_projection_outbox_oldest_pending_age_seconds` | Age of the oldest pending event                                  |
+| `formbricks_authzed_reconciliation_audit_total`      | Scheduled audit outcomes                                                     |
+| `formbricks_authzed_reconciliation_drift_total`      | Attributable drift and failures observed by scheduled audits                 |
 
 Starting PromQL checks:
 
@@ -504,8 +537,7 @@ sum(rate(formbricks_authzed_authorization_comparisons_total{
 ```
 
 The v6 direct-authority release replaces comparison outcomes with bounded authoritative decision and latency
-metrics and adds outbox backlog/age, revocation latency, dead-letter, scheduled-audit, drift, and repair metrics.
-Use the exact metric names shipped by the v6 release. Required gates are no dead-letter revocations, no
+metrics. Required gates are no dead-letter revocations, no
 normal-operation 60-second freshness guard, clean scheduled audits, operational errors at or below 0.1%, p95
 below 250 ms, and p99 below one second.
 

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -319,9 +319,9 @@ procedure.
 ## Inspect and drain durable delivery
 
 The v6 bridge writes projection intent in the same PostgreSQL transaction as an authorization source change.
-BullMQ wakes the delivery worker, but PostgreSQL remains the durable queue. Updates and deletes are treated as
-revocations; direct authority fails closed when a revocation remains unresolved for 60 seconds or enters dead
-letter.
+BullMQ wakes the delivery worker, but PostgreSQL remains the durable queue. Deletes, and updates that are not
+provably grants, are treated as revocations; direct authority fails closed when a revocation remains unresolved
+for 60 seconds or enters dead letter.
 
 ```bash
 formbricks-authzed outbox status
@@ -332,8 +332,11 @@ formbricks-authzed outbox replay
 
 `status` prints aggregate queue counts and ages only. It exits `0` when healthy, `2` at the 15-second warning or
 45-second critical thresholds (and for any dead letter), and `1` for an operational failure. `drain` processes
-revocations first. `replay` resets unresolved dead letters so the normal idempotent reconcilers can retry them;
-investigate the cause before replaying.
+revocations first and stops at the first batch that delivers nothing; a partially delivered batch is normal,
+because a failure is charged only to the events it is attributable to. `replay` resets unresolved dead letters
+so the normal idempotent reconcilers can retry them; investigate the cause before replaying. A SpiceDB outage
+never produces a dead letter, so one always means PostgreSQL and SpiceDB genuinely disagree. The six-hour audit
+replays dead letters on its own after a clean run, which bounds a fail-closed denial at six hours.
 
 These results contain no source IDs, relationship strings, credentials, or raw errors. This is different from
 the detailed backfill report below, which intentionally contains operational identifiers.

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -334,8 +334,10 @@ formbricks-authzed outbox replay
 45-second critical thresholds (and for any dead letter), and `1` for an operational failure. `drain` processes
 revocations first and stops at the first batch that delivers nothing; a partially delivered batch is normal,
 because a failure is charged only to the events it is attributable to. `replay` resets unresolved dead letters
-so the normal idempotent reconcilers can retry them; investigate the cause before replaying. A SpiceDB outage
-never produces a dead letter, so one always means PostgreSQL and SpiceDB genuinely disagree. The six-hour audit
+so the normal idempotent reconcilers can retry them; investigate the cause before replaying. Dead-lettering
+requires ten solitary failures carrying a code an event can actually cause, so no SpiceDB outage — unreachable,
+rejected credential or internal error — produces one, and a dead letter always means PostgreSQL and SpiceDB
+genuinely disagree. The six-hour audit
 replays dead letters on its own after a clean run, which bounds a fail-closed denial at six hours.
 
 These results contain no source IDs, relationship strings, credentials, or raw errors. This is different from

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -181,6 +181,24 @@ By default, the seed script uses `upsert` to ensure it can be run multiple times
    - Copies the file to Prisma's internal directory
    - Applies the migration to the database
 
+### Indexes Prisma cannot express
+
+Prisma's `@@index` has no `where`, so a **partial index** can only live in hand-written migration SQL. When a
+model needs one, declare **no** `@@index` for it at all and leave a comment on the model pointing at the
+migration — do not also declare an approximate non-partial copy.
+
+Both ways of keeping one are worse than keeping none. Under the same index name, `prisma db push` sees a name
+match with a different definition, drops the index and recreates it without the predicate, and the migration's
+`CREATE INDEX IF NOT EXISTS` then skips it — leaving a silently wrong shape. Under a different name, dev
+databases accumulate both sets.
+
+Deployments are unaffected either way: `prisma migrate deploy` never reads the schema file. The cost is that a
+developer who runs `db push` loses the partial indexes until they rerun the migration, which is the same
+contract any hand-written trigger or function in a migration already lives under — so write those statements to
+be rerunnable (`CREATE INDEX IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, `DROP ... IF EXISTS`).
+
+`AuthzedProjectionOutbox` is the worked example.
+
 ### Adding a Data Migration
 
 1. Navigate to the `packages/database` directory

--- a/packages/database/migration/20260818120000_add_authzed_projection_outbox/migration.sql
+++ b/packages/database/migration/20260818120000_add_authzed_projection_outbox/migration.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS "AuthzedProjectionOutbox" (
     "secondaryId" TEXT,
     "isRevocation" BOOLEAN NOT NULL DEFAULT false,
     "attempts" INTEGER NOT NULL DEFAULT 0,
+    "permanentFailures" INTEGER NOT NULL DEFAULT 0,
     "availableAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "leasedAt" TIMESTAMP(3),
     "leaseExpiresAt" TIMESTAMP(3),
@@ -21,20 +22,96 @@ CREATE TABLE IF NOT EXISTS "AuthzedProjectionOutbox" (
     CONSTRAINT "AuthzedProjectionOutbox_pkey" PRIMARY KEY ("id")
 );
 
-CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_pending_idx"
-  ON "AuthzedProjectionOutbox"("processedAt", "deadLetteredAt", "availableAt", "createdAt");
-CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_revocation_idx"
-  ON "AuthzedProjectionOutbox"("isRevocation", "processedAt", "deadLetteredAt", "createdAt");
-CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_leaseExpiresAt_idx"
-  ON "AuthzedProjectionOutbox"("leaseExpiresAt");
-CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_target_idx"
-  ON "AuthzedProjectionOutbox"("targetType", "primaryId", "secondaryId");
+-- `attempts` drives the retry backoff and tells an operator how many times delivery was tried.
+-- `permanentFailures` is the separate, much smaller budget that gates dead-lettering, so that a
+-- SpiceDB outage of any duration can never dead-letter healthy events. See outbox-repository.ts.
+ALTER TABLE "AuthzedProjectionOutbox"
+  ADD COLUMN IF NOT EXISTS "permanentFailures" INTEGER NOT NULL DEFAULT 0;
+
+-- One index per access pattern, each partial to the rows that pattern can ever match. Processed rows
+-- are retained for seven days, so only the prune index below is allowed to carry that history —
+-- otherwise every hot-path lookup pays for a week of delivered events.
+--
+-- These predicates cannot be expressed in Prisma (`@@index` has no `where`), so the model in
+-- packages/database/schema/main.prisma deliberately declares no indexes and points here instead.
+-- `prisma db push` on a dev database therefore drops them; rerunning this migration restores them,
+-- which is the same contract the triggers below already live under.
+DROP INDEX IF EXISTS "AuthzedProjectionOutbox_pending_idx";
+DROP INDEX IF EXISTS "AuthzedProjectionOutbox_revocation_idx";
+DROP INDEX IF EXISTS "AuthzedProjectionOutbox_leaseExpiresAt_idx";
+DROP INDEX IF EXISTS "AuthzedProjectionOutbox_target_idx";
+
+-- The claim. Its key columns ARE the claim's ORDER BY, so the LIMIT is served by an ordered index
+-- scan with no sort. Also serves the freshness guard's overdue-revocation EXISTS (equality on the
+-- leading key, range on the second) and every pending counter in the status query.
+CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_claim_idx"
+  ON "AuthzedProjectionOutbox"("isRevocation" DESC, "createdAt" ASC)
+  WHERE "processedAt" IS NULL AND "deadLetteredAt" IS NULL;
+
+-- Dead letters: the freshness guard's second EXISTS, the dead-letter gauge, and `outbox replay`.
+-- A dead-lettered row always has a NULL `processedAt` — the claim skips dead letters, and replay
+-- clears `deadLetteredAt` before delivery is possible — so this predicate loses no rows.
+CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_dead_letter_idx"
+  ON "AuthzedProjectionOutbox"("isRevocation", "deadLetteredAt")
+  WHERE "processedAt" IS NULL AND "deadLetteredAt" IS NOT NULL;
+
+-- History prune. The only index that carries delivered rows.
+CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_processed_idx"
+  ON "AuthzedProjectionOutbox"("processedAt")
+  WHERE "processedAt" IS NOT NULL;
+
+/**
+ * Does this UPDATE provably leave the projected relationship set a superset of what it was?
+ *
+ * `isRevocation` has exactly one reader: the fail-closed freshness guard. So the question it must
+ * answer is "could an undelivered copy of this event leave SpiceDB granting access that PostgreSQL
+ * has taken away?" — a property of how the projectors *write*, not of the permission closure in
+ * authzed/schema.zed. Deriving it from that closure would put a second, untestable copy of the
+ * schema here; deriving it from the write shape keeps it checkable against the reconcilers.
+ *
+ * Deny by default. An unmapped target type, an unmapped column, or any enum move is a revocation.
+ * In particular the role ladder is deliberately NOT encoded: OrganizationRole is rankable, but a
+ * rank table here has no compile-time backstop the way relationship-map.ts does, so adding a role
+ * to schema.zed would silently make this wrong in the fail-OPEN direction. Role changes are
+ * one-at-a-time admin actions rather than the bulk operations this classifier exists to keep off
+ * the guard, so denying them costs nothing. Revisit only if a bulk re-roling path appears.
+ */
+CREATE OR REPLACE FUNCTION authzed_projection_is_grant(
+  target_type text,
+  previous_source jsonb,
+  source jsonb
+) RETURNS boolean AS $$
+  SELECT CASE target_type
+    -- reconcileUser deletes every relationship while `isActive` is false, so false -> true can only
+    -- add them back. `isActive` is the only column the User trigger watches.
+    WHEN 'user' THEN
+      (previous_source ->> 'isActive') IS DISTINCT FROM 'true'
+      AND (source ->> 'isActive') = 'true'
+
+    -- feedback-directory.ts writes assignment edges as `delete` while the directory is archived and
+    -- `touch` once it is not. Its parent edge is only ever touched, never re-pointed, so an
+    -- organizationId move leaves the old organization's administrators in place: still a revocation.
+    WHEN 'feedback_directory' THEN
+      (previous_source ->> 'isArchived') = 'true'
+      AND (source ->> 'isArchived') IS DISTINCT FROM 'true'
+      AND previous_source ->> 'organizationId' IS NOT DISTINCT FROM source ->> 'organizationId'
+
+    -- organization-membership.ts projects every membership row regardless of `accepted` (see the
+    -- comment on its readSnapshot), so accepting an invite writes byte-identical relationships.
+    -- A `role` move always deletes the relation for the old role, so it stays a revocation.
+    WHEN 'membership' THEN
+      previous_source ->> 'role' IS NOT DISTINCT FROM source ->> 'role'
+
+    ELSE false
+  END;
+$$ LANGUAGE sql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION enqueue_authzed_projection()
 RETURNS trigger AS $$
 DECLARE
   source jsonb;
   previous_source jsonb;
+  is_revocation boolean;
   target_type text := TG_ARGV[0];
   primary_field text := TG_ARGV[1];
   secondary_field text := NULLIF(TG_ARGV[2], '');
@@ -70,6 +147,12 @@ BEGIN
     END IF;
   END IF;
 
+  is_revocation := CASE
+    WHEN TG_OP = 'INSERT' THEN false
+    WHEN TG_OP = 'DELETE' THEN true
+    ELSE NOT authzed_projection_is_grant(target_type, previous_source, source)
+  END;
+
   INSERT INTO "AuthzedProjectionOutbox" (
     "id",
     "targetType",
@@ -82,7 +165,7 @@ BEGIN
     target_type,
     source ->> primary_field,
     CASE WHEN secondary_field IS NULL THEN NULL ELSE source ->> secondary_field END,
-    TG_OP <> 'INSERT',
+    is_revocation,
     NOW()
   );
 

--- a/packages/database/migration/20260818120000_add_authzed_projection_outbox/migration.sql
+++ b/packages/database/migration/20260818120000_add_authzed_projection_outbox/migration.sql
@@ -1,0 +1,150 @@
+-- ENG-2408: authorization source changes and their projection intent must commit atomically.
+-- PostgreSQL is the durable queue; BullMQ only wakes a worker that claims rows from this table.
+
+CREATE TABLE IF NOT EXISTS "AuthzedProjectionOutbox" (
+    "id" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "primaryId" TEXT NOT NULL,
+    "secondaryId" TEXT,
+    "isRevocation" BOOLEAN NOT NULL DEFAULT false,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "availableAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "leasedAt" TIMESTAMP(3),
+    "leaseExpiresAt" TIMESTAMP(3),
+    "leaseOwner" TEXT,
+    "processedAt" TIMESTAMP(3),
+    "deadLetteredAt" TIMESTAMP(3),
+    "lastAttemptAt" TIMESTAMP(3),
+    "lastErrorCode" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "AuthzedProjectionOutbox_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_pending_idx"
+  ON "AuthzedProjectionOutbox"("processedAt", "deadLetteredAt", "availableAt", "createdAt");
+CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_revocation_idx"
+  ON "AuthzedProjectionOutbox"("isRevocation", "processedAt", "deadLetteredAt", "createdAt");
+CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_leaseExpiresAt_idx"
+  ON "AuthzedProjectionOutbox"("leaseExpiresAt");
+CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_target_idx"
+  ON "AuthzedProjectionOutbox"("targetType", "primaryId", "secondaryId");
+
+CREATE OR REPLACE FUNCTION enqueue_authzed_projection()
+RETURNS trigger AS $$
+DECLARE
+  source jsonb;
+  previous_source jsonb;
+  target_type text := TG_ARGV[0];
+  primary_field text := TG_ARGV[1];
+  secondary_field text := NULLIF(TG_ARGV[2], '');
+BEGIN
+  source := CASE WHEN TG_OP = 'DELETE' THEN to_jsonb(OLD) ELSE to_jsonb(NEW) END;
+
+  -- A relationship source can move from one logical pair to another. Reconcile the old pair as a
+  -- revocation before reconciling the current pair; otherwise the old edge is no longer discoverable
+  -- from PostgreSQL and could survive with stale access.
+  IF TG_OP = 'UPDATE' THEN
+    previous_source := to_jsonb(OLD);
+    IF previous_source ->> primary_field IS DISTINCT FROM source ->> primary_field
+      OR (
+        secondary_field IS NOT NULL
+        AND previous_source ->> secondary_field IS DISTINCT FROM source ->> secondary_field
+      )
+    THEN
+      INSERT INTO "AuthzedProjectionOutbox" (
+        "id",
+        "targetType",
+        "primaryId",
+        "secondaryId",
+        "isRevocation",
+        "updatedAt"
+      ) VALUES (
+        gen_random_uuid()::text,
+        target_type,
+        previous_source ->> primary_field,
+        CASE WHEN secondary_field IS NULL THEN NULL ELSE previous_source ->> secondary_field END,
+        true,
+        NOW()
+      );
+    END IF;
+  END IF;
+
+  INSERT INTO "AuthzedProjectionOutbox" (
+    "id",
+    "targetType",
+    "primaryId",
+    "secondaryId",
+    "isRevocation",
+    "updatedAt"
+  ) VALUES (
+    gen_random_uuid()::text,
+    target_type,
+    source ->> primary_field,
+    CASE WHEN secondary_field IS NULL THEN NULL ELSE source ->> secondary_field END,
+    TG_OP <> 'INSERT',
+    NOW()
+  );
+
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "authzed_projection_organization" ON "Organization";
+CREATE TRIGGER "authzed_projection_organization"
+AFTER INSERT OR DELETE ON "Organization"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('organization', 'id', '');
+
+DROP TRIGGER IF EXISTS "authzed_projection_membership" ON "Membership";
+CREATE TRIGGER "authzed_projection_membership"
+AFTER INSERT OR DELETE OR UPDATE OF "role", "accepted", "organizationId", "userId" ON "Membership"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('membership', 'organizationId', 'userId');
+
+DROP TRIGGER IF EXISTS "authzed_projection_user" ON "User";
+CREATE TRIGGER "authzed_projection_user"
+AFTER INSERT OR DELETE OR UPDATE OF "isActive" ON "User"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('user', 'id', '');
+
+DROP TRIGGER IF EXISTS "authzed_projection_team" ON "Team";
+CREATE TRIGGER "authzed_projection_team"
+AFTER INSERT OR DELETE OR UPDATE OF "organizationId" ON "Team"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('team', 'id', '');
+
+DROP TRIGGER IF EXISTS "authzed_projection_team_user" ON "TeamUser";
+CREATE TRIGGER "authzed_projection_team_user"
+AFTER INSERT OR DELETE OR UPDATE OF "role", "teamId", "userId" ON "TeamUser"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('team_membership', 'teamId', 'userId');
+
+DROP TRIGGER IF EXISTS "authzed_projection_workspace" ON "Workspace";
+CREATE TRIGGER "authzed_projection_workspace"
+AFTER INSERT OR DELETE OR UPDATE OF "organizationId" ON "Workspace"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('workspace', 'id', '');
+
+DROP TRIGGER IF EXISTS "authzed_projection_workspace_team" ON "WorkspaceTeam";
+CREATE TRIGGER "authzed_projection_workspace_team"
+AFTER INSERT OR DELETE OR UPDATE OF "permission", "workspaceId", "teamId" ON "WorkspaceTeam"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('workspace_team', 'workspaceId', 'teamId');
+
+DROP TRIGGER IF EXISTS "authzed_projection_api_key" ON "ApiKey";
+CREATE TRIGGER "authzed_projection_api_key"
+AFTER INSERT OR DELETE OR UPDATE OF "organizationId", "organizationAccess" ON "ApiKey"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('api_key', 'id', '');
+
+DROP TRIGGER IF EXISTS "authzed_projection_api_key_workspace" ON "ApiKeyWorkspace";
+CREATE TRIGGER "authzed_projection_api_key_workspace"
+AFTER INSERT OR DELETE OR UPDATE OF "permission", "apiKeyId", "workspaceId" ON "ApiKeyWorkspace"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('api_key_workspace', 'apiKeyId', 'workspaceId');
+
+DROP TRIGGER IF EXISTS "authzed_projection_feedback_directory" ON "FeedbackDirectory";
+CREATE TRIGGER "authzed_projection_feedback_directory"
+AFTER INSERT OR DELETE OR UPDATE OF "isArchived", "organizationId" ON "FeedbackDirectory"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection('feedback_directory', 'id', '');
+
+DROP TRIGGER IF EXISTS "authzed_projection_feedback_directory_workspace" ON "FeedbackDirectoryWorkspace";
+CREATE TRIGGER "authzed_projection_feedback_directory_workspace"
+AFTER INSERT OR DELETE OR UPDATE OF "feedbackDirectoryId", "workspaceId" ON "FeedbackDirectoryWorkspace"
+FOR EACH ROW EXECUTE FUNCTION enqueue_authzed_projection(
+  'feedback_directory_assignment',
+  'feedbackDirectoryId',
+  'workspaceId'
+);

--- a/packages/database/migration/20260818120000_add_authzed_projection_outbox/migration.sql
+++ b/packages/database/migration/20260818120000_add_authzed_projection_outbox/migration.sql
@@ -40,6 +40,7 @@ DROP INDEX IF EXISTS "AuthzedProjectionOutbox_pending_idx";
 DROP INDEX IF EXISTS "AuthzedProjectionOutbox_revocation_idx";
 DROP INDEX IF EXISTS "AuthzedProjectionOutbox_leaseExpiresAt_idx";
 DROP INDEX IF EXISTS "AuthzedProjectionOutbox_target_idx";
+DROP INDEX IF EXISTS "AuthzedProjectionOutbox_dead_letter_idx";
 
 -- The claim. Its key columns ARE the claim's ORDER BY, so the LIMIT is served by an ordered index
 -- scan with no sort. Also serves the freshness guard's overdue-revocation EXISTS (equality on the
@@ -48,12 +49,20 @@ CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_claim_idx"
   ON "AuthzedProjectionOutbox"("isRevocation" DESC, "createdAt" ASC)
   WHERE "processedAt" IS NULL AND "deadLetteredAt" IS NULL;
 
--- Dead letters: the freshness guard's second EXISTS, the dead-letter gauge, and `outbox replay`.
+-- Everything still undelivered: the freshness guard's dead-letter EXISTS, `outbox replay`, and the
+-- status aggregate the delivery job runs every five seconds.
+--
+-- The predicate is deliberately the whole undelivered set rather than the dead letters alone. The
+-- status aggregate's own WHERE is a bare `processedAt IS NULL`, which does not imply a narrower
+-- predicate, so PostgreSQL cannot use a dead-letters-only index for it and would fall back to
+-- scanning all seven days of retained history twelve times a minute. Widened to this, the aggregate
+-- is an index-only scan and the dead-letter probe still has `isRevocation` as its leading key.
+--
 -- A dead-lettered row always has a NULL `processedAt` — the claim skips dead letters, and replay
--- clears `deadLetteredAt` before delivery is possible — so this predicate loses no rows.
-CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_dead_letter_idx"
-  ON "AuthzedProjectionOutbox"("isRevocation", "deadLetteredAt")
-  WHERE "processedAt" IS NULL AND "deadLetteredAt" IS NOT NULL;
+-- clears `deadLetteredAt` before delivery is possible — so no dead letter is lost here.
+CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_undelivered_idx"
+  ON "AuthzedProjectionOutbox"("isRevocation", "deadLetteredAt", "createdAt")
+  WHERE "processedAt" IS NULL;
 
 -- History prune. The only index that carries delivered rows.
 CREATE INDEX IF NOT EXISTS "AuthzedProjectionOutbox_processed_idx"

--- a/packages/database/schema/main.prisma
+++ b/packages/database/schema/main.prisma
@@ -1487,3 +1487,30 @@ model FeedbackDirectoryWorkspace {
   @@id([feedbackDirectoryId, workspaceId])
   @@index([workspaceId])
 }
+
+/// Durable PostgreSQL queue for rebuilding SpiceDB relationships after an authorization source changes.
+/// Source-table triggers insert these rows in the same transaction as the mutation. Identifiers are
+/// operationally sensitive and must never be included in logs, metrics, or CLI output.
+model AuthzedProjectionOutbox {
+  id             String    @id @default(uuid())
+  targetType     String
+  primaryId      String
+  secondaryId    String?
+  isRevocation   Boolean   @default(false)
+  attempts       Int       @default(0)
+  availableAt    DateTime  @default(now())
+  leasedAt       DateTime?
+  leaseExpiresAt DateTime?
+  leaseOwner     String?
+  processedAt    DateTime?
+  deadLetteredAt DateTime?
+  lastAttemptAt  DateTime?
+  lastErrorCode  String?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  @@index([processedAt, deadLetteredAt, availableAt, createdAt], map: "AuthzedProjectionOutbox_pending_idx")
+  @@index([isRevocation, processedAt, deadLetteredAt, createdAt], map: "AuthzedProjectionOutbox_revocation_idx")
+  @@index([leaseExpiresAt], map: "AuthzedProjectionOutbox_leaseExpiresAt_idx")
+  @@index([targetType, primaryId, secondaryId], map: "AuthzedProjectionOutbox_target_idx")
+}

--- a/packages/database/schema/main.prisma
+++ b/packages/database/schema/main.prisma
@@ -1491,26 +1491,35 @@ model FeedbackDirectoryWorkspace {
 /// Durable PostgreSQL queue for rebuilding SpiceDB relationships after an authorization source changes.
 /// Source-table triggers insert these rows in the same transaction as the mutation. Identifiers are
 /// operationally sensitive and must never be included in logs, metrics, or CLI output.
+///
+/// This model declares NO indexes on purpose. All three live in
+/// `migration/20260818120000_add_authzed_projection_outbox/migration.sql`, because each one is
+/// partial (`WHERE "processedAt" IS NULL AND ...`) and Prisma's `@@index` has no `where`. Declaring
+/// approximate non-partial copies here would be worse than declaring none: `prisma db push` would
+/// see a name match with a different definition, drop and recreate them without the predicate, and
+/// the migration's `CREATE INDEX IF NOT EXISTS` would then skip them — leaving a silently wrong
+/// shape that carries a week of delivered rows on every hot-path lookup. Deployments are unaffected
+/// either way (`prisma migrate deploy` never reads this file); a dev who runs `db push` restores
+/// them by rerunning the migration, which is the same contract its triggers already live under.
 model AuthzedProjectionOutbox {
-  id             String    @id @default(uuid())
-  targetType     String
-  primaryId      String
-  secondaryId    String?
-  isRevocation   Boolean   @default(false)
-  attempts       Int       @default(0)
-  availableAt    DateTime  @default(now())
-  leasedAt       DateTime?
-  leaseExpiresAt DateTime?
-  leaseOwner     String?
-  processedAt    DateTime?
-  deadLetteredAt DateTime?
-  lastAttemptAt  DateTime?
-  lastErrorCode  String?
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
-
-  @@index([processedAt, deadLetteredAt, availableAt, createdAt], map: "AuthzedProjectionOutbox_pending_idx")
-  @@index([isRevocation, processedAt, deadLetteredAt, createdAt], map: "AuthzedProjectionOutbox_revocation_idx")
-  @@index([leaseExpiresAt], map: "AuthzedProjectionOutbox_leaseExpiresAt_idx")
-  @@index([targetType, primaryId, secondaryId], map: "AuthzedProjectionOutbox_target_idx")
+  id                String    @id @default(uuid())
+  targetType        String
+  primaryId         String
+  secondaryId       String?
+  isRevocation      Boolean   @default(false)
+  /// Total delivery attempts. Drives the retry backoff and reports how hard delivery was tried.
+  attempts          Int       @default(0)
+  /// Non-retryable failures attributable to this event alone. The only input to dead-lettering, so
+  /// that a SpiceDB outage of any duration cannot dead-letter events that were never the problem.
+  permanentFailures Int       @default(0)
+  availableAt       DateTime  @default(now())
+  leasedAt          DateTime?
+  leaseExpiresAt    DateTime?
+  leaseOwner        String?
+  processedAt       DateTime?
+  deadLetteredAt    DateTime?
+  lastAttemptAt     DateTime?
+  lastErrorCode     String?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 }

--- a/packages/jobs/src/constants.ts
+++ b/packages/jobs/src/constants.ts
@@ -4,6 +4,8 @@ export const JOBS_QUEUE_NAME = "background-jobs";
 export const JOBS_PREFIX = "{formbricks:jobs}";
 
 export const JOB_NAMES = {
+  authzedProjectionDelivery: "authzed-projection.deliver",
+  authzedReconciliationAudit: "authzed-reconciliation.audit",
   testLog: "system.test-log",
   responsePipeline: "response-pipeline.process",
   surveyScheduling: "survey-scheduling.reconcile",

--- a/packages/jobs/src/processors.test.ts
+++ b/packages/jobs/src/processors.test.ts
@@ -276,9 +276,10 @@ describe("@formbricks/jobs processor registry", () => {
     );
   });
 
-  // One factory backs all three recurring fallbacks, so they are covered together — survey-archive-purge
-  // and workflow-run.reconcile previously had no test at all.
+  // One factory backs every recurring fallback, so they are covered together.
   test.each([
+    [JOB_NAMES.authzedProjectionDelivery, "AuthZed projection delivery"],
+    [JOB_NAMES.authzedReconciliationAudit, "AuthZed reconciliation audit"],
     [JOB_NAMES.surveyArchivePurge, "survey archive purge"],
     [JOB_NAMES.surveyScheduling, "survey scheduling"],
     [JOB_NAMES.workflowRunReconcile, "workflow run reconcile"],

--- a/packages/jobs/src/queue.test.ts
+++ b/packages/jobs/src/queue.test.ts
@@ -340,6 +340,8 @@ describe("@formbricks/jobs queue helpers", () => {
   // These ids address schedules that already exist in production Redis. Changing one orphans the live
   // schedule instead of updating it, so they are pinned as literals here rather than derived.
   test.each([
+    ["authzedProjectionDelivery", "authzed-projection.deliver:global:authzed-projection-delivery"],
+    ["authzedReconciliationAudit", "authzed-reconciliation.audit:global:authzed-reconciliation-audit"],
     ["surveyArchivePurge", "survey-archive-purge.process:global:daily-survey-archive-purge"],
     ["surveyScheduling", "survey-scheduling.reconcile:global:daily-survey-scheduling"],
     ["workflowRunReconcile", "workflow-run.reconcile:global:workflow-run-reconcile"],

--- a/packages/jobs/src/recurring.ts
+++ b/packages/jobs/src/recurring.ts
@@ -58,6 +58,16 @@ export const defineRecurringJob = ({
 
 /** Every recurring job in the system. Adding one here wires the registry, the producer and the exports. */
 export const recurringJobDescriptors = {
+  authzedProjectionDelivery: defineRecurringJob({
+    label: "AuthZed projection delivery",
+    name: JOB_NAMES.authzedProjectionDelivery,
+    scheduleId: "authzed-projection-delivery",
+  }),
+  authzedReconciliationAudit: defineRecurringJob({
+    label: "AuthZed reconciliation audit",
+    name: JOB_NAMES.authzedReconciliationAudit,
+    scheduleId: "authzed-reconciliation-audit",
+  }),
   surveyArchivePurge: defineRecurringJob({
     label: "survey archive purge",
     name: JOB_NAMES.surveyArchivePurge,

--- a/scripts/start-authzed-ci.sh
+++ b/scripts/start-authzed-ci.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly CONTAINER_NAME="formbricks-authzed-ci"
+readonly SPICEDB_IMAGE="${SPICEDB_IMAGE_REF:-authzed/spicedb:v1.52.0}"
+readonly ZED_IMAGE="${ZED_IMAGE_REF:-authzed/zed:v1.1.1}"
+
+AUTHZED_TOKEN="${AUTHZED_TOKEN:-}"
+if [[ -z "${AUTHZED_TOKEN}" && -f .env ]]; then
+  AUTHZED_TOKEN="$(sed -n 's/^AUTHZED_TOKEN=//p' .env | tail -n 1)"
+fi
+if [[ -z "${AUTHZED_TOKEN}" ]]; then
+  printf '%s\n' "AUTHZED_TOKEN is missing from the environment and repository .env file." >&2
+  exit 1
+fi
+readonly AUTHZED_TOKEN
+
+docker rm --force "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+
+docker run --detach \
+  --name "${CONTAINER_NAME}" \
+  --network host \
+  --memory 512m \
+  --env SPICEDB_DATASTORE_ENGINE=memory \
+  --env SPICEDB_GRPC_PRESHARED_KEY="${AUTHZED_TOKEN}" \
+  --env SPICEDB_LOG_FORMAT=json \
+  --env SPICEDB_LOG_LEVEL=info \
+  --env SPICEDB_TELEMETRY_ENDPOINT= \
+  "${SPICEDB_IMAGE}" \
+  serve >/dev/null
+
+for _ in $(seq 1 30); do
+  if docker exec "${CONTAINER_NAME}" \
+    /usr/local/bin/grpc_health_probe -addr=localhost:50051 >/dev/null 2>&1; then
+    docker run --rm \
+      --network host \
+      --entrypoint zed \
+      --volume "${PWD}/authzed/schema.zed:/schema.zed:ro" \
+      "${ZED_IMAGE}" \
+      schema write /schema.zed \
+      --endpoint localhost:50051 \
+      --token "${AUTHZED_TOKEN}" \
+      --insecure \
+      --skip-version-check >/dev/null
+
+    printf '%s\n' "AuthZed CI fixture is healthy and the canonical schema is installed."
+    exit 0
+  fi
+  sleep 2
+done
+
+printf '%s\n' "AuthZed CI fixture did not become healthy." >&2
+docker logs "${CONTAINER_NAME}" >&2 || true
+exit 1


### PR DESCRIPTION
Fixes ENG-2408

## What & why

- PostgreSQL source mutations currently project relationships synchronously and best-effort, so a SpiceDB outage can leave durable authorization drift with no guaranteed replay.
- Adds a transactional PostgreSQL outbox populated by database triggers for every Phase 1 relationship source, leased delivery with revocation priority, bounded retry/dead-letter handling, and idempotent reconciliation through the existing projectors.
- Adds a 60-second stale-revocation authorization guard, a six-hour full audit/repair job, bounded operational metrics, and sanitized `formbricks-authzed outbox status|drain|replay` commands.
- Keeps PostgreSQL authoritative, legacy authorization authoritative, and SpiceDB startup/health independent while producing the durable bridge required by the direct-cutover stack.

The guard is the load-bearing part, and it is global and unscoped: `spicedb-evaluator.ts` calls it on every permission check and `coordinator.ts` rethrows under enforcement with no legacy fallback, so **anything that arms it — spuriously or permanently — denies every enforced check in the deployment**. Three properties exist to keep that from happening:

- **An undelivered event only arms the guard if it could actually leave stale access.** The trigger classifies through a deny-by-default predicate rather than treating every `UPDATE` as a revocation. Only three transitions are grants, each proven from the projectors' own write shape: reactivating a user, unarchiving a feedback directory that stays in its organization, and any membership update leaving `role` unchanged (the projected snapshot ignores `accepted`, so accepting an invite writes byte-identical relationships). A mass invite acceptance therefore cannot arm the guard. The role ladder is deliberately **not** encoded in SQL — it is rankable, but a rank table in a migration has no compile-time backstop the way `relationship-map.ts` does, so a change to `schema.zed` would silently make it wrong in the fail-*open* direction.
- **A failure is charged only to the events it is attributable to.** A claimed batch delivers as six independent groups; a failing group takes only its own events. A retryable failure releases every remaining group untried. When a code could plausibly belong to one event (`authzed_projection_invalid_source`, `authzed_invalid_request`) the group is halved until the culprit is alone; codes that describe the instance are not split.
- **Dead-lettering requires the failure to *name* an event.** A new `permanentFailures` column gates it, and three things must hold together before it increments: the code is non-retryable, the attempt covered exactly one event, and the code is one an event can actually cause. The third condition is the one that is easy to miss — on a five-second cadence most groups hold a single event, so size alone would charge whichever revocations happened to be travelling alone when SpiceDB rejected a credential. The consequence is the property worth remembering: **no SpiceDB outage, of any duration or kind, can dead-letter an event that was never the problem.** The six-hour audit replays dead letters after a clean run, bounding a fail-closed denial at six hours rather than at operator attention.

## Breaking changes

None. The outbox table, its columns and its indexes are all introduced by this PR, so there is nothing deployed for them to break. No API, SDK, route, env var, config key, default or webhook payload changes.

## Migrations & env

- Adds the `AuthzedProjectionOutbox` table (including the `permanentFailures` column), three indexes — `_claim_idx`, `_undelivered_idx`, `_processed_idx` — and trigger functions in migration `20260818120000_add_authzed_projection_outbox`.
- The migration installs idempotent triggers on organization, membership, user, team, workspace, API-key, feedback-directory, grant, and deletion-cascade sources, plus the `authzed_projection_is_grant` classifier function.
- All three indexes are **partial** (`WHERE "processedAt" IS NULL AND …`), which Prisma's `@@index` cannot express — so `model AuthzedProjectionOutbox` deliberately declares no indexes and points at the migration. The convention and its `db push` caveat are documented in `packages/database/README.md`. A dev who runs `db push` restores them by rerunning the migration, the same contract the triggers already live under.
- No new environment variables. Existing AuthZed and jobs/Redis configuration is reused.
- Deploy the jobs worker with the application migration; legacy authorization remains authoritative on this branch.

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Grants are not classified as revocations | integration (real PostgreSQL): `outbox-trigger.integration.test.ts` | Drives the **real triggers**, not the SQL function directly. Invite acceptance and reactivation enqueue `isRevocation = false`; role moves, unmapped enum moves, unarchive-plus-tenant-move and deletes enqueue `true`; a key move enqueues the old pair `true` and the new pair `false`. |
| A grant pending far past the window leaves the guard disarmed | integration: `outbox-trigger.integration.test.ts` | An hour-old non-revocation returns `false` from `hasStaleAuthzedRevocation`; an hour-old revocation and a *fresh* dead letter both return `true`. |
| One poison event does not take healthy events with it | unit (mutation): `outbox-processor.test.ts` — `pnpm --filter=@formbricks/web test lib/authzed` | A failing group is released while the other five are delivered. A 4-event group failing on `authzed_projection_invalid_source` isolates one and delivers three. A group failing on `authzed_internal` is **not** split — asserted at exactly one reconciler call, which is the test that stops a 2×N regression. |
| A SpiceDB outage never dead-letters | integration + unit (mutation): `outbox-trigger.integration.test.ts`, `outbox-repository.test.ts`, `outbox-processor.test.ts` | 15 consecutive retryable failures leave `permanentFailures` at 0 and `deadLetteredAt` null. A group failure at `MAX-1` also does not dead-letter. Crucially, neither does a *single-event* group failing on `authzed_unauthenticated` / `authzed_internal` / `authzed_permission_denied` — those describe the instance, not the event. Only solitary, event-attributable failures dead-letter, at the tenth. `authzed_projection_unstable` is treated as retryable at the outbox boundary without changing the projector contract. |
| The guard ignores revocations that were actually delivered | integration: `outbox-trigger.integration.test.ts` | An hour-old revocation with `processedAt` set leaves the guard disarmed. Delivered rows are retained seven days, so without this predicate a healthy deployment would deny permanently — and every other guard test uses undelivered rows, so nothing else would have noticed. |
| The 5-second status aggregate does not scan retained history | integration: `outbox-trigger.integration.test.ts`; measured with `EXPLAIN (ANALYZE, BUFFERS)` | Against 200,000 delivered + 50 live rows the aggregate is an **Index Only Scan** on `_undelivered_idx` touching 5 buffers / 50 rows (0.04 ms), versus a parallel seq scan over all 200,050 before. The index predicate is the whole undelivered set precisely because a bare `processedAt IS NULL` implies neither complementary partial predicate. |
| Backoff grows per row and is capped | integration: `outbox-trigger.integration.test.ts` | Computed in SQL from each row's own `attempts`; a later attempt backs off further, and `attempts = 40` stays under the five-minute ceiling instead of overflowing. A release by a lease the row no longer owns changes nothing. |
| Freshness guard costs one query, not one per check | unit (mutation): `outbox-freshness.test.ts` | Five concurrent checks collapse to one query; a re-read happens after the TTL; a **failed** read is not memoized and still denies. React `cache()` is gone — the Route Handler runtime carries no cache dispatcher and 9 of 11 rollout targets are Route-Handler-only, so it was previously one uncached query per authorization *check*. |
| Claims are served in index order | integration: `outbox-trigger.integration.test.ts` | With a 2,000-row backlog and `ANALYZE`, `EXPLAIN` shows `AuthzedProjectionOutbox_claim_idx` and **no `Sort` node**. Seeded deliberately — on an empty table the planner picks a seq scan whatever indexes exist, so an unseeded plan assertion measures nothing. |
| Dead letters clear themselves after a clean audit | unit (mutation): `scheduled-reconciliation.test.ts` | Replay runs on `reconciled` and not on `drifted` or `failed`. |
| Source mutation and outbox insertion share one transaction | unit (mutation): `outbox-migration.test.ts`; manual PostgreSQL 16 migration exercise | Rollback produced zero events; committed writes across all 11 trigger sources produced durable events. |
| Leases, key moves, irrelevant updates, replay | unit (mutation): `outbox-repository.test.ts`, `outbox-processor.test.ts`, `outbox-cli*.test.ts` | Revocations are claimed first, key moves enqueue old/new targets, irrelevant API-key use updates are ignored, replay restores both `attempts` and the permanent-failure budget. |
| Six-hour reconciliation repairs only attributable safe drift | unit (mutation): `scheduled-reconciliation.test.ts` | Missing and mismatched-permission edges repair; parent mismatches, invalid, unmanaged, and destructive prune remain manual. |
| Worker registration and recurring cadence | unit (mutation): `instrumentation-jobs.test.ts`, `packages/jobs` tests | Delivery is scheduled every 5 seconds and reconciliation every 6 hours without duplicate registrations. |
| CLI and telemetry remain bounded and secret-safe | unit (mutation): CLI and metrics tests | Output carries aggregate counts and stable codes only. The delivery warning logs a sorted set of enumerable error codes — no target IDs, relationships, tokens, or raw SDK errors. |
| Canonical schema and live SpiceDB behavior | integration: `pnpm authzed:validate`, `pnpm authzed:smoke` | 36 relationships, 157 assertions, and 6 expected relations validated; isolated persistence/outage/recovery smoke passed. |
| Deployment manifests retain their AuthZed contracts | static integration: `docker/authzed-compose-contract.sh`; Helm lint | Production/dev Compose contracts and both Formbricks/operator charts validated. |
| Migration is rerunnable | manual PostgreSQL 16 exercise | Applied twice in a row against a live database; second run is a clean no-op (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, `DROP TRIGGER IF EXISTS`). |
| No build-time AuthZed RPC | production builds with AuthZed disabled and with `127.0.0.1:9` configured | Both builds completed successfully without contacting SpiceDB. |

Every `unit (mutation)` and `integration` row above was checked by reverting the behaviour it names and confirming the named test goes red — including the three fixes in `cc40a095`, which came out of a self-review pass over `3a7c428` and are the reason that commit exists. Whole-suite state: `apps/web` unit suite 679 files / 8,974 tests green; outbox integration 17 tests green; `packages/database` and `packages/jobs` green; typecheck, ESLint and `prettier --check .` clean.

**Open gaps**

- **The freshness guard is still global.** Tenant-scoping it was considered and deliberately not done — it is not fully achievable (user deactivation is genuinely cross-tenant, and 5 of the 11 sources carry no `organizationId` the trigger can reach without a parent lookup on every source mutation). Fixing the classification removes the bulk amplifier that made a global guard a practical outage; scoping remains available later if a real single-tenant backlog appears.
- **Parent moves are unprojectable, not merely unclassified.** `createParentUpdate`/`parentUpdate` only ever *touch* the new parent, so moving a Team/Workspace/ApiKey/FeedbackDirectory between organizations leaves the old organization's owners with access. These are classified as revocations, but the event then delivers "successfully" and disarms the guard — so the guard does not protect against this class. `backfill.ts` already reports it as `mismatchedParents` and deliberately does not repair it. Pre-existing; worth its own ticket.
- The immutable bridge image cannot be frozen or deployed to `authzed-sandbox` until this stacked PR and its prerequisite PRs merge.
- Live crash/replay, alert timing, rollback, and 24-hour sandbox-soak evidence belongs to ENG-2469 and ENG-2470 after the bridge image exists.
- Staging and production rollout are intentionally blocked by the sandbox exit gate.
- Four integration files (`modules/auth/*`, `modules/ee/workflows/*`) fail locally on missing SMTP and mail-URL configuration. Confirmed pre-existing: identical failures on the unmodified parent commit.

**Risks**

- Database triggers are the atomicity boundary; source-table schema changes must update the trigger contract, the classifier's watched-column reasoning, and the migration regression test.
- The classifier is deny-by-default, so the failure mode of getting it wrong is denial, not leakage — but adding a target type to the grant `CASE` without re-reading that projector's write shape would invert that.
- Projection is at-least-once. A worker can replay after a lost lease, so projectors must remain idempotent.
- A stale/dead-letter revocation intentionally fails protected SpiceDB operations closed while `/health`, readiness, and startup stay independent.
- The freshness memo widens the effective window by up to 1s on a 60s budget — bounded and explicit, in exchange for removing an uncached query from every authorization check. It reads the monotonic clock, so a backwards NTP step cannot extend that bound.
- Attribution is deliberately conservative: an event carrying a genuinely poisonous payload under a code *outside* `PER_EVENT_ERROR_CODES` will retry indefinitely at the five-minute ceiling rather than dead-letter. That keeps it visible (the guard stays armed if it is a revocation) instead of silently parked, but it means the dead-letter queue is not a catch-all for every stuck event.
- The scheduled repair never prunes or repairs tenant-parent mismatches automatically; operators must investigate those security-sensitive cases.

---

> [!NOTE]
> **AI model used** — original implementation GPT-5.6, reasoning effort high; review-fix commits `3a7c428` and `cc40a095` Claude Opus 5, reasoning effort high.


**CI follow-up**

- The E2E and Better Auth integration workflows now start a pinned ephemeral SpiceDB fixture and apply the canonical schema before application code runs. This removes projection retry amplification while preserving real AuthZed behavior.
- Local evidence: the fixture health/schema bootstrap passed, and the real Better Auth integration suite completed with 32 files and 141 tests passing. Failure diagnostics include sanitized SpiceDB container logs.