### PR TITLE
feat: make authorization lists SpiceDB authoritative

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/actions.ts
@@ -2,13 +2,8 @@
 
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
-import {
-  AuthorizationError,
-  OperationNotAllowedError,
-  ResourceNotFoundError,
-} from "@formbricks/types/errors";
+import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { ZWorkspaceUpdateInput } from "@formbricks/types/workspace";
-import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getOrganization } from "@/lib/organization/service";
 import { capturePostHogEvent, groupIdentifyPostHog } from "@/lib/posthog";
 import { updateUser } from "@/lib/user/service";
@@ -148,13 +143,7 @@ export const getWorkspacesForSwitcherAction = authenticatedActionClient
       ],
     });
 
-    // Need membership for getWorkspacesByUserId (1 DB query)
-    const membership = await getMembershipByUserIdOrganizationId(ctx.user.id, parsedInput.organizationId);
-    if (!membership) {
-      throw new AuthorizationError("Membership not found");
-    }
-
-    return await getWorkspacesByUserId(ctx.user.id, membership);
+    return await getWorkspacesByUserId(ctx.user.id, parsedInput.organizationId);
   });
 
 const ZGetWritableWorkspacesAction = z.object({
@@ -179,10 +168,5 @@ export const getWritableWorkspacesAction = authenticatedActionClient
       ],
     });
 
-    const membership = await getMembershipByUserIdOrganizationId(ctx.user.id, parsedInput.organizationId);
-    if (!membership) {
-      throw new AuthorizationError("Membership not found");
-    }
-
-    return await getWritableWorkspacesByUserId(ctx.user.id, membership);
+    return await getWritableWorkspacesByUserId(ctx.user.id, parsedInput.organizationId);
   });

