### PR TITLE
feat: add AuthZed-default self-hosted upgrade gates

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -166,6 +166,24 @@ jobs:
           test "$status" -eq 1
           test "$output" = '{"status":"disabled"}'
 
+          set +e
+          upgrade_output="$(docker run --rm \
+            --entrypoint formbricks-authzed \
+            -e DATABASE_URL="postgresql://test:test@192.0.2.1:5432/formbricks" \
+            -e ENCRYPTION_KEY="$DUMMY_ENCRYPTION_KEY" \
+            -e REDIS_URL="redis://192.0.2.1:6379" \
+            -e HUB_API_URL="http://192.0.2.1:4000" \
+            -e HUB_API_KEY="build-time-placeholder" \
+            -e CUBEJS_API_URL="http://192.0.2.1:4000" \
+            -e CUBEJS_API_SECRET="build-time-placeholder" \
+            -e AUTHZED_ENABLED="false" \
+            "$IMAGE" upgrade check 2>&1)"
+          upgrade_status=$?
+          set -e
+
+          test "$upgrade_status" -eq 1
+          test "$upgrade_output" = '{"code":"authzed_disabled","retryable":false,"status":"failed"}'
+
       - name: Reject Invalid Environment Before Database Setup
         shell: bash
         env:

--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -277,6 +277,10 @@ jobs:
             --set formbricks.webappUrl=https://qa.example.com \
             --set postgresql.enabled=false \
             --set-string postgresql.externalDatabaseUrl=postgresql://user:password@external-postgresql:5432/formbricks \
+            --set authzed.mode=external \
+            --set authzed.operator.install=false \
+            --set authzed.endpoint=grpc.authzed.com:443 \
+            --set authzed.auth.existingSecret=formbricks-authzed \
             --show-only templates/migration-job.yaml > "$render_dir/external.yaml"
           grep -q 'packages/database/dist/scripts/wait-for-database.js' "$render_dir/external.yaml"
 

--- a/apps/web/lib/authzed/upgrade-cli-command.test.ts
+++ b/apps/web/lib/authzed/upgrade-cli-command.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { parseAuthzedUpgradeCliCommand } from "./upgrade-cli-command";
+
+const DIGEST = `sha256:${"a".repeat(64)}`;
+
+describe("parseAuthzedUpgradeCliCommand", () => {
+  test.each([
+    [["check"], { action: "check" }],
+    [["prepare"], { action: "prepare" }],
+    [["prepare", "--expected-current-digest", DIGEST], { action: "prepare", expectedCurrentDigest: DIGEST }],
+  ])("parses %j", (args, expected) => {
+    expect(parseAuthzedUpgradeCliCommand(args)).toEqual(expected);
+  });
+
+  test.each([
+    { args: [] },
+    { args: ["check", "extra"] },
+    { args: ["prepare", "--expected-current-digest"] },
+    { args: ["prepare", "--expected-current-digest", "sha256:not-a-digest"] },
+    { args: ["prepare", "--unknown", DIGEST] },
+    { args: ["apply"] },
+  ])("rejects $args", ({ args }) => {
+    expect(parseAuthzedUpgradeCliCommand(args)).toBeUndefined();
+  });
+});

--- a/apps/web/lib/authzed/upgrade-cli-command.ts
+++ b/apps/web/lib/authzed/upgrade-cli-command.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+export type TAuthzedUpgradeCliCommand =
+  | Readonly<{ action: "check" }>
+  | Readonly<{ action: "prepare"; expectedCurrentDigest?: string }>;
+
+const SCHEMA_DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/;
+
+/** Parse upgrade arguments before loading application configuration or constructing a client. */
+export const parseAuthzedUpgradeCliCommand = (
+  args: ReadonlyArray<string>
+): TAuthzedUpgradeCliCommand | undefined => {
+  if (args.length === 1 && args[0] === "check") {
+    return { action: "check" };
+  }
+
+  if (args[0] !== "prepare") {
+    return undefined;
+  }
+
+  if (args.length === 1) {
+    return { action: "prepare" };
+  }
+
+  if (
+    args.length === 3 &&
+    args[1] === "--expected-current-digest" &&
+    SCHEMA_DIGEST_PATTERN.test(args[2] ?? "")
+  ) {
+    return { action: "prepare", expectedCurrentDigest: args[2] };
+  }
+
+  return undefined;
+};

--- a/apps/web/lib/authzed/upgrade-cli.test.ts
+++ b/apps/web/lib/authzed/upgrade-cli.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test, vi } from "vitest";
+import type { TAuthzedBackfillResult } from "./backfill";
+import { runAuthzedUpgradeCli } from "./upgrade-cli";
+
+const health = { latencyMs: 4, status: "healthy" } as const;
+const schema = {
+  differenceCount: 0,
+  differenceKinds: {},
+  remoteDigest: `sha256:${"a".repeat(64)}` as const,
+  remoteState: "present",
+  sourceDigest: `sha256:${"a".repeat(64)}` as const,
+  status: "matched",
+} as const;
+const outbox = {
+  deadLettered: 0,
+  oldestPendingAgeSeconds: null,
+  overdueRevocations: 0,
+  pending: 0,
+  revocationsPastCritical: 0,
+  revocationsPastWarning: 0,
+} as const;
+const counters = {
+  failed: 0,
+  ignored: 0,
+  invalid: 0,
+  mismatchedParents: 0,
+  mismatchedPermissions: 0,
+  missing: 0,
+  orphaned: 0,
+  pruned: 0,
+  reconciled: 0,
+  scanned: 12,
+  skipped: 0,
+  unmanaged: 0,
+} as const;
+
+const audit = (status: TAuthzedBackfillResult["status"] = "reconciled"): TAuthzedBackfillResult => ({
+  completedAtSnapshot: null,
+  counters,
+  failures: [],
+  lastOrganizationId: "tenant_identifier_must_not_escape",
+  mismatchedParents: [],
+  mismatchedPermissions: [],
+  mode: "dry_run",
+  orphanScope: "all",
+  orphans: [],
+  scope: "all",
+  status,
+  truncated: false,
+  unmanaged: [],
+});
+
+const dependencies = (overrides: Record<string, unknown> = {}) => {
+  const outputs: string[] = [];
+
+  return {
+    outputs,
+    values: {
+      applySchema: vi.fn().mockResolvedValue({ ...schema, status: "unchanged" }),
+      audit: vi.fn().mockResolvedValue(audit()),
+      checkHealth: vi.fn().mockResolvedValue(health),
+      checkSchema: vi.fn().mockResolvedValue(schema),
+      closeClient: vi.fn(),
+      configureBulkClient: vi.fn(),
+      consistency: vi.fn().mockReturnValue("fully_consistent"),
+      drainOutbox: vi.fn().mockResolvedValue({
+        claimed: 2,
+        deadLettered: 0,
+        delivered: 2,
+        failed: 0,
+        remaining: 0,
+        status: "drained",
+      }),
+      isEnabled: vi.fn().mockReturnValue(true),
+      outboxStatus: vi.fn().mockResolvedValue(outbox),
+      writeOutput: (output: string) => outputs.push(output),
+      ...overrides,
+    },
+  };
+};
+
+describe("runAuthzedUpgradeCli", () => {
+  test("reports a clean read-only preflight without tenant identifiers", async () => {
+    const deps = dependencies();
+
+    await expect(runAuthzedUpgradeCli({ action: "check" }, deps.values)).resolves.toBe(0);
+
+    const result = JSON.parse(deps.outputs.join(""));
+    expect(result).toMatchObject({
+      audit: { counters, failureCount: 0, status: "reconciled", truncated: false },
+      datastoreMigrations: "ready",
+      health,
+      outbox,
+      schema,
+      status: "ready",
+    });
+    expect(deps.outputs.join("")).not.toContain("tenant_identifier_must_not_escape");
+    expect(deps.values.configureBulkClient).toHaveBeenCalledBefore(deps.values.checkHealth);
+    expect(deps.values.closeClient).toHaveBeenCalledOnce();
+  });
+
+  test.each([
+    [{ isEnabled: vi.fn().mockReturnValue(false) }, "authzed_disabled"],
+    [{ consistency: vi.fn().mockReturnValue("minimize_latency") }, "authzed_failed_precondition"],
+  ])("fails closed for unsafe configuration", async (override, code) => {
+    const deps = dependencies(override);
+
+    await expect(runAuthzedUpgradeCli({ action: "check" }, deps.values)).resolves.toBe(1);
+
+    expect(JSON.parse(deps.outputs.join(""))).toEqual({ code, retryable: false, status: "failed" });
+    expect(deps.values.checkHealth).not.toHaveBeenCalled();
+  });
+
+  test("prepares schema, drains delivery, reconciles, and verifies the final graph", async () => {
+    const deps = dependencies();
+    const digest = `sha256:${"b".repeat(64)}`;
+
+    await expect(
+      runAuthzedUpgradeCli({ action: "prepare", expectedCurrentDigest: digest }, deps.values)
+    ).resolves.toBe(0);
+
+    expect(deps.values.applySchema).toHaveBeenCalledWith(digest);
+    expect(deps.values.drainOutbox).toHaveBeenCalledOnce();
+    expect(deps.values.audit).toHaveBeenNthCalledWith(1, "apply", expect.any(Object));
+    expect(deps.values.audit).toHaveBeenNthCalledWith(2, "dry_run", expect.any(Object));
+    expect(JSON.parse(deps.outputs.join(""))).toMatchObject({ status: "prepared" });
+  });
+
+  test("blocks when the final audit still finds drift", async () => {
+    const drifted = audit("drifted");
+    const deps = dependencies({
+      audit: vi.fn().mockResolvedValueOnce(audit()).mockResolvedValueOnce(drifted),
+    });
+
+    await expect(runAuthzedUpgradeCli({ action: "prepare" }, deps.values)).resolves.toBe(2);
+
+    expect(JSON.parse(deps.outputs.join(""))).toMatchObject({
+      audit: { status: "drifted" },
+      status: "blocked",
+    });
+  });
+
+  test("sanitizes unexpected failures", async () => {
+    const deps = dependencies({ checkHealth: vi.fn().mockRejectedValue(new Error("raw secret")) });
+
+    await expect(runAuthzedUpgradeCli({ action: "check" }, deps.values)).resolves.toBe(1);
+
+    expect(JSON.parse(deps.outputs.join(""))).toEqual({
+      code: "authzed_internal",
+      retryable: false,
+      status: "failed",
+    });
+    expect(deps.outputs.join("")).not.toContain("raw secret");
+  });
+});

