### PR TITLE
fix(surveys): close the editor by navigating, not by history [ENG-2476]

### DIFF
--- a/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
+++ b/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
@@ -481,7 +481,18 @@ export const SurveyMenuBar = ({
       // in-app history entry behind it (new tab, pasted/bookmarked URL, hard reload), and back()
       // silently no-ops there — the survey saves but the editor never closes. The publish path
       // already navigates to the summary this way.
-      router.push(`${workspaceBasePath}/surveys/${localSurvey.id}/summary`);
+      //
+      // Both branches navigate, but not to the same place, because the two callers arrive here from
+      // different pages. The "Save & Close" button renders only for a non-draft, and its editor is
+      // reached from the summary. A draft gets here only through the unsaved-changes dialog, opened
+      // by the back arrow, and its editor is reached from the survey list — the list deliberately
+      // never links a draft to /summary (see `linkHref` in `survey/list/components/survey-card.tsx`),
+      // since a draft has no responses to summarise. So a draft closes to the list.
+      router.push(
+        localSurvey.status === "draft"
+          ? `${workspaceBasePath}/surveys`
+          : `${workspaceBasePath}/surveys/${localSurvey.id}/summary`
+      );
     }
   };
 

--- a/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
+++ b/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
@@ -477,7 +477,11 @@ export const SurveyMenuBar = ({
     const isSurveySaved =
       localSurvey.status === "draft" ? await handleSurveySaveDraft() : await handleSurveySave();
     if (isSurveySaved) {
-      router.back();
+      // Navigate explicitly rather than router.back(): the editor is often reached without an
+      // in-app history entry behind it (new tab, pasted/bookmarked URL, hard reload), and back()
+      // silently no-ops there — the survey saves but the editor never closes. The publish path
+      // already navigates to the summary this way.
+      router.push(`${workspaceBasePath}/surveys/${localSurvey.id}/summary`);
     }
   };
 


### PR DESCRIPTION
## What & why

The survey editor's **Save & Close** button saved but did not close, so people were left on the editor with no idea whether their change had landed — reported from support with a screenshot of a published survey.

`handleSaveAndGoBack` finished the flow with `router.back()`, which walks browser history and therefore silently no-ops whenever the editor was reached without an in-app entry behind it: opened in a new tab, from a pasted or bookmarked URL, or after a hard reload. The save itself always worked (the "changes saved" toast fired), only the close was lost.

It now navigates explicitly, which is what the publish path a few lines below already does. A control labelled "Close" shouldn't depend on how the user arrived at the page.

Where it navigates to depends on the status, because `handleSaveAndGoBack` has two callers that arrive from different pages. The **Save & Close** button renders only for `status !== "draft"`, and that editor is reached from the summary — so a non-draft closes to its summary. A **draft** reaches this handler only through the unsaved-changes dialog's confirm (opened by the back arrow), and its editor is reached from the survey list — so a draft closes to the list. Sending a draft to the summary would have been a new destination the app deliberately never uses: `linkHref` in `survey/list/components/survey-card.tsx` routes drafts to `/edit`, never `/summary`, because a draft has no responses to summarise. Raised by CodeRabbit.

Two other call sites share the same root cause and are deliberately left alone here to keep the diff reviewable — the back arrow (`survey-menu-bar.tsx:181`) and "discard changes and leave" in the unsaved-changes dialog (`survey-menu-bar.tsx:697`). Both are no-ops under the same no-history conditions; noted on the ticket as a follow-up.

## Linear ticket

Fixes ENG-2476


https://github.com/user-attachments/assets/b66dbf0e-5d1b-47f3-800b-37a5eb579c41



## How this was tested

- **Root cause confirmed in the code path, not guessed.** `handleSaveAndGoBack` → `router.back()` at `survey-menu-bar.tsx:476`, against `router.push(.../summary?success=true)` on the publish path at `:533`. The button only renders for `status !== "draft"`, which matches the reporter's screenshot (the auto-save indicator he sees is the *disabled* state, since auto-save is draft-only).
- **Both destinations traced to their entry point, not assumed.** The button's own render guard is `localSurvey.status !== "draft"` (`survey-menu-bar.tsx:659`), so the draft branch is reachable only via `onConfirm={handleSaveAndGoBack}` on the dialog (`:703`). The draft destination is matched to `linkHref` in `survey/list/components/survey-card.tsx`, which is what puts a draft in the editor in the first place.
- `npx prettier --write apps/web/modules/survey/editor/components/survey-menu-bar.tsx` → `(unchanged)`
- `npx eslint modules/survey/editor/components/survey-menu-bar.tsx` from `apps/web` → clean, no output
- `pnpm turbo run typecheck --filter=@formbricks/web` → **12 tasks successful** (a full run through the dependency graph, so no stale `dist/`; the earlier OOM on a bare `tsc` is gone)
- **Not yet verified in a running browser.** Reproducing needs a published survey plus an editor loaded with no history behind it; worth a click-through on preview before merge — steps in the QA plan below.
- No unit test added: this is a `.tsx` component and `AGENTS.md` rules out component unit tests. No Playwright spec covers the editor save/close flow today; adding one is a bigger piece than this fix.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Publish a survey, then open its editor **in a new tab** by pasting the `/workspaces/<id>/surveys/<surveyId>/edit` URL directly, so there is no history behind the page → editor loads
- [ ] Change something (a question headline is enough) → **Save & Close** becomes enabled
- [ ] Click **Save & Close** → "changes saved" toast appears **and** the app navigates to the survey summary page. Before this fix the toast appeared but the editor stayed open
- [ ] Reopen the editor and confirm the change persisted → your edit is there
- [ ] Normal navigation path: open the survey list → survey → edit, change something, **Save & Close** → still lands on the summary (this path worked before and must keep working)
- [ ] Draft survey → the **Save & Close** button is not rendered at all; **Save as draft** / **Publish** unchanged
- [ ] **Draft, via the dialog** (the second caller): open a draft's editor in a new tab, change something, click the **back arrow** → unsaved-changes dialog → confirm (**Save as draft**) → saves **and** lands on the survey list, not the summary and not stuck on the editor
- [ ] Save failure path: make the survey invalid (e.g. an app survey with no trigger), click **Save & Close** → error toast, editor stays open, no navigation

**Preconditions / test data**

- A workspace with at least one **published** (non-draft) survey — the button is hidden for drafts
- No feature flag or entitlement involved; behaves the same on Cloud and self-host

**Risks & regressions**

- Navigation target changed from "previous history entry" to the survey summary. Anyone who relied on Save & Close returning to a *specific* earlier page (e.g. straight back to the survey list) now lands on the summary instead — this is the intended behaviour, and matches publish
- `handleSurveySave()` still calls `router.refresh()` immediately before this navigation. A `push` supersedes it, where the previous `back()` could be swallowed by the in-flight refresh — so if anything, this also removes an intermittency
- The dialog's confirm is the only other caller. For a non-draft it lands on the summary like the button; for a draft it lands on the survey list. Both are covered in the QA steps above
- The dialog's **discard** action (`:701`) and the back arrow's no-change path (`:181`) still use `router.back()` and are still no-ops without history — unchanged by this PR, and the follow-up noted on the ticket

**Migrations / env / cutover**

- none

