### PR TITLE
fix(security): bump deepmerge-ts to 8.0.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   valibot: 1.4.2
   socket.io-parser@4: 4.2.7
   fast-uri@3: 3.1.5
+  deepmerge-ts: 8.0.1
 
 importers:
 
@@ -7788,8 +7789,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   deepmerge@4.3.1:
@@ -16235,7 +16236,7 @@ snapshots:
   '@prisma/config@7.8.0(magicast@0.5.2)':
     dependencies:
       c12: 3.3.4(magicast@0.5.2)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       effect: 3.20.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -20335,7 +20336,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   deepmerge@4.3.1: {}
 
@@ -22565,7 +22566,7 @@ snapshots:
 
   next-safe-action@8.1.10(next@16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       next: 16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
   valibot: 1.4.2
   socket.io-parser@4: 4.2.7
   fast-uri@3: 3.1.5
-  deepmerge-ts: 8.0.1
+  deepmerge-ts@7: 8.0.1
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -151,6 +151,17 @@ overrides:
   # backslash authority introducer; patched in 3.1.5. Previously self-resolved, reopened by the new
   # advisory. load-bearing: @redocly/ajv and ajv pull 3.1.4 (dev-only, API-docs tooling).
   fast-uri@3: 3.1.5
+  # ENG-2433 / ENG-2430 / GHSA-ggr8-5vv4-36mx (CVE-2026-40345): deepmerge-ts <8.0.0 has no cycle
+  # detection in its recursive record-merge routine, so two recursive object graphs sharing a
+  # property path exhaust the call stack (DoS); patched in 8.0.0. Pinned to 8.0.1 (lowest patched
+  # release, past the `minimumReleaseAge` cooldown as of 2026-08-19). This is a cross-major coercion
+  # of the only consumer, which declares a 7.x dependency — verified safe: @prisma/config only uses
+  # deepmerge-ts to merge developer-authored prisma.config.ts contents at CLI time, so the input is
+  # never attacker-controlled, and `prisma generate` / `prisma migrate` continue to resolve config
+  # correctly under 8.0.1.
+  # load-bearing: apps/web > @better-auth/oauth-provider > better-auth > @better-auth/prisma-adapter >
+  # @prisma/client > prisma > @prisma/config resolves 7.1.5.
+  deepmerge-ts: 8.0.1
   # === Removed once upstream caught up (kept as a record of what no longer needs a pin) ===
   # ajv@6, @babel/core, body-parser, engine.io@6, linkify-it, protobufjs@7 and uuid@11
   # all resolve to the patched version on their own now.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -155,13 +155,19 @@ overrides:
   # detection in its recursive record-merge routine, so two recursive object graphs sharing a
   # property path exhaust the call stack (DoS); patched in 8.0.0. Pinned to 8.0.1 (lowest patched
   # release, past the `minimumReleaseAge` cooldown as of 2026-08-19). This is a cross-major coercion
-  # of the only consumer, which declares a 7.x dependency — verified safe: @prisma/config only uses
-  # deepmerge-ts to merge developer-authored prisma.config.ts contents at CLI time, so the input is
-  # never attacker-controlled, and `prisma generate` / `prisma migrate` continue to resolve config
+  # of two consumers, both of which declare a 7.x dependency — verified safe: @prisma/config only
+  # merges developer-authored prisma.config.ts contents at CLI time, and next-safe-action merges
+  # middleware context (plain objects, 2-3 levels, no Map/Set) via `deepmerge`, so none of 8.0.0's
+  # breaking changes apply: the deepmergeInto mutation fix and the renamed mergeInfo/
+  # DeepMergeIntoUtils types are out of scope, the mergeMaps collision change needs a Map, and the
+  # new maxDepth defaults to 1000. `prisma generate` / `prisma migrate` still resolve config
   # correctly under 8.0.1.
-  # load-bearing: apps/web > @better-auth/oauth-provider > better-auth > @better-auth/prisma-adapter >
-  # @prisma/client > prisma > @prisma/config resolves 7.1.5.
-  deepmerge-ts: 8.0.1
+  # load-bearing (runtime): apps/web > next-safe-action (direct, ^7.1.5) merges server-action
+  # middleware ctx (ActionClientCtx — ipAddress/oldObject/newObject can carry request-derived data)
+  # on every invocation.
+  # load-bearing (dev-only, Prisma CLI): apps/web > @better-auth/oauth-provider > better-auth >
+  # @better-auth/prisma-adapter > @prisma/client > prisma > @prisma/config resolves 7.1.5.
+  deepmerge-ts@7: 8.0.1
   # === Removed once upstream caught up (kept as a record of what no longer needs a pin) ===
   # ajv@6, @babel/core, body-parser, engine.io@6, linkify-it, protobufjs@7 and uuid@11
   # all resolve to the patched version on their own now.


### PR DESCRIPTION
Fixes ENG-2433
Fixes ENG-2430

## What & why

Daily Dependabot security sweep. `deepmerge-ts@7.1.5` (resolved tree-wide, single version) is vulnerable to [GHSA-ggr8-5vv4-36mx](https://github.com/advisories/GHSA-ggr8-5vv4-36mx) (CVE-2026-40345): the recursive record-merge routine has no cycle detection, so two recursive object graphs sharing a property path exhaust the call stack (DoS). Patched in `8.0.0`.

There are **two** consumers, both declaring `^7.1.5`:

```
apps/web > next-safe-action (direct) > deepmerge-ts
apps/web > @better-auth/oauth-provider > better-auth > @better-auth/prisma-adapter > @prisma/client > prisma > @prisma/config > deepmerge-ts
```

- `@prisma/config` only merges the developer-authored contents of `prisma.config.ts` at CLI time — never attacker-controlled.
- `next-safe-action` calls `deepmerge` in its middleware chain (`dist/index.mjs:322`) on **every server action invocation**, merging `ActionClientCtx` (`apps/web/lib/utils/action-client/types/context.ts`), which carries request-derived data (`ipAddress`, `oldObject`/`newObject` entity snapshots). This is a request-serving path, and pinning across the 7→8 major coerces it too.

Verified this is still safe: diffed 8.0.0's breaking changes against `ActionClientCtx` — the only one that reaches `deepmerge` (not `deepmergeInto`) is Map-collision merging, and `ActionClientCtx` is plain records/strings/optional fields with no `Map`/`Set` anywhere in the type. Behavior is identical for our shapes.

Added a `pnpm-workspace.yaml` override pinning `deepmerge-ts@7` to `8.0.1` (lowest patched release, past the repo's 3-day `minimumReleaseAge` cooldown as of 2026-08-19), scoped to the `7.x` line so a future `9.x` requester isn't silently downgraded. This is the only open `[Dependabot #...]` security issue in Linear right now, so the batch is a single package.

| Package | Old version | New version | GHSA/CVE | Severity | Linear issue | Direct or override |
| --- | --- | --- | --- | --- | --- | --- |
| `deepmerge-ts` | 7.1.5 | 8.0.1 | GHSA-ggr8-5vv4-36mx / CVE-2026-40345 | High | ENG-2433 (Dependabot #719), ENG-2430 | Override (transitive, both `@prisma/config` and `next-safe-action`) |

### Needs a human

None — this fix is a clean version pin with no breaking changes for either consumer.

## Breaking changes

- [ ] This PR contains breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `deepmerge-ts` resolves to the patched version everywhere in the tree | manual (`pnpm why deepmerge-ts`) | Before: single resolved version `7.1.5` across all paths. After: single resolved version `8.0.1`, still true after scoping the override to `@7` |
| `pnpm audit` no longer reports the advisory | manual | Before: `deepmerge-ts` GHSA-ggr8-5vv4-36mx listed (high). After: only the two already-tracked/deferred findings remain — `brace-expansion` (ENG-2234, its own deferred PR) and `@better-auth/oauth-provider` (accepted risk, being closed by the separate #8835 for ENG-2343) |
| The coerced `@prisma/config` chain still resolves `prisma.config.ts` correctly | manual | `DATABASE_URL=... pnpm --filter @formbricks/database exec prisma generate` — loads `prisma.config.ts` and generates the Prisma client and json-types successfully under `deepmerge-ts@8.0.1` |
| The coerced `next-safe-action` runtime path (server-action middleware ctx merge) still behaves correctly | unit (guard) + manual diff | `apps/web/lib/utils/action-client/index.test.ts` and `action-client-middleware.test.ts` (54 tests) pass unmocked/mocked respectively against the real installed `next-safe-action@8.1.10` + `deepmerge-ts@8.0.1`. Manually diffed 8.0.0's breaking changes against `ActionClientCtx`'s actual shape — no `Map`/`Set` field exists, so the one behavior-affecting change (Map colliding-key merge) doesn't apply |
| No regression elsewhere | unit + lint + format | `pnpm lint` — 21/21 packages pass (pre-existing `react-hooks/exhaustive-deps` warnings only, unrelated to this diff). `pnpm test` — 627/627 test files, 8289/8289 tests pass. `pnpm format` — no changes needed (`format:check` clean) |

**Open gaps**

- none

**Risks**

- The `8.x` line is a major bump for `deepmerge-ts`'s merge semantics, and it now covers a request-serving path (`next-safe-action`'s middleware ctx merge), not just CLI-time config resolution. A future change to `ActionClientCtx` that introduces a `Map` or `Set` field would need re-checking against 8.x's Map-collision-merge behavior change before this override could be assumed safe again.