--- a/apps/web/lib/authzed/upgrade-cli.ts
+++ b/apps/web/lib/authzed/upgrade-cli.ts
@@ -1,0 +1,218 @@
+import "server-only";
+import { env } from "@/lib/env";
+import { type TAuthzedBackfillApply, type TAuthzedBackfillResult, runAuthzedBackfill } from "./backfill";
+import { createAuthzedBackfillApply, createAuthzedBackfillNoopApply } from "./backfill-apply";
+import { closeAuthzedClient, configureAuthzedClientForBulkWork, getAuthzedClient } from "./client";
+import { AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN } from "./constants";
+import { AUTHZED_ERROR_CODES, AuthzedError, type TAuthzedErrorCode, mapAuthzedError } from "./errors";
+import { type TAuthzedHealthResult, checkAuthzedHealth } from "./health";
+import { drainAuthzedOutbox } from "./outbox-processor";
+import { getAuthzedOutboxStatus } from "./outbox-repository";
+import type { TAuthzedOutboxDrainResult, TAuthzedOutboxStatus } from "./outbox-types";
+import {
+  type TAuthzedSchemaApplyResult,
+  type TAuthzedSchemaCheckResult,
+  applyCanonicalAuthzedSchema,
+  checkCanonicalAuthzedSchema,
+} from "./schema";
+import type { TAuthzedUpgradeCliCommand } from "./upgrade-cli-command";
+
+type TAuthzedUpgradeAudit = Readonly<{
+  counters: TAuthzedBackfillResult["counters"];
+  failureCount: number;
+  status: TAuthzedBackfillResult["status"];
+  truncated: boolean;
+}>;
+
+type TAuthzedUpgradeResult = Readonly<{
+  audit?: TAuthzedUpgradeAudit;
+  code?: TAuthzedErrorCode;
+  datastoreMigrations?: "ready";
+  health?: TAuthzedHealthResult;
+  outbox?: TAuthzedOutboxStatus | TAuthzedOutboxDrainResult;
+  retryable?: boolean;
+  schema?: TAuthzedSchemaApplyResult | TAuthzedSchemaCheckResult;
+  status: "blocked" | "failed" | "prepared" | "ready";
+}>;
+
+type TAuthzedUpgradeCliDependencies = Readonly<{
+  applySchema: (expectedCurrentDigest?: string) => Promise<TAuthzedSchemaApplyResult>;
+  audit: (mode: "apply" | "dry_run", apply: TAuthzedBackfillApply) => Promise<TAuthzedBackfillResult>;
+  checkHealth: () => Promise<TAuthzedHealthResult>;
+  checkSchema: () => Promise<TAuthzedSchemaCheckResult>;
+  closeClient: () => void;
+  configureBulkClient: () => void;
+  consistency: () => string | undefined;
+  drainOutbox: () => Promise<TAuthzedOutboxDrainResult>;
+  isEnabled: () => boolean;
+  outboxStatus: () => Promise<TAuthzedOutboxStatus>;
+  writeOutput: (output: string) => void;
+}>;
+
+const runFullAudit = (mode: "apply" | "dry_run", apply: TAuthzedBackfillApply) =>
+  runAuthzedBackfill(
+    {
+      maxPrune: AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN,
+      mode,
+      prune: false,
+      scope: { kind: "all" },
+    },
+    { apply, client: getAuthzedClient() }
+  );
+
+const defaultDependencies: TAuthzedUpgradeCliDependencies = {
+  applySchema: applyCanonicalAuthzedSchema,
+  audit: runFullAudit,
+  checkHealth: checkAuthzedHealth,
+  checkSchema: checkCanonicalAuthzedSchema,
+  closeClient: closeAuthzedClient,
+  configureBulkClient: configureAuthzedClientForBulkWork,
+  consistency: () => env.AUTHZED_CONSISTENCY,
+  drainOutbox: drainAuthzedOutbox,
+  isEnabled: () => env.AUTHZED_ENABLED === "true" || env.AUTHZED_ENABLED === "1",
+  outboxStatus: getAuthzedOutboxStatus,
+  writeOutput: (output) => process.stdout.write(output),
+};
+
+const summarizeAudit = (result: TAuthzedBackfillResult): TAuthzedUpgradeAudit => ({
+  counters: result.counters,
+  failureCount: result.failures.length,
+  status: result.status,
+  truncated: result.truncated,
+});
+
+const isOutboxClean = (status: TAuthzedOutboxStatus): boolean =>
+  status.deadLettered === 0 &&
+  status.overdueRevocations === 0 &&
+  status.pending === 0 &&
+  status.revocationsPastCritical === 0 &&
+  status.revocationsPastWarning === 0;
+
+const assertUpgradeConfiguration = (dependencies: TAuthzedUpgradeCliDependencies): void => {
+  if (!dependencies.isEnabled()) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.DISABLED,
+      operation: "upgrade_check_configuration",
+      retryable: false,
+    });
+  }
+
+  if (dependencies.consistency() !== "fully_consistent") {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.FAILED_PRECONDITION,
+      operation: "upgrade_check_consistency",
+      retryable: false,
+    });
+  }
+};
+
+const failed = (error: unknown): TAuthzedUpgradeResult => {
+  const mapped = error instanceof AuthzedError ? error : mapAuthzedError(error, "upgrade_cli", 1);
+
+  return { code: mapped.code, retryable: mapped.retryable, status: "failed" };
+};
+
+const runCheck = async (dependencies: TAuthzedUpgradeCliDependencies): Promise<TAuthzedUpgradeResult> => {
+  const health = await dependencies.checkHealth();
+  if (health.status !== "healthy") {
+    return { health, status: "blocked" };
+  }
+
+  const schema = await dependencies.checkSchema();
+  if (schema.status !== "matched") {
+    return { datastoreMigrations: "ready", health, schema, status: "blocked" };
+  }
+
+  const outbox = await dependencies.outboxStatus();
+  if (!isOutboxClean(outbox)) {
+    return { datastoreMigrations: "ready", health, outbox, schema, status: "blocked" };
+  }
+
+  const audit = summarizeAudit(await dependencies.audit("dry_run", createAuthzedBackfillNoopApply()));
+  return {
+    audit,
+    datastoreMigrations: "ready",
+    health,
+    outbox,
+    schema,
+    status: audit.status === "reconciled" ? "ready" : audit.status === "failed" ? "failed" : "blocked",
+  };
+};
+
+const runPrepare = async (
+  command: Extract<TAuthzedUpgradeCliCommand, { action: "prepare" }>,
+  dependencies: TAuthzedUpgradeCliDependencies
+): Promise<TAuthzedUpgradeResult> => {
+  const health = await dependencies.checkHealth();
+  if (health.status !== "healthy") {
+    return { health, status: "blocked" };
+  }
+
+  const schema = await dependencies.applySchema(command.expectedCurrentDigest);
+  const drain = await dependencies.drainOutbox();
+  if (drain.status !== "drained" || drain.deadLettered > 0 || drain.failed > 0) {
+    return { datastoreMigrations: "ready", health, outbox: drain, schema, status: "blocked" };
+  }
+
+  const reconciliation = await dependencies.audit("apply", createAuthzedBackfillApply());
+  if (reconciliation.status === "failed") {
+    return {
+      audit: summarizeAudit(reconciliation),
+      datastoreMigrations: "ready",
+      health,
+      outbox: drain,
+      schema,
+      status: "failed",
+    };
+  }
+
+  const audit = summarizeAudit(await dependencies.audit("dry_run", createAuthzedBackfillNoopApply()));
+  const outbox = await dependencies.outboxStatus();
+  return {
+    audit,
+    datastoreMigrations: "ready",
+    health,
+    outbox,
+    schema,
+    status:
+      audit.status === "failed"
+        ? "failed"
+        : audit.status === "reconciled" && isOutboxClean(outbox)
+          ? "prepared"
+          : "blocked",
+  };
+};
+
+/**
+ * Release-matched, fail-closed v6 upgrade gate.
+ *
+ * Output intentionally contains aggregate counters only. Detailed repair output remains available from
+ * the explicit backfill command and is never folded into unattended upgrade logs.
+ */
+export const runAuthzedUpgradeCli = async (
+  command: TAuthzedUpgradeCliCommand,
+  dependencyOverrides: Partial<TAuthzedUpgradeCliDependencies> = {}
+): Promise<number> => {
+  const dependencies = { ...defaultDependencies, ...dependencyOverrides };
+  let result: TAuthzedUpgradeResult;
+
+  try {
+    assertUpgradeConfiguration(dependencies);
+    dependencies.configureBulkClient();
+    result =
+      command.action === "prepare" ? await runPrepare(command, dependencies) : await runCheck(dependencies);
+  } catch (error) {
+    result = failed(error);
+  } finally {
+    try {
+      dependencies.closeClient();
+    } catch {
+      // Cleanup failures must not replace the sanitized upgrade result.
+    }
+  }
+
+  dependencies.writeOutput(`${JSON.stringify(result)}\n`);
+  return result.status === "ready" || result.status === "prepared" ? 0 : result.status === "blocked" ? 2 : 1;
+};

--- a/apps/web/scripts/authzed-entrypoints.test.ts
+++ b/apps/web/scripts/authzed-entrypoints.test.ts
@@ -63,6 +63,12 @@ describe("AuthZed script entrypoints", () => {
       name: "packaged health",
       script: "scripts/docker/authzed-cli.ts",
     },
+    {
+      args: ["upgrade", "--unknown"],
+      expected: INVALID_REQUEST_RESULT,
+      name: "packaged upgrade",
+      script: "scripts/docker/authzed-cli.ts",
+    },
   ])("$name rejects invalid arguments with one sanitized JSON result", ({ args, expected, script }) => {
     expectSingleJsonFailure(runEntrypoint(script, args), expected);
   });
