### PR TITLE
chore(rustfs): upgrade RustFS from 1.0.0-alpha.93 to 1.0.0-rc.2

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -156,7 +156,7 @@ jobs:
             -e RUSTFS_ADDRESS=:9000 \
             -e RUSTFS_CONSOLE_ENABLE=true \
             -e RUSTFS_CONSOLE_ADDRESS=:9001 \
-            rustfs/rustfs:1.0.0-alpha.93 \
+            rustfs/rustfs:1.0.0-rc.2@sha256:7d6d361c49c08d427250fb59aae5d78df83d644c3405d9ccf4b21cda0b0692d0 \
             /data
 
           echo "RustFS server started"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -88,7 +88,7 @@ services:
       - rustfs-data:/data
 
   rustfs:
-    image: rustfs/rustfs:1.0.0-alpha.93
+    image: rustfs/rustfs:1.0.0-rc.2@sha256:7d6d361c49c08d427250fb59aae5d78df83d644c3405d9ccf4b21cda0b0692d0
     depends_on:
       rustfs-perms:
         condition: service_completed_successfully

--- a/docker/formbricks.sh
+++ b/docker/formbricks.sh
@@ -764,7 +764,7 @@ EOF
       cat >> "$services_snippet_file" << EOF
   rustfs:
     restart: always
-    image: rustfs/rustfs:1.0.0-alpha.93
+    image: rustfs/rustfs:1.0.0-rc.2@sha256:7d6d361c49c08d427250fb59aae5d78df83d644c3405d9ccf4b21cda0b0692d0
     depends_on:
       rustfs-perms:
         condition: service_completed_successfully

--- a/docs/self-hosting/configuration/file-uploads.mdx
+++ b/docs/self-hosting/configuration/file-uploads.mdx
@@ -357,9 +357,11 @@ RUSTFS_CORS_ALLOWED_ORIGINS=https://app.yourdomain.com
   that excludes your Formbricks origin — set it to (or add) your origin. Use an explicit origin list in
   production; `*` allows all origins and should be avoided outside local testing.
 
