### PR TITLE
fix(security): stop publishing the bundled Valkey session store to the host [ENG-2184]

### DIFF
--- a/docker/__tests__/formbricks-script.test.ts
+++ b/docker/__tests__/formbricks-script.test.ts
@@ -1,3 +1,4 @@
+import { load } from "js-yaml";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -75,21 +76,20 @@ describe("docker/docker-compose.yml Redis/Valkey exposure (ENG-2184)", () => {
   // The bundled Valkey is Better Auth's session/token store (secondaryStorage). Publishing it to
   // the host binds 0.0.0.0:6379 with no password, exposing every live session token — and Docker's
   // port rule bypasses host firewalls like ufw. The app reaches it over the internal compose
-  // network (REDIS_URL=redis://redis:6379), so no host publish is needed. It must stay internal,
-  // exactly like the postgres service.
-  test("does not publish the session store to the host", () => {
-    const composeContents = readFileSync(dockerComposeTemplatePath, "utf8");
-    const redisBlock = getServiceBlock(composeContents, "redis");
+  // network (REDIS_URL=redis://redis:6379), so no host publish is needed. Assert on the *resolved*
+  // compose model — js-yaml expands anchors and merge keys — so a port smuggled in via an alias or
+  // a `<<` merge cannot slip past a raw-text check.
+  test("the redis service publishes no host port", () => {
+    const doc = load(readFileSync(dockerComposeTemplatePath, "utf8")) as {
+      services?: Record<string, { ports?: unknown }>;
+    };
+    const redis = doc.services?.redis;
 
-    expect(redisBlock).not.toMatch(/^\s*ports:/m);
-    expect(redisBlock).not.toContain("6379:6379");
-  });
-
-  test("keeps postgres internal too, as the reference pattern", () => {
-    const composeContents = readFileSync(dockerComposeTemplatePath, "utf8");
-    const postgresBlock = getServiceBlock(composeContents, "postgres");
-
-    expect(postgresBlock).not.toMatch(/^\s*ports:/m);
+    expect(redis, "the redis service is missing from docker-compose.yml").toBeTypeOf("object");
+    expect(
+      redis?.ports ?? [],
+      "the redis (Valkey) service must not publish any host port — it is reachable only on the internal compose network (ENG-2184)"
+    ).toEqual([]);
   });
 });
 

--- a/docker/__tests__/formbricks-script.test.ts
+++ b/docker/__tests__/formbricks-script.test.ts
@@ -71,6 +71,28 @@ describe("docker/docker-compose.yml Cube configuration", () => {
   });
 });
 