@@ -89,6 +95,12 @@ describe("AuthZed script entrypoints", () => {
         status: "unhealthy",
       },
       name: "packaged health",
+      script: "scripts/docker/authzed-cli.ts",
+    },
+    {
+      args: ["upgrade", "check"],
+      expected: INVALID_CONFIGURATION_RESULT,
+      name: "packaged upgrade",
       script: "scripts/docker/authzed-cli.ts",
     },
   ])("$name sanitizes runtime-loading failures", ({ args, expected, script }) => {

--- a/apps/web/scripts/docker/authzed-cli.ts
+++ b/apps/web/scripts/docker/authzed-cli.ts
@@ -102,6 +102,23 @@ const run = async (): Promise<void> => {
         process.exitCode = await runAuthzedOutboxCli(outboxCommand);
         return;
       }
+      case "upgrade": {
+        const { parseAuthzedUpgradeCliCommand } = await import("../../lib/authzed/upgrade-cli-command");
+        const upgradeCommand = parseAuthzedUpgradeCliCommand(args);
+
+        if (!upgradeCommand) {
+          console.error = originalConsoleError;
+          writeResult(INVALID_REQUEST_RESULT);
+          process.exitCode = 1;
+          return;
+        }
+
+        shouldCloseDatabase = true;
+        const { runAuthzedUpgradeCli } = await import("../../lib/authzed/upgrade-cli");
+        console.error = originalConsoleError;
+        process.exitCode = await runAuthzedUpgradeCli(upgradeCommand);
+        return;
+      }
       default:
         console.error = originalConsoleError;
         writeResult(INVALID_REQUEST_RESULT);

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -625,6 +625,21 @@ workflow above. Successfully delivered outbox rows are retained for seven days;
 the scheduled audit removes at most 10,000 expired rows per run. Pending and
 dead-letter rows are never removed by retention cleanup.
 
+## Self-hosted v6 upgrade gate
+
+Release images expose two aggregate-only orchestration commands:
+
+```bash
+formbricks-authzed upgrade prepare
+formbricks-authzed upgrade check
+```
+
+`prepare` requires `AUTHZED_ENABLED=true` and `AUTHZED_CONSISTENCY=fully_consistent`, checks authenticated
+datastore health, applies an empty or guarded canonical schema, drains the outbox, runs attributable repair, and
+audits the final graph. `check` repeats the health, schema, outbox, and full dry-run audit without writing. It
+exits 0 only for a direct-authority-ready deployment, 2 when readiness is blocked by drift, and 1 for a failed
+configuration or operation. Unlike the detailed backfill report, both commands emit aggregate counters only.
+
 ## Deliberately not modeled (stays in application code)
 
 - Managers may only assign the `member` role when inviting/updating members.

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -39,6 +39,7 @@ the graph. On the direct-authority artifact, operational AuthZed failures fail p
 pnpm authzed:health     # 0 healthy, 1 otherwise
 pnpm authzed:schema check   # 0 matched, 2 drifted, 1 failed
 formbricks-authzed outbox status  # 0 healthy, 2 warning/critical, 1 failed
+formbricks-authzed upgrade check  # 0 direct-authority ready, 2 blocked, 1 failed
 ```
 
 Note `status: "disabled"` from the health command exits **1**. A deployment that believes AuthZed is on
@@ -311,6 +312,10 @@ the service recovers:
    `authzed_projection_stale` denial clears within six hours even if nobody intervenes.
 4. Run the complete dry-run audit, apply attributable repair, and require two consecutive clean audits.
 5. Keep direct-authority cutover blocked while a revocation is pending, dead-lettered, or older than its SLA.
+
+For a self-hosted major upgrade, `formbricks-authzed upgrade prepare` composes steps 1 through 4 and then runs a
+final audit. Always follow it with the read-only `upgrade check`; do not treat a completed write phase as proof
+that concurrent source changes left the graph clean.
 
 In the direct-authority artifact, a SpiceDB, datastore, resolver, configuration, freshness, or unsupported-result
 failure is not an ordinary denial and never falls back. The protected operation receives a sanitized operational

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -58,16 +58,16 @@ single-replica deployment.
 
 ## AuthZed / SpiceDB
 
-AuthZed is disabled by default. To deploy SpiceDB with Formbricks and the bundled PostgreSQL chart:
+Formbricks v6 enables AuthZed, `fully_consistent` authorization, and the bundled SpiceDB operator by default.
+For a cluster where a compatible operator already watches the Formbricks namespace:
 
 ```yaml
 authzed:
-  enabled: true
   operator:
-    install: true
+    install: false
 ```
 
-This installs the pinned SpiceDB operator, creates a two-replica `SpiceDBCluster`, and creates a dedicated
+The default installs the pinned SpiceDB operator, creates a two-replica `SpiceDBCluster`, and creates a dedicated
 `spicedb` database and role in the bundled PostgreSQL server. During normal Helm installs and upgrades, the
 chart reuses generated credentials from the existing cluster Secret. Renderers without live Secret access,
 including offline `helm template` and Argo CD manifest generation, must provide persistent credentials through
@@ -89,10 +89,9 @@ postgresql:
         memory: 1Gi
 ```
 
-Helm cannot condition values passed to the PostgreSQL dependency on the sibling `authzed.enabled` value, so the
-safe database baseline remains in effect when AuthZed is disabled. Override `authzed.cluster.resources` and
-`postgresql.primary.resources` to match the expected authorization traffic and the other workloads using the
-bundled database. Installations that keep AuthZed disabled may explicitly choose smaller PostgreSQL resources.
+Helm cannot condition values passed to the PostgreSQL dependency on a sibling value, so the safe database
+baseline remains in effect. Override `authzed.cluster.resources` and `postgresql.primary.resources` to match the
+expected authorization traffic and the other workloads using the bundled database.
 
 Install only one operator per Kubernetes cluster. When a platform-managed operator already watches the Formbricks
 namespace, keep `authzed.operator.install=false`; the Formbricks release still owns its `SpiceDBCluster`.
@@ -185,6 +184,8 @@ scheme, and reference a Secret containing `preshared_key`:
 authzed:
   enabled: true
   mode: external
+  operator:
+    install: false
   endpoint: grpc.authzed.com:443
   insecure: false
   auth:
@@ -197,12 +198,14 @@ endpoint; plaintext transport sends the preshared token without TLS protection. 
 the Formbricks app. Authorization checks must fail closed once product enforcement is enabled; general
 Formbricks readiness remains independent from transient SpiceDB availability.
 
-The chart deliberately does not install or update the Formbricks authorization schema. After SpiceDB is ready,
-run the release-matched command inside the Formbricks application deployment:
+Fresh installs run a release-matched initialization Job that applies the canonical schema and verifies the empty
+or reconciled graph. Existing releases never run that Job as an upgrade hook. Before the first v6 upgrade, run:
 
 ```bash
 kubectl exec -n <namespace> deployment/<release-name> -- formbricks-authzed health
 kubectl exec -n <namespace> deployment/<release-name> -- formbricks-authzed schema check
+kubectl exec -n <namespace> deployment/<release-name> -- formbricks-authzed upgrade prepare
+kubectl exec -n <namespace> deployment/<release-name> -- formbricks-authzed upgrade check
 
 # Empty instances only
 kubectl exec -n <namespace> deployment/<release-name> -- formbricks-authzed schema apply
@@ -213,8 +216,9 @@ kubectl exec -n <namespace> deployment/<release-name> -- formbricks-authzed sche
 ```
 
 The initial apply to an empty instance needs no digest. A non-empty instance must first be checked and then
-applied with `--expected-current-digest sha256:<digest-from-check>`. This separation keeps schema changes out of
-Helm hooks, app startup, migrations, liveness, and readiness. Back up the current schema and affected
+prepared with `--expected-current-digest sha256:<digest-from-check>`. Once `upgrade check` exits `0`, set
+`authzed.migrationAcknowledged=true` in the v6 upgrade values. The chart refuses an unacknowledged upgrade,
+`authzed.enabled=false`, or consistency other than `fully_consistent`. Back up the current schema and affected
 relationships before replacement; see the repository `authzed/README.md` for exit codes and rollback rules.
 The public [AuthZed operations guide](../../docs/self-hosting/advanced/authzed-operations.mdx) covers backups,
 restoration, schema lifecycle, relationship repair, and monitoring.

--- a/charts/formbricks/templates/NOTES.txt
+++ b/charts/formbricks/templates/NOTES.txt
@@ -187,6 +187,13 @@ AuthZed / SpiceDB Operations:
    kubectl exec -n {{ .Release.Namespace }} deployment/{{ include "formbricks.name" . }} -- formbricks-authzed schema check
    ```
 
+   Before upgrading an existing installation to v6, complete the release-matched preparation and
+   read-only gate, then set `authzed.migrationAcknowledged=true`:
+   ```sh
+   kubectl exec -n {{ .Release.Namespace }} deployment/{{ include "formbricks.name" . }} -- formbricks-authzed upgrade prepare
+   kubectl exec -n {{ .Release.Namespace }} deployment/{{ include "formbricks.name" . }} -- formbricks-authzed upgrade check
+   ```
+
    Schema application and relationship repair are explicit operator actions and never run as Helm
    hooks. Read the safeguards and backup requirements before changing authorization state:
    https://formbricks.com/docs/self-hosting/advanced/authzed-operations

--- a/charts/formbricks/templates/authzed-initialize-job.yaml
+++ b/charts/formbricks/templates/authzed-initialize-job.yaml
@@ -1,0 +1,134 @@
+{{- if and .Values.authzed.enabled (or .Release.IsInstall (and .Release.IsUpgrade .Values.authzed.migrationAcknowledged)) }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "formbricks.name" . }}-authzed-initialize
+  labels:
+    {{- include "formbricks.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "1"
+    helm.sh/hook: {{ ternary "post-install" "pre-upgrade" .Release.IsInstall }}
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "formbricks.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: authzed-initialize
+    spec:
+      restartPolicy: Never
+      {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.deployment.tolerations }}
+      tolerations:
+        {{- toYaml .Values.deployment.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.deployment.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if .Values.rbac.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.rbac.serviceAccount.name | default (include "formbricks.name" .) }}
+      {{- end }}
+      {{- if .Values.deployment.securityContext }}
+      securityContext:
+        {{- toYaml .Values.deployment.securityContext | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: initialize
+          image: {{ include "formbricks.deploymentImage" . }}
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          command: ["sh", "-ec"]
+          args:
+            - |
+              attempts=0
+              until formbricks-authzed upgrade prepare; do
+                attempts=$((attempts + 1))
+                if [ "$attempts" -ge 120 ]; then
+                  echo '{"code":"authzed_unavailable","retryable":true,"status":"failed"}'
+                  exit 1
+                fi
+                sleep 5
+              done
+              formbricks-authzed upgrade check
+          {{- if or .Values.deployment.envFrom (or (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) .Values.secret.enabled) }}
+          envFrom:
+            {{- if or .Values.secret.enabled (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) }}
+            - secretRef:
+                name: {{ template "formbricks.name" . }}-app-secrets
+            {{- end }}
+            {{- range $value := .Values.deployment.envFrom }}
+            {{- if eq .type "configmap" }}
+            - configMapRef:
+                {{- if .name }}
+                name: {{ include "formbricks.tplvalues.render" (dict "value" $value.name "context" $) }}
+                {{- else if .nameSuffix }}
+                name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" (dict "value" $value.nameSuffix "context" $) }}
+                {{- else }}
+                name: {{ template "formbricks.name" $ }}
+                {{- end }}
+            {{- else if eq .type "secret" }}
+            - secretRef:
+                {{- if .name }}
+                name: {{ include "formbricks.tplvalues.render" (dict "value" $value.name "context" $) }}
+                {{- else if .nameSuffix }}
+                name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" (dict "value" $value.nameSuffix "context" $) }}
+                {{- else }}
+                name: {{ template "formbricks.name" $ }}
+                {{- end }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          env:
+            {{- if hasKey .Values.deployment.env "DATABASE_URL" }}
+            {{- include "formbricks.envVar" (dict "name" "DATABASE_URL" "value" (index .Values.deployment.env "DATABASE_URL") "context" $) | nindent 12 }}
+            {{- end }}
+            {{- if hasKey .Values.deployment.env "MIGRATE_DATABASE_URL" }}
+            {{- include "formbricks.envVar" (dict "name" "MIGRATE_DATABASE_URL" "value" (index .Values.deployment.env "MIGRATE_DATABASE_URL") "context" $) | nindent 12 }}
+            {{- end }}
+            - name: LOG_LEVEL
+              value: fatal
+            - name: CUBEJS_API_URL
+              value: http://localhost
+            - name: CUBEJS_API_SECRET
+              value: authzed-initialize-unused
+            - name: HUB_API_URL
+              value: http://localhost
+            - name: HUB_API_KEY
+              value: authzed-initialize-unused
+            - name: REDIS_URL
+              value: redis://localhost
+            - name: ENCRYPTION_KEY
+              value: authzed-initialize-unused
+            - name: AUTHZED_ENABLED
+              value: "true"
+            - name: AUTHZED_ENDPOINT
+              value: {{ include "formbricks.authzedEndpoint" . | quote }}
+            - name: AUTHZED_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "formbricks.authzedAuthSecretName" . }}
+                  key: {{ .Values.authzed.auth.tokenKey }}
+            - name: AUTHZED_SYSTEM_KEY
+              value: {{ .Values.authzed.systemKey | quote }}
+            - name: AUTHZED_INSECURE
+              value: {{ include "formbricks.authzedInsecure" . | quote }}
+            - name: AUTHZED_CONSISTENCY
+              value: fully_consistent
+{{- end }}

--- a/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
+++ b/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
@@ -58,6 +58,7 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
     argocd.argoproj.io/sync-wave: "-1"
     helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: {{ $bootstrap.backoffLimit }}

--- a/charts/formbricks/templates/authzed-validation.yaml
+++ b/charts/formbricks/templates/authzed-validation.yaml
@@ -1,9 +1,21 @@
+{{- if not .Values.authzed.enabled -}}
+{{- fail "Formbricks v6 requires AuthZed. Follow the v6 migration guide instead of upgrading with authzed.enabled=false" -}}
+{{- end -}}
+{{- if and .Release.IsUpgrade (not .Values.authzed.migrationAcknowledged) -}}
+{{- fail "AuthZed v6 upgrade preparation is not acknowledged. Complete formbricks-authzed upgrade prepare and upgrade check, then set authzed.migrationAcknowledged=true" -}}
+{{- end -}}
+{{- if ne .Values.authzed.consistency "fully_consistent" -}}
+{{- fail "Formbricks v6 requires authzed.consistency=fully_consistent" -}}
+{{- end -}}
 {{- if .Values.authzed.enabled -}}
 {{- if not (has .Values.authzed.mode (list "selfHosted" "external")) -}}
 {{- fail "authzed.mode must be one of: selfHosted, external" -}}
 {{- end -}}
 {{- if and (eq .Values.authzed.mode "external") (not .Values.authzed.auth.existingSecret) -}}
 {{- fail "authzed.auth.existingSecret is required when authzed.mode=external" -}}
+{{- end -}}
+{{- if and (eq .Values.authzed.mode "external") .Values.authzed.operator.install -}}
+{{- fail "Set authzed.operator.install=false when authzed.mode=external" -}}
 {{- end -}}
 {{- if and (ne .Values.authzed.insecure nil) (not (kindIs "bool" .Values.authzed.insecure)) -}}
 {{- fail "authzed.insecure must be true, false, or null" -}}

--- a/charts/formbricks/templates/deployment.yaml
+++ b/charts/formbricks/templates/deployment.yaml
@@ -8,13 +8,18 @@ metadata:
     {{- if .Values.deployment.additionalLabels }}
     {{- toYaml .Values.deployment.additionalLabels | nindent 4 }}
     {{- end }}
-  {{- if or .Values.deployment.annotations .Values.deployment.reloadOnChange }}
+  {{- if or .Values.deployment.annotations .Values.deployment.reloadOnChange .Values.authzed.enabled }}
   annotations:
     {{- if .Values.deployment.annotations }}
     {{- toYaml .Values.deployment.annotations | nindent 4 }}
     {{- end }}
   {{- if .Values.deployment.reloadOnChange }}
     reloader.stakater.com/auto: "true"
+  {{- end }}
+  {{- if and .Values.authzed.enabled (not (hasKey .Values.deployment.annotations "argocd.argoproj.io/sync-wave")) }}
+    # The release-matched AuthZed preparation runs at wave 1. This orders GitOps reconciliation without
+    # coupling the application process, startup, or probes to SpiceDB availability.
+    argocd.argoproj.io/sync-wave: "2"
   {{- end }}
   {{- end }}
 spec:

--- a/charts/formbricks/tests/authzed-operations.sh
+++ b/charts/formbricks/tests/authzed-operations.sh
@@ -55,7 +55,7 @@ assert_safe_authzed_notes() {
   fi
 }
 
-disabled_notes="$(render_notes authzed-disabled)"
+disabled_notes="$(render_notes authzed-disabled --set authzed.enabled=false)"
 if grep --fixed-strings "AuthZed / SpiceDB Operations:" <<<"${disabled_notes}" >/dev/null; then
   printf '%s\n' "AuthZed operations notes must be hidden when AuthZed is disabled." >&2
   exit 1
@@ -64,6 +64,7 @@ fi
 external_notes="$(render_notes authzed-external \
   --set authzed.enabled=true \
   --set authzed.mode=external \
+  --set authzed.operator.install=false \
   --set authzed.endpoint=grpc.authzed.com:443 \
   --set authzed.insecure=false \
   --set authzed.auth.existingSecret=formbricks-authzed)"
@@ -72,8 +73,40 @@ authzed_notes="$(authzed_operations_notes "${external_notes}")"
 grep --fixed-strings 'SpiceDB is configured in `external` mode.' <<<"${authzed_notes}" >/dev/null
 grep --fixed-strings 'formbricks-authzed health' <<<"${authzed_notes}" >/dev/null
 grep --fixed-strings 'formbricks-authzed schema check' <<<"${authzed_notes}" >/dev/null
+grep --fixed-strings 'formbricks-authzed upgrade prepare' <<<"${authzed_notes}" >/dev/null
+grep --fixed-strings 'formbricks-authzed upgrade check' <<<"${authzed_notes}" >/dev/null
 grep --fixed-strings 'self-hosting/advanced/authzed-operations' <<<"${authzed_notes}" >/dev/null
 assert_safe_authzed_notes authzed-external "${authzed_notes}"
+
+# AuthZed is the v6 authorization engine. Fresh installs render the initialization Job, while an
+# existing release must explicitly acknowledge the completed release-matched preparation.
+default_install="$(helm template authzed-default "${CHART_DIR}" "${COMMON_ARGS[@]}")"
+grep --fixed-strings 'name: formbricks-authzed-initialize' <<<"${default_install}" >/dev/null
+grep --fixed-strings 'helm.sh/hook-weight: "10"' <<<"${default_install}" >/dev/null
+grep --fixed-strings 'helm.sh/hook-weight: "-10"' <<<"${default_install}" >/dev/null
+grep --fixed-strings 'value: fully_consistent' <<<"${default_install}" >/dev/null
+
+if helm template authzed-disabled "${CHART_DIR}" "${COMMON_ARGS[@]}" \
+  --set authzed.enabled=false >/dev/null 2>&1; then
+  printf '%s\n' "Formbricks v6 must refuse a chart deployment with AuthZed disabled." >&2
+  exit 1
+fi
+
+if helm template authzed-upgrade "${CHART_DIR}" "${COMMON_ARGS[@]}" \
+  --is-upgrade >/dev/null 2>&1; then
+  printf '%s\n' "An existing Helm release must acknowledge the AuthZed v6 migration." >&2
+  exit 1
+fi
+
+acknowledged_upgrade="$(helm template authzed-upgrade "${CHART_DIR}" "${COMMON_ARGS[@]}" \
+  --is-upgrade \
+  --set global.postgresql.auth.password=test-password \
+  --set global.postgresql.auth.postgresPassword=test-password \
+  --set authzed.migrationAcknowledged=true)"
+if ! grep --fixed-strings 'helm.sh/hook: pre-upgrade' <<<"${acknowledged_upgrade}" >/dev/null; then
+  printf '%s\n' "An acknowledged Helm upgrade must run the release-matched AuthZed gate before rollout." >&2
+  exit 1
+fi
 
 # Render each supported ownership and datastore shape. These are intentionally render-only checks: none
 # of the operational commands are Helm hooks or automatically created Jobs.
@@ -122,6 +155,7 @@ assert_safe_authzed_notes authzed-managed-postgresql \
 helm template authzed-external "${CHART_DIR}" "${COMMON_ARGS[@]}" \
   --set authzed.enabled=true \
   --set authzed.mode=external \
+  --set authzed.operator.install=false \
   --set authzed.endpoint=grpc.authzed.com:443 \
   --set authzed.insecure=false \
   --set authzed.auth.existingSecret=formbricks-authzed >/dev/null

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -592,9 +592,12 @@ externalSecret:
 # AuthZed / SpiceDB Authorization Configuration
 ##########################################################
 authzed:
-  # Enables the Formbricks AuthZed runtime contract. Product authorization
-  # enforcement is introduced separately; this section owns deployment only.
-  enabled: false
+  # Formbricks v6 uses SpiceDB as its sole authorization decision engine.
+  enabled: true
+
+  # Existing releases must complete the documented schema/backfill/audit preparation before their
+  # first v6 Helm upgrade. Fresh installs do not need to set this value.
+  migrationAcknowledged: false
 
   # selfHosted creates a SpiceDBCluster. external only configures the app client.
   mode: selfHosted
@@ -609,7 +612,7 @@ authzed:
   # selfHosted service and TLS for external endpoints. Set true explicitly only
   # when an external endpoint intentionally accepts plaintext gRPC.
   insecure: null
-  consistency: minimize_latency
+  consistency: fully_consistent
 
   auth:
     # Secret must contain tokenKey. When empty in selfHosted mode, the chart
@@ -690,7 +693,8 @@ authzed:
   # Install one operator per cluster. Disable this when a shared operator
   # already watches the Formbricks namespace (the Formbricks Cloud topology).
   operator:
-    install: false
+    # Set false when a compatible cluster-wide operator already watches this namespace.
+    install: true
 
 # Values passed to the bundled spicedb-operator dependency when
 # authzed.operator.install=true.

--- a/docker/README.md
+++ b/docker/README.md
@@ -99,18 +99,24 @@ docker compose --profile authzed-ops run --rm authzed-ops schema apply \
 
 # Relationship audit (dry run)
 docker compose --profile authzed-ops run --rm authzed-ops backfill
+
+# Release-matched v6 readiness gate
+docker compose --profile authzed-ops run --rm authzed-ops upgrade prepare
+docker compose --profile authzed-ops run --rm authzed-ops upgrade check
 ```
 
 The first apply to an empty SpiceDB needs no additional argument. Replacing a non-empty schema requires
 `--expected-current-digest sha256:<digest-from-check>`. The command verifies the write by reading and comparing
-the schema again. It is never invoked by `docker compose up`, Formbricks startup, or `/health`. See
+the schema again. Fresh installs run the idempotent `authzed-initialize` service independently; Formbricks
+startup and `/health` do not depend on it. Existing upgrades require the explicit preparation and read-only gate. See
 the [public operations guide](../docs/self-hosting/advanced/authzed-operations.mdx) for the JSON contract, exit
 codes, backup requirements, repair, and rollback rules. Repository development retains the equivalent
 `pnpm authzed:*` commands.
 
 `AUTHZED_ENABLED` and `AUTHZED_INSECURE` accept `true`, `false`, `1`, and `0`. Unset means disabled and secure
 TLS, respectively. `AUTHZED_ENDPOINT` is a bare `host:port` (including bracketed IPv6) with no scheme or path;
-`AUTHZED_CONSISTENCY` accepts `minimize_latency` (the default) or `fully_consistent`.
+`AUTHZED_CONSISTENCY` accepts both client values, but released v6 Compose deployments require and default to
+`fully_consistent`.
 
 To use the optional authenticated grpcui browser in development:
 
@@ -120,9 +126,10 @@ docker compose -f docker-compose.dev.yml --profile authzed-ui up -d authzed-ui
 
 Open `http://127.0.0.1:50052`. The browser UI and gRPC port are development-only.
 
-Existing one-click installations keep their customized Compose file during `formbricks.sh update`. Add the
-three AuthZed services and two generated secrets manually from the release-matched Compose file; back up the
-shared PostgreSQL volume first and never use `docker compose down -v` during migration or rollback.
+Existing one-click installations keep their customized Compose file during `formbricks.sh update`. Merge all
+release-matched AuthZed services and the two generated secrets manually, pass `upgrade prepare` and `upgrade
+check`, and only then set `FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true`. Back up both databases first and
+never use `docker compose down -v` during migration or rollback.
 
 The bundled PostgreSQL service keeps `track_commit_timestamp` at its default `off` value. SpiceDB therefore
 logs that its Watch API is disabled; schema, relationship, and permission-check APIs are unaffected. A future

--- a/docker/__tests__/formbricks-script.test.ts
+++ b/docker/__tests__/formbricks-script.test.ts
@@ -109,7 +109,39 @@ describe("docker/formbricks.sh AuthZed setup", () => {
     expect(output).not.toContain(authzedDatabasePassword);
     expect(env.get("AUTHZED_TOKEN")).toBe(authzedToken);
     expect(env.get("AUTHZED_DATABASE_PASSWORD")).toBe(authzedDatabasePassword);
+    expect(env.get("AUTHZED_ENABLED")).toBe("true");
+    expect(env.get("AUTHZED_CONSISTENCY")).toBe("fully_consistent");
+    expect(env.get("FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED")).toBe("true");
     expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  test("blocks customized updates until the AuthZed v6 contract is present and acknowledged", () => {
+    const script = readFileSync(formbricksScriptPath, "utf8");
+    const updateFunction = script.slice(
+      script.indexOf("update_formbricks()"),
+      script.indexOf("restart_formbricks()")
+    );
+
+    expect(updateFunction).toContain(
+      "This installation does not yet contain the AuthZed v6 Compose services"
+    );
+    expect(updateFunction).toContain("FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true");
+    expect(updateFunction).toContain("authzed-ops upgrade prepare");
+    expect(updateFunction).toContain("authzed-ops upgrade check");
+    expect(updateFunction.indexOf("upgrade check")).toBeLessThan(updateFunction.indexOf("compose down"));
+  });
+
+  test("waits for the source migration before preparing a fresh AuthZed graph", () => {
+    const script = readFileSync(formbricksScriptPath, "utf8");
+    const setupStart = script.indexOf(
+      "docker compose up -d postgres authzed-db-bootstrap spicedb-migrate spicedb formbricks-migrate"
+    );
+    const migrationWait = script.indexOf("docker compose wait formbricks-migrate", setupStart);
+    const upgradePrepare = script.indexOf("authzed-ops upgrade prepare", setupStart);
+
+    expect(setupStart).toBeGreaterThanOrEqual(0);
+    expect(migrationWait).toBeGreaterThan(setupStart);
+    expect(upgradePrepare).toBeGreaterThan(migrationWait);
   });
 
   test("pins and verifies the downloaded bootstrap helper before making it executable", () => {
@@ -143,6 +175,7 @@ describe("docker/formbricks.sh Traefik label injection", () => {
     const formbricksBlock = getServiceBlock(composeContents, "formbricks");
     const authzedBootstrapBlock = getServiceBlock(composeContents, "authzed-db-bootstrap");
     const authzedOpsBlock = getServiceBlock(composeContents, "authzed-ops");
+    const authzedInitializeBlock = getServiceBlock(composeContents, "authzed-initialize");
     const spicedbBlock = getServiceBlock(composeContents, "spicedb");
 
     expect(formbricksMigrateBlock).not.toContain("    labels:");
@@ -153,6 +186,8 @@ describe("docker/formbricks.sh Traefik label injection", () => {
     expect(spicedbBlock).not.toContain("traefik.enable=true");
     expect(authzedOpsBlock).toContain('profiles: ["authzed-ops"]');
     expect(authzedOpsBlock).not.toContain("traefik.enable=true");
+    expect(authzedInitializeBlock).toContain('command: ["upgrade", "prepare"]');
+    expect(authzedInitializeBlock).not.toContain("traefik.enable=true");
     expect(formbricksBlock).toContain("    labels:");
     expect(formbricksBlock.indexOf("    labels:")).toBeLessThan(formbricksBlock.indexOf("    environment:"));
     expect(formbricksBlock).toContain("traefik.http.routers.formbricks.rule=Host(`example.com`)");

--- a/docker/authzed-compose-contract.sh
+++ b/docker/authzed-compose-contract.sh
@@ -45,7 +45,7 @@ jq --exit-status --arg token "${AUTHZED_TOKEN}" '
   .services.formbricks.environment.AUTHZED_TOKEN == $token and
   .services.formbricks.environment.AUTHZED_SYSTEM_KEY == "formbricks" and
   .services.formbricks.environment.AUTHZED_INSECURE == "true" and
-  .services.formbricks.environment.AUTHZED_CONSISTENCY == "minimize_latency" and
+  .services.formbricks.environment.AUTHZED_CONSISTENCY == "fully_consistent" and
   .services.formbricks.depends_on.spicedb? == null and
   .services["authzed-ops"].image == .services.formbricks.image and
   .services["authzed-ops"].profiles == ["authzed-ops"] and
@@ -54,10 +54,19 @@ jq --exit-status --arg token "${AUTHZED_TOKEN}" '
   .services["authzed-ops"].depends_on.postgres.condition == "service_healthy" and
   .services["authzed-ops"].depends_on.spicedb.condition == "service_healthy" and
   .services["authzed-ops"].environment.DATABASE_URL == .services.formbricks.environment.DATABASE_URL and
+  .services["authzed-ops"].environment.AUTHZED_CONSISTENCY == "fully_consistent" and
+  .services["authzed-initialize"].image == .services.formbricks.image and
+  .services["authzed-initialize"].entrypoint == ["formbricks-authzed"] and
+  .services["authzed-initialize"].command == ["upgrade", "prepare"] and
+  .services["authzed-initialize"].restart == "no" and
+  .services["authzed-initialize"].depends_on["formbricks-migrate"].condition == "service_completed_successfully" and
+  .services["authzed-initialize"].depends_on.spicedb.condition == "service_healthy" and
+  (.services["authzed-initialize"] | has("ports") | not) and
+  (.services["authzed-initialize"] | has("volumes") | not) and
   (.services["authzed-ops"] | has("ports") | not) and
   (.services["authzed-ops"] | has("volumes") | not) and
   (.services["authzed-ops"] | has("restart") | not) and
-  ([.services | to_entries[] | select(.value.environment.AUTHZED_TOKEN? != null) | .key] | sort) == ["authzed-ops", "formbricks"]
+  ([.services | to_entries[] | select(.value.environment.AUTHZED_TOKEN? != null) | .key] | sort) == ["authzed-initialize", "authzed-ops", "formbricks"]
 ' "${temp_dir}/production.json" >/dev/null
 
 if grep --fixed-strings --line-regexp "authzed-ops" "${temp_dir}/production-services.txt" >/dev/null; then

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -362,7 +362,7 @@ services:
       AUTHZED_TOKEN: ${AUTHZED_TOKEN:?AUTHZED_TOKEN is required}
       AUTHZED_SYSTEM_KEY: ${AUTHZED_SYSTEM_KEY:-formbricks}
       AUTHZED_INSECURE: ${AUTHZED_INSECURE:-true}
-      AUTHZED_CONSISTENCY: ${AUTHZED_CONSISTENCY:-minimize_latency}
+      AUTHZED_CONSISTENCY: ${AUTHZED_CONSISTENCY:-fully_consistent}
 
   # Opt-in AuthZed health, schema, and relationship-repair commands. This profile never starts with
   # the normal stack. Example: docker compose --profile authzed-ops run --rm authzed-ops health
@@ -387,10 +387,39 @@ services:
       AUTHZED_TOKEN: ${AUTHZED_TOKEN:?AUTHZED_TOKEN is required}
       AUTHZED_SYSTEM_KEY: ${AUTHZED_SYSTEM_KEY:-formbricks}
       AUTHZED_INSECURE: ${AUTHZED_INSECURE:-true}
-      AUTHZED_CONSISTENCY: ${AUTHZED_CONSISTENCY:-minimize_latency}
+      AUTHZED_CONSISTENCY: ${AUTHZED_CONSISTENCY:-fully_consistent}
     depends_on:
       postgres:
         condition: service_healthy
+      spicedb:
+        condition: service_healthy
+
+  # Idempotently prepares a fresh authorization datastore without making Formbricks startup, health,
+  # readiness, or liveness depend on SpiceDB. Existing installations are gated by formbricks.sh and
+  # the explicit v6 migration acknowledgement before this release is started.
+  authzed-initialize:
+    image: ghcr.io/formbricks/formbricks:latest
+    restart: "no"
+    entrypoint: ["formbricks-authzed"]
+    command: ["upgrade", "prepare"]
+    environment:
+      <<: *formbricks-database
+      ENCRYPTION_KEY: authzed-initialize-unused
+      CUBEJS_API_SECRET: authzed-initialize-unused
+      CUBEJS_API_URL: http://localhost
+      HUB_API_KEY: authzed-initialize-unused
+      HUB_API_URL: http://localhost
+      REDIS_URL: redis://localhost
+      LOG_LEVEL: fatal
+      AUTHZED_ENABLED: ${AUTHZED_ENABLED:-true}
+      AUTHZED_ENDPOINT: ${AUTHZED_ENDPOINT:-spicedb:50051}
+      AUTHZED_TOKEN: ${AUTHZED_TOKEN:?AUTHZED_TOKEN is required}
+      AUTHZED_SYSTEM_KEY: ${AUTHZED_SYSTEM_KEY:-formbricks}
+      AUTHZED_INSECURE: ${AUTHZED_INSECURE:-true}
+      AUTHZED_CONSISTENCY: ${AUTHZED_CONSISTENCY:-fully_consistent}
+    depends_on:
+      formbricks-migrate:
+        condition: service_completed_successfully
       spicedb:
         condition: service_healthy
 

--- a/docker/formbricks.sh
+++ b/docker/formbricks.sh
@@ -178,6 +178,9 @@ write_base_env_file() {
   upsert_dotenv_var "CUBEJS_JWT_AUDIENCE" "formbricks-cube" "$env_file"
   upsert_dotenv_var "AUTHZED_TOKEN" "$authzed_token" "$env_file"
   upsert_dotenv_var "AUTHZED_DATABASE_PASSWORD" "$authzed_database_password" "$env_file"
+  upsert_dotenv_var "AUTHZED_ENABLED" "true" "$env_file"
+  upsert_dotenv_var "AUTHZED_CONSISTENCY" "fully_consistent" "$env_file"
+  upsert_dotenv_var "FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED" "true" "$env_file"
   chmod 600 "$env_file"
 }
 
@@ -957,6 +960,11 @@ EOF
 
   newgrp docker <<END
 
+set -e
+docker compose up -d postgres authzed-db-bootstrap spicedb-migrate spicedb formbricks-migrate
+docker compose wait formbricks-migrate
+docker compose --profile authzed-ops run --rm authzed-ops upgrade prepare
+docker compose --profile authzed-ops run --rm authzed-ops upgrade check
 docker compose up -d
 
 echo "🔗 To edit more variables and deeper config, go to the formbricks/docker-compose.yml, edit the file, and restart the container!"
@@ -1002,7 +1010,28 @@ stop_formbricks() {
 update_formbricks() {
   echo "🔄 Updating Formbricks..."
   cd formbricks
+
+  if ! grep -Eq '^  authzed-ops:$' docker-compose.yml || ! grep -Eq '^  spicedb:$' docker-compose.yml; then
+    echo "❌ This installation does not yet contain the AuthZed v6 Compose services."
+    echo "Your customized Compose file was not changed. Follow the v6 AuthZed migration guide before updating:"
+    echo "https://formbricks.com/docs/self-hosting/advanced/authzed-operations#upgrade-an-existing-installation-to-v6"
+    exit 1
+  fi
+
+  if ! grep -Eq '^FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true$' .env; then
+    echo "❌ The AuthZed v6 migration has not been acknowledged for this installation."
+    echo "Back up PostgreSQL, add the documented AuthZed services and secrets, then run the upgrade preparation."
+    echo "After its final check is clean, set FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true in .env and retry."
+    echo "https://formbricks.com/docs/self-hosting/advanced/authzed-operations#upgrade-an-existing-installation-to-v6"
+    exit 1
+  fi
+
   sudo docker compose pull
+  # The outbox migration is backward compatible with the still-running v5 application. Apply it before
+  # the release-matched operator checks so the old deployment stays available if preparation blocks.
+  sudo docker compose run --rm formbricks-migrate
+  sudo docker compose --profile authzed-ops run --rm authzed-ops upgrade prepare
+  sudo docker compose --profile authzed-ops run --rm authzed-ops upgrade check
   sudo docker compose down
   sudo docker compose up -d
   echo "🎉 Formbricks updated successfully!"

--- a/docs/self-hosting/advanced/authzed-operations.mdx
+++ b/docs/self-hosting/advanced/authzed-operations.mdx
@@ -9,10 +9,10 @@ authorization. PostgreSQL remains the source of truth. Formbricks projects membe
 API-key changes into SpiceDB after their PostgreSQL transaction commits.
 
 <Note>
-  Current v5 releases use AuthZed as a rebuildable projection while the legacy evaluator remains available. The
-  planned v6 authorization upgrade makes SpiceDB the sole decision engine, uses durable outbox delivery, and has
-  no runtime legacy fallback. Existing installations must complete the release-matched migration preflight before
-  upgrading; do not infer v6 readiness from a healthy v5 connection alone.
+  Formbricks v6 makes SpiceDB the sole authorization decision engine and has no runtime legacy fallback.
+  PostgreSQL remains the relationship source of truth, with durable outbox delivery into SpiceDB. Existing
+  installations must complete the release-matched preparation and read-only gate before upgrading; a healthy
+  connection alone is not sufficient.
 </Note>
 
 <Warning>
@@ -30,14 +30,10 @@ API-key changes into SpiceDB after their PostgreSQL transaction commits.
 | Formbricks projection layer  | Copies committed PostgreSQL authorization changes into SpiceDB                  |
 | AuthZed operator commands    | Check health and schema state, then audit or repair relationship drift          |
 
-In current v5 bridge releases, projection is synchronous but best-effort: Formbricks waits for an attempted
-projection, but a projection failure never changes the result of an already committed PostgreSQL mutation. A
-SpiceDB outage can therefore leave the graph behind PostgreSQL. Run a relationship audit after recovery.
-
-The v6 direct-authority release adds a PostgreSQL transactional outbox, bounded revocation freshness, automatic
-scheduled audit, and fail-closed authorization. Its migration preflight requires a drained outbox and clean graph
-before the application can rely on SpiceDB decisions. The detailed v6 commands remain release-specific until the
-upgrade implementation ships.
+Formbricks writes projection intent in the same PostgreSQL transaction as the source mutation. BullMQ wakes the
+delivery worker, but PostgreSQL is the durable queue. A failed delivery is retried idempotently and a stale or
+dead-lettered revocation makes protected operations fail closed. A six-hour audit repairs attributable missing
+or mismatched edges; operators must investigate state that cannot be repaired safely.
 
 The general Formbricks `/health` endpoint, application startup, and Kubernetes readiness and liveness probes
 do not depend on SpiceDB. This prevents a SpiceDB outage from restarting unrelated Formbricks workloads. It
@@ -49,12 +45,12 @@ There is no browser health or administration page. Use the release-matched opera
 
 | Variable                    | Purpose                                                             | Default                                             |
 | --------------------------- | ------------------------------------------------------------------- | --------------------------------------------------- |
-| `AUTHZED_ENABLED`           | Enables the AuthZed client and relationship projection              | `true` in bundled Docker, `false` in Helm           |
+| `AUTHZED_ENABLED`           | Enables the required AuthZed authorization engine                    | `true` in bundled Docker and Helm                    |
 | `AUTHZED_ENDPOINT`          | Bare gRPC `host:port` endpoint                                      | `spicedb:50051` in Docker                           |
 | `AUTHZED_TOKEN`             | SpiceDB preshared authentication token                              | No default                                          |
 | `AUTHZED_SYSTEM_KEY`        | Stable Formbricks authorization namespace identifier                | `formbricks`                                        |
 | `AUTHZED_INSECURE`          | Uses plaintext gRPC when enabled                                    | `true` for bundled Docker and chart-managed SpiceDB |
-| `AUTHZED_CONSISTENCY`       | Default read consistency                                            | `minimize_latency`                                  |
+| `AUTHZED_CONSISTENCY`       | Authorization read consistency                                      | `fully_consistent`                                  |
 | `AUTHZED_DATABASE_PASSWORD` | Password for Docker's dedicated `spicedb` PostgreSQL role           | No default                                          |
 | `SPICEDB_IMAGE_REF`         | Reviewed override used by both Docker migration and server services | `authzed/spicedb:v1.52.0`                           |
 
@@ -86,25 +82,28 @@ bundled PostgreSQL container. Startup is ordered as follows:
 
 ```text
 postgres → authzed-db-bootstrap → spicedb-migrate → spicedb
+        ↘ formbricks-migrate ───────────────↗ authzed-initialize
 ```
 
 Database bootstrap and datastore migration are idempotent. Migration and serving always use the same
 `SPICEDB_IMAGE_REF`. SpiceDB is reachable only as `spicedb:50051` inside the Compose network.
 
-The `authzed-ops` profile is a short-lived operator container. It uses the same Formbricks image as the
-application and does not start during a normal `docker compose up`.
+`authzed-initialize` is an idempotent, one-shot service that prepares fresh installations. Formbricks does not
+depend on it, so application startup and `/health` remain independent from SpiceDB. The `authzed-ops` profile is
+a short-lived operator container using the same release image and never starts during a normal Compose run.
 
 ```bash
 docker compose --profile authzed-ops run --rm authzed-ops health
 docker compose --profile authzed-ops run --rm authzed-ops schema check
 docker compose --profile authzed-ops run --rm authzed-ops backfill
+docker compose --profile authzed-ops run --rm authzed-ops upgrade check
 ```
 
-Fresh one-click installations generate `AUTHZED_TOKEN` and `AUTHZED_DATABASE_PASSWORD` without printing them.
-The update command preserves customized Compose files, so an older installation must merge the released
-AuthZed services, environment, bootstrap helper, and `authzed-ops` profile manually. Follow the
-[Docker migration steps](/self-hosting/setup/docker#add-spicedb-to-an-existing-docker-installation) before
-starting a release that depends on SpiceDB.
+Fresh one-click installations generate `AUTHZED_TOKEN` and `AUTHZED_DATABASE_PASSWORD`, prepare the graph, and
+run the read-only gate before reporting success. The update command preserves customized Compose files. An older
+installation must merge the released AuthZed services and environment manually, then explicitly acknowledge the
+v6 migration. The updater refuses to stop the existing application until `upgrade prepare` and `upgrade check`
+succeed.
 
 <Warning>
   `docker compose down` preserves PostgreSQL data. `docker compose down -v` deletes the volume containing both
@@ -125,7 +124,6 @@ For a chart-managed cluster:
 
 ```yaml
 authzed:
-  enabled: true
   mode: selfHosted
   operator:
     install: true
@@ -195,14 +193,18 @@ For an external AuthZed endpoint:
 authzed:
   enabled: true
   mode: external
+  operator:
+    install: false
   endpoint: grpc.authzed.com:443
   insecure: false
   auth:
     existingSecret: formbricks-authzed
 ```
 
-The operator runs SpiceDB datastore migrations. The Formbricks chart deliberately does not install the
-Formbricks authorization schema and does not run relationship repair as a Helm hook.
+AuthZed and `fully_consistent` authorization are enabled by default. The operator runs SpiceDB datastore
+migrations. A fresh Helm installation runs a release-matched, aggregate-only initialization Job after the
+datastore and Formbricks migrations become available. Application startup and probes do not depend on this Job.
+Existing releases never run it as an upgrade hook; they must use the explicit upgrade commands below.
 
 The release notes print the exact deployment command. With the default release:
 
@@ -210,10 +212,44 @@ The release notes print the exact deployment command. With the default release:
 kubectl exec -n formbricks deployment/formbricks -- formbricks-authzed health
 kubectl exec -n formbricks deployment/formbricks -- formbricks-authzed schema check
 kubectl exec -n formbricks deployment/formbricks -- formbricks-authzed backfill
+kubectl exec -n formbricks deployment/formbricks -- formbricks-authzed upgrade check
 ```
 
 Replace the namespace and deployment name if you override them. These commands execute inside the existing
 application pod and do not require exposing PostgreSQL or SpiceDB.
+
+## Upgrade an existing installation to v6
+
+Formbricks v6 has no legacy authorization fallback. Do not deploy it over an installation whose graph has not
+been proven complete. First upgrade to the bridge-compatible v5 release named in the v6 release notes, enable
+durable projection, and take coordinated Formbricks and SpiceDB backups.
+
+Run the release-matched v6 image as the operator container or executable while the bridge release still serves
+traffic:
+
+```bash
+formbricks-authzed upgrade prepare
+formbricks-authzed upgrade check
+```
+
+`prepare` verifies configuration and datastore readiness, applies an empty or already-matching canonical schema,
+drains the outbox, reconciles attributable relationships, and runs a final audit. If the remote schema is
+non-empty and differs, first run `schema check`, review the diff and backup, then pass its exact `remoteDigest`:
+
+```bash
+formbricks-authzed upgrade prepare \
+  --expected-current-digest sha256:<reviewed-remote-digest>
+```
+
+`check` is read-only. It exits `0` only when AuthZed is enabled with `fully_consistent`, authenticated health is
+good, the canonical schema matches, the outbox has no pending or dead-lettered work, no revocation has crossed a
+warning threshold, and a complete dry-run relationship audit is clean. Exit `2` means the release remains
+blocked; exit `1` means configuration or an operation failed. Output contains only aggregate counters and stable
+error codes.
+
+For one-click, set `FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true` in `.env` only after those commands pass.
+For Helm, set `authzed.migrationAcknowledged=true` only in the v6 upgrade values. The chart refuses an upgrade
+without it and refuses `authzed.enabled=false` or consistency weaker than `fully_consistent`.
 
 ## Activate or upgrade SpiceDB
 
@@ -270,6 +306,15 @@ Use the following sequence for a new deployment, schema change, SpiceDB version 
     Require a clean result before relying on SpiceDB authorization decisions.
 
   </Step>
+  <Step title="Run the release gate">
+
+    ```bash
+    formbricks-authzed upgrade check
+    ```
+
+    Do not start a direct-authority release unless this exits `0`.
+
+  </Step>
   <Step title="Restart and observe">
     Restart Formbricks after environment changes. Recheck AuthZed health, schema status, projection metrics,
     retry metrics, and SpiceDB logs.
@@ -278,6 +323,17 @@ Use the following sequence for a new deployment, schema change, SpiceDB version 
 
 The Docker examples use the `docker compose --profile authzed-ops run --rm authzed-ops` prefix. Kubernetes
 examples use `kubectl exec ... --`. The command names and arguments after those prefixes are identical.
+
+### Roll back a v6 upgrade
+
+Keep the exact bridge-compatible v5 image, Compose or Helm values, application database backup, SpiceDB backup,
+and schema digest until v6 acceptance is complete. Rollback means restoring that bridge image and its matching
+configuration; do not disable AuthZed inside a v6 image. Verify outbox delivery and a clean audit before resuming
+mutations. If either datastore was restored, use coordinated restore points or rebuild SpiceDB from PostgreSQL.
+
+The moving `latest` tag remains on the bridge-compatible v5 release for at least 30 days after v6 stable is
+published. Existing installations must select v6 explicitly during that window; this prevents an unattended
+image pull from bypassing the migration gate.
 
 ## Back up and restore
 

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -4,6 +4,32 @@ description: "Formbricks Self-hosted version migration"
 icon: "arrow-right"
 ---
 
+## v6
+
+Formbricks v6 replaces the legacy authorization evaluator with AuthZed SpiceDB. PostgreSQL remains the source
+of roles and grants, but SpiceDB is the sole decision engine. There is no runtime fallback, so an existing
+installation must migrate through the bridge-compatible v5 release identified in the v6 release notes.
+
+Before selecting a v6 image:
+
+1. Back up the Formbricks and SpiceDB PostgreSQL databases, secrets, deployment configuration, image versions,
+   and canonical schema digest.
+2. Merge the release-matched AuthZed deployment services or Helm values without overwriting proxy, storage,
+   SMTP, or external-datastore customization.
+3. Run the v6 database migrations while the bridge application remains available.
+4. Run `formbricks-authzed upgrade prepare`, then require `formbricks-authzed upgrade check` to exit `0`.
+5. For one-click or Compose, set `FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true`. For Helm, set
+   `authzed.migrationAcknowledged=true` in the v6 upgrade values.
+6. Deploy v6 and verify critical allow, deny, revocation, and cross-tenant cases.
+
+The update scripts and chart fail before replacing the running release when the deployment contract,
+acknowledgement, schema, outbox, or relationship graph is not ready. Do not bypass the acknowledgement to silence
+a failed gate. See [AuthZed Operations](/self-hosting/advanced/authzed-operations#upgrade-an-existing-installation-to-v6)
+for Docker and Kubernetes commands, guarded schema replacement, backups, repair, and rollback.
+
+The moving `latest` image tag remains on the bridge-compatible v5 release for at least 30 days after v6 stable
+publication. Existing installations opt into v6 explicitly during that migration window.
+
 ## v5.4
 
 v5.4 carries one breaking change, and it is narrow: it affects **API keys** used against the Feedback

--- a/docs/self-hosting/configuration/environment-variables.mdx
+++ b/docs/self-hosting/configuration/environment-variables.mdx
@@ -153,17 +153,18 @@ bundled Docker Compose or Helm assets, the following variables apply:
 
 #### AuthZed / SpiceDB Authorization
 
-These variables define the supported authorization-client contract. The Helm chart injects them when
-`authzed.enabled=true`; the bundled Docker and development Compose stacks enable them by default.
+These variables define the supported authorization-client contract. Formbricks v6 enables AuthZed by default
+for fresh Docker, one-click, and Helm installations. Existing installations must pass the release-matched
+upgrade gate before enabling the v6 application image.
 
 | Variable            | Description                                                                                                      | Required when enabled | Default            |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------- | ------------------ |
-| AUTHZED_ENABLED     | Enables the supported AuthZed authorization client path.                                                         | required              | `false` in Helm; `true` in bundled Docker/dev |
+| AUTHZED_ENABLED     | Enables the required AuthZed authorization engine.                                                              | required              | `true` in bundled Docker, Helm, and dev |
 | AUTHZED_ENDPOINT    | AuthZed gRPC endpoint as `host:port`. The default Helm-managed service is `formbricks-spicedb:50051`.             | required              | `spicedb:50051` in Docker; `localhost:50051` in dev |
 | AUTHZED_TOKEN       | Preshared API token. Always load this from a secret.                                                             | required              |                    |
 | AUTHZED_SYSTEM_KEY  | Stable namespace for Formbricks authorization objects and relationships.                                         | required              | `formbricks`       |
 | AUTHZED_INSECURE    | Allows plaintext gRPC for an in-cluster service. Keep disabled for endpoints outside the trusted cluster network. | optional              | `true` in Helm and bundled Docker/dev |
-| AUTHZED_CONSISTENCY | Default consistency policy used by the application client.                                                       | optional              | `minimize_latency` |
+| AUTHZED_CONSISTENCY | Consistency policy used by authorization decisions.                                                            | optional              | `fully_consistent` in released Docker and Helm |
 
 Docker Compose additionally requires `AUTHZED_DATABASE_PASSWORD` for its dedicated `spicedb` PostgreSQL
 login. Generate both it and `AUTHZED_TOKEN` with `openssl rand -hex 32`. `SPICEDB_IMAGE_REF` can override the
@@ -176,7 +177,8 @@ be a bare `host:port` with an explicit port from 1 through 65535, for example `s
 `grpc.authzed.com:443`, or `[::1]:50051`. Do not include a URL scheme, path, query, credentials, or whitespace.
 `AUTHZED_SYSTEM_KEY` must be a 3–64 character lowercase SpiceDB identifier made from letters, digits, and
 underscores; it must start with a letter or underscore and end with a letter or digit. The supported
-consistency values are `minimize_latency` and `fully_consistent`; the default is `minimize_latency`.
+consistency values are `minimize_latency` and `fully_consistent`. Released v6 Docker and Helm deployments
+require `fully_consistent`; the upgrade gate rejects weaker consistency.
 
 Valid endpoint, token, and system-key values may be set before enabling AuthZed. Invalid supplied values are
 rejected even while it is disabled. Changing any AuthZed setting requires restarting the Formbricks process.
@@ -187,6 +189,7 @@ data:
 
 ```bash
 docker compose --profile authzed-ops run --rm authzed-ops health
+docker compose --profile authzed-ops run --rm authzed-ops upgrade check
 ```
 
 For Helm, run `formbricks-authzed health` inside a Formbricks application pod. Repository development can keep
@@ -208,10 +211,10 @@ This check is intentionally a CLI rather than a browser page or HTTP endpoint. A
 general `/health` response, Kubernetes readiness, or application startup, so a transient SpiceDB outage does
 not restart or mark the rest of Formbricks unhealthy.
 
-In the v6 direct-authority release, failed or unavailable permission checks fail the protected operation closed;
-there is no runtime fallback to legacy authorization. Existing installations must complete the release-matched
-AuthZed migration preflight before upgrading. Do not make the general application readiness probe depend on
-AuthZed availability; this avoids a transient authorization outage restarting unrelated Formbricks workloads.
+Failed or unavailable permission checks fail the protected operation closed; there is no runtime fallback to
+legacy authorization. Existing installations must complete `formbricks-authzed upgrade prepare` followed by
+`upgrade check` before upgrading. The general application readiness probe remains independent from AuthZed so a
+transient authorization outage does not restart unrelated Formbricks workloads.
 
 #### Cube Analytics
 

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -144,9 +144,10 @@ Docker and Docker Compose are usually included in tools like Docker Desktop and 
 ## AuthZed and SpiceDB
 
 The bundled SpiceDB service stores its data in a dedicated `spicedb` database and login inside the existing
-PostgreSQL container. The bootstrap and datastore migration containers run on every `docker compose up` and
-are idempotent. SpiceDB is reachable only inside the Compose network at `spicedb:50051`; it is not published
-on the host or routed through Traefik.
+PostgreSQL container. Database bootstrap, datastore migration, and the release-matched `authzed-initialize`
+service are idempotent. Fresh installs apply the canonical schema and verify an empty or reconciled graph
+without making Formbricks startup or `/health` depend on SpiceDB. SpiceDB is reachable only inside the Compose
+network at `spicedb:50051`; it is not published on the host or routed through Traefik.
 
 The Formbricks container receives the supported AuthZed variables automatically. Keep `AUTHZED_TOKEN` and
 `AUTHZED_DATABASE_PASSWORD` private and include `.env` and the PostgreSQL volume in your backup plan. Running
@@ -158,6 +159,7 @@ The release image includes an opt-in operations CLI. It does not start during no
 docker compose --profile authzed-ops run --rm authzed-ops health
 docker compose --profile authzed-ops run --rm authzed-ops schema check
 docker compose --profile authzed-ops run --rm authzed-ops backfill
+docker compose --profile authzed-ops run --rm authzed-ops upgrade check
 ```
 
 See [AuthZed Operations](/self-hosting/advanced/authzed-operations) before applying a schema, repairing
@@ -351,19 +353,32 @@ first release that requires the AuthZed runtime:
 1. Back up `.env`, `docker-compose.yml`, and the PostgreSQL volume.
 2. Download `authzed-postgres-bootstrap.sh` from the same Formbricks release as the Compose file.
 3. Generate `AUTHZED_TOKEN` and `AUTHZED_DATABASE_PASSWORD` with `openssl rand -hex 32` and add them to `.env`.
-4. Merge `authzed-db-bootstrap`, `spicedb-migrate`, `spicedb`, and the profiled `authzed-ops` service, plus the
-   six `AUTHZED_*` Formbricks variables, from the released Compose file into your customized file. Preserve your
-   existing proxy, storage, and SMTP settings.
-5. Run `docker compose config`, followed by `docker compose pull` and `docker compose up -d`.
-6. Confirm both one-shot AuthZed services completed and `spicedb` is healthy with `docker compose ps -a`.
-7. Run the release-matched health, schema, and dry-run audit commands from the
-   [AuthZed Operations guide](/self-hosting/advanced/authzed-operations).
-8. Back up the new authorization database with
+4. Merge `authzed-db-bootstrap`, `spicedb-migrate`, `spicedb`, `authzed-initialize`, and the profiled
+   `authzed-ops` service, plus the six `AUTHZED_*` Formbricks variables, from the released Compose file into your
+   customized file. Use `AUTHZED_CONSISTENCY=fully_consistent`. Preserve proxy, storage, and SMTP settings.
+5. Run `docker compose config` and `docker compose pull`. Apply the release's Formbricks database migrations
+   while the old application remains available: `docker compose run --rm formbricks-migrate`.
+6. Start PostgreSQL and SpiceDB, then run the guarded preparation and read-only gate:
+
+   ```bash
+   docker compose up -d postgres authzed-db-bootstrap spicedb-migrate spicedb
+   docker compose --profile authzed-ops run --rm authzed-ops upgrade prepare
+   docker compose --profile authzed-ops run --rm authzed-ops upgrade check
+   ```
+
+   A non-empty mismatched schema requires the reviewed `remoteDigest` as described in
+   [AuthZed Operations](/self-hosting/advanced/authzed-operations#upgrade-an-existing-installation-to-v6).
+7. Only after `upgrade check` exits `0`, set `FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true` in `.env` and
+   run `docker compose up -d`. The one-click updater performs the same preparation before it stops the old app.
+8. Confirm `authzed-db-bootstrap`, `spicedb-migrate`, and `authzed-initialize` completed and `spicedb` is healthy
+   with `docker compose ps -a`.
+9. Back up the new authorization database with
    `docker compose exec -T postgres pg_dump -U postgres -d spicedb > spicedb-backup.sql` after validation and
    include it in future database backup procedures.
 
-To roll back the runtime before application enforcement is enabled, restore the backed-up Compose and `.env`
-files and run `docker compose up -d`. Do not delete or replace the PostgreSQL volume.
+To roll back v6, restore the exact bridge-compatible v5 image and configuration kept for the migration. Keep
+outbox delivery enabled, require a clean audit, and do not delete or replace either PostgreSQL database. See the
+rollback procedure in [AuthZed Operations](/self-hosting/advanced/authzed-operations#roll-back-a-v6-upgrade).
 
 <Info>
   For a major migration such as Formbricks 4.x to 5.0, update your compose structure and configuration first.

--- a/docs/self-hosting/setup/kubernetes.mdx
+++ b/docs/self-hosting/setup/kubernetes.mdx
@@ -107,20 +107,20 @@ If your cluster already uses an external secret manager, enable `externalSecret`
 SecretStore. Ensure the resulting app secret exposes the values your deployment needs, including `DATABASE_URL`,
 `REDIS_URL`, and `HUB_API_KEY`.
 
-### Optional AuthZed / SpiceDB
+### AuthZed / SpiceDB
 
-AuthZed is disabled by default. To deploy SpiceDB with the chart-managed PostgreSQL server:
+Formbricks v6 uses AuthZed as its authorization engine. Fresh chart installations enable a private,
+two-replica SpiceDB cluster and `fully_consistent` decisions by default. If the cluster already has a compatible
+SpiceDB operator, keep the authorization runtime enabled but disable this release's operator installation:
 
 ```yaml
 authzed:
-  enabled: true
   operator:
-    install: true
+    install: false
 ```
 
-This installs the pinned SpiceDB operator, creates a two-replica SpiceDB cluster, and bootstraps a dedicated
-`spicedb` database and login. Install only one operator in a Kubernetes cluster. If your platform already runs
-the operator and watches the Formbricks namespace, keep `authzed.operator.install: false`.
+The default `authzed.operator.install: true` installs the pinned operator, creates the cluster, and bootstraps a
+dedicated `spicedb` database and login. Install only one operator in a Kubernetes cluster.
 
 For managed PostgreSQL, create a separate SpiceDB database and login first. Store its connection URI and a
 strong API token in a Kubernetes Secret using the keys `datastore_uri` and `preshared_key`, then configure:
@@ -134,21 +134,26 @@ authzed:
     existingSecret: formbricks-authzed
 ```
 
-Use `authzed.mode: external`, `authzed.endpoint: <host>:<port>`, and `authzed.insecure: false` when connecting
+Use `authzed.mode: external`, `authzed.operator.install: false`, `authzed.endpoint: <host>:<port>`, and
+`authzed.insecure: false` when connecting
 to an externally managed AuthZed endpoint. The external endpoint must serve TLS because the preshared token is
 sent on every authenticated request. The application endpoint remains internal and uses plaintext gRPC by
 default when the chart owns SpiceDB.
 
-When AuthZed is enabled, Helm prints release-specific commands that execute the release-matched operator CLI
+Helm prints release-specific commands that execute the release-matched operator CLI
 inside a Formbricks pod. Start with:
 
 ```bash
 kubectl exec -n <namespace> deployment/<release-name> -- formbricks-authzed health
 kubectl exec -n <namespace> deployment/<release-name> -- formbricks-authzed schema check
+kubectl exec -n <namespace> deployment/<release-name> -- formbricks-authzed upgrade check
 ```
 
-The chart does not apply the Formbricks schema or repair relationships automatically. Follow
-[AuthZed Operations](/self-hosting/advanced/authzed-operations) before either action. Do not expose SpiceDB
+A fresh install runs an idempotent initialization Job, but application startup and probes remain independent
+from it. Upgrades never run relationship preparation automatically. Before the first v6 upgrade, run
+`formbricks-authzed upgrade prepare`, require `upgrade check` to exit `0`, and then set
+`authzed.migrationAcknowledged: true`. The chart refuses an unacknowledged upgrade, disabled AuthZed, or weaker
+consistency. Follow [AuthZed Operations](/self-hosting/advanced/authzed-operations) and do not expose SpiceDB
 through an Ingress.
 
 ## 3. v5-Specific Deployment Notes

--- a/docs/self-hosting/setup/one-click.mdx
+++ b/docs/self-hosting/setup/one-click.mdx
@@ -53,10 +53,10 @@ curl -fsSL https://raw.githubusercontent.com/formbricks/formbricks/stable/docker
 ```
 
 <Info>
-  The current v5 one-click stack is based on the production Docker Compose file and includes Formbricks Hub
+  The v6 one-click stack is based on the production Docker Compose file and includes Formbricks Hub
   and Cube as part of the baseline (Cube configuration lives under `formbricks/cube/`). Ensure your generated
   `formbricks/docker-compose.yml` contains a non-empty `HUB_API_KEY` and that `formbricks/.env` contains
-  `CUBEJS_API_SECRET`, `AUTHZED_TOKEN`, and `AUTHZED_DATABASE_PASSWORD` before treating the v5 stack as ready.
+  `CUBEJS_API_SECRET`, `AUTHZED_TOKEN`, and `AUTHZED_DATABASE_PASSWORD` before treating the stack as ready.
   The installer generates these values without printing them and restricts `.env` to `0600`. `HUB_API_URL`
   should normally stay at `http://hub:8080`. Bundled SpiceDB is installed for every new setup and does not
   require an Enterprise license check.
@@ -327,7 +327,8 @@ To update Formbricks for a minor or patch release, run:
 ./formbricks.sh update
 ```
 
-The script pulls the latest images, stops the running containers, and starts the stack again.
+The script pulls the latest images, runs database migrations, executes the AuthZed v6 preparation and read-only
+gate, and only then stops and restarts the running stack. A failed gate leaves the existing application running.
 
 <Warning>
   `./formbricks.sh update` does **not** rewrite your existing `formbricks/docker-compose.yml`. For a major
@@ -335,7 +336,9 @@ The script pulls the latest images, stops the running containers, and starts the
   first, merge the current v5 Compose changes into your existing deployment, confirm `HUB_API_KEY` is set, and
   only then run the update command. If your older one-click install also uses bundled MinIO for file uploads,
   review that storage path separately before the first v5 restart; newer self-hosting updates move the bundled
-  object-storage path to RustFS, while external S3-compatible storage keeps the same `S3_*` app contract.
+  object-storage path to RustFS, while external S3-compatible storage keeps the same `S3_*` app contract. The
+  v6 updater also refuses to continue until the Compose file contains the release-matched AuthZed services and
+  `.env` contains `FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true` after a clean preparation.
 </Warning>
 
 ### Add SpiceDB to an Existing One-Click Installation
@@ -346,14 +349,24 @@ Before upgrading to a release that uses AuthZed:
 1. Back up `formbricks/.env`, `formbricks/docker-compose.yml`, and the PostgreSQL volume.
 2. Download the release-matched `authzed-postgres-bootstrap.sh` into the `formbricks` directory.
 3. Generate and add `AUTHZED_TOKEN` and `AUTHZED_DATABASE_PASSWORD` to `.env` using `openssl rand -hex 32`.
-4. Merge the three AuthZed services and Formbricks environment variables from the released Compose file while
-   preserving the installer-added Traefik, storage, and mail configuration. Also copy the profiled
-   `authzed-ops` service; it has no Traefik labels and does not start during a normal installation.
-5. Run `docker compose config`, `docker compose pull`, and `docker compose up -d` from the `formbricks` directory.
-6. Verify `authzed-db-bootstrap` and `spicedb-migrate` completed and `spicedb` is healthy.
-7. Run the health, schema, and dry-run relationship audit in the
-   [AuthZed Operations guide](/self-hosting/advanced/authzed-operations).
-8. Back up the authorization database with
+4. Merge `authzed-db-bootstrap`, `spicedb-migrate`, `spicedb`, `authzed-initialize`, and the profiled
+   `authzed-ops` service from the released Compose file while preserving installer-added Traefik, storage, and
+   mail configuration. Add the six application variables and use `AUTHZED_CONSISTENCY=fully_consistent`.
+5. Run `docker compose config`, `docker compose pull`, and `docker compose run --rm formbricks-migrate` from the
+   `formbricks` directory. The current application can remain running during these backward-compatible database
+   migrations.
+6. Start the datastore services, then prepare and verify the graph:
+
+   ```bash
+   docker compose up -d postgres authzed-db-bootstrap spicedb-migrate spicedb
+   docker compose --profile authzed-ops run --rm authzed-ops upgrade prepare
+   docker compose --profile authzed-ops run --rm authzed-ops upgrade check
+   ```
+
+7. If `upgrade check` exits `0`, add `FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true` to `.env` and run
+   `./formbricks.sh update`. Do not set the acknowledgement to bypass a blocked check.
+8. Verify `authzed-db-bootstrap`, `spicedb-migrate`, and `authzed-initialize` completed and `spicedb` is healthy.
+9. Back up the authorization database with
    `docker compose exec -T postgres pg_dump -U postgres -d spicedb > spicedb-backup.sql` and add it to your
    regular backup procedure.
 


### PR DESCRIPTION
Fixes ENG-2452

## What & why

- Makes SpiceDB the required self-hosted authorization engine for the v6 Docker, one-click, and Helm contracts.
- Adds release-matched `formbricks-authzed upgrade check` and `upgrade prepare` commands that validate health, the guarded schema digest, durable outbox delivery, and a complete relationship audit using aggregate-only JSON output.
- Initializes fresh Docker and Helm deployments automatically while keeping application startup and `/health` independent from SpiceDB.
- Blocks existing one-click and Helm upgrades until the operator has backed up the deployment, prepared the graph, and explicitly acknowledged the migration.
- Documents activation, rollback to the immutable bridge-compatible v5 image, backups, external AuthZed, shared Kubernetes operators, and the 30-day v5 `latest` compatibility window.
- This is based on merged #8916 and follows the preceding direct-cutover PRs.

## Breaking changes

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| Self-hosted authorization engine | AuthZed could be disabled and `minimize_latency` was the deployment default | AuthZed is required and released deployments use `fully_consistent` | Docker, one-click, and Helm operators upgrading to v6 | Back up both datastores, deploy the bridge-compatible v5 migration, run `upgrade prepare` and `upgrade check`, then acknowledge the migration |
| Helm defaults | The chart did not install AuthZed or its operator by default | Fresh installs create the self-hosted AuthZed contract and initialization Job by default | Fresh and existing Helm installations | Existing clusters with a shared operator must set `authzed.operator.install=false`; upgrades must set `authzed.migrationAcknowledged=true` only after preparation passes |
| One-click update flow | Update pulled and restarted the customized Compose stack directly | Update preserves custom files but refuses an unprepared v6 deployment | Existing one-click installations | Add the documented AuthZed services/secrets and acknowledgement before retrying the update |

## Migrations & env

- No new migration is introduced by this PR; the release-matched commands require the durable outbox migration from the stacked foundation.
- New Helm value: `authzed.migrationAcknowledged` (default `false` for upgrades).
- Fresh one-click installs persist `AUTHZED_ENABLED=true`, `AUTHZED_CONSISTENCY=fully_consistent`, and `FORMBRICKS_AUTHZED_V6_MIGRATION_ACKNOWLEDGED=true` in the mode-`0600` `.env` file.
- Existing installations must follow the guarded digest, schema, drain, reconcile, audit, backup, and rollback sequence in the v6 migration guide.

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Upgrade parser rejects malformed commands and accepts an optional guarded digest | unit (mutation): `pnpm --filter @formbricks/web exec vitest run lib/authzed/upgrade-cli-command.test.ts` | Valid commands parsed; incomplete, unknown, and invalid-digest forms rejected |
| Upgrade preparation is fail-closed and emits no tenant cursor or source identifier | unit (mutation): `pnpm --filter @formbricks/web exec vitest run lib/authzed/upgrade-cli.test.ts` | Disabled/weak consistency failed; health, schema, drain, reconcile, final audit, and sanitization paths passed |
| Packaged operator entrypoint preserves one-JSON-result behavior | unit (mutation): `pnpm --filter @formbricks/web exec vitest run scripts/authzed-entrypoints.test.ts` | Invalid request and invalid environment paths returned sanitized stable results |
| Fresh one-click and customized-update gates preserve secrets and ordering | unit (mutation): `pnpm exec vitest run docker/__tests__/formbricks-script.test.ts` | Nine cases passed, including migration wait before graph preparation and pre-shutdown validation |
| Docker service ordering, private SpiceDB, image parity, profile isolation, and token scoping | manual contract: `bash docker/authzed-compose-contract.sh` | Contract passed; normal service list excludes the operations profile and application startup has no SpiceDB dependency |
| Helm fresh install, acknowledged upgrade, self-hosted/external modes, shared operator, and secret-safe notes | manual contract: `bash charts/formbricks/tests/authzed-operations.sh` | All supported render shapes passed; unsafe disabled, weak-consistency, and unacknowledged upgrade shapes were rejected |
| Managed PostgreSQL render selects an explicit compatible AuthZed ownership mode | unit (guard): Helm validation workflow render | External PostgreSQL plus external TLS AuthZed renders the migration Job without implicitly creating an unusable self-hosted datastore |
| Canonical schema and isolated SpiceDB lifecycle | e2e: `pnpm authzed:validate && pnpm authzed:smoke` | 157 assertions passed; projection, repair, user/API-key decisions, outage recovery, migration idempotency, and persistence passed |
| Production image packages the CLI for the non-root user | manual: local `docker buildx build` followed by `docker run --entrypoint formbricks-authzed ... upgrade check` | Image built; executable/schema were readable as non-root; disabled check returned exactly one sanitized JSON result |
| Build performs no AuthZed RPC | manual: forced web build once disabled without credentials and once enabled against `192.0.2.1:50051` | Both builds completed successfully without reaching the endpoint |

**Open gaps**

- Live `authzed-sandbox` deployment, immutable bridge/candidate digest recording, rollback rehearsal, and the required 24-hour authoritative soak are intentionally blocked until this stack merges and release images are published.
- Existing customized one-click and Helm installations need real deployment QA against the published bridge and candidate images before staging begins.

**Risks**

- An incorrect schema digest or incomplete relationship graph blocks the upgrade by design; operators must investigate rather than bypass the acknowledgement.
- Fresh Compose starts the application independently while the one-shot graph initializer runs, so protected operations fail closed until initialization succeeds; `/health` remains independent.
- Installing more than one SpiceDB operator in a Kubernetes cluster is unsupported; shared-operator clusters must explicitly disable the chart dependency.

---

> [!NOTE]
> **AI model used** — `GPT-5`, reasoning effort `high`.


### Stack refresh — merged prerequisites

- Replayed only the two ENG-2452 self-hosted upgrade commits onto live base `7b4c7f03e10348be5c5b0d8e2a92a4ac3e52d10b` after #8916 merged.
- The PR now contains exactly two commits and no duplicated direct-cutover foundation changes.
- Post-rebase validation: 32 focused CLI, entrypoint, and installer tests passed; Compose and Helm AuthZed contracts passed; schema validation passed with 36 relationships, 157 assertions, and 6 expected relations; web typecheck, diff checks, and changed-file formatting passed.
- Behavior and rollout scope are unchanged.