-  RustFS versions up to `1.0.0-beta.1` instead reflected any request origin back when this variable was unset
-  ([GHSA-x5xv-223c-8vm7](https://github.com/rustfs/rustfs/security/advisories/GHSA-x5xv-223c-8vm7)). If you are
-  upgrading from one of those and relied on that permissive default, set this variable explicitly.
+  This changed in `1.0.0-beta.2`. Older images baked `RUSTFS_CORS_ALLOWED_ORIGINS=*` in, so leaving it unset
+  was permissive by default — and on versions up to `1.0.0-beta.1` the server reflected the caller's origin back
+  with `Access-Control-Allow-Credentials: true`
+  ([GHSA-x5xv-223c-8vm7](https://github.com/rustfs/rustfs/security/advisories/GHSA-x5xv-223c-8vm7)). The image no
+  longer bakes that value. If you relied on the old default, set this variable explicitly when you upgrade.
 </Note>
 
 <Warning>

--- a/docs/self-hosting/configuration/file-uploads.mdx
+++ b/docs/self-hosting/configuration/file-uploads.mdx
@@ -351,10 +351,15 @@ RUSTFS_CORS_ALLOWED_ORIGINS=https://app.yourdomain.com
 ```
 
 <Note>
-  When `RUSTFS_CORS_ALLOWED_ORIGINS` is unset, the RustFS server allows **all** origins; a non-empty value is
-  treated as an allow-list. So if browser uploads fail with a CORS error while the file still appears in RustFS,
-  this variable is most likely already set to a value that excludes your Formbricks origin — add your origin to it
-  (or set it to `*` to allow all). Use an explicit origin list in production.
+  When `RUSTFS_CORS_ALLOWED_ORIGINS` is unset, the RustFS server emits **no** CORS headers at all, so browsers
+  block cross-origin uploads; a non-empty value is treated as an allow-list. So if browser uploads fail with a
+  CORS error while the file still appears in RustFS, this variable is most likely either unset or set to a value
+  that excludes your Formbricks origin — set it to (or add) your origin. Use an explicit origin list in
+  production; `*` allows all origins and should be avoided outside local testing.
+
+  RustFS versions up to `1.0.0-beta.1` instead reflected any request origin back when this variable was unset
+  ([GHSA-x5xv-223c-8vm7](https://github.com/rustfs/rustfs/security/advisories/GHSA-x5xv-223c-8vm7)). If you are
+  upgrading from one of those and relied on that permissive default, set this variable explicitly.
 </Note>
 
 <Warning>

--- a/docs/self-hosting/configuration/file-uploads.mdx
+++ b/docs/self-hosting/configuration/file-uploads.mdx
@@ -360,8 +360,8 @@ RUSTFS_CORS_ALLOWED_ORIGINS=https://app.yourdomain.com
 <Warning>
   For standalone deployments, prefer the server-level `RUSTFS_CORS_ALLOWED_ORIGINS` variable over manually applying
   a per-bucket CORS policy: RustFS's support for the S3 `PutBucketCors` API has varied across releases and can
-  return "not implemented" on some builds. (The bundled bootstrap pins a RustFS version where per-bucket
-  `mc cors set` works.)
+  return "not implemented" on some builds. (The bundled bootstrap pins `rustfs/rustfs:1.0.0-rc.2`, on which
+  per-bucket `mc cors set` is verified to work.)
 </Warning>
 
 ### RustFS Security

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -416,7 +416,8 @@ services:
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       # CORS for browser uploads: set to your Formbricks origin(s), comma-separated.
-      # Unset = allow all origins; a value is treated as an allow-list. See the File Uploads guide.
+      # Unset = no CORS headers are emitted, so browser uploads fail; a value is treated as an allow-list.
+      # See the File Uploads guide.
       RUSTFS_CORS_ALLOWED_ORIGINS: "https://app.yourdomain.com"
     ports:
       - "9000:9000"

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -403,7 +403,7 @@ services:
       - rustfs-data:/data
 
   rustfs:
-    image: rustfs/rustfs:1.0.0-alpha.93
+    image: rustfs/rustfs:1.0.0-rc.2@sha256:7d6d361c49c08d427250fb59aae5d78df83d644c3405d9ccf4b21cda0b0692d0
     restart: always
     depends_on:
       rustfs-perms:

--- a/docs/self-hosting/setup/one-click.mdx
+++ b/docs/self-hosting/setup/one-click.mdx
@@ -334,6 +334,13 @@ The script pulls the latest images, stops the running containers, and starts the
   only then run the update command. If your older one-click install also uses bundled MinIO for file uploads,
   review that storage path separately before the first v5 restart; newer self-hosting updates move the bundled
   object-storage path to RustFS, while external S3-compatible storage keeps the same `S3_*` app contract.
+
+  The same applies to pinned third-party images. Because the update command only re-pulls what your Compose
+  file already names, a bundled `rustfs` service stays on whatever version it was installed with — `docker
+  compose pull` cannot move a pinned tag. To take a newer RustFS, edit the `image:` line of the `rustfs`
+  service in `formbricks/docker-compose.yml` to match the version in the [Docker
+  guide](/self-hosting/setup/docker), then run the update command. Your `rustfs-data` volume is reused as-is;
+  roll back by restoring the previous `image:` line.
 </Warning>
 
 ## Stop


### PR DESCRIPTION
Fixes ENG-2474

## What & why

All four Formbricks-owned RustFS pins were still on `1.0.0-alpha.93` (released 2026-04-10). Upstream has shipped 20 non-preview releases since and is now at `1.0.0-rc.2` (2026-08-14), which carries substantial security work — OIDC egress-policy enforcement, federated STS/root-principal collision protection, authenticated internode mutation bodies, atomic and replay-safe authenticated writes, extra secret/metadata redaction — plus repeated GET/PUT allocation, streaming, locking and small-object hot-path improvements.

This bumps every pin to the immutable multi-arch reference and brings dev, E2E, the self-hosting installer and the self-hosting docs onto one reviewed version:

- `docker-compose.dev.yml`, `docker/formbricks.sh` (installer heredoc), `docs/self-hosting/setup/docker.mdx` (manual-setup snippet), `.github/workflows/e2e.yml` → `rustfs/rustfs:1.0.0-rc.2@sha256:7d6d…92d0`. The `tag@digest` form keeps the version readable while being immutable, and matches the digest convention already used for `valkey` and `minio/mc` in the same compose file. No floating `latest`.
- `docs/self-hosting/configuration/file-uploads.mdx` — the `PutBucketCors` warning said the bootstrap "pins a RustFS version where per-bucket `mc cors set` works", a claim about alpha.93. It now names `1.0.0-rc.2` and says it was verified. The standalone-deployment guidance (prefer server-level `RUSTFS_CORS_ALLOWED_ORIGINS`) is unchanged.
- `docs/self-hosting/configuration/file-uploads.mdx` + `docs/self-hosting/setup/docker.mdx` — both said an unset `RUSTFS_CORS_ALLOWED_ORIGINS` means "allow all origins". That stopped being true in `1.0.0-beta.2`; on rc.2 unset emits **no** CORS headers at all. Corrected, including the troubleshooting hint that previously pointed readers away from the fix. Caught in review — see the fold below.
- `docs/self-hosting/setup/one-click.mdx` — the update command cannot move a pinned tag, so existing bundled installs stay on whatever RustFS version they were installed with. The guide's existing "update does not rewrite your Compose file" warning now carries the concrete step for the `rustfs` `image:` line. Also caught in review — see **Migrations & env**.

**Digest correction:** the digest recorded on ENG-2474 is 63 hex characters — one short. The real manifest-list digest, confirmed with `docker buildx imagetools inspect`, is `sha256:7d6d361c49c08d427250fb59aae5d78df83d644c3405d9ccf4b21cda0b0692d0` (OCI index over `linux/amd64` + `linux/arm64`).

<details>
<summary>Upstream breaking changes in the alpha.94 → rc.2 range, and why neither applies</summary>

Every release body in the range was reviewed (`gh api repos/rustfs/rustfs/releases`). Exactly two breaking changes are documented:

1. **beta.9/beta.10 — internode RPC secret fails closed.** RustFS now aborts at startup when it would derive the RPC secret from the credential pair while `RUSTFS_SECRET_KEY` is still the upstream default `rustfsadmin`. Not applicable: dev compose and E2E set `devrustfs123`, and `docker/formbricks.sh:552` generates the self-hosting admin password with `openssl rand -base64 20`. No `RUSTFS_RPC_SECRET` is introduced — confirmed by containers starting cleanly in the smoke tests below.
2. **beta.2 — `RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS` default changed from `*` to empty** (console becomes same-origin only). Not applicable: the console is only enabled in dev compose and E2E and is reached same-origin on `localhost:9001`; the installer does not enable it at all.

Nothing in the range changes `RUSTFS_ACCESS_KEY`, `RUSTFS_SECRET_KEY`, `RUSTFS_ADDRESS`, `RUSTFS_CONSOLE_ENABLE`, `RUSTFS_CONSOLE_ADDRESS`, `RUSTFS_CORS_ALLOWED_ORIGINS`, the default ports, the `/data` positional command arg, or the UID-10001 data-dir ownership that `rustfs-perms` sets up. rc.1 also added HTTP 426 for unmatched admin v4 routes so madmin-go v4 clients auto-downgrade to v3 — that helps the pinned `minio/mc`, it does not break it.
</details>

<details>
<summary>The behaviour change that a release-body scan misses: GHSA-x5xv-223c-8vm7</summary>

Scanning release notes found the two breaking changes above, but one behaviour change shipped as a **security advisory** instead and so wasn't in that list. [GHSA-x5xv-223c-8vm7](https://github.com/rustfs/rustfs/security/advisories/GHSA-x5xv-223c-8vm7) (medium, affected `<= 1.0.0-beta.1`, fixed `>= 1.0.0-beta.2`): `ConditionalCorsLayer` used to reflect any request `Origin` back as `Access-Control-Allow-Origin` together with `Access-Control-Allow-Credentials: true` when `RUSTFS_CORS_ALLOWED_ORIGINS` was unset. The fix makes unset emit no CORS headers at all.

Verified against the pinned rc.2 image rather than taken from the advisory text:

| Config | `OPTIONS` preflight w/ `Origin` | Result |
| --- | --- | --- |
| unset | `https://attacker.example` | **no `access-control-*` headers** (also none on `GET /`) |
| `https://app.example.com` | `https://app.example.com` | `access-control-allow-origin: https://app.example.com` |
| `https://app.example.com` | `https://attacker.example` | no `access-control-*` headers |
| `*` | `https://anything.example` | `access-control-allow-origin: *` |

**No effect on any bundled Formbricks path** — the RustFS server is never given `RUSTFS_CORS_ALLOWED_ORIGINS` in dev compose, E2E, or the installer. Dev/E2E pass it only to the `rustfs-init` container, which applies a *per-bucket* rule via `mc cors set`; the installer handles browser CORS at the Traefik `rustfs-cors` middleware. It affects standalone self-hosters, which is why it is called out in **Migrations & env** and fixed in the docs.
</details>

<details>
<summary>Production Helm ownership</summary>

`charts/formbricks` contains zero references to rustfs, minio or any `S3_*` / object-storage value; `Chart.yaml` declares only `postgresql`, `gateway-helm` (envoy), `redis` and `vllm-stack`. The public chart is intentionally external-object-storage-only, so there is no chart pin to bump. Recorded here rather than adding an unused RustFS dependency, per the ticket's last acceptance criterion.
</details>

## Breaking changes

- [x] This PR contains breaking changes

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| Effective default of `RUSTFS_CORS_ALLOWED_ORIGINS` | Unset meant allow-all: the alpha.93 image baked `RUSTFS_CORS_ALLOWED_ORIGINS=*` into its config, and up to `1.0.0-beta.1` the server reflected the caller's origin back with `Access-Control-Allow-Credentials: true` | Unset emits **no** `Access-Control-*` headers at all, so browsers block cross-origin requests. The rc.2 image no longer bakes the value | Standalone RustFS operators who serve browser uploads and never set the variable. **Not** the bundled Formbricks stack, which configures per-bucket CORS via `mc cors set` (dev, E2E) or the Traefik `rustfs-cors` middleware (installer) | Set `RUSTFS_CORS_ALLOWED_ORIGINS` on the RustFS server to your Formbricks origin(s) — your `WEBAPP_URL` — before or with the upgrade |
| Bundled RustFS version does not advance on update | `./formbricks.sh update` re-pulled whatever the operator's Compose file named | Unchanged mechanically — but the pin this PR moves only reaches **fresh** installs, so existing installs silently stay on alpha.93 and do not receive the security work motivating this upgrade | Existing bundled self-hosters | Edit the `image:` line of the `rustfs` service in `formbricks/docker-compose.yml` to the rc.2 reference, then run `./formbricks.sh update`. The `rustfs-data` volume is reused as-is; roll back by restoring the previous line |

<details>
<summary>Why this was initially filed as non-breaking</summary>

The box started unticked on the reasoning that no Formbricks-facing contract changes — no env var added or renamed, no port moves, `/data` and the UID-10001 volume ownership unchanged. That reasoning was scoped to the Formbricks diff and missed two things review surfaced: a **default does move** (upstream's, but carried by the image this PR pins), and **manual migration action is required** for two distinct audiences. The template counts both as breaking, so the box is ticked. Leaving it unticked would have kept exactly these two rows out of the release notes and the self-hoster migration guide, which is where they need to appear.
</details>

## Migrations & env

- No env or DB changes.
- **Fresh bundled installs** land on rc.2 with no action.
- **Existing bundled installs do _not_ pick this up automatically**, and an earlier version of this description wrongly said they would. `install_formbricks()` skips the rustfs block when a `rustfs:` service already exists (`docker/formbricks.sh:747`), and `update_formbricks()` only runs `pull` / `down` / `up -d` against the operator's existing `docker-compose.yml` — which still names alpha.93. `docker compose pull` cannot move a pinned tag. **Existing operators must edit the `image:` line of their `rustfs` service by hand**; that step is now documented in the one-click guide. The `rustfs-data` volume is reused as-is (verified below), so it is an image swap and nothing more.
- **Standalone RustFS operators** who relied on an unset `RUSTFS_CORS_ALLOWED_ORIGINS` behaving as allow-all: browser uploads stop working until it is set to your Formbricks origin(s). Upstream's change, not a Formbricks one — the alpha.93 image baked `RUSTFS_CORS_ALLOWED_ORIGINS=*` into its config and rc.2 does not.
- **Rollback:** restore `rustfs/rustfs:1.0.0-alpha.93` against the untouched `rustfs-data` volume and restart. Tested, not assumed — see the rollback row below.

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Bootstrap provisions bucket, CORS, policy and service user on rc.2 (`docker/rustfs-init.sh`) | manual | `rustfs-init` exits 0 on **both** `linux/arm64` and `linux/amd64`. `mc cors set` returns "Set bucket CORS config successfully" — this was the highest risk, since the docs warned `PutBucketCors` support "has varied across releases". `mc cors get` reads back the exact generated rule (5 methods, `ExposeHeader ETag`, `MaxAgeSeconds 3000`). |
| S3 round-trip as the least-privilege service user, fresh volume | manual | 1 MiB random blob PUT → GET is byte-identical by md5 on both arches; DELETE removes it; `GET /health` returns 200. `mc admin user list` as the service user is correctly **denied**, so the bucket-scoped policy is still least-privilege on rc.2. |
| In-place upgrade over an alpha.93 data volume | manual | Wrote a 2 MiB binary + a text object under alpha.93, stopped it, started rc.2 on the **same** volume: healthy in 2s, both objects read back byte-identical (md5 `47d5e681…`, `4cee2fee…`), the IAM service user still authenticates and the bucket CORS config survived. New PUT round-trips; DELETE works on both an rc.2-written and an alpha.93-written object. |
| Rollback rc.2 → alpha.93 on the same volume | manual | alpha.93 restarted on the rc.2-touched volume: healthy in 1s, IAM intact, the 2 MiB object still byte-identical, and writes still succeed. |
| CORS semantics on rc.2 with the variable unset / set / wildcard | manual | Probed the pinned rc.2 image directly with `curl`: unset emits **no** `access-control-*` headers on either `GET /` or an `OPTIONS` preflight; an allow-listed origin gets them; a non-listed origin does not; `*` still allows all. This is what the two docs corrections are based on. |
| RustFS web console on `:9001`, which dev compose and E2E both enable | manual | Compared alpha.93 and rc.2 side by side on identical config: **identical** on both — `/rustfs/console/` serves `200 text/html`, `/` returns `403 application/xml`. So the beta.2 `RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS` default change is exercised, not just argued, and the console is unaffected. |
| Existing bundled installs are not reached by a pin bump | manual | Read the installer paths rather than inferring: `docker/formbricks.sh:747` sets `insert_rustfs="n"` when a `rustfs:` service is already present, `update_formbricks()` (L980–988) only does `pull` / `down` / `up -d`, and no `sed` anywhere rewrites an `image:` line. So `formbricks.sh update` re-pulls alpha.93 from the operator's unchanged Compose file. Documented rather than code-fixed — see Open gaps. |
| Which image default actually changed for CORS | manual | `docker image inspect` on both pins: alpha.93 bakes `RUSTFS_CORS_ALLOWED_ORIGINS=*`, rc.2 does not. That is the mechanism behind the docs correction. Both still bake `RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS=*`, so the console keeps its permissive value and the beta.2 console-CORS change is a non-event here — consistent with the side-by-side console check below. |
| Dev compose still parses with the digest ref | manual | `docker compose -f docker-compose.dev.yml config` OK; resolved image is the rc.2 digest. |
| Installer-generated compose still parses | manual | Rendered the three rustfs heredocs from `docker/formbricks.sh` with representative values, assembled them into `docker/docker-compose.yml` exactly as the installer's `awk` insertion does, then `docker compose config` OK. The digest passes through the unquoted heredoc unescaped (it contains no `$`). |
| Generated init script stays byte-identical to the template | unit (guard) | `pnpm test --filter=@formbricks/storage` — 79/79 pass, including `rustfs-init-bootstrap.test.ts`, which asserts the script emitted by `docker/formbricks.sh` matches `docker/rustfs-init.sh` byte for byte. Neither file is touched by this PR, so the guard holds unmodified. |

Smoke tests ran the real `docker/rustfs-init.sh` against real containers via the digest-pinned `minio/mc`, mirroring what `e2e.yml` does — not a mock.

**Open gaps**

- **The installer is not fixed, only documented.** `update_formbricks()` still cannot move a pinned image, so existing bundled operators need a manual edit. This is structural and predates this PR — every pinned third-party image in the bundled stack (`busybox`, `minio/mc`, `valkey`) has the same gap — so fixing it means changing how the installer rewrites Compose, which is a larger change than a version bump should carry. Worth a follow-up ticket; happy to take it here instead if reviewers prefer.
- The E2E workflow itself only runs on this PR. `e2e.yml` is the sole CI job that exercises RustFS end to end (bucket `formbricks-e2e`, browser-upload CORS, presigned POST), so that gate closes here rather than locally.
- The amd64 fresh-volume run used an arm64 `mc` client against the amd64 RustFS server — Docker's content store cannot hold two arch variants under one manifest-list digest locally. The *server* under test was genuinely amd64 (`docker image inspect` → `Architecture: amd64`); only the S3 client differed, and the client arch does not affect what is being verified. On CI both are amd64.
- `docker/formbricks.sh` was not run end to end (it is interactive and performs host package installs); its compose output was reproduced and validated instead, as described above.

**Risks**

- Bundled-RustFS self-hosters get a new server binary on their next pull. The in-place upgrade and rollback are both verified above; if object reads regress after deploy, roll back to `rustfs/rustfs:1.0.0-alpha.93` against the same volume.
- Browser uploads depend on the per-bucket CORS rule applied by the bootstrap. `mc cors set` and `mc cors get` were verified on rc.2, and E2E covers the browser-upload path.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.