+describe("docker/docker-compose.yml Redis/Valkey exposure (ENG-2184)", () => {
+  // The bundled Valkey is Better Auth's session/token store (secondaryStorage). Publishing it to
+  // the host binds 0.0.0.0:6379 with no password, exposing every live session token — and Docker's
+  // port rule bypasses host firewalls like ufw. The app reaches it over the internal compose
+  // network (REDIS_URL=redis://redis:6379), so no host publish is needed. It must stay internal,
+  // exactly like the postgres service.
+  test("does not publish the session store to the host", () => {
+    const composeContents = readFileSync(dockerComposeTemplatePath, "utf8");
+    const redisBlock = getServiceBlock(composeContents, "redis");
+
+    expect(redisBlock).not.toMatch(/^\s*ports:/m);
+    expect(redisBlock).not.toContain("6379:6379");
+  });
+
+  test("keeps postgres internal too, as the reference pattern", () => {
+    const composeContents = readFileSync(dockerComposeTemplatePath, "utf8");
+    const postgresBlock = getServiceBlock(composeContents, "postgres");
+
+    expect(postgresBlock).not.toMatch(/^\s*ports:/m);
+  });
+});
+
 describe("docker/formbricks.sh Traefik label injection", () => {
   test("adds HTTPS Traefik labels to the formbricks service only", () => {
     const composePath = writeDockerComposeTemplate();

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -254,14 +254,16 @@ services:
 
   # Redis/Valkey service for caching, rate limiting, and audit logging
   # Remove this service if you want to use an external Redis/Valkey instance
+  # No host port is published: this instance is Better Auth's session/token store and is reached
+  # only over the internal compose network (REDIS_URL=redis://redis:6379). Publishing 6379 to the
+  # host would expose every live session token unauthenticated (and Docker's port rule bypasses
+  # host firewalls like ufw). Same treatment as the postgres service above.
   redis:
     restart: always
     image: valkey/valkey@sha256:12ba4f45a7c3e1d0f076acd616cb230834e75a77e8516dde382720af32832d6d
     command: valkey-server --appendonly yes --maxmemory-policy noeviction
     volumes:
       - redis:/data
-    ports:
-      - "6379:6379"
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 5s

--- a/docker/package.json
+++ b/docker/package.json
@@ -6,7 +6,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
+    "@types/js-yaml": "4.0.9",
     "@vitest/coverage-v8": "4.1.6",
+    "js-yaml": "4.3.1",
     "vite": "7.3.5",
     "vitest": "4.1.6"
   }

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -618,11 +618,17 @@ Common checks:
 
   **If the port was reachable from an untrusted network, also invalidate existing sessions.** Valkey persists
   to its `redis` volume, so removing the port does not clear session or token state an attacker may already
-  have written — a forged session can remain valid afterwards. After closing the port, rotate `NEXTAUTH_SECRET`
-  (and `BETTER_AUTH_SECRET`, if you set it) and restart the stack: this invalidates every session cookie, so
-  all users must sign in again, while stored data, the job queue, and the cache stay intact. Leave
-  `ENCRYPTION_KEY` unchanged, and do **not** run a blanket `FLUSHDB` — the same Valkey also holds BullMQ job
-  queues and the application cache.
+  have written — a forged session can remain valid afterward. After closing the port, set a new
+  `NEXTAUTH_SECRET` in your `.env`, then recreate the app container so it picks up the change:
+  ```bash
+  docker compose up -d --force-recreate formbricks
+  ```
+  A plain `docker compose restart` keeps the container's original environment, so the rotated secret would not
+  take effect. Recreating invalidates every session cookie, so all users must sign in again, while stored
+  data, the job queue, and the cache stay intact. (If you added `BETTER_AUTH_SECRET` to the `formbricks`
+  service environment yourself, rotate that instead — Better Auth prefers it over `NEXTAUTH_SECRET`; the
+  bundled compose ships only `NEXTAUTH_SECRET`.) Leave `ENCRYPTION_KEY` unchanged, and do **not** run a blanket
+  `FLUSHDB` — the same Valkey also holds BullMQ job queues and the application cache.
 </Warning>
 
 <Note>

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -588,10 +588,26 @@ Common checks:
 - **Hub auth errors**: Confirm the same `HUB_API_KEY` from `.env` is used by Formbricks Web and the Hub
   service.
 - **Port conflicts**: Confirm port `3000` and any optional service ports you enabled are not already in use on
-  the host. The bundled Valkey is not published to the host — it is reachable only on the internal compose
-  network — so it does not need port `6379` free on the host.
+  the host. The current template does not publish the bundled Valkey (`redis` service) to the host — it is
+  reachable only on the internal compose network — so a fresh install does not need port `6379` free on the
+  host.
 - **Optional Qwen/vLLM issues**: Check GPU availability, NVIDIA Container Toolkit installation, and
   `docker compose --profile qwen logs --tail=200 vllm`.
+
+<Warning>
+  **Existing installs: remove the bundled Valkey host port.** Older templates published the `redis`
+  (Valkey) service on `0.0.0.0:6379` with no password. That instance stores Better Auth sessions and
+  verification tokens, so an exposed port lets anyone who can reach it read live sessions and take over
+  accounts. Updating Formbricks (`docker compose pull` / `up -d`) does **not** rewrite your existing
+  `docker-compose.yml`, so the mapping stays until you remove it. Open your `docker-compose.yml`, delete the
+  ```yaml
+  ports:
+    - "6379:6379"
+  ```
+  lines from the `redis:` service, then run `docker compose up -d`. The app reaches Valkey over the internal
+  compose network, so nothing else needs to change. Only keep a publish if an external tool genuinely needs
+  it, and then bind it to loopback (`127.0.0.1:6379:6379`) rather than all interfaces.
+</Warning>
 
 <Note>
   To edit any of the available environment variables, check out our

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -587,8 +587,9 @@ Common checks:
   exist, then inspect `docker compose logs cube`.
 - **Hub auth errors**: Confirm the same `HUB_API_KEY` from `.env` is used by Formbricks Web and the Hub
   service.
-- **Port conflicts**: Confirm ports `3000`, `6379`, and any optional service ports you enabled are not already
-  in use on the host.
+- **Port conflicts**: Confirm port `3000` and any optional service ports you enabled are not already in use on
+  the host. The bundled Valkey is not published to the host — it is reachable only on the internal compose
+  network — so it does not need port `6379` free on the host.
 - **Optional Qwen/vLLM issues**: Check GPU availability, NVIDIA Container Toolkit installation, and
   `docker compose --profile qwen logs --tail=200 vllm`.
 

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -309,6 +309,14 @@ See our [migration guide](/self-hosting/advanced/migration) for version-specific
    docker compose up -d
    ```
 
+<Warning>
+  **Security (existing installs):** these steps — and the [one-click setup script](/self-hosting/setup/one-click)
+  updater, which runs the same `pull` / `down` / `up -d` — do **not** rewrite your existing
+  `docker-compose.yml`. If your bundled `redis` (Valkey) service still publishes `ports: - "6379:6379"`, it
+  stays exposed to the host after updating. See [Debug](#debug) for how to remove the mapping and, if the port
+  was reachable from an untrusted network, invalidate existing sessions.
+</Warning>
+
 ## Optional: Add RustFS for File Storage
 
 RustFS provides S3-compatible object storage for file uploads in Formbricks. It is not required for the
@@ -605,8 +613,16 @@ Common checks:
     - "6379:6379"
   ```
   lines from the `redis:` service, then run `docker compose up -d`. The app reaches Valkey over the internal
-  compose network, so nothing else needs to change. Only keep a publish if an external tool genuinely needs
-  it, and then bind it to loopback (`127.0.0.1:6379:6379`) rather than all interfaces.
+  compose network, so no other configuration change is needed. Only keep a publish if an external tool
+  genuinely needs it, and then bind it to loopback (`127.0.0.1:6379:6379`) rather than all interfaces.
+
+  **If the port was reachable from an untrusted network, also invalidate existing sessions.** Valkey persists
+  to its `redis` volume, so removing the port does not clear session or token state an attacker may already
+  have written — a forged session can remain valid afterwards. After closing the port, rotate `NEXTAUTH_SECRET`
+  (and `BETTER_AUTH_SECRET`, if you set it) and restart the stack: this invalidates every session cookie, so
+  all users must sign in again, while stored data, the job queue, and the cache stay intact. Leave
+  `ENCRYPTION_KEY` unchanged, and do **not** run a blanket `FLUSHDB` — the same Valkey also holds BullMQ job
+  queues and the application cache.
 </Warning>
 
 <Note>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,9 +677,15 @@ importers:
 
   docker:
     devDependencies:
+      '@types/js-yaml':
+        specifier: 4.0.9
+        version: 4.0.9
       '@vitest/coverage-v8':
         specifier: 4.1.6
         version: 4.1.6(vitest@4.1.6)
+      js-yaml:
+        specifier: 4.3.1
+        version: 4.3.1
       vite:
         specifier: 7.3.5
         version: 7.3.5(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)


### PR DESCRIPTION
Fixes ENG-2184

## What & why

The self-hosting `docker/docker-compose.yml` published the bundled Valkey service on the host with `ports: - "6379:6379"`, which binds `0.0.0.0:6379` with no password. That instance is Better Auth's `secondaryStorage` (`apps/web/modules/auth/lib/auth.ts`), holding live sessions — keyed by the raw session token — plus verification tokens and rate-limit counters.

Because the app resolves identity from the cached session JSON (better-auth's `findSession` returns the cached `{session, user}` without re-reading the DB on a cache hit, and the app DAL `getSession` only re-checks `isUserActive`), anyone able to reach the port could read every live session token and overwrite their own cached session to be served as any other user, including owners — no victim password and no `BETTER_AUTH_SECRET` required. Docker's published-port iptables rule also bypasses host firewalls like `ufw`, so a host-level firewall does not mitigate it.

The fix removes the host port mapping so Valkey is reachable only on the internal compose network. The app already connects via `REDIS_URL=redis://redis:6379` (service DNS), so nothing about app behaviour changes. This aligns the `redis` service with:
- the `postgres` service in the same file, which publishes no host port;
- `docker/migrate-to-v4.sh`'s `add_redis_service`, which already injects redis without a `ports:` mapping;
- the Helm chart, which ships `--requirepass` + `ClusterIP`.

The docs are updated too: the "Port conflicts" note no longer implies `6379` must be free; a warning tells **existing** self-hosters to remove the mapping themselves (updating does not rewrite an already-downloaded `docker-compose.yml`); and, for installs whose port was reachable from an untrusted network, a remediation step to invalidate potentially-forged sessions (Valkey's AOF volume persists them across the fix).

## Breaking changes

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| Bundled Valkey (`redis` service) host port | `6379` published on `0.0.0.0` (host-reachable) | not published — internal compose network only | Self-hosters using the bundled compose who reached Valkey from the host, and **all existing installs** (updating does not rewrite their `docker-compose.yml`) | New installs: none. Existing installs: delete `ports: - "6379:6379"` from the `redis:` service and run `docker compose up -d`. If the port was reachable from an untrusted network, also invalidate potentially-forged sessions — set a new `NEXTAUTH_SECRET` in `.env` and `docker compose up -d --force-recreate formbricks` (not `restart`, which keeps the old env). If an external tool genuinely needs access, bind it to loopback (`127.0.0.1:6379:6379`). The Formbricks app itself is unaffected — it uses the internal service address. |

## Migrations & env

- No change required for the fix itself. Existing self-hosters whose bundled Valkey port was reachable from an untrusted network should follow the remediation in the Breaking-changes table (remove the mapping; rotate `NEXTAUTH_SECRET` and recreate the `formbricks` container). Full steps in `docs/self-hosting/setup/docker.mdx`.

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `redis` service must not publish a host port | `unit (red on main)` — `docker/__tests__/formbricks-script.test.ts` → "the redis service publishes no host port". Asserts on the js-yaml-resolved compose model (`services.redis.ports` absent/empty), so anchors/`<<` merges can't smuggle a publish past it. | Re-adding `ports: - "6379:6379"` to the `redis` service and running `cd docker && pnpm test` → **1 failed / 5 passed**. With the fix → **all 6 pass**. |
| Existing-install remediation guidance is accurate | `manual` — code inspection of `update_formbricks()` in `docker/formbricks.sh` (rerun: `sed -n '980,990p' docker/formbricks.sh`) | Confirmed it runs only `docker compose pull` / `down` / `up -d` and never re-fetches the template, so the warning's premise (existing installs keep the mapping after updating) holds. |

`docker compose -f docker/docker-compose.yml config -q` still validates after the change.

**Open gaps**

- The "resolve identity from the cached blob" behaviour is upstream better-auth and is unchanged here — this PR closes the network exposure rather than altering session validation.
- Any other container on the compose default bridge can still reach Valkey unauthenticated. Adding `--requirepass` for defense-in-depth is intentionally deferred to a follow-up to keep this fix minimal and backportable.
- Existing installs are remediated by documentation only; the installer/update path is not auto-patched to strip the mapping. Propagating the callout into the dedicated one-click setup doc and a coordinated release advisory are follow-ups for a maintainer (raised in review).

**Risks**

- Only affects reachability of the bundled Valkey from the host. Anything that relied on `localhost:6379` against the compose Valkey must switch to the internal network address (see Breaking changes).

---

> [!NOTE]
> **AI model used** — `claude-opus-4-8`, reasoning effort `high`.