--- a/apps/web/app/(app)/workspaces/[workspaceId]/lib/organization.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/lib/organization.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { lookupAuthorizedOrganizationIds } from "@/lib/authorization/resource-list";
 import { getOrganizationsByUserId } from "./organization";
 
 vi.mock("@formbricks/database", () => ({
@@ -11,6 +12,12 @@ vi.mock("@formbricks/database", () => ({
     },
   },
 }));
+vi.mock("@/lib/authorization/resource-list", () => ({ lookupAuthorizedOrganizationIds: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValue(["org1", "org2"]);
+});
 
 describe("Organization", () => {
   describe("getOrganizationsByUserId", () => {
@@ -26,11 +33,7 @@ describe("Organization", () => {
 
       expect(prisma.organization.findMany).toHaveBeenCalledWith({
         where: {
-          memberships: {
-            some: {
-              userId: "user1",
-            },
-          },
+          id: { in: ["org1", "org2"] },
         },
         orderBy: [{ createdAt: "asc" }, { id: "asc" }],
         select: {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/lib/organization.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/lib/organization.ts
@@ -3,6 +3,7 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { ZString } from "@formbricks/types/common";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { lookupAuthorizedOrganizationIds } from "@/lib/authorization/resource-list";
 import { validateInputs } from "@/lib/utils/validate";
 
 export const getOrganizationsByUserId = reactCache(
@@ -10,13 +11,12 @@ export const getOrganizationsByUserId = reactCache(
     validateInputs([userId, ZString]);
 
     try {
+      const organizationIds = await lookupAuthorizedOrganizationIds({ type: "user", id: userId });
+      if (organizationIds.length === 0) return [];
+
       const organizations = await prisma.organization.findMany({
         where: {
-          memberships: {
-            some: {
-              userId,
-            },
-          },
+          id: { in: [...organizationIds] },
         },
         // Deterministic order so callers that take organizations[0] (e.g. account settings'
         // default org) always resolve the same organization for a given user. id breaks ties when

--- a/apps/web/app/(app)/workspaces/[workspaceId]/lib/workspace.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/lib/workspace.test.ts
@@ -1,298 +1,80 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
-import { TMembership } from "@formbricks/types/memberships";
+import { lookupAuthorizedWorkspaceIds } from "@/lib/authorization/resource-list";
 import { getWorkspacesByUserId, getWritableWorkspacesByUserId } from "./workspace";
 
 vi.mock("@formbricks/database", () => ({
-  prisma: {
-    workspace: {
-      findMany: vi.fn(),
-    },
-  },
+  prisma: { workspace: { findMany: vi.fn() } },
 }));
+vi.mock("@/lib/authorization/resource-list", () => ({ lookupAuthorizedWorkspaceIds: vi.fn() }));
 
-describe("Workspace", () => {
-  describe("getUserWorkspaces", () => {
-    const mockAdminMembership: TMembership = {
-      role: "manager",
-      organizationId: "org1",
-      userId: "user1",
-      accepted: true,
-    };
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(["workspace1", "workspace2"]);
+});
 
-    const mockMemberMembership: TMembership = {
-      role: "member",
-      organizationId: "org1",
-      userId: "user1",
-      accepted: true,
-    };
+describe("authoritative workspace switcher lists", () => {
+  test("resolves readable workspaces through SpiceDB and scopes the data query to the organization", async () => {
+    const workspaces = [
+      { id: "workspace1", name: "Workspace 1" },
+      { id: "workspace2", name: "Workspace 2" },
+    ];
+    vi.mocked(prisma.workspace.findMany).mockResolvedValue(workspaces as never);
 
-    test("should return workspaces for admin role", async () => {
-      const mockWorkspaces = [
-        { id: "workspace1", name: "Workspace 1" },
-        { id: "workspace2", name: "Workspace 2" },
-      ];
+    await expect(getWorkspacesByUserId("user1", "org1")).resolves.toEqual(workspaces);
 
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as any);
-
-      const result = await getWorkspacesByUserId("user1", mockAdminMembership);
-
-      expect(prisma.workspace.findMany).toHaveBeenCalledWith({
-        where: {
-          organizationId: "org1",
-        },
-        select: {
-          id: true,
-          name: true,
-        },
-        orderBy: { createdAt: "asc" },
-      });
-      expect(result).toEqual(mockWorkspaces);
-    });
-
-    test("should return workspaces for member role with team restrictions", async () => {
-      const mockWorkspaces = [{ id: "workspace1", name: "Workspace 1" }];
-
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as any);
-
-      const result = await getWorkspacesByUserId("user1", mockMemberMembership);
-
-      expect(prisma.workspace.findMany).toHaveBeenCalledWith({
-        where: {
-          organizationId: "org1",
-          workspaceTeams: {
-            some: {
-              team: {
-                teamUsers: {
-                  some: {
-                    userId: "user1",
-                  },
-                },
-              },
-            },
-          },
-        },
-        select: {
-          id: true,
-          name: true,
-        },
-        orderBy: { createdAt: "asc" },
-      });
-      expect(result).toEqual(mockWorkspaces);
-    });
-
-    test("should return empty array when no workspaces found", async () => {
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue([]);
-
-      const result = await getWorkspacesByUserId("user1", mockAdminMembership);
-
-      expect(result).toEqual([]);
-    });
-
-    test("should throw DatabaseError on Prisma error", async () => {
-      const prismaError = new Prisma.PrismaClientKnownRequestError("Database error", {
-        code: "P2002",
-        clientVersion: "5.0.0",
-      });
-
-      vi.mocked(prisma.workspace.findMany).mockRejectedValue(prismaError);
-
-      await expect(getWorkspacesByUserId("user1", mockAdminMembership)).rejects.toThrow(
-        new DatabaseError("Database error")
-      );
-    });
-
-    test("should re-throw unknown errors", async () => {
-      const unknownError = new Error("Unknown error");
-      vi.mocked(prisma.workspace.findMany).mockRejectedValue(unknownError);
-
-      await expect(getWorkspacesByUserId("user1", mockAdminMembership)).rejects.toThrow(unknownError);
-    });
-
-    test("should validate inputs correctly", async () => {
-      await expect(getWorkspacesByUserId(123 as any, mockAdminMembership)).rejects.toThrow();
-    });
-
-    test("should validate membership input correctly", async () => {
-      const invalidMembership = {} as TMembership;
-      await expect(getWorkspacesByUserId("user1", invalidMembership)).rejects.toThrow();
-    });
-
-    test("should handle owner role like manager", async () => {
-      const mockOwnerMembership: TMembership = {
-        role: "owner",
-        organizationId: "org1",
-        userId: "user1",
-        accepted: true,
-      };
-
-      const mockWorkspaces = [{ id: "workspace1", name: "Workspace 1" }];
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as any);
-
-      const result = await getWorkspacesByUserId("user1", mockOwnerMembership);
-
-      expect(prisma.workspace.findMany).toHaveBeenCalledWith({
-        where: {
-          organizationId: "org1",
-        },
-        select: {
-          id: true,
-          name: true,
-        },
-        orderBy: { createdAt: "asc" },
-      });
-      expect(result).toEqual(mockWorkspaces);
+    expect(lookupAuthorizedWorkspaceIds).toHaveBeenCalledExactlyOnceWith(
+      { id: "user1", type: "user" },
+      "read"
+    );
+    expect(prisma.workspace.findMany).toHaveBeenCalledWith({
+      orderBy: { createdAt: "asc" },
+      select: { id: true, name: true },
+      where: { id: { in: ["workspace1", "workspace2"] }, organizationId: "org1" },
     });
   });
 
-  describe("getWritableWorkspacesByUserId", () => {
-    const mockOwnerMembership: TMembership = {
-      role: "owner",
-      organizationId: "org1",
-      userId: "user1",
-      accepted: true,
-    };
+  test("uses workspace.write for writable destination lists", async () => {
+    vi.mocked(prisma.workspace.findMany).mockResolvedValue([]);
 
-    const mockManagerMembership: TMembership = {
-      role: "manager",
-      organizationId: "org1",
-      userId: "user1",
-      accepted: true,
-    };
+    await expect(getWritableWorkspacesByUserId("user1", "org1")).resolves.toEqual([]);
 
-    const mockMemberMembership: TMembership = {
-      role: "member",
-      organizationId: "org1",
-      userId: "user1",
-      accepted: true,
-    };
+    expect(lookupAuthorizedWorkspaceIds).toHaveBeenCalledExactlyOnceWith(
+      { id: "user1", type: "user" },
+      "write"
+    );
+  });
 
-    test("should return all workspaces in org for owner role without team filter", async () => {
-      const mockWorkspaces = [
-        { id: "workspace1", name: "Workspace 1" },
-        { id: "workspace2", name: "Workspace 2" },
-      ];
+  test("does not query PostgreSQL when SpiceDB returns no workspaces", async () => {
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue([]);
 
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as any);
+    await expect(getWorkspacesByUserId("user1", "org1")).resolves.toEqual([]);
 
-      const result = await getWritableWorkspacesByUserId("user1", mockOwnerMembership);
+    expect(prisma.workspace.findMany).not.toHaveBeenCalled();
+  });
 
-      expect(prisma.workspace.findMany).toHaveBeenCalledWith({
-        where: {
-          organizationId: "org1",
-        },
-        select: {
-          id: true,
-          name: true,
-        },
-        orderBy: { createdAt: "asc" },
-      });
-      expect(result).toEqual(mockWorkspaces);
+  test("translates Prisma failures without converting them into an empty list", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Database error", {
+      clientVersion: "5.0.0",
+      code: "P2002",
     });
+    vi.mocked(prisma.workspace.findMany).mockRejectedValue(prismaError);
 
-    test("should return all workspaces in org for manager role without team filter", async () => {
-      const mockWorkspaces = [{ id: "workspace1", name: "Workspace 1" }];
+    await expect(getWorkspacesByUserId("user1", "org1")).rejects.toBeInstanceOf(DatabaseError);
+  });
 
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as any);
+  test("propagates AuthZed lookup failures", async () => {
+    const unavailable = new Error("AuthZed unavailable");
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockRejectedValue(unavailable);
 
-      const result = await getWritableWorkspacesByUserId("user1", mockManagerMembership);
+    await expect(getWorkspacesByUserId("user1", "org1")).rejects.toBe(unavailable);
+  });
 
-      expect(prisma.workspace.findMany).toHaveBeenCalledWith({
-        where: {
-          organizationId: "org1",
-        },
-        select: {
-          id: true,
-          name: true,
-        },
-        orderBy: { createdAt: "asc" },
-      });
-      expect(result).toEqual(mockWorkspaces);
-    });
-
-    test("should filter to readWrite or manage team workspaces for member role", async () => {
-      const mockWorkspaces = [{ id: "workspace1", name: "Workspace 1" }];
-
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as any);
-
-      const result = await getWritableWorkspacesByUserId("user1", mockMemberMembership);
-
-      expect(prisma.workspace.findMany).toHaveBeenCalledWith({
-        where: {
-          organizationId: "org1",
-          workspaceTeams: {
-            some: {
-              permission: { in: ["readWrite", "manage"] },
-              team: {
-                teamUsers: {
-                  some: {
-                    userId: "user1",
-                  },
-                },
-              },
-            },
-          },
-        },
-        select: {
-          id: true,
-          name: true,
-        },
-        orderBy: { createdAt: "asc" },
-      });
-      expect(result).toEqual(mockWorkspaces);
-    });
-
-    test("should include workspaces where member has manage permission", async () => {
-      const mockWorkspaces = [{ id: "workspace-manage", name: "Managed Workspace" }];
-
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as any);
-
-      const result = await getWritableWorkspacesByUserId("user1", mockMemberMembership);
-
-      const callArgs = vi.mocked(prisma.workspace.findMany).mock.calls.at(-1)?.[0];
-      const permissionFilter = (callArgs?.where as any)?.workspaceTeams?.some?.permission;
-      expect(permissionFilter).toEqual({ in: ["readWrite", "manage"] });
-      expect(permissionFilter.in).toContain("manage");
-      expect(result).toEqual(mockWorkspaces);
-    });
-
-    test("should return empty array when member has no readWrite or manage team access", async () => {
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue([]);
-
-      const result = await getWritableWorkspacesByUserId("user1", mockMemberMembership);
-
-      expect(result).toEqual([]);
-    });
-
-    test("should throw DatabaseError on Prisma error", async () => {
-      const prismaError = new Prisma.PrismaClientKnownRequestError("Database error", {
-        code: "P2002",
-        clientVersion: "5.0.0",
-      });
-
-      vi.mocked(prisma.workspace.findMany).mockRejectedValue(prismaError);
-
-      await expect(getWritableWorkspacesByUserId("user1", mockOwnerMembership)).rejects.toThrow(
-        new DatabaseError("Database error")
-      );
-    });
-
-    test("should re-throw unknown errors", async () => {
-      const unknownError = new Error("Unknown error");
-      vi.mocked(prisma.workspace.findMany).mockRejectedValue(unknownError);
-
-      await expect(getWritableWorkspacesByUserId("user1", mockOwnerMembership)).rejects.toThrow(unknownError);
-    });
-
-    test("should validate inputs correctly", async () => {
-      await expect(getWritableWorkspacesByUserId(123 as any, mockOwnerMembership)).rejects.toThrow();
-    });
-
-    test("should validate membership input correctly", async () => {
-      const invalidMembership = {} as TMembership;
-      await expect(getWritableWorkspacesByUserId("user1", invalidMembership)).rejects.toThrow();
-    });
+  test("validates actor and organization inputs before authorization lookup", async () => {
+    await expect(getWorkspacesByUserId(123 as never, "org1")).rejects.toThrow();
+    await expect(getWorkspacesByUserId("user1", {} as never)).rejects.toThrow();
+    expect(lookupAuthorizedWorkspaceIds).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/(app)/workspaces/[workspaceId]/lib/workspace.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/lib/workspace.ts
@@ -3,40 +3,27 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { ZId } from "@formbricks/types/common";
 import { DatabaseError } from "@formbricks/types/errors";
-import { TMembership, ZMembership } from "@formbricks/types/memberships";
+import { lookupAuthorizedWorkspaceIds } from "@/lib/authorization/resource-list";
 import { validateInputs } from "@/lib/utils/validate";
 
-const findWorkspacesForMembership = async (
+const findWorkspacesForOrganization = async (
   userId: string,
-  orgMembership: TMembership,
+  organizationId: string,
   { writableOnly }: { writableOnly: boolean }
 ): Promise<{ id: string; name: string }[]> => {
-  validateInputs([userId, ZId], [orgMembership, ZMembership]);
-
-  let workspaceWhereClause: Prisma.WorkspaceWhereInput = {};
-
-  if (orgMembership.role === "member") {
-    workspaceWhereClause = {
-      workspaceTeams: {
-        some: {
-          ...(writableOnly && { permission: { in: ["readWrite", "manage"] } }),
-          team: {
-            teamUsers: {
-              some: {
-                userId,
-              },
-            },
-          },
-        },
-      },
-    };
-  }
+  validateInputs([userId, ZId], [organizationId, ZId]);
 
   try {
+    const workspaceIds = await lookupAuthorizedWorkspaceIds(
+      { type: "user", id: userId },
+      writableOnly ? "write" : "read"
+    );
+    if (workspaceIds.length === 0) return [];
+
     const workspaces = await prisma.workspace.findMany({
       where: {
-        organizationId: orgMembership.organizationId,
-        ...workspaceWhereClause,
+        id: { in: [...workspaceIds] },
+        organizationId,
       },
       select: {
         id: true,
@@ -57,11 +44,11 @@ const findWorkspacesForMembership = async (
 };
 
 export const getWorkspacesByUserId = reactCache(
-  async (userId: string, orgMembership: TMembership): Promise<{ id: string; name: string }[]> =>
-    findWorkspacesForMembership(userId, orgMembership, { writableOnly: false })
+  async (userId: string, organizationId: string): Promise<{ id: string; name: string }[]> =>
+    findWorkspacesForOrganization(userId, organizationId, { writableOnly: false })
 );
 
 export const getWritableWorkspacesByUserId = reactCache(
-  async (userId: string, orgMembership: TMembership): Promise<{ id: string; name: string }[]> =>
-    findWorkspacesForMembership(userId, orgMembership, { writableOnly: true })
+  async (userId: string, organizationId: string): Promise<{ id: string; name: string }[]> =>
+    findWorkspacesForOrganization(userId, organizationId, { writableOnly: true })
 );

--- a/apps/web/app/api/v3/workspaces/lib/operations.test.ts
+++ b/apps/web/app/api/v3/workspaces/lib/operations.test.ts
@@ -1,17 +1,16 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
-import { observeWorkspaceListAuthorization } from "@/lib/authorization/workspace-list-observer";
-import { getOrganizationsByUserId } from "@/lib/organization/service";
-import { getUserWorkspaces, getWorkspacesByIds } from "@/lib/workspace/service";
+import { lookupAuthorizedWorkspaceIds } from "@/lib/authorization/resource-list";
+import { getWorkspacesByIds, getWorkspacesByIdsForUser } from "@/lib/workspace/service";
 import { listV3Workspaces } from "./operations";
 
 const loggerMocks = vi.hoisted(() => ({ error: vi.fn() }));
 
-vi.mock("@/lib/organization/service", () => ({ getOrganizationsByUserId: vi.fn() }));
-vi.mock("@/lib/workspace/service", () => ({ getUserWorkspaces: vi.fn(), getWorkspacesByIds: vi.fn() }));
-vi.mock("@/lib/authorization/workspace-list-observer", () => ({
-  observeWorkspaceListAuthorization: vi.fn(),
+vi.mock("@/lib/workspace/service", () => ({
+  getWorkspacesByIds: vi.fn(),
+  getWorkspacesByIdsForUser: vi.fn(),
 }));
+vi.mock("@/lib/authorization/resource-list", () => ({ lookupAuthorizedWorkspaceIds: vi.fn() }));
 vi.mock("@formbricks/logger", () => ({
   logger: { withContext: vi.fn(() => loggerMocks) },
 }));
@@ -42,18 +41,17 @@ const ws = (id: string, name: string, organizationId: string) =>
 describe("listV3Workspaces", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue([]);
   });
 
   test("session user: aggregates + dedupes across orgs and returns the minimal DTO only", async () => {
-    vi.mocked(getOrganizationsByUserId).mockResolvedValue([
-      { id: "org_1", name: "Org 1" },
-      { id: "org_2", name: "Org 2" },
-    ] as any);
-    vi.mocked(getUserWorkspaces).mockImplementation(async (_userId: string, orgId: string) =>
-      orgId === "org_1"
-        ? [ws("w1", "Alpha", "org_1"), ws("w2", "Beta", "org_1")]
-        : [ws("w2", "Beta", "org_1"), ws("w3", "Gamma", "org_2")]
-    );
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(["w1", "w2", "w3"]);
+    vi.mocked(getWorkspacesByIdsForUser).mockResolvedValue([
+      ws("w1", "Alpha", "org_1"),
+      ws("w2", "Beta", "org_1"),
+      ws("w2", "Beta", "org_1"),
+      ws("w3", "Gamma", "org_2"),
+    ]);
 
     const res = await listV3Workspaces(params(sessionAuth));
     expect(res.status).toBe(200);
@@ -67,20 +65,13 @@ describe("listV3Workspaces", () => {
     expect(body.meta.totalCount).toBe(3);
     // Only the DTO fields — no config/styling/entity internals leak.
     expect(Object.keys(body.data[0])).toEqual(["id", "name", "organizationId"]);
-    expect(observeWorkspaceListAuthorization).toHaveBeenCalledExactlyOnceWith({
-      actor: { id: "user_1", type: "user" },
-      organizationIds: ["org_1", "org_2"],
-      workspaces: [
-        { id: "w1", organizationId: "org_1" },
-        { id: "w2", organizationId: "org_1" },
-        { id: "w3", organizationId: "org_2" },
-      ],
-    });
+    expect(lookupAuthorizedWorkspaceIds).toHaveBeenCalledExactlyOnceWith({ id: "user_1", type: "user" });
+    expect(getWorkspacesByIdsForUser).toHaveBeenCalledExactlyOnceWith("user_1", ["w1", "w2", "w3"]);
   });
 
   test("returns workspaces in a deterministic order (name, then id)", async () => {
-    vi.mocked(getOrganizationsByUserId).mockResolvedValue([{ id: "org_1", name: "Org 1" }] as any);
-    vi.mocked(getUserWorkspaces).mockResolvedValue([
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(["w3", "w1", "w2"]);
+    vi.mocked(getWorkspacesByIdsForUser).mockResolvedValue([
       ws("w3", "Zeta", "org_1"),
       ws("w1", "alpha", "org_1"),
       ws("w2", "Beta", "org_1"),
@@ -92,20 +83,17 @@ describe("listV3Workspaces", () => {
     expect(body.data.map((w: { name: string }) => w.name)).toEqual(["alpha", "Beta", "Zeta"]);
   });
 
-  test("session user with no orgs → empty list, no workspace lookups", async () => {
-    vi.mocked(getOrganizationsByUserId).mockResolvedValue([] as any);
+  test("session user with no authorized workspaces → empty list", async () => {
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue([]);
+    vi.mocked(getWorkspacesByIdsForUser).mockResolvedValue([]);
 
     const res = await listV3Workspaces(params(sessionAuth));
     const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(body.data).toEqual([]);
-    expect(getUserWorkspaces).not.toHaveBeenCalled();
-    expect(observeWorkspaceListAuthorization).toHaveBeenCalledExactlyOnceWith({
-      actor: { id: "user_1", type: "user" },
-      organizationIds: [],
-      workspaces: [],
-    });
+    expect(lookupAuthorizedWorkspaceIds).toHaveBeenCalledExactlyOnceWith({ id: "user_1", type: "user" });
+    expect(getWorkspacesByIdsForUser).toHaveBeenCalledExactlyOnceWith("user_1", []);
   });
 
   test("api key: returns only same-organization workspaces in workspacePermissions", async () => {
@@ -117,6 +105,7 @@ describe("listV3Workspaces", () => {
         { workspaceId: "w9", permission: "write" },
       ],
     } as unknown as TV3Authentication;
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(["w1", "w9"]);
     vi.mocked(getWorkspacesByIds).mockResolvedValue([ws("w1", "Alpha", "org_1")]);
 
     const res = await listV3Workspaces(params(keyAuth));
@@ -124,23 +113,22 @@ describe("listV3Workspaces", () => {
 
     expect(body.data).toEqual([{ id: "w1", name: "Alpha", organizationId: "org_1" }]);
     expect(getWorkspacesByIds).toHaveBeenCalledExactlyOnceWith("org_1", ["w1", "w9"]);
-    // API-key path must never fall back to the user/org aggregation.
-    expect(getOrganizationsByUserId).not.toHaveBeenCalled();
-    expect(observeWorkspaceListAuthorization).toHaveBeenCalledExactlyOnceWith({
-      actor: { id: "key_1", type: "apiKey" },
-      organizationIds: ["org_1"],
-      workspaces: [{ id: "w1", organizationId: "org_1" }],
+    // API-key path must never use the user membership resolver.
+    expect(getWorkspacesByIdsForUser).not.toHaveBeenCalled();
+    expect(lookupAuthorizedWorkspaceIds).toHaveBeenCalledExactlyOnceWith({
+      id: "key_1",
+      type: "apiKey",
     });
   });
 
   test("no authentication → 401", async () => {
     const res = await listV3Workspaces(params(null));
     expect(res.status).toBe(401);
-    expect(observeWorkspaceListAuthorization).not.toHaveBeenCalled();
+    expect(lookupAuthorizedWorkspaceIds).not.toHaveBeenCalled();
   });
 
   test("an unexpected service failure is logged and returned as a 500 (never thrown)", async () => {
-    vi.mocked(getOrganizationsByUserId).mockRejectedValue(new Error("db exploded"));
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockRejectedValue(new Error("AuthZed exploded"));
     const res = await listV3Workspaces(params(sessionAuth));
     expect(res.status).toBe(500);
   });

--- a/apps/web/app/api/v3/workspaces/lib/operations.ts
+++ b/apps/web/app/api/v3/workspaces/lib/operations.ts
@@ -4,9 +4,10 @@ import type { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { getV3AuthorizationActor } from "@/app/api/v3/lib/auth";
 import { problemInternalError, problemUnauthorized, successListResponse } from "@/app/api/v3/lib/response";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
-import { observeWorkspaceListAuthorization } from "@/lib/authorization/workspace-list-observer";
-import { getOrganizationsByUserId } from "@/lib/organization/service";
-import { getUserWorkspaces, getWorkspacesByIds } from "@/lib/workspace/service";
+import type { TAuthorizationActor } from "@/lib/authorization";
+import { lookupAuthorizedWorkspaceIds } from "@/lib/authorization/resource-list";
+import { AuthzedError } from "@/lib/authzed/errors";
+import { getWorkspacesByIds, getWorkspacesByIdsForUser } from "@/lib/workspace/service";
 
 type TListV3WorkspacesParams = {
   authentication: TV3Authentication;
@@ -23,7 +24,6 @@ type TV3WorkspaceListItem = {
 
 type TResolvedWorkspaceList = Readonly<{
   items: ReadonlyArray<TV3WorkspaceListItem>;
-  organizationIds: ReadonlyArray<string>;
 }>;
 
 const serializeV3WorkspaceListItem = (workspace: {
@@ -36,33 +36,30 @@ const serializeV3WorkspaceListItem = (workspace: {
   organizationId: workspace.organizationId,
 });
 
-/**
- * Session user's accessible workspaces: every workspace across the orgs they're a member of. Scoping is
- * enforced by the reused services — `getOrganizationsByUserId` limits to the user's own orgs, and
- * `getUserWorkspaces` returns all of an org's workspaces for owners/managers but only team-scoped ones
- * for `member`-role users.
- */
-async function fetchSessionWorkspaces(userId: string): Promise<TResolvedWorkspaceList> {
-  const organizations = await getOrganizationsByUserId(userId);
-  const workspacesPerOrg = await Promise.all(
-    organizations.map((organization) => getUserWorkspaces(userId, organization.id))
-  );
+/** Session user's accessible workspaces from one authoritative `LookupResources(workspace, read)`. */
+async function fetchSessionWorkspaces(
+  userId: string,
+  actor: Extract<TAuthorizationActor, { type: "user" }>
+): Promise<TResolvedWorkspaceList> {
+  const workspaceIds = await lookupAuthorizedWorkspaceIds(actor);
+  const workspaces = await getWorkspacesByIdsForUser(userId, [...workspaceIds]);
   return {
-    items: workspacesPerOrg.flat().map(serializeV3WorkspaceListItem),
-    organizationIds: organizations.map(({ id }) => id),
+    items: workspaces.map(serializeV3WorkspaceListItem),
   };
 }
 
-/** API key's accessible workspaces: exactly the ones named in its `workspacePermissions`, nothing else. */
-async function fetchApiKeyWorkspaces(keyAuth: TAuthenticationApiKey): Promise<TResolvedWorkspaceList> {
-  const workspaceIds = Array.from(new Set(keyAuth.workspacePermissions.map((p) => p.workspaceId)));
-  const workspaces = await getWorkspacesByIds(keyAuth.organizationId, workspaceIds);
+/** API key's accessible workspaces: the authoritative SpiceDB `workspace.read` result in its organization. */
+async function fetchApiKeyWorkspaces(
+  keyAuth: TAuthenticationApiKey,
+  actor: Extract<TAuthorizationActor, { type: "apiKey" }>
+): Promise<TResolvedWorkspaceList> {
+  const workspaceIds = await lookupAuthorizedWorkspaceIds(actor);
+  const workspaces = await getWorkspacesByIds(keyAuth.organizationId, [...workspaceIds]);
   const sameOrganizationWorkspaces = workspaces.filter(
     (workspace) => workspace.organizationId === keyAuth.organizationId
   );
   return {
     items: sameOrganizationWorkspaces.map(serializeV3WorkspaceListItem),
-    organizationIds: [keyAuth.organizationId],
   };
 }
 
@@ -94,13 +91,15 @@ export async function listV3Workspaces({
     let resolved: TResolvedWorkspaceList;
 
     if ("user" in authentication && authentication.user?.id) {
-      resolved = await fetchSessionWorkspaces(authentication.user.id);
+      if (actor.type !== "user") return problemUnauthorized(requestId, "Not authenticated", instance);
+      resolved = await fetchSessionWorkspaces(authentication.user.id, actor);
     } else if (
       "apiKeyId" in authentication &&
       authentication.apiKeyId &&
       Array.isArray(authentication.workspacePermissions)
     ) {
-      resolved = await fetchApiKeyWorkspaces(authentication);
+      if (actor.type !== "apiKey") return problemUnauthorized(requestId, "Not authenticated", instance);
+      resolved = await fetchApiKeyWorkspaces(authentication, actor);
     } else {
       return problemUnauthorized(requestId, "Not authenticated", instance);
     }
@@ -111,12 +110,6 @@ export async function listV3Workspaces({
       (a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id)
     );
 
-    observeWorkspaceListAuthorization({
-      actor,
-      organizationIds: resolved.organizationIds,
-      workspaces: deduped.map(({ id, organizationId }) => ({ id, organizationId })),
-    });
-
     // No pagination: a principal's accessible workspaces are bounded by their memberships (small), so we
     // return them all. No arbitrary cap — a truncation here would silently hide workspaces (the tool
     // accepts no cursor) without bounding DB work, which was already done above.
@@ -126,9 +119,14 @@ export async function listV3Workspaces({
       { requestId, cache: "private, no-store" }
     );
   } catch (error) {
-    // Log every failure with request context (not just DatabaseError) so nothing significant is lost,
-    // and always return a clean 500 instead of throwing a raw error past this boundary.
-    log.error({ error, statusCode: 500 }, "Failed to list workspaces");
+    // Keep this boundary observable without serializing raw SDK/database errors or tenant identifiers.
+    log.error(
+      {
+        errorCode: error instanceof AuthzedError ? error.code : "internal",
+        statusCode: 500,
+      },
+      "Failed to list workspaces"
+    );
     return problemInternalError(requestId, "An unexpected error occurred.", instance);
   }
 }

--- a/apps/web/lib/authorization/README.md
+++ b/apps/web/lib/authorization/README.md
@@ -219,11 +219,14 @@ These read a role but do not decide access, so they stay as they are:
 - **Invite fan-out.** The signup and invite paths derive from the _invited_
   role whether to create `TeamUser` rows, since owners and managers get
   workspace access from the role itself. That is a statement about the invite.
-- **List scoping during the bridge.** Workspace list queries remain PostgreSQL-authoritative and narrow by
-  role while the bridge is deployed. MCP `list_workspaces` has one bounded `LookupResources(workspace, read)`
-  migration observation rather than one check per row. ENG-2449 replaces every current-model organization
-  and workspace authorization list with an authoritative bounded lookup before the direct-authority artifact
-  can ship.
+- **Authoritative list scoping.** Current-model organization and workspace discovery uses one
+  `LookupResources` operation per resource type, followed by a tenant-scoped PostgreSQL data query. This
+  covers the application organization/workspace switchers, survey-list workspace navigation, API v2 `/me`,
+  and V3/MCP workspace discovery. PostgreSQL supplies current resource data and API-key permission labels;
+  it does not widen the SpiceDB allowlist. Unknown, deleted, or foreign-tenant lookup results are discarded,
+  and lookup or projection-freshness failures fail the list closed. V3/MCP workspace discovery performs one
+  `LookupResources(workspace, read)` operation regardless of list size. Generic Phase 2 list authorization
+  remains ENG-1713.
 
 New authorization-sensitive code must use `can` or `assertCan`; it must not add
 callers to the deprecated action-client adapter or reintroduce a role-name gate.

--- a/apps/web/lib/authorization/README.md
+++ b/apps/web/lib/authorization/README.md
@@ -224,9 +224,12 @@ These read a role but do not decide access, so they stay as they are:
   covers the application organization/workspace switchers, survey-list workspace navigation, API v2 `/me`,
   and V3/MCP workspace discovery. PostgreSQL supplies current resource data and API-key permission labels;
   it does not widen the SpiceDB allowlist. Unknown, deleted, or foreign-tenant lookup results are discarded,
-  and lookup or projection-freshness failures fail the list closed. V3/MCP workspace discovery performs one
-  `LookupResources(workspace, read)` operation regardless of list size. Generic Phase 2 list authorization
-  remains ENG-1713.
+  and lookup or projection-freshness failures fail the list closed. Billing-role users receive no workspace
+  results even if a stale team membership exists, matching their lack of product-data access instead of the
+  former switcher-only exception. React request caching deduplicates identical lookup tuples inside an RSC
+  request; API handlers do not rely on that cache and invoke each required lookup helper once. V3/MCP
+  workspace discovery therefore performs one `LookupResources(workspace, read)` operation per list call,
+  regardless of list size. Generic Phase 2 list authorization remains ENG-1713.
 
 New authorization-sensitive code must use `can` or `assertCan`; it must not add
 callers to the deprecated action-client adapter or reintroduce a role-name gate.

--- a/apps/web/lib/authorization/checks-per-request-workspace-discovery.integration.test.ts
+++ b/apps/web/lib/authorization/checks-per-request-workspace-discovery.integration.test.ts
@@ -1,8 +1,17 @@
-import { beforeAll, describe, expect, test } from "vitest";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { listV3Workspaces } from "@/app/api/v3/workspaces/lib/operations";
 import { resetDb } from "@/integration/reset-db";
 import { getIssuedAuthorizationCheckCount, withAuthorizationSurface } from "./context";
+
+const lookupResources = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/authzed/client", () => ({
+  getAuthzedClient: () => ({ lookupResources }),
+}));
+vi.mock("@/lib/authzed/outbox-freshness", () => ({
+  assertAuthzedProjectionFreshness: vi.fn(),
+}));
 
 const scenario = { organizationId: "", userId: "" };
 
@@ -22,6 +31,17 @@ beforeAll(async () => {
   scenario.organizationId = organization.id;
   scenario.userId = user.id;
 }, 120_000);
+
+beforeEach(() => {
+  lookupResources.mockImplementation(async () => ({
+    resourceIds: (
+      await prisma.workspace.findMany({
+        where: { organizationId: scenario.organizationId },
+        select: { id: true },
+      })
+    ).map(({ id }) => id),
+  }));
+});
 
 const listAndCount = async (): Promise<Readonly<{ checksIssued: number; workspaceCount: number }>> =>
   withAuthorizationSurface("mcp", async () => {

--- a/apps/web/lib/authorization/checks-per-request-workspace-discovery.integration.test.ts
+++ b/apps/web/lib/authorization/checks-per-request-workspace-discovery.integration.test.ts
@@ -61,7 +61,7 @@ const listAndCount = async (): Promise<Readonly<{ checksIssued: number; workspac
     };
   });
 
-describe("MCP workspace discovery authorization amplification, against a real database", () => {
+describe("MCP workspace discovery amplification with a mocked lookup and real PostgreSQL resolution", () => {
   test("one and one hundred workspaces each produce exactly one central operation", async () => {
     await prisma.workspace.create({
       data: { name: "Discovery Workspace 1", organizationId: scenario.organizationId },

--- a/apps/web/lib/authorization/resource-list.test.ts
+++ b/apps/web/lib/authorization/resource-list.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getAuthzedClient } from "@/lib/authzed/client";
+import { assertAuthzedProjectionFreshness } from "@/lib/authzed/outbox-freshness";
+import { recordAuthorizationCheckIssued } from "./context";
+import { lookupAuthorizedOrganizationIds, lookupAuthorizedWorkspaceIds } from "./resource-list";
+
+vi.mock("@/lib/authzed/client", () => ({ getAuthzedClient: vi.fn() }));
+vi.mock("@/lib/authzed/outbox-freshness", () => ({ assertAuthzedProjectionFreshness: vi.fn() }));
+vi.mock("./context", () => ({ recordAuthorizationCheckIssued: vi.fn() }));
+
+const lookupResources = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getAuthzedClient).mockReturnValue({ lookupResources } as never);
+  lookupResources.mockResolvedValue({ resourceIds: [] });
+});
+
+describe("authoritative resource lists", () => {
+  test("looks up readable organizations for a user after the freshness guard", async () => {
+    lookupResources.mockResolvedValue({ resourceIds: ["organization-1"] });
+
+    await expect(lookupAuthorizedOrganizationIds({ type: "user", id: "user-1" })).resolves.toEqual([
+      "organization-1",
+    ]);
+
+    expect(assertAuthzedProjectionFreshness).toHaveBeenCalledOnce();
+    expect(recordAuthorizationCheckIssued).toHaveBeenCalledOnce();
+    expect(lookupResources).toHaveBeenCalledExactlyOnceWith({
+      permission: "read",
+      resourceType: "organization",
+      subject: { objectId: "user-1", objectType: "user" },
+    });
+  });
+
+  test.each(["read", "write"] as const)(
+    "looks up %s workspaces for an API key using the mapped object type",
+    async (permission) => {
+      lookupResources.mockResolvedValue({ resourceIds: ["workspace-1", "workspace-2"] });
+
+      await expect(
+        lookupAuthorizedWorkspaceIds({ type: "apiKey", id: "key-1" }, permission)
+      ).resolves.toEqual(["workspace-1", "workspace-2"]);
+
+      expect(lookupResources).toHaveBeenCalledExactlyOnceWith({
+        permission,
+        resourceType: "workspace",
+        subject: { objectId: "key-1", objectType: "api_key" },
+      });
+    }
+  );
+
+  test("fails closed before lookup when projection freshness cannot be established", async () => {
+    const stale = new Error("stale projection");
+    vi.mocked(assertAuthzedProjectionFreshness).mockRejectedValue(stale);
+
+    await expect(lookupAuthorizedWorkspaceIds({ type: "user", id: "user-1" })).rejects.toBe(stale);
+    expect(getAuthzedClient).not.toHaveBeenCalled();
+  });
+
+  test("propagates lookup operational failures without returning a partial list", async () => {
+    const unavailable = new Error("AuthZed unavailable");
+    lookupResources.mockRejectedValue(unavailable);
+
+    await expect(lookupAuthorizedWorkspaceIds({ type: "user", id: "user-1" })).rejects.toBe(unavailable);
+  });
+});

--- a/apps/web/lib/authorization/resource-list.ts
+++ b/apps/web/lib/authorization/resource-list.ts
@@ -1,0 +1,42 @@
+import "server-only";
+import { cache as reactCache } from "react";
+import { getAuthzedClient } from "@/lib/authzed/client";
+import { assertAuthzedProjectionFreshness } from "@/lib/authzed/outbox-freshness";
+import { recordAuthorizationCheckIssued } from "./context";
+import type { TAuthorizationActor } from "./contract";
+import { getSpicedbObjectType } from "./object-type";
+
+type TCurrentListResource = "organization" | "workspace";
+type TCurrentListPermission = "read" | "write";
+
+const lookupAuthorizationResourceIds = reactCache(
+  async (
+    actorType: TAuthorizationActor["type"],
+    actorId: string,
+    resourceType: TCurrentListResource,
+    permission: TCurrentListPermission
+  ): Promise<ReadonlyArray<string>> => {
+    recordAuthorizationCheckIssued();
+    await assertAuthzedProjectionFreshness();
+
+    const result = await getAuthzedClient().lookupResources({
+      permission,
+      resourceType: getSpicedbObjectType(resourceType),
+      subject: {
+        objectId: actorId,
+        objectType: getSpicedbObjectType(actorType),
+      },
+    });
+
+    return result.resourceIds;
+  }
+);
+
+export const lookupAuthorizedOrganizationIds = (actor: TAuthorizationActor): Promise<ReadonlyArray<string>> =>
+  lookupAuthorizationResourceIds(actor.type, actor.id, "organization", "read");
+
+export const lookupAuthorizedWorkspaceIds = (
+  actor: TAuthorizationActor,
+  permission: TCurrentListPermission = "read"
+): Promise<ReadonlyArray<string>> =>
+  lookupAuthorizationResourceIds(actor.type, actor.id, "workspace", permission);

--- a/apps/web/lib/organization/service.test.ts
+++ b/apps/web/lib/organization/service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { lookupAuthorizedOrganizationIds } from "@/lib/authorization/resource-list";
 import { reconcileApiKeyRelationships } from "@/lib/authzed/api-key";
 import { reconcileFeedbackDirectoryRelationships } from "@/lib/authzed/feedback-directory";
 import { deleteOrganizationRelationships } from "@/lib/authzed/organization-membership";
@@ -53,6 +54,7 @@ vi.mock("@/lib/user/service", () => ({
 vi.mock("@/lib/workspace/service", () => ({
   getWorkspaces: vi.fn(),
 }));
+vi.mock("@/lib/authorization/resource-list", () => ({ lookupAuthorizedOrganizationIds: vi.fn() }));
 
 vi.mock("@/lib/authzed/organization-membership", () => ({
   deleteOrganizationRelationships: vi.fn(),
@@ -82,6 +84,7 @@ vi.mock("@/modules/hub/service", () => ({
 describe("Organization Service", () => {
   beforeEach(() => {
     vi.mocked(ensureCloudStripeSetupForOrganization).mockResolvedValue(undefined);
+    vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValue(["org1"]);
   });
 
   afterEach(() => {
@@ -171,11 +174,7 @@ describe("Organization Service", () => {
       expect(result).toEqual(mockOrganizations);
       expect(prisma.organization.findMany).toHaveBeenCalledWith({
         where: {
-          memberships: {
-            some: {
-              userId: "user1",
-            },
-          },
+          id: { in: ["org1"] },
         },
         select: expect.any(Object),
       });

--- a/apps/web/lib/organization/service.ts
+++ b/apps/web/lib/organization/service.ts
@@ -14,6 +14,7 @@ import {
   ZOrganizationCreateInput,
 } from "@formbricks/types/organizations";
 import { TUserNotificationSettings } from "@formbricks/types/user";
+import { lookupAuthorizedOrganizationIds } from "@/lib/authorization/resource-list";
 import { reconcileApiKeyRelationships } from "@/lib/authzed/api-key";
 import { reconcileFeedbackDirectoryRelationships } from "@/lib/authzed/feedback-directory";
 import { deleteOrganizationRelationships } from "@/lib/authzed/organization-membership";
@@ -94,13 +95,12 @@ export const getOrganizationsByUserId = reactCache(
     validateInputs([userId, ZString], [page, ZOptionalNumber]);
 
     try {
+      const organizationIds = await lookupAuthorizedOrganizationIds({ type: "user", id: userId });
+      if (organizationIds.length === 0) return [];
+
       const organizations = await prisma.organization.findMany({
         where: {
-          memberships: {
-            some: {
-              userId,
-            },
-          },
+          id: { in: [...organizationIds] },
         },
         select,
         take: page ? ITEMS_PER_PAGE : undefined,

--- a/apps/web/lib/workspace/service.test.ts
+++ b/apps/web/lib/workspace/service.test.ts
@@ -1,8 +1,12 @@
 import { createId } from "@paralleldrive/cuid2";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
-import { OrganizationRole, Prisma, WidgetPlacement, Workspace } from "@formbricks/database/prisma";
+import { Prisma, WidgetPlacement, Workspace } from "@formbricks/database/prisma";
 import { DatabaseError, ValidationError } from "@formbricks/types/errors";
+import {
+  lookupAuthorizedOrganizationIds,
+  lookupAuthorizedWorkspaceIds,
+} from "@/lib/authorization/resource-list";
 import { ITEMS_PER_PAGE } from "../constants";
 import {
   getUserWorkspaces,
@@ -13,6 +17,7 @@ import {
   getWorkspaceMembers,
   getWorkspaces,
   getWorkspacesByIds,
+  getWorkspacesByIdsForUser,
 } from "./service";
 
 vi.mock("@formbricks/database", () => ({
@@ -27,6 +32,10 @@ vi.mock("@formbricks/database", () => ({
       findMany: vi.fn(),
     },
   },
+}));
+vi.mock("@/lib/authorization/resource-list", () => ({
+  lookupAuthorizedOrganizationIds: vi.fn(),
+  lookupAuthorizedWorkspaceIds: vi.fn(),
 }));
 
 describe("Workspace Service", () => {
@@ -145,12 +154,8 @@ describe("Workspace Service", () => {
       },
     ];
 
-    vi.mocked(prisma.membership.findFirst).mockResolvedValue({
-      userId,
-      organizationId,
-      role: OrganizationRole.owner,
-      accepted: true,
-    });
+    vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValue([organizationId]);
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(mockWorkspaces.map(({ id }) => id));
 
     vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as unknown as Workspace[]);
 
@@ -159,6 +164,7 @@ describe("Workspace Service", () => {
     expect(result).toEqual(mockWorkspaces);
     expect(prisma.workspace.findMany).toHaveBeenCalledWith({
       where: {
+        id: { in: mockWorkspaces.map(({ id }) => id) },
         organizationId,
       },
       select: expect.any(Object),
@@ -197,12 +203,8 @@ describe("Workspace Service", () => {
       },
     ];
 
-    vi.mocked(prisma.membership.findFirst).mockResolvedValue({
-      userId,
-      organizationId,
-      role: OrganizationRole.member,
-      accepted: true,
-    });
+    vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValue([organizationId]);
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(mockWorkspaces.map(({ id }) => id));
 
     vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as unknown as Workspace[]);
 
@@ -211,18 +213,8 @@ describe("Workspace Service", () => {
     expect(result).toEqual(mockWorkspaces);
     expect(prisma.workspace.findMany).toHaveBeenCalledWith({
       where: {
+        id: { in: mockWorkspaces.map(({ id }) => id) },
         organizationId,
-        workspaceTeams: {
-          some: {
-            team: {
-              teamUsers: {
-                some: {
-                  userId,
-                },
-              },
-            },
-          },
-        },
       },
       select: expect.any(Object),
       take: undefined,
@@ -230,55 +222,40 @@ describe("Workspace Service", () => {
     });
   });
 
-  test("getUserWorkspacesByOrganizationIds team-scopes non-owner/manager roles (owner/manager get all)", async () => {
+  test("getUserWorkspacesByOrganizationIds resolves only authoritative workspace ids in the organizations", async () => {
     const userId = createId();
     const orgManager = createId();
     const orgBilling = createId();
 
-    vi.mocked(prisma.membership.findMany).mockResolvedValue([
-      { userId, organizationId: orgManager, role: OrganizationRole.manager, accepted: true },
-      { userId, organizationId: orgBilling, role: OrganizationRole.billing, accepted: true },
-    ]);
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(["workspace-1"]);
     vi.mocked(prisma.workspace.findMany).mockResolvedValue([]);
 
     await getUserWorkspacesByOrganizationIds([orgManager, orgBilling], userId);
 
-    const teamScope = { some: { team: { teamUsers: { some: { userId } } } } };
     expect(prisma.workspace.findMany).toHaveBeenCalledWith({
       where: {
-        OR: [
-          // manager: all of the org's workspaces (no team filter)
-          { organizationId: orgManager },
-          // billing: team-scoped only (regression: previously unscoped → every workspace)
-          { organizationId: orgBilling, workspaceTeams: teamScope },
-        ],
+        id: { in: ["workspace-1"] },
+        organizationId: { in: [orgManager, orgBilling] },
       },
       select: { id: true },
     });
   });
 
-  test("getUserWorkspaces should team-scope a billing user (not return every workspace)", async () => {
+  test("getUserWorkspaces does not widen a billing user's empty SpiceDB workspace list", async () => {
     const userId = createId();
     const organizationId = createId();
 
-    vi.mocked(prisma.membership.findFirst).mockResolvedValue({
-      userId,
-      organizationId,
-      role: OrganizationRole.billing,
-      accepted: true,
-    });
+    vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValue([organizationId]);
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue([]);
     vi.mocked(prisma.workspace.findMany).mockResolvedValue([]);
 
     await getUserWorkspaces(userId, organizationId);
 
-    // Billing is not owner/manager, so it must be scoped to team-accessible workspaces — never the
-    // whole org (regression: `role === "member"` previously leaked all workspaces to billing users).
+    // SpiceDB's workspace.read excludes billing, so no role-name SQL branch can accidentally widen it.
     expect(prisma.workspace.findMany).toHaveBeenCalledWith({
       where: {
+        id: { in: [] },
         organizationId,
-        workspaceTeams: {
-          some: { team: { teamUsers: { some: { userId } } } },
-        },
       },
       select: expect.any(Object),
       take: undefined,
@@ -290,7 +267,8 @@ describe("Workspace Service", () => {
     const userId = createId();
     const organizationId = createId();
 
-    vi.mocked(prisma.membership.findFirst).mockResolvedValue(null);
+    vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValue([]);
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue([]);
 
     await expect(getUserWorkspaces(userId, organizationId)).rejects.toThrow(ValidationError);
   });
@@ -325,12 +303,8 @@ describe("Workspace Service", () => {
       },
     ];
 
-    vi.mocked(prisma.membership.findFirst).mockResolvedValue({
-      userId,
-      organizationId,
-      role: OrganizationRole.owner,
-      accepted: true,
-    });
+    vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValue([organizationId]);
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(mockWorkspaces.map(({ id }) => id));
 
     vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as unknown as Workspace[]);
 
@@ -340,6 +314,7 @@ describe("Workspace Service", () => {
     expect(result).toEqual(mockWorkspaces);
     expect(prisma.workspace.findMany).toHaveBeenCalledWith({
       where: {
+        id: { in: mockWorkspaces.map(({ id }) => id) },
         organizationId,
       },
       select: expect.any(Object),
@@ -490,6 +465,27 @@ describe("Workspace Service", () => {
 
   test("getWorkspacesByIds skips the database for an empty workspace list", async () => {
     await expect(getWorkspacesByIds(createId(), [])).resolves.toEqual([]);
+    expect(prisma.workspace.findMany).not.toHaveBeenCalled();
+  });
+
+  test("getWorkspacesByIdsForUser verifies lookup results against current tenant membership", async () => {
+    const userId = createId();
+    const workspaceIds = [createId(), createId()];
+    const mockWorkspaces = workspaceIds.map((id) => ({ id, organizationId: createId() }));
+    vi.mocked(prisma.workspace.findMany).mockResolvedValue(mockWorkspaces as unknown as Workspace[]);
+
+    await expect(getWorkspacesByIdsForUser(userId, workspaceIds)).resolves.toEqual(mockWorkspaces);
+    expect(prisma.workspace.findMany).toHaveBeenCalledExactlyOnceWith({
+      where: {
+        id: { in: workspaceIds },
+        organization: { memberships: { some: { userId } } },
+      },
+      select: expect.any(Object),
+    });
+  });
+
+  test("getWorkspacesByIdsForUser skips PostgreSQL for an empty authoritative list", async () => {
+    await expect(getWorkspacesByIdsForUser(createId(), [])).resolves.toEqual([]);
     expect(prisma.workspace.findMany).not.toHaveBeenCalled();
   });
 

--- a/apps/web/lib/workspace/service.ts
+++ b/apps/web/lib/workspace/service.ts
@@ -5,6 +5,10 @@ import { Prisma } from "@formbricks/database/prisma";
 import { ZId, ZOptionalNumber, ZString } from "@formbricks/types/common";
 import { DatabaseError, ValidationError } from "@formbricks/types/errors";
 import type { TWorkspace } from "@formbricks/types/workspace";
+import {
+  lookupAuthorizedOrganizationIds,
+  lookupAuthorizedWorkspaceIds,
+} from "@/lib/authorization/resource-list";
 import { ITEMS_PER_PAGE } from "../constants";
 import { normalizeEmailForComparison } from "../utils/email";
 import { validateInputs } from "../utils/validate";
@@ -34,44 +38,21 @@ export const getUserWorkspaces = reactCache(
   async (userId: string, organizationId: string, page?: number): Promise<TWorkspace[]> => {
     validateInputs([userId, ZString], [organizationId, ZId], [page, ZOptionalNumber]);
 
-    const orgMembership = await prisma.membership.findFirst({
-      where: {
-        userId,
-        organizationId,
-      },
-    });
+    const actor = { type: "user", id: userId } as const;
+    const [authorizedOrganizationIds, authorizedWorkspaceIds] = await Promise.all([
+      lookupAuthorizedOrganizationIds(actor),
+      lookupAuthorizedWorkspaceIds(actor),
+    ]);
 
-    if (!orgMembership) {
+    if (!authorizedOrganizationIds.includes(organizationId)) {
       throw new ValidationError("User is not a member of this organization");
-    }
-
-    let workspaceWhereClause: Prisma.WorkspaceWhereInput = {};
-
-    // Only org owners/managers get every workspace. Every other role (member, billing, …) is scoped to
-    // the workspaces whose teams they belong to — mirroring the per-workspace v3 authorization
-    // (`requireV3WorkspaceAccess`: org owner/manager OR workspace-team membership). Special-casing only
-    // `member` here previously leaked all workspaces to `billing` members, who cannot access them.
-    if (orgMembership.role !== "owner" && orgMembership.role !== "manager") {
-      workspaceWhereClause = {
-        workspaceTeams: {
-          some: {
-            team: {
-              teamUsers: {
-                some: {
-                  userId,
-                },
-              },
-            },
-          },
-        },
-      };
     }
 
     try {
       const workspaces = await prisma.workspace.findMany({
         where: {
+          id: { in: [...authorizedWorkspaceIds] },
           organizationId,
-          ...workspaceWhereClause,
         },
         select: selectWorkspace,
         take: page ? ITEMS_PER_PAGE : undefined,
@@ -129,6 +110,34 @@ export const getWorkspacesByIds = reactCache(
         where: {
           id: { in: workspaceIds },
           organizationId,
+        },
+        select: selectWorkspace,
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw new DatabaseError(error.message);
+      }
+
+      throw error;
+    }
+  }
+);
+
+/**
+ * Resolve authoritative workspace lookup results for a user through their current organization
+ * memberships. The ID allowlist comes from SpiceDB; this query only verifies existence and tenant
+ * membership before returning application data, and never re-evaluates roles or team grants.
+ */
+export const getWorkspacesByIdsForUser = reactCache(
+  async (userId: string, workspaceIds: string[]): Promise<TWorkspace[]> => {
+    validateInputs([userId, ZId], [workspaceIds, ZId.array()]);
+    if (workspaceIds.length === 0) return [];
+
+    try {
+      return await prisma.workspace.findMany({
+        where: {
+          id: { in: workspaceIds },
+          organization: { memberships: { some: { userId } } },
         },
         select: selectWorkspace,
       });
@@ -275,49 +284,13 @@ export const getUserWorkspacesByOrganizationIds = reactCache(
         return [];
       }
 
-      const memberships = await prisma.membership.findMany({
-        where: {
-          userId,
-          organizationId: {
-            in: organizationIds,
-          },
-        },
-      });
-
-      if (memberships.length === 0) {
-        return [];
-      }
-
-      const whereConditions: Prisma.WorkspaceWhereInput[] = memberships.map((membership) => {
-        let workspaceWhereClause: Prisma.WorkspaceWhereInput = {
-          organizationId: membership.organizationId,
-        };
-
-        // Same scoping as getUserWorkspaces: only owner/manager see all of an org's workspaces; every
-        // other role (member, billing, …) is limited to their team-scoped workspaces.
-        if (membership.role !== "owner" && membership.role !== "manager") {
-          workspaceWhereClause = {
-            ...workspaceWhereClause,
-            workspaceTeams: {
-              some: {
-                team: {
-                  teamUsers: {
-                    some: {
-                      userId,
-                    },
-                  },
-                },
-              },
-            },
-          };
-        }
-
-        return workspaceWhereClause;
-      });
+      const workspaceIds = await lookupAuthorizedWorkspaceIds({ type: "user", id: userId });
+      if (workspaceIds.length === 0) return [];
 
       const workspaces = await prisma.workspace.findMany({
         where: {
-          OR: whereConditions,
+          id: { in: [...workspaceIds] },
+          organizationId: { in: organizationIds },
         },
         select: { id: true },
       });

--- a/apps/web/modules/api/v2/me/route.test.ts
+++ b/apps/web/modules/api/v2/me/route.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { lookupAuthorizedWorkspaceIds } from "@/lib/authorization/resource-list";
+import type { authenticatedApiClient } from "@/modules/api/v2/auth/authenticated-api-client";
+import { hasApiKeyOrganizationAccess } from "@/modules/organization/settings/api-keys/lib/utils";
+
+const { mockAuthenticatedApiClient, mockHandleApiError, mockSuccessResponse } = vi.hoisted(() => ({
+  mockAuthenticatedApiClient: vi.fn(),
+  mockHandleApiError: vi.fn(),
+  mockSuccessResponse: vi.fn(),
+}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: { workspace: { findMany: vi.fn() } },
+}));
+vi.mock("@/lib/authorization/resource-list", () => ({ lookupAuthorizedWorkspaceIds: vi.fn() }));
+vi.mock("@/modules/api/v2/auth/authenticated-api-client", () => ({
+  authenticatedApiClient: mockAuthenticatedApiClient,
+}));
+vi.mock("@/modules/api/v2/lib/response", () => ({
+  responses: { successResponse: mockSuccessResponse },
+}));
+vi.mock("@/modules/api/v2/lib/utils", () => ({ handleApiError: mockHandleApiError }));
+vi.mock("@/modules/organization/settings/api-keys/lib/utils", () => ({
+  hasApiKeyOrganizationAccess: vi.fn(),
+}));
+
+const authentication = {
+  apiKeyId: "api-key-1",
+  organizationAccess: { accessControl: { read: true, write: false } },
+  organizationId: "organization-1",
+  type: "apiKey",
+  workspacePermissions: [
+    { permission: "read", workspaceId: "workspace-1", workspaceName: "One" },
+    { permission: "manage", workspaceId: "workspace-2", workspaceName: "Two" },
+    { permission: "read", workspaceId: "foreign-workspace", workspaceName: "Foreign" },
+  ],
+} as const;
+
+const request = new Request("http://localhost/api/v2/me");
+
+describe("GET /api/v2/me", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(hasApiKeyOrganizationAccess).mockResolvedValue(true);
+    mockAuthenticatedApiClient.mockImplementation(
+      async ({ handler }: Parameters<typeof authenticatedApiClient>[0]) =>
+        handler({ authentication, request } as never)
+    );
+    mockSuccessResponse.mockImplementation((body: unknown) => Response.json(body));
+    mockHandleApiError.mockImplementation((_request, error) => Response.json({ error }, { status: 403 }));
+  });
+
+  test("returns only workspace grants authorized by SpiceDB and scoped to the API-key organization", async () => {
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(["workspace-2", "workspace-1"]);
+    vi.mocked(prisma.workspace.findMany).mockResolvedValue([
+      { id: "workspace-1", legacyEnvironmentId: "environment-1" },
+      { id: "workspace-2", legacyEnvironmentId: null },
+    ] as never);
+
+    const { GET } = await import("./route");
+    const response = await GET(request as never);
+    const body = await response.json();
+
+    expect(lookupAuthorizedWorkspaceIds).toHaveBeenCalledExactlyOnceWith({
+      id: "api-key-1",
+      type: "apiKey",
+    });
+    expect(prisma.workspace.findMany).toHaveBeenCalledExactlyOnceWith({
+      where: {
+        id: { in: ["workspace-1", "workspace-2"] },
+        organizationId: "organization-1",
+      },
+      select: { id: true, legacyEnvironmentId: true },
+    });
+    expect(body.data.workspacePermissions).toEqual([
+      { permissions: "read", workspaceId: "workspace-1", workspaceName: "One" },
+      { permissions: "manage", workspaceId: "workspace-2", workspaceName: "Two" },
+    ]);
+    expect(body.data.environmentPermissions).toEqual([
+      {
+        environmentId: "environment-1",
+        environmentType: "production",
+        permissions: "read",
+        projectId: "workspace-1",
+        projectName: "One",
+      },
+    ]);
+  });
+
+  test("fails closed when the authoritative workspace lookup fails", async () => {
+    const unavailable = new Error("AuthZed unavailable");
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockRejectedValue(unavailable);
+
+    const { GET } = await import("./route");
+    await expect(GET(request as never)).rejects.toBe(unavailable);
+    expect(prisma.workspace.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/api/v2/me/route.test.ts
+++ b/apps/web/modules/api/v2/me/route.test.ts
@@ -52,7 +52,11 @@ describe("GET /api/v2/me", () => {
   });
 
   test("returns only workspace grants authorized by SpiceDB and scoped to the API-key organization", async () => {
-    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue(["workspace-2", "workspace-1"]);
+    vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValue([
+      "workspace-2",
+      "workspace-1",
+      "foreign-workspace",
+    ]);
     vi.mocked(prisma.workspace.findMany).mockResolvedValue([
       { id: "workspace-1", legacyEnvironmentId: "environment-1" },
       { id: "workspace-2", legacyEnvironmentId: null },
@@ -68,7 +72,7 @@ describe("GET /api/v2/me", () => {
     });
     expect(prisma.workspace.findMany).toHaveBeenCalledExactlyOnceWith({
       where: {
-        id: { in: ["workspace-1", "workspace-2"] },
+        id: { in: ["workspace-1", "workspace-2", "foreign-workspace"] },
         organizationId: "organization-1",
       },
       select: { id: true, legacyEnvironmentId: true },
@@ -86,6 +90,12 @@ describe("GET /api/v2/me", () => {
         projectName: "One",
       },
     ]);
+    expect(body.data.workspacePermissions).not.toContainEqual(
+      expect.objectContaining({ workspaceId: "foreign-workspace" })
+    );
+    expect(body.data.environmentPermissions).not.toContainEqual(
+      expect.objectContaining({ projectId: "foreign-workspace" })
+    );
   });
 
   test("fails closed when the authoritative workspace lookup fails", async () => {

--- a/apps/web/modules/api/v2/me/route.ts
+++ b/apps/web/modules/api/v2/me/route.ts
@@ -36,7 +36,11 @@ export const GET = async (request: NextRequest) =>
       });
 
       const legacyEnvIdByWorkspaceId = new Map(workspaces.map((w) => [w.id, w.legacyEnvironmentId]));
-      const workspacePermissions = authorizedWorkspacePermissions.map((permission) => ({
+      const resolvedWorkspaceIds = new Set(workspaces.map(({ id }) => id));
+      const resolvedWorkspacePermissions = authorizedWorkspacePermissions.filter(({ workspaceId }) =>
+        resolvedWorkspaceIds.has(workspaceId)
+      );
+      const workspacePermissions = resolvedWorkspacePermissions.map((permission) => ({
         permissions: permission.permission,
         workspaceId: permission.workspaceId,
         workspaceName: permission.workspaceName,
@@ -44,7 +48,7 @@ export const GET = async (request: NextRequest) =>
 
       // Backwards compat: expose environment-shaped permissions for consumers
       // from before the Environment model was removed.
-      const environmentPermissions = authorizedWorkspacePermissions.flatMap((permission) => {
+      const environmentPermissions = resolvedWorkspacePermissions.flatMap((permission) => {
         const legacyEnvironmentId = legacyEnvIdByWorkspaceId.get(permission.workspaceId);
         if (!legacyEnvironmentId) return [];
         return [

--- a/apps/web/modules/api/v2/me/route.ts
+++ b/apps/web/modules/api/v2/me/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@formbricks/database";
 import { OrganizationAccessType } from "@formbricks/types/api-key";
+import { lookupAuthorizedWorkspaceIds } from "@/lib/authorization/resource-list";
 import { authenticatedApiClient } from "@/modules/api/v2/auth/authenticated-api-client";
 import { responses } from "@/modules/api/v2/lib/response";
 import { handleApiError } from "@/modules/api/v2/lib/utils";
@@ -18,14 +19,24 @@ export const GET = async (request: NextRequest) =>
         });
       }
 
-      const workspaceIds = authentication.workspacePermissions.map((p) => p.workspaceId);
+      const workspaceIds = await lookupAuthorizedWorkspaceIds({
+        id: authentication.apiKeyId,
+        type: "apiKey",
+      });
+      const authorizedWorkspaceIds = new Set(workspaceIds);
+      const authorizedWorkspacePermissions = authentication.workspacePermissions.filter((permission) =>
+        authorizedWorkspaceIds.has(permission.workspaceId)
+      );
       const workspaces = await prisma.workspace.findMany({
-        where: { id: { in: workspaceIds } },
+        where: {
+          id: { in: authorizedWorkspacePermissions.map(({ workspaceId }) => workspaceId) },
+          organizationId: authentication.organizationId,
+        },
         select: { id: true, legacyEnvironmentId: true },
       });
 
       const legacyEnvIdByWorkspaceId = new Map(workspaces.map((w) => [w.id, w.legacyEnvironmentId]));
-      const workspacePermissions = authentication.workspacePermissions.map((permission) => ({
+      const workspacePermissions = authorizedWorkspacePermissions.map((permission) => ({
         permissions: permission.permission,
         workspaceId: permission.workspaceId,
         workspaceName: permission.workspaceName,
@@ -33,7 +44,7 @@ export const GET = async (request: NextRequest) =>
 
       // Backwards compat: expose environment-shaped permissions for consumers
       // from before the Environment model was removed.
-      const environmentPermissions = authentication.workspacePermissions.flatMap((permission) => {
+      const environmentPermissions = authorizedWorkspacePermissions.flatMap((permission) => {
         const legacyEnvironmentId = legacyEnvIdByWorkspaceId.get(permission.workspaceId);
         if (!legacyEnvironmentId) return [];
         return [

--- a/apps/web/modules/settings/lib/navigation-data.ts
+++ b/apps/web/modules/settings/lib/navigation-data.ts
@@ -83,7 +83,7 @@ export const getSettingsLayoutData = async (
     getAccessControlPermission(organization.id),
     getEnterpriseLicense(),
     getOrganizationWorkspacesLimit(organization.id),
-    getWorkspacesByUserId(userId, membership),
+    getWorkspacesByUserId(userId, organization.id),
   ]);
 
   const responseCount = IS_FORMBRICKS_CLOUD ? await getMonthlyOrganizationResponseCount(organization.id) : 0;

--- a/apps/web/modules/survey/list/lib/workspace.test.ts
+++ b/apps/web/modules/survey/list/lib/workspace.test.ts
@@ -3,6 +3,10 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { DatabaseError, ResourceNotFoundError, ValidationError } from "@formbricks/types/errors";
+import {
+  lookupAuthorizedOrganizationIds,
+  lookupAuthorizedWorkspaceIds,
+} from "@/lib/authorization/resource-list";
 import { TWorkspaceWithLanguages } from "@/modules/survey/list/types/surveys";
 import { TUserWorkspace } from "@/modules/survey/list/types/workspaces";
 import { doesWorkspaceExist, getUserWorkspaces, getWorkspace, getWorkspaceWithLanguages } from "./workspace";
@@ -16,10 +20,12 @@ vi.mock("@formbricks/database", () => ({
       findUnique: vi.fn(),
       findMany: vi.fn(),
     },
-    membership: {
-      findFirst: vi.fn(),
-    },
   },
+}));
+
+vi.mock("@/lib/authorization/resource-list", () => ({
+  lookupAuthorizedOrganizationIds: vi.fn(),
+  lookupAuthorizedWorkspaceIds: vi.fn(),
 }));
 
 vi.mock("@formbricks/logger", () => ({
@@ -176,73 +182,31 @@ describe("Workspace module", () => {
   });
 
   describe("getUserWorkspaces", () => {
-    test("should return user workspaces for manager role", async () => {
-      const mockOrgMembership = {
-        userId: "user-id",
-        organizationId: "org-id",
-        role: "manager",
-      };
-
+    test("returns authoritative workspace ids scoped to the selected organization", async () => {
       const mockWorkspaces: TUserWorkspace[] = [
         { id: "workspace-1", name: "Workspace 1" },
         { id: "workspace-2", name: "Workspace 2" },
       ] as any;
 
-      vi.mocked(prisma.membership.findFirst).mockResolvedValueOnce(mockOrgMembership as any);
+      vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValueOnce(["org-id"]);
+      vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValueOnce(["workspace-1", "workspace-2"]);
       vi.mocked(prisma.workspace.findMany).mockResolvedValueOnce(mockWorkspaces as any);
 
       const result = await getUserWorkspaces("user-id", "org-id");
 
       expect(result).toEqual(mockWorkspaces);
-      expect(prisma.membership.findFirst).toHaveBeenCalledWith({
-        where: {
-          userId: "user-id",
-          organizationId: "org-id",
-        },
+      expect(lookupAuthorizedOrganizationIds).toHaveBeenCalledExactlyOnceWith({
+        id: "user-id",
+        type: "user",
+      });
+      expect(lookupAuthorizedWorkspaceIds).toHaveBeenCalledExactlyOnceWith({
+        id: "user-id",
+        type: "user",
       });
       expect(prisma.workspace.findMany).toHaveBeenCalledWith({
         where: {
+          id: { in: ["workspace-1", "workspace-2"] },
           organizationId: "org-id",
-        },
-        select: {
-          id: true,
-          name: true,
-        },
-      });
-    });
-
-    test("should return user workspaces for member role with workspace team filter", async () => {
-      const mockOrgMembership = {
-        userId: "user-id",
-        organizationId: "org-id",
-        role: "member",
-      };
-
-      const mockWorkspaces: TUserWorkspace[] = [
-        { id: "workspace-1", name: "Workspace 1" },
-        { id: "workspace-2", name: "Workspace 2" },
-      ] as any;
-
-      vi.mocked(prisma.membership.findFirst).mockResolvedValueOnce(mockOrgMembership as any);
-      vi.mocked(prisma.workspace.findMany).mockResolvedValueOnce(mockWorkspaces as any);
-
-      const result = await getUserWorkspaces("user-id", "org-id");
-
-      expect(result).toEqual(mockWorkspaces);
-      expect(prisma.workspace.findMany).toHaveBeenCalledWith({
-        where: {
-          organizationId: "org-id",
-          workspaceTeams: {
-            some: {
-              team: {
-                teamUsers: {
-                  some: {
-                    userId: "user-id",
-                  },
-                },
-              },
-            },
-          },
         },
         select: {
           id: true,
@@ -252,42 +216,42 @@ describe("Workspace module", () => {
     });
 
     test("should throw ValidationError when user is not a member of the organization", async () => {
-      vi.mocked(prisma.membership.findFirst).mockResolvedValueOnce(null);
+      vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValueOnce([]);
+      vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValueOnce([]);
 
       await expect(getUserWorkspaces("user-id", "org-id")).rejects.toThrow(ValidationError);
+      expect(prisma.workspace.findMany).not.toHaveBeenCalled();
     });
 
     test("should handle DatabaseError when Prisma throws known request error", async () => {
-      const mockOrgMembership = {
-        userId: "user-id",
-        organizationId: "org-id",
-        role: "admin",
-      };
-
       const prismaError = new Prisma.PrismaClientKnownRequestError("Database error", {
         clientVersion: "1.0.0",
         code: "P2002",
       });
 
-      vi.mocked(prisma.membership.findFirst).mockResolvedValueOnce(mockOrgMembership as any);
+      vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValueOnce(["org-id"]);
+      vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValueOnce(["workspace-1"]);
       vi.mocked(prisma.workspace.findMany).mockRejectedValueOnce(prismaError);
 
       await expect(getUserWorkspaces("user-id", "org-id")).rejects.toThrow(DatabaseError);
     });
 
     test("should rethrow unknown errors", async () => {
-      const mockOrgMembership = {
-        userId: "user-id",
-        organizationId: "org-id",
-        role: "admin",
-      };
-
       const error = new Error("Unknown error");
 
-      vi.mocked(prisma.membership.findFirst).mockResolvedValueOnce(mockOrgMembership as any);
+      vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValueOnce(["org-id"]);
+      vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValueOnce(["workspace-1"]);
       vi.mocked(prisma.workspace.findMany).mockRejectedValueOnce(error);
 
       await expect(getUserWorkspaces("user-id", "org-id")).rejects.toThrow("Unknown error");
+    });
+
+    test("propagates AuthZed lookup failures", async () => {
+      const unavailable = new Error("AuthZed unavailable");
+      vi.mocked(lookupAuthorizedOrganizationIds).mockRejectedValueOnce(unavailable);
+
+      await expect(getUserWorkspaces("user-id", "org-id")).rejects.toBe(unavailable);
+      expect(prisma.workspace.findMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/modules/survey/list/lib/workspace.test.ts
+++ b/apps/web/modules/survey/list/lib/workspace.test.ts
@@ -183,14 +183,14 @@ describe("Workspace module", () => {
 
   describe("getUserWorkspaces", () => {
     test("returns authoritative workspace ids scoped to the selected organization", async () => {
-      const mockWorkspaces: TUserWorkspace[] = [
+      const mockWorkspaces = [
         { id: "workspace-1", name: "Workspace 1" },
         { id: "workspace-2", name: "Workspace 2" },
-      ] as any;
+      ] satisfies TUserWorkspace[];
 
       vi.mocked(lookupAuthorizedOrganizationIds).mockResolvedValueOnce(["org-id"]);
       vi.mocked(lookupAuthorizedWorkspaceIds).mockResolvedValueOnce(["workspace-1", "workspace-2"]);
-      vi.mocked(prisma.workspace.findMany).mockResolvedValueOnce(mockWorkspaces as any);
+      vi.mocked(prisma.workspace.findMany).mockResolvedValueOnce(mockWorkspaces as never);
 
       const result = await getUserWorkspaces("user-id", "org-id");
 

--- a/apps/web/modules/survey/list/lib/workspace.ts
+++ b/apps/web/modules/survey/list/lib/workspace.ts
@@ -5,6 +5,10 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { DatabaseError, ResourceNotFoundError, ValidationError } from "@formbricks/types/errors";
+import {
+  lookupAuthorizedOrganizationIds,
+  lookupAuthorizedWorkspaceIds,
+} from "@/lib/authorization/resource-list";
 import { validateInputs } from "@/lib/utils/validate";
 import { TWorkspaceWithLanguages } from "@/modules/survey/list/types/surveys";
 import { TUserWorkspace } from "@/modules/survey/list/types/workspaces";
@@ -75,40 +79,21 @@ export const getWorkspaceWithLanguages = reactCache(
 
 export const getUserWorkspaces = reactCache(
   async (userId: string, organizationId: string): Promise<TUserWorkspace[]> => {
+    const actor = { type: "user", id: userId } as const;
+    const [authorizedOrganizationIds, authorizedWorkspaceIds] = await Promise.all([
+      lookupAuthorizedOrganizationIds(actor),
+      lookupAuthorizedWorkspaceIds(actor),
+    ]);
+
+    if (!authorizedOrganizationIds.includes(organizationId)) {
+      throw new ValidationError("User is not a member of this organization");
+    }
+
     try {
-      const orgMembership = await prisma.membership.findFirst({
-        where: {
-          userId,
-          organizationId,
-        },
-      });
-
-      if (!orgMembership) {
-        throw new ValidationError("User is not a member of this organization");
-      }
-
-      let workspaceWhereClause: Prisma.WorkspaceWhereInput = {};
-
-      if (orgMembership.role === "member") {
-        workspaceWhereClause = {
-          workspaceTeams: {
-            some: {
-              team: {
-                teamUsers: {
-                  some: {
-                    userId,
-                  },
-                },
-              },
-            },
-          },
-        };
-      }
-
       const workspaces = await prisma.workspace.findMany({
         where: {
+          id: { in: [...authorizedWorkspaceIds] },
           organizationId,
-          ...workspaceWhereClause,
         },
         select: {
           id: true,


### PR DESCRIPTION
Fixes ENG-2449

## What & why

- Current organization and workspace discovery still used PostgreSQL role and grant filters even after scalar authorization became SpiceDB-authoritative.
- Adds a private, server-only list authorization helper backed by one bounded `LookupResources` operation per resource/permission/actor tuple.
- Routes shared organization/workspace services, application switchers, survey lists, V3/MCP workspace discovery, and API v2 `/me` workspace grants through authoritative SpiceDB results.
- Resolves returned IDs through tenant-scoped PostgreSQL queries for existence and DTO data without re-evaluating authorization.
- Preserves response shapes, ordering, pagination, API-key permission labels, and the empty-list response contract; lookup, freshness, and resolver failures fail closed.
- Deliberately removes the former switcher-only exception that showed billing-role users team workspaces they could not open; authoritative lists now match their lack of product-data access.

This is based on merged #8913 (ENG-2446), which makes scalar `can()` / `assertCan()` decisions SpiceDB-authoritative and forces fully-consistent reads. Its prerequisite chain is #8912, #8910, and #8909. No schema, projection, action vocabulary, or new product permission is introduced here.

## Breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| User and API-key organization/workspace lookups use the mapped SpiceDB subject and requested permission | unit (mutation): `lib/authorization/resource-list.test.ts` | Fully-consistent client lookup results are deduplicated and failures propagate without fallback |
| Shared organization/workspace services resolve only authorized IDs inside the current tenant | unit (mutation): `lib/organization/service.test.ts`, `lib/workspace/service.test.ts` | Covers authorized, empty, stale, and cross-tenant IDs plus membership integrity checks |
| Application organization/workspace/survey selectors retain ordering and access behavior | unit (mutation): application helper and survey workspace tests | Owner/member list paths and read/write workspace selections use authoritative resource IDs |
| V3/MCP workspace discovery uses one lookup for users and API keys and preserves its DTO/order/error contract | unit (mutation): `app/api/v3/workspaces/lib/operations.test.ts` | Covers multi-workspace, empty, stale, foreign-organization, auth-shape, and sanitized operational failures |
| API v2 `/me` intersects authoritative workspace IDs with source permission metadata | unit (mutation): `modules/api/v2/me/route.test.ts` | Stale/foreign grants are omitted; errors do not return a partial legacy-authoritative list |
| Lookup request amplification is constant for 1 versus 100 returned workspaces | integration (mutation; mocked AuthZed boundary): `lib/authorization/checks-per-request-workspace-discovery.integration.test.ts` | Both cases issue exactly one central authorization operation while resolving the returned IDs against real PostgreSQL data |
| Canonical schema remains valid and application production build performs no startup authorization RPC | manual | Schema validation passed with 36 relationships, 157 assertions, and 6 expected relations; the forced web build completed successfully |

**Open gaps**

- `pnpm authzed:smoke` completed PostgreSQL bootstrap, SpiceDB migration, schema/relationship, persistence, restart, and initial repair phases, then the local Node 24 runner repeatedly failed while spawning a later `tsx` command with `Named export 'version' not found` from the CommonJS `esbuild` package. The same CLI command succeeds alone. CI must provide the complete smoke result.
- Live sandbox QA is intentionally gated on the complete direct-authority candidate stack and immutable image digest; this PR does not deploy independently.

**Risks**

- A missing/stale relationship now removes a resource from lists instead of allowing PostgreSQL to compensate. ENG-2408's durable outbox, freshness guard, and repair cycle are therefore prerequisites.
- The application and survey switchers share these services. If a legitimate resource disappears, inspect AuthZed relationship delivery and audit results before changing SQL filters.
- This PR still contains the old shadow observer implementation as dead compatibility code; ENG-2450 removes the selector, queue, observer, and legacy evaluator together after authoritative telemetry lands.

---

> [!NOTE]
> **AI model used** — `GPT-5.3-Codex`, reasoning effort `high`.


### Stack maintenance — CI fixture restack

- Rebased onto the corrected direct-authority head, which provisions a real in-memory SpiceDB fixture in CI, applies the canonical schema, reconciles the integration graph, and runs the Playwright outbox worker.
- The authoritative list behavior is unchanged; the rewritten stack removes the earlier false `authzed_unavailable` and stale-projection failures caused by CI running without the required decision engine.

### Parent-merge ancestry refresh

- After #8913 merged, replayed only this PR's authoritative-list commit onto merge commit `d4595e2e3`, eliminating the duplicate stack ancestry and GitHub conflict.

### Reviewer follow-up

- Documented the deliberate user-visible narrowing for billing-role users with stale team membership: inaccessible workspaces now disappear from lists.
- Clarified that the amplification integration test mocks the AuthZed lookup boundary while exercising real PostgreSQL resource resolution.
- Documented the cache boundary: identical tuples deduplicate inside an RSC request; API handlers invoke the required list helper once and do not rely on React request caching.
- Verified the parent concern about archived feedback directories against the merged source-scope resolver and its regression test: archived directories resolve to a genuine denial before any SpiceDB permission check.
- Filtered both API v2 `/me` permission arrays through the tenant-scoped workspace records actually resolved from PostgreSQL. The regression now gives SpiceDB a foreign workspace ID and proves neither response array exposes it.
- Removed the untyped workspace fixture cast called out by CodeRabbit; the fixture now uses `satisfies TUserWorkspace[]` and narrows only at the Prisma mock boundary.