### PR TITLE
fix(a11y): give the public survey a semantic heading structure [ENG-2336]

### DIFF
--- a/apps/web/playwright/survey-accessibility.spec.ts
+++ b/apps/web/playwright/survey-accessibility.spec.ts
@@ -3,8 +3,12 @@ import { type Locator, type Page, expect } from "@playwright/test";
 import { logger } from "@formbricks/logger";
 import { test } from "./lib/fixtures";
 import {
+  A11Y_SURVEY_NAME,
   ENDING_CARD_HEADLINE,
+  OPEN_TEXT_HEADLINE,
+  SINGLE_SELECT_HEADLINE,
   type SeededAccessibilitySurveys,
+  WELCOME_CARD_HEADLINE,
   seedAccessibilitySurveys,
 } from "./utils/accessibility";
 import { mockStorageUploads } from "./utils/helper";
@@ -241,13 +245,13 @@ const getActiveCardId = async (page: Page): Promise<string | null> => {
 
 const advanceButton = (card: Locator): Locator => card.locator(ADVANCE_BUTTON_SELECTOR);
 
-// The ending card renders its (fixture-controlled) headline as the page's <h1>; that
-// is a stable positive signal that the survey completed (unlike "no nav button",
-// which is also briefly true during the 600ms card transition animation). The welcome
-// card also renders an <h1>, so the ending is matched by its exact headline text —
-// endings are not language-patched, so this holds in the RTL variant too.
+// The ending card renders its (fixture-controlled) headline as an <h2>; that is a stable
+// positive signal that the survey completed (unlike "no nav button", which is also briefly
+// true during the 600ms card transition animation). Every card headline is an h2 — the survey
+// name is the page's only h1 (ENG-2336) — so the ending is matched by its exact headline text.
+// Endings are not language-patched, so this holds in the RTL variant too.
 const endingCardLocator = (page: Page): Locator =>
-  page.getByRole("heading", { level: 1, name: ENDING_CARD_HEADLINE });
+  page.getByRole("heading", { level: 2, name: ENDING_CARD_HEADLINE });
 
 const isOnEndingCard = (page: Page): Promise<boolean> =>
   endingCardLocator(page)
@@ -281,6 +285,32 @@ const waitForSettled = async (page: Page, selector: string): Promise<void> => {
 
 const waitForCardSettled = (page: Page, cardId: string): Promise<void> =>
   waitForSettled(page, `[id="${cardId}"]`);
+
+/**
+ * Locator-based twin of `waitForSettled`, for elements that cannot be named by a stable CSS
+ * selector. The ending card is matched by role + heading text because peeking cards carry
+ * identical markup, so `document.querySelector` would settle on the wrong one.
+ */
+const waitForLocatorSettled = async (locator: Locator): Promise<void> => {
+  await expect
+    .poll(
+      () =>
+        locator
+          .evaluate((node: HTMLElement) => {
+            let el: HTMLElement | null = node;
+            while (el) {
+              if (getComputedStyle(el).opacity !== "1") return false;
+              el = el.parentElement;
+            }
+            return true;
+          })
+          .catch(() => false),
+      { timeout: 5000, intervals: [100] }
+    )
+    .toBe(true)
+    // Mirrors waitForSettled: a timeout is not an error here, the caller's assertions decide.
+    .catch(() => undefined);
+};
 
 /**
  * After clicking advance, wait for a STABLE next state: either a different active card
@@ -425,7 +455,7 @@ const walkAndScan = async (
     endingCardLocator(page).first(),
     `ending card should be visible for variant "${variant}"`
   ).toBeVisible({ timeout: CARD_TIMEOUT });
-  await waitForSettled(page, "#fbjs h1");
+  await waitForLocatorSettled(endingCardLocator(page).first());
   await scan(page, variant, "ending-card", failSink);
 };
 
@@ -575,6 +605,63 @@ test.describe("Survey accessibility (axe-core) @slow", () => {
       await walkAndScan(page, "dark", seeded.surveyUrl, violations);
       reportAndAssert("dark", violations);
     });
+  });
+
+  /**
+   * Heading structure (ENG-2336, WCAG 2.4.6). axe cannot gate this: `page-has-heading-one` and
+   * `heading-order` are best-practice rules, so they only WARN in this suite. The three things
+   * that can silently regress are asserted directly — the single h1, the absence of a skipped
+   * level, and the two associations the heading wrapper had to preserve (`htmlFor` on the nested
+   * label, and `headlineId` still naming the radiogroup through aria-labelledby).
+   */
+  test("heading structure: one h1 names the survey, card headlines are h2", async ({ page }) => {
+    test.setTimeout(120_000);
+    const widget = page.locator("#fbjs");
+
+    await page.goto(seeded.surveyUrl, { waitUntil: "domcontentloaded" });
+    await expect(activeCard(page).first(), "welcome card should render").toBeVisible({
+      timeout: CARD_TIMEOUT,
+    });
+
+    // One h1 for the whole survey, carrying the survey name. Without it every card headline is an
+    // orphaned h2 and heading navigation gives the respondent no idea what they are answering.
+    await expect(widget.getByRole("heading", { level: 1 })).toHaveCount(1);
+    await expect(widget.getByRole("heading", { level: 1 })).toHaveText(A11Y_SURVEY_NAME);
+
+    // Nothing deeper than h2 anywhere, so h1 -> h2 cannot become a skipped level.
+    await expect(widget.locator("h3, h4, h5, h6")).toHaveCount(0);
+
+    await expect(
+      page.getByRole("heading", { level: 2, name: WELCOME_CARD_HEADLINE }),
+      "welcome card headline should be an h2, not a styled div"
+    ).toBeVisible();
+
+    const firstCardId = await openFirstQuestionCard(page, seeded.surveyUrl);
+    const firstCard = page.locator(`[id="${firstCardId}"]`);
+
+    // Still exactly one h1 on a question card: the heading lives on the container, so the stacked
+    // layout's peeking cards must not each contribute their own.
+    await expect(widget.getByRole("heading", { level: 1 })).toHaveCount(1);
+
+    // The open-text prompt is an h2 that WRAPS the <label> bound to the input. If a future refactor
+    // turns the label itself into the heading, the input loses its accessible name — hence both
+    // halves are asserted: the heading contains a real label[for], and the input resolves by label.
+    const promptHeading = firstCard.getByRole("heading", { level: 2, name: OPEN_TEXT_HEADLINE });
+    await expect(promptHeading).toBeVisible();
+    await expect(promptHeading.locator("label[for]")).toHaveCount(1);
+    await expect(firstCard.getByLabel(OPEN_TEXT_HEADLINE)).toBeVisible();
+
+    // Advance to the single-select card: its radiogroup is named through aria-labelledby pointing at
+    // the headline id, which now sits on an element nested inside the h2.
+    await answerCurrentCard(page, firstCard);
+    await advanceButton(firstCard).first().click({ timeout: ACTION_TIMEOUT });
+    await waitForCardTransition(page, firstCardId);
+
+    await expect(
+      page.getByRole("radiogroup", { name: SINGLE_SELECT_HEADLINE }),
+      "the radiogroup must still be named by its headline via aria-labelledby"
+    ).toBeVisible({ timeout: CARD_TIMEOUT });
+    await expect(page.getByRole("heading", { level: 2, name: SINGLE_SELECT_HEADLINE })).toBeVisible();
   });
 
   test("rtl multi-language (Arabic): full walk has no WCAG AA violations", async ({ page }) => {

--- a/apps/web/playwright/utils/accessibility.ts
+++ b/apps/web/playwright/utils/accessibility.ts
@@ -48,7 +48,7 @@ const buildKitchenSinkQuestions = (baseURL: string) => [
   {
     id: createId(),
     type: "openText",
-    headline: i18nValue("What feedback do you have for us?"),
+    headline: i18nValue(OPEN_TEXT_HEADLINE),
     subheader: i18nValue("Share anything that comes to mind."),
     placeholder: i18nValue("Type your answer here..."),
     required: true,
@@ -58,7 +58,7 @@ const buildKitchenSinkQuestions = (baseURL: string) => [
   {
     id: createId(),
     type: "multipleChoiceSingle",
-    headline: i18nValue("Which plan are you on?"),
+    headline: i18nValue(SINGLE_SELECT_HEADLINE),
     required: true,
     choices: [
       { id: createId(), label: i18nValue("Free") },
@@ -151,17 +151,32 @@ const buildKitchenSinkQuestions = (baseURL: string) => [
   },
 ];
 
+/**
+ * Survey name of the single-language kitchen-sink fixture. The public survey exposes it as its
+ * one top-level `<h1>` (ENG-2336), so the heading-structure spec asserts against it.
+ */
+export const A11Y_SURVEY_NAME = "A11y Kitchen Sink";
+
+/** Welcome-card headline, exposed as an `<h2>` like every other card headline. */
+export const WELCOME_CARD_HEADLINE = "Welcome to our feedback survey";
+
+/** Headline of the first (open text) question — an `<h2>` wrapping a real `<label>`. */
+export const OPEN_TEXT_HEADLINE = "What feedback do you have for us?";
+
+/** Headline of the single-select question, which names its radiogroup via aria-labelledby. */
+export const SINGLE_SELECT_HEADLINE = "Which plan are you on?";
+
 const buildWelcomeCard = () => ({
   enabled: true,
-  headline: i18nValue("Welcome to our feedback survey"),
+  headline: i18nValue(WELCOME_CARD_HEADLINE),
   subheader: i18nValue("It only takes a minute."),
   timeToFinish: true,
   showResponseCount: false,
 });
 
 /**
- * Ending-card headline, exported so the spec can positively detect survey completion
- * via the rendered `<h1>` (the ending card no longer carries a dedicated DOM hook).
+ * Ending-card headline, exported so the spec can positively detect survey completion via the
+ * rendered `<h2>` (the ending card carries no dedicated DOM hook of its own).
  */
 export const ENDING_CARD_HEADLINE = "Thank you!";
 
@@ -313,8 +328,8 @@ export const seedAccessibilitySurveys = async (
   }
 
   const [mainSurveyId, rtlSurveyId] = await Promise.all([
-    createKitchenSinkSurvey(workspaceId, user.id, "A11y Kitchen Sink", baseURL),
-    createKitchenSinkSurvey(workspaceId, user.id, "A11y Kitchen Sink (RTL)", baseURL),
+    createKitchenSinkSurvey(workspaceId, user.id, A11Y_SURVEY_NAME, baseURL),
+    createKitchenSinkSurvey(workspaceId, user.id, `${A11Y_SURVEY_NAME} (RTL)`, baseURL),
   ]);
   await attachArabicLanguage(rtlSurveyId, workspaceId);
 

--- a/apps/web/playwright/utils/helper.ts
+++ b/apps/web/playwright/utils/helper.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { Page } from "playwright";
+import { Locator, Page } from "playwright";
 import { logger } from "@formbricks/logger";
 import { CreateSurveyParams, CreateSurveyWithLogicParams } from "@/playwright/utils/mock";
 
@@ -671,6 +671,18 @@ export const createSurvey = async (page: Page, params: CreateSurveyParams) => {
   await page.getByPlaceholder("Option 5").fill(params.ranking.choices[4]);
 };
 
+/**
+ * A question's collapsed card heading inside the survey editor's element list.
+ *
+ * Scoped to the editor `<main>` on purpose. The editor renders a LIVE PREVIEW of the survey into
+ * the same document (the `<aside>` holding `#survey-preview`, visible from the `md` breakpoint up),
+ * and since ENG-2336 that preview exposes each element prompt as an `<h2>`. An unscoped
+ * `getByRole("heading", { name })` would then match both the accordion heading and the preview's
+ * prompt whenever the previewed card is the one being edited, failing Playwright's strict mode.
+ */
+const editorElementHeading = (page: Page, name: string): Locator =>
+  page.getByRole("main").getByRole("heading", { name });
+
 export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWithLogicParams) => {
   const addBlock = "Add BlockChoose the first question on your Block";
 
@@ -892,7 +904,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
 
   // Adding logic to blocks
   // Block 1 (Open Text Question)
-  await page.getByRole("heading", { name: params.openTextQuestion.question }).click();
+  await editorElementHeading(page, params.openTextQuestion.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").first().click();
@@ -931,7 +943,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 2 (Single Select Question)
-  await page.getByRole("heading", { name: params.singleSelectQuestion.question }).click();
+  await editorElementHeading(page, params.singleSelectQuestion.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").first().click();
@@ -969,7 +981,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 3 (Multi Select Question)
-  await page.getByRole("heading", { name: params.multiSelectQuestion.question }).click();
+  await editorElementHeading(page, params.multiSelectQuestion.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").click();
@@ -1020,7 +1032,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 4 (Picture Select Question)
-  await page.getByRole("heading", { name: params.pictureSelectQuestion.question }).click();
+  await editorElementHeading(page, params.pictureSelectQuestion.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").click();
@@ -1053,7 +1065,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 5 (Rating Question)
-  await page.getByRole("heading", { name: params.ratingQuestion.question }).click();
+  await editorElementHeading(page, params.ratingQuestion.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").click();
@@ -1088,7 +1100,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 6 (NPS Question)
-  await page.getByRole("heading", { name: params.npsQuestion.question }).click();
+  await editorElementHeading(page, params.npsQuestion.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").click();
@@ -1162,7 +1174,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 7 (Ranking Question)
-  await page.getByRole("heading", { name: params.ranking.question }).click();
+  await editorElementHeading(page, params.ranking.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").click();
@@ -1195,7 +1207,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 8 (Matrix Question)
-  await page.getByRole("heading", { name: params.matrix.question }).click();
+  await editorElementHeading(page, params.matrix.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").first().click();
@@ -1239,7 +1251,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 9 (CTA Question)
-  await page.getByRole("heading", { name: params.ctaQuestion.question }).click();
+  await editorElementHeading(page, params.ctaQuestion.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").click();
@@ -1278,7 +1290,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 10 (Consent Question)
-  await page.getByRole("heading", { name: params.consentQuestion.question }).click();
+  await editorElementHeading(page, params.consentQuestion.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#action-0-objective").first().click();
@@ -1297,7 +1309,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 11 (File Upload Question)
-  await page.getByRole("heading", { name: params.fileUploadQuestion.question }).click();
+  await editorElementHeading(page, params.fileUploadQuestion.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#action-0-objective").first().click();
@@ -1364,7 +1376,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 13 (Cal Question)
-  await page.getByRole("heading", { name: params.cal.question }).click();
+  await editorElementHeading(page, params.cal.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#condition-0-0-conditionValue").click();
@@ -1387,7 +1399,7 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
     .click();
 
   // Block 14 (Address Question)
-  await page.getByRole("heading", { name: params.address.question }).click();
+  await editorElementHeading(page, params.address.question).click();
   await page.getByText("Show Block settings").first().click();
   await page.getByRole("button", { name: "Add logic" }).first().click();
   await page.locator("#action-0-objective").first().click();

--- a/packages/survey-ui/src/components/general/element-header.tsx
+++ b/packages/survey-ui/src/components/general/element-header.tsx
@@ -21,6 +21,12 @@ interface ElementHeaderProps extends React.ComponentProps<"div"> {
    * (media, etc.) inside a <legend> (invalid HTML).
    */
   headlineId?: string;
+  /**
+   * Heading level the element prompt is exposed at (WCAG 2.4.6). Defaults to 2: the survey name
+   * is the page's only h1, so every card prompt sits one level under it. A block that renders
+   * several elements gets sibling headings at the same level, never a nested run.
+   */
+  headingLevel?: 2 | 3;
 }
 
 function ElementHeader({
@@ -35,9 +41,16 @@ function ElementHeader({
   videoUrl,
   imageAltText,
   headlineId,
+  headingLevel = 2,
   ...props
 }: Readonly<ElementHeaderProps>): React.JSX.Element {
   const isMediaAvailable = Boolean(imageUrl) || Boolean(videoUrl);
+  // The heading WRAPS the Label rather than replacing it: the six call sites that pass `htmlFor`
+  // need the prompt to stay a real <label> bound to their input, the grouped questions need
+  // `headlineId` to stay on the element whose text names the fieldset via aria-labelledby, and
+  // user theming targets the `label-headline` class (styles.ts `addCustomThemeToDom`), not the tag.
+  // A <label> nested inside a heading is valid HTML and changes neither association.
+  const HeadingTag = `h${headingLevel.toString()}` as "h2" | "h3";
 
   return (
     <div className={cn("space-y-2", className)} {...props}>
@@ -49,11 +62,11 @@ function ElementHeader({
       {/* Headline */}
       <div>
         <div>{required ? <span className="label-card mb-[3px]">{requiredLabel}</span> : null}</div>
-        <div className="flex">
+        <HeadingTag className="flex" data-slot="element-headline">
           <Label htmlFor={htmlFor} id={headlineId} variant="headline">
             {headline}
           </Label>
-        </div>
+        </HeadingTag>
       </div>
 
       {/* Description/Subheader */}

--- a/packages/survey-ui/src/styles/globals.css
+++ b/packages/survey-ui/src/styles/globals.css
@@ -180,6 +180,25 @@
   font-size: var(--fb-button-font-size);
 }
 
+/*
+ * Element prompts are wrapped in a real heading for WCAG 2.4.6 (see element-header.tsx). The
+ * heading is a semantic wrapper only — the visible text is still the <Label> inside it — so the
+ * UA's own heading typography and margins have to be neutralised or the prompt gains size and
+ * spacing it never had. `packages/surveys/preflight.css` already does this for the bundled
+ * survey, but that preflight ships with the surveys package and this stylesheet is consumed on
+ * its own too (Storybook, and any standalone React consumer), so survey-ui declares it itself.
+ */
+#fbjs h1,
+#fbjs h2,
+#fbjs h3,
+#fbjs h4,
+#fbjs h5,
+#fbjs h6 {
+  font-size: inherit;
+  font-weight: inherit;
+  margin: 0;
+}
+
 #fbjs .label-headline,
 #fbjs .label-headline * {
   font-family: var(--fb-element-headline-font-family);

--- a/packages/surveys/src/components/elements/cal-element.tsx
+++ b/packages/surveys/src/components/elements/cal-element.tsx
@@ -53,11 +53,7 @@ export function CalElement({
       className="w-full">
       <div>
         {isMediaAvailable ? <ElementMedia imgUrl={element.imageUrl} videoUrl={element.videoUrl} /> : null}
-        <Headline
-          headline={getLocalizedValue(element.headline, languageCode)}
-          elementId={element.id}
-          required={element.required}
-        />
+        <Headline headline={getLocalizedValue(element.headline, languageCode)} required={element.required} />
         <Subheader subheader={element.subheader ? getLocalizedValue(element.subheader, languageCode) : ""} />
         <CalEmbed key={element.id} element={element} onSuccessfulBooking={onSuccessfulBooking} />
         {errorMessage ? (

--- a/packages/surveys/src/components/general/ending-card.tsx
+++ b/packages/surveys/src/components/general/ending-card.tsx
@@ -167,7 +167,6 @@ export function EndingCard({
                       variablesData,
                       languageCode
                     )}
-                    elementId="EndingCard"
                   />
                   <Subheader
                     subheader={replaceRecallInfo(
@@ -200,11 +199,7 @@ export function EndingCard({
               <>
                 {isPreviewMode ? (
                   <div>
-                    <Headline
-                      alignTextCenter
-                      headline={t("common.respondents_will_not_see_this_card")}
-                      elementId="EndingCard"
-                    />
+                    <Headline alignTextCenter headline={t("common.respondents_will_not_see_this_card")} />
                     <Subheader subheader={t("common.they_will_be_redirected_immediately")} />
                   </div>
                 ) : (
@@ -220,7 +215,9 @@ export function EndingCard({
             <div className="my-3">
               <LoadingSpinner />
             </div>
-            <h1 className="text-brand">{t("common.sending_responses")}</h1>
+            {/* A transient status message, not a section heading — it used to be an <h1>, which
+                put a second top-level heading on the page and skipped the survey's structure. */}
+            <p className="text-brand">{t("common.sending_responses")}</p>
           </>
         )}
         {isOfflineWithPending && isResponseSendingFinished && (

--- a/packages/surveys/src/components/general/headline.tsx
+++ b/packages/surveys/src/components/general/headline.tsx
@@ -3,23 +3,25 @@ import { isValidHTML, sanitizeSurveyHtml, stripInlineStyles } from "@/lib/html-u
 
 interface HeadlineProps {
   headline: string;
-  elementId: string;
   required?: boolean;
   alignTextCenter?: boolean;
+  /**
+   * Heading level this prompt is exposed at (WCAG 2.4.6). Defaults to 2: the survey name is the
+   * page's only h1 (rendered once by SurveyContainer), so every card headline — welcome, element
+   * prompt, ending — is one level under it.
+   */
+  headingLevel?: 1 | 2;
 }
 
 export function Headline({
   headline,
-  elementId,
   required = false,
   alignTextCenter = false,
+  headingLevel = 2,
 }: Readonly<HeadlineProps>) {
   const hasRequiredRule = required;
   const { t } = useTranslation();
-  const isQuestionCard = elementId !== "EndingCard" && elementId !== "welcomeCard";
-  // Welcome / ending cards are the top of the screen (h1); question cards sit
-  // under the survey form region, so their prompt is an h2.
-  const HeadingTag = isQuestionCard ? "h2" : "h1";
+  const HeadingTag = `h${headingLevel.toString()}` as "h1" | "h2";
   // Strip inline styles BEFORE parsing to avoid CSP violations
   const strippedHeadline = stripInlineStyles(headline);
   const isHeadlineHtml = isValidHTML(strippedHeadline);
@@ -27,7 +29,7 @@ export function Headline({
 
   return (
     <div className="text-heading mb-[3px] flex flex-col">
-      {hasRequiredRule && isQuestionCard && (
+      {hasRequiredRule && (
         <span
           className="label-card mb-[3px] text-xs leading-6 font-normal"
           tabIndex={-1}

--- a/packages/surveys/src/components/general/render-survey.tsx
+++ b/packages/surveys/src/components/general/render-survey.tsx
@@ -68,7 +68,8 @@ export function RenderSurvey(props: SurveyContainerProps) {
       clickOutside={props.clickOutside}
       onClose={close}
       isOpen={isOpen}
-      dir={dir}>
+      dir={dir}
+      surveyName={props.survey.name}>
       <Survey
         {...props}
         autoFocus={autoFocus}

--- a/packages/surveys/src/components/general/welcome-card.tsx
+++ b/packages/surveys/src/components/general/welcome-card.tsx
@@ -162,7 +162,6 @@ export function WelcomeCard({
             variablesData,
             languageCode
           )}
-          elementId="welcomeCard"
         />
         <Subheader
           subheader={replaceRecallInfo(

--- a/packages/surveys/src/components/wrappers/survey-container.tsx
+++ b/packages/surveys/src/components/wrappers/survey-container.tsx
@@ -19,6 +19,8 @@ interface SurveyContainerProps {
   clickOutside?: boolean;
   isOpen?: boolean;
   dir?: "ltr" | "rtl" | "auto";
+  /** Survey name, exposed as the survey's single top-level heading (WCAG 2.4.6). */
+  surveyName?: string;
 }
 
 export function SurveyContainer({
@@ -30,6 +32,7 @@ export function SurveyContainer({
   clickOutside,
   isOpen = true,
   dir = "auto",
+  surveyName,
 }: Readonly<SurveyContainerProps>) {
   const isModal = mode === "modal";
   const { t } = useTranslation();
@@ -127,9 +130,22 @@ export function SurveyContainer({
 
   if (!isOpen) return null;
 
+  // The survey's one top-level heading. Card headlines (welcome, element prompts, ending) are all
+  // h2, so without this they would be orphaned: a screen reader user pressing H would land inside
+  // the survey with nothing naming what they are answering. It lives here rather than in
+  // survey.tsx's getCardContent, which runs once per card and would emit one h1 per peeking card
+  // in the stacked layout. Visually hidden because the card designs have no room for a title — the
+  // survey name is already the document title on link surveys.
+  //
+  // It is rendered as a sibling of `children` in BOTH branches so that it always ends up inside the
+  // dialog on the modal path: `aria-modal="true"` makes assistive tech ignore everything outside
+  // the dialog element, so a heading placed on the #fbjs root would be unreachable there.
+  const surveyHeading = surveyName ? <h1 className="sr-only">{surveyName}</h1> : null;
+
   if (!isModal) {
     return (
       <div id="fbjs" className="formbricks-form" style={{ height: "100%", width: "100%" }} dir={dir}>
+        {surveyHeading}
         {children}
       </div>
     );
@@ -165,7 +181,10 @@ export function SurveyContainer({
               isOpen ? "opacity-100" : "opacity-0",
               "rounded-custom pointer-events-auto absolute bottom-0 h-fit w-full overflow-visible bg-white shadow-lg transition-all duration-500 ease-in-out sm:m-4 sm:max-w-sm"
             )}>
-            <div>{children}</div>
+            <div>
+              {surveyHeading}
+              {children}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes ENG-2336

## What & why

The public survey UI rendered **no heading on a question card**. The VPAT records this as *Partially Supports* against WCAG 2.0 SC 2.4.6 (Level AA) — "All fields have descriptive labels. Headings are not present."

Why the existing code looked like it already handled this but didn't:

- `packages/surveys`' own `Headline` did have an `h2` branch, but 14 of the 15 element types render through `@formbricks/survey-ui`'s `ElementHeader` → `Label`, which emits a `<label>` or a `<span>`. Only `cal-element.tsx` still used `Headline`, so the `h2` branch was effectively dead.
- Welcome and ending cards each carried an `h1`, but they are *separate cards* — never on screen at the same time as a question. A respondent answering question 3 had nothing to navigate by at all.

After this PR the survey exposes one `h1` (the survey name, visually hidden, rendered once) with every card headline — welcome, each element prompt in a block, ending — as an `h2` beneath it. Multi-element blocks yield sibling `h2`s; no level is skipped.

```
h1  Q3 Customer Satisfaction        ← survey name, sr-only, rendered once
h2  Welcome to our feedback survey
h2  What feedback do you have for us?
h2  Which plan are you on?
h2  Thank you!
```

The heading **wraps** the existing `Label` rather than retagging it, because three things hang off that element and all had to survive:

| Depends on | Call sites | How it survives |
| --- | --- | --- |
| `htmlFor` — the prompt *is* the input's `<label>` | `open-text`, `cta`, `ranking`, `consent`, `date`, `file-upload` | `<label>` nested in a heading is valid HTML; the binding is untouched |
| `headlineId` — names grouped questions via `aria-labelledby` | `matrix`, `picture-select`, `date`, `rating`, `single-select`, `multi-select`, `nps` | the id stays on the `Label`, so the computed accessible name is unchanged |
| `label-headline` class — runtime theming targets it with `!important` (`styles.ts` `addCustomThemeToDom`) | all | class stays on the `Label`, not moved to the tag |

The heading inherits the `flex` class the wrapper `<div>` already carried, so layout is byte-identical.

<details>
<summary>Rendered DOM, before → after</summary>

```html
<!-- before: ElementHeader with htmlFor -->
<div class="flex">
  <label for="my-input" class="… label-headline select-text">What feedback do you have?</label>
</div>

<!-- after -->
<h2 data-slot="element-headline" class="flex">
  <label for="my-input" class="… label-headline select-text">What feedback do you have?</label>
</h2>

<!-- before: ElementHeader with headlineId (grouped question) -->
<div class="flex">
  <span id="q1-headline" class="… label-headline select-text">Which plan are you on?</span>
</div>

<!-- after -->
<h2 data-slot="element-headline" class="flex">
  <span id="q1-headline" class="… label-headline select-text">Which plan are you on?</span>
</h2>
```
</details>

On the **modal** path the heading is rendered inside the `role="dialog"` element rather than on the `#fbjs` root: `aria-modal="true"` makes assistive tech ignore everything outside the dialog, so a root-level heading would have been unreachable for app surveys with an overlay.

Also in this diff:

- **`survey-ui/src/styles/globals.css`** gains the `h1…h6` reset it lacked. `packages/surveys/preflight.css` already neutralises heading typography inside `#fbjs`, but that preflight ships with the surveys package and this stylesheet is consumed standalone too (Storybook / any React consumer), where the prompt would otherwise pick up UA heading size and margins.
- The ending card's "sending responses" status text was a **second `h1`**, outside `Headline` and without `label-headline`. It is a transient status message, so it is now a `<p>`.
- `Headline` takes an explicit `headingLevel` instead of inferring the level by comparing `elementId` against the string literals `"welcomeCard"` / `"EndingCard"`. `elementId` had no other use and is gone.
- The editor's 13 e2e question-heading locators are scoped to the editor `<main>`. The editor renders a **live preview of the survey into the same document** (`#survey-preview`, in an `<aside>` visible from the `md` breakpoint up), so an unscoped `getByRole("heading", { name })` now matches the preview's `h2` as well and would fail Playwright's strict mode.
- Both new `headingLevel` props are optional and default to `2`, so no existing call site had to change to keep its current output. `Headline` is internal to `packages/surveys` (not exported from the package entry) and its three call sites are all updated; `ElementHeader`'s is public API on `@formbricks/survey-ui`.

### Screenshots

This is a semantics-only change, so **the correct screenshot result is no difference** — and that is what these are evidence of. Both rendered from the real built survey bundle (`surveys.umd.cjs`), before and after, at 2× device scale.

**Question card** — the card that previously had no heading at all

| Before | After |
| --- | --- |
| <img src="https://github.com/formbricks/formbricks/raw/assets-itsjavi-prs/pr-8919/before-question-card.jpg" width="420" /> | <img src="https://github.com/formbricks/formbricks/raw/assets-itsjavi-prs/pr-8919/after-question-card.jpg" width="420" /> |
| headings in `#fbjs`: **none** | `h1` Q3 Customer Satisfaction (sr-only) · `h2` What feedback do you have for us? |

**Welcome card** — headline moves `h1` → `h2` under the survey name

| Before | After |
| --- | --- |
| <img src="https://github.com/formbricks/formbricks/raw/assets-itsjavi-prs/pr-8919/before-welcome-card.jpg" width="420" /> | <img src="https://github.com/formbricks/formbricks/raw/assets-itsjavi-prs/pr-8919/after-welcome-card.jpg" width="420" /> |
| `h1` Welcome to our feedback survey | `h1` Q3 Customer Satisfaction (sr-only) · `h2` Welcome to our feedback survey |

**Ending card** — headline moves `h1` → `h2`, and the "sending responses" status text stops being a second `h1`

| Before | After |
| --- | --- |
| <img src="https://github.com/formbricks/formbricks/raw/assets-itsjavi-prs/pr-8919/before-ending-card.jpg" width="420" /> | <img src="https://github.com/formbricks/formbricks/raw/assets-itsjavi-prs/pr-8919/after-ending-card.jpg" width="420" /> |
| `h1` Thank you! | `h1` Q3 Customer Satisfaction (sr-only) · `h2` Thank you! |

The `h1` → `<p>` demotion on the ending card's transient "sending responses" state is not screenshotted, because it is a flash between submit and the thank-you card — capturing it reliably is not possible here. What it actually depends on is measured instead: an `h1` and a `p` carrying the same class, injected into `#fbjs` and read back through `getComputedStyle`, resolve identically on **both** sides — `font-size: 16px`, `font-weight: 400`, `margin: 0`, `color: rgb(30, 64, 175)`, `line-height: normal` — because `preflight.css` already neutralises heading typography inside `#fbjs`. So the demotion removes a heading from the a11y tree and changes nothing on screen.

The two images in each row are **byte-identical**, not merely similar:

```
f38705cf6e7929b7a6f8af4f62121b61  before-question-card.jpg
f38705cf6e7929b7a6f8af4f62121b61  after-question-card.jpg
1e005f3fe8bb9d8507057baca2895351  before-welcome-card.jpg
1e005f3fe8bb9d8507057baca2895351  after-welcome-card.jpg
53f2ede5da1fd866c52e2df2ddfe5f9e  before-ending-card.jpg
53f2ede5da1fd866c52e2df2ddfe5f9e  after-ending-card.jpg
```

## Breaking changes

- [ ] This PR contains breaking changes

None — both new `headingLevel` props are optional and default to `2`, so every existing consumer renders exactly as before. Nothing is removed, renamed or re-typed, and `packages/surveys/src/index.ts` and the `js-core` exports are untouched.

## Migrations & env

- none

## How this was tested

**Coverage**

Per AGENTS.md, `.tsx` components are covered by Playwright rather than component unit tests, so the heading semantics are asserted in the existing axe suite. Note that axe **cannot** gate this: `page-has-heading-one` and `heading-order` are best-practice rules, which this suite runs as warn-only (`WARN_TAGS`) — only `wcag2a/2aa/21a/21aa/22a/22aa` fail the build. Hence the explicit assertions.

| Behaviour | How | Outcome |
| --- | --- | --- |
| Survey exposes exactly one `h1`, carrying the survey name | e2e | New `heading structure: one h1 names the survey, card headlines are h2` in `survey-accessibility.spec.ts`. Also re-asserted *after* advancing to a question card — the stacked layout renders up to three peeking cards, so a heading placed per-card would show up here as a count > 1 |
| No skipped heading level | e2e | Same test: `widget.locator("h3, h4, h5, h6")` is empty, so `h1 → h2` is the whole tree |
| Welcome and ending headlines are `h2`, not styled divs | e2e | Same test for welcome; `endingCardLocator` in the same spec now resolves the ending card by `level: 2` and is exercised by all nine existing walk variants |
| `htmlFor` label association survives the heading wrapper | e2e | Same test: the `h2` contains exactly one `label[for]`, **and** the input still resolves via `getByLabel(OPEN_TEXT_HEADLINE)` — both halves, so retagging the label in future fails here rather than silently stripping the input's accessible name |
| `headlineId` still names a grouped question | e2e | Same test: `getByRole("radiogroup", { name: SINGLE_SELECT_HEADLINE })` on the single-select card, which is named purely through `aria-labelledby` → the id nested inside the new `h2` |
| No new WCAG AA violations on any card | e2e | The nine pre-existing variants in `survey-accessibility.spec.ts` (desktop / mobile / tablet / forced-colors / reduced-motion / dark / empty-submit / back-nav / RTL Arabic) walk every card type with an empty allowlist |
| Real rendered heading tree, from the built bundle | manual | Rendered the built `surveys.umd.cjs` and read the headings out of `#fbjs` per card: question card went from `[]` to `["H1: Q3 Customer Satisfaction", "H2: What feedback do you have for us?"]`; the ending card from `["H1: Thank you!"]` to `["H1: Q3 Customer Satisfaction", "H2: Thank you!"]`; same `h1` on every card, never duplicated |
| Rendering is unchanged | manual | Byte-identical screenshots above (md5 match) for the question, welcome **and ending** cards. Separately pixel-diffed the PNG originals: 0 of 924 000 pixels differ on each of the welcome, question, ending and switcher-collapsed frames. The ending card's `h1` → `<p>` status text is covered by the computed-style probe described with the screenshots, since that state is too transient to capture |
| Rendered DOM keeps every association | manual | Rendered `ElementHeader` (both `htmlFor` and `headlineId` paths) and `SurveyContainer` (inline + modal) under happy-dom and inspected the HTML: wrapper went from `<div class="flex">` to `<h2 class="flex">` with identical classes and children; `label-headline`, `for` and `id` all present; modal `h1` resolves inside `[role="dialog"]` |
| Monorepo still builds and passes | manual | `pnpm typecheck` (27 tasks), `pnpm lint`, `pnpm test` (615 files / 8203 tests), `pnpm format:check` — all clean |

**Open gaps**

- The `sr-only` `h1` is not verified against a real screen reader. The ticket asks for an NVDA `H`-key and VoiceOver-rotor pass, and for an IBM Equal Access + ANDI re-run; neither is available in CI. The axe suite plus the DOM assertions above are what can be automated — a manual AT pass is still worth doing before the VPAT row is flipped to *Supports*.
- The `h1` carries `survey.name`, which is an internally-authored field. It is already the basis of the link survey's `<title>` (`metadata-utils.ts` falls back to it), so this exposes nothing new, but a workspace whose survey names are cryptic gets a cryptic heading. No product decision was made here.
- The visually-hidden `h1` is a11y-only by design — the card layouts have no room for a visible title. Flagged in the ticket as wanting sign-off from Kristian / pain.design.

**Risks**

- **Playwright strict mode in the editor.** The live preview now emits `h2` prompts into the editor's document. The 13 known locators in `playwright/utils/helper.ts` are scoped, but any *new* unscoped `getByRole("heading")` written against the editor will be ambiguous whenever the previewed card is the one being edited. The new `editorElementHeading` helper carries that warning at its definition.
- **Third-party `dist/` consumers of `@formbricks/survey-ui`.** A consumer that renders `ElementHeader` outside `#fbjs` gets an unreset heading, since both the new rule and the surveys preflight are `#fbjs`-scoped. That was already true of every `label-*` class in this package (they resolve `--fb-*` vars only defined under `#fbjs`), so it is not a new constraint.
- If a card headline ever needs to sit under another heading, pass `headingLevel={3}`. Nothing uses it yet, so that path is typed and implemented but exercised by no test — the e2e assertions only cover the `h1`/`h2` tree that ships.

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.
