### PR TITLE
fix(sentry): fix source map uploads and stop them failing silently

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -474,8 +474,8 @@ if (process.env.WEBAPP_URL) {
 // derived in lib/constants.ts. CI bumps apps/web/package.json to the release version before
 // the image build (.github/actions/build-and-push-docker/action.yml), so the release the
 // artifacts are uploaded under and the release the events are tagged with always agree.
-// A local or PR build still carries the unbumped 0.0.0 and deliberately yields no release,
-// rather than uploading under one literally named "undefined".
+// It doubles as the "is this an official release build?" signal below: only CI bumps this
+// file, so an unbumped 0.0.0 means a local or self-hosted build.
 const sentryRelease = (() => {
   try {
     const { version } = require("./package.json");
@@ -502,15 +502,33 @@ const sentryOptions = {
   // Automatically tree-shake Sentry logger statements to reduce bundle size
   disableLogger: false,
 
+  sourcemaps: {
+    // The SDK documents this as defaulting to true, but it only applies that default on the
+    // same path that turns `productionBrowserSourceMaps` on for you — and line 57 already
+    // sets that explicitly, so the SDK bails out first. Without this the generated .map
+    // files stay in the image and are served publicly.
+    deleteSourcemapsAfterUpload: true,
+
+    // Only an official release build uploads. A local or self-hosted build carries 0.0.0, and
+    // its token either has no access to this org (so the upload fails) or does (so a laptop
+    // would create a git-SHA release in our production project). "disable-upload" skips the
+    // upload while still injecting Debug IDs — `true` would skip those too, which would leave
+    // the image unsymbolicatable and defeat the point of the read-secrets.sh change. The
+    // string is honoured by the underlying bundler plugin; @sentry/nextjs types the field as
+    // boolean, so re-verify this if the SDK is upgraded.
+    disable: sentryRelease ? false : "disable-upload",
+  },
+
   release: { name: sentryRelease },
 
   // The plugin's default is to log an upload failure and leave the build green, which is why
-  // a wrong project slug went unnoticed for two years. Fail the build instead: an image whose
-  // source maps never uploaded produces unreadable production stack traces, and that is not
-  // something to discover later from Sentry.
-  errorHandler: (err) => {
-    throw err;
-  },
+  // a wrong project slug went unnoticed for two years. On a release build, fail instead: an
+  // image whose source maps never uploaded produces unreadable production stack traces.
+  errorHandler: sentryRelease
+    ? (err) => {
+        throw err;
+      }
+    : undefined,
 };
 
 // Always enable Sentry plugin to inject Debug IDs

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -470,10 +470,27 @@ if (process.env.WEBAPP_URL) {
   };
 }
 
+// Build-time release identifier, derived exactly the way the runtime `SENTRY_RELEASE` is
+// derived in lib/constants.ts. CI bumps apps/web/package.json to the release version before
+// the image build (.github/actions/build-and-push-docker/action.yml), so the release the
+// artifacts are uploaded under and the release the events are tagged with always agree.
+// A local or PR build still carries the unbumped 0.0.0 and deliberately yields no release,
+// rather than uploading under one literally named "undefined".
+const sentryRelease = (() => {
+  try {
+    const { version } = require("./package.json");
+    return version && version !== "0.0.0" ? `${version}` : undefined;
+  } catch {
+    return undefined;
+  }
+})();
+
 const sentryOptions = {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
-  project: "formbricks-cloud",
+  // Production ingests into formbricks/formbricks (EU). "formbricks-cloud" lives in a
+  // different org (formbricks-us), so uploads were rejected with "projects are invalid".
+  project: "formbricks",
   org: "formbricks",
 
   // Enable logging to debug sourcemap generation issues
@@ -484,6 +501,16 @@ const sentryOptions = {
 
   // Automatically tree-shake Sentry logger statements to reduce bundle size
   disableLogger: false,
+
+  release: { name: sentryRelease },
+
+  // The plugin's default is to log an upload failure and leave the build green, which is why
+  // a wrong project slug went unnoticed for two years. Fail the build instead: an image whose
+  // source maps never uploaded produces unreadable production stack traces, and that is not
+  // something to discover later from Sentry.
+  errorHandler: (err) => {
+    throw err;
+  },
 };
 
 // Always enable Sentry plugin to inject Debug IDs

--- a/apps/web/scripts/docker/read-secrets.sh
+++ b/apps/web/scripts/docker/read-secrets.sh
@@ -86,22 +86,17 @@ else
 fi
 
 if [ -f "/run/secrets/sentry_auth_token" ]; then
-  # Only upload sourcemaps on amd64 platform to avoid duplicate uploads
-  # Sourcemaps are platform-agnostic, so we only need to upload once
-  # TARGETARCH is automatically set by Docker during multi-platform builds
-  if [ "${TARGETARCH:-}" = "amd64" ]; then
-    IFS= read -r SENTRY_AUTH_TOKEN < /run/secrets/sentry_auth_token || true
-    SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN%$'\n'}
-    export SENTRY_AUTH_TOKEN
-    echo "✅ Sentry auth token found. Sourcemaps will be uploaded during build (${TARGETARCH} platform)."
-    echo "🔧 SENTRY_AUTH_TOKEN environment variable exported for build process."
-  else
-    echo "✅ Sentry auth token found but skipping upload on ${TARGETARCH:-unknown} platform."
-    echo "ℹ️  Sourcemaps will only be uploaded on amd64 platform to avoid duplicates."
-    echo "🔧 Debug IDs will still be injected for proper error correlation."
-  fi
+  # The token must be exported on every platform, not just amd64. next.config.mjs only wraps
+  # the app in withSentryConfig when SENTRY_AUTH_TOKEN is set, so gating the export by arch
+  # meant an arm64 image got no Debug IDs at all and its stack traces could never be
+  # symbolicated. Uploading the same Debug IDs twice is idempotent and costs a little build
+  # time; shipping an unsymbolicatable image is not a trade worth making.
+  IFS= read -r SENTRY_AUTH_TOKEN < /run/secrets/sentry_auth_token || true
+  SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN%$'\n'}
+  export SENTRY_AUTH_TOKEN
+  echo "✅ Sentry auth token found. Debug IDs will be injected and sourcemaps uploaded (${TARGETARCH:-unknown} platform)."
 else
-  echo "⚠️  SENTRY_AUTH_TOKEN secret not found. Sourcemaps will not be uploaded but Debug IDs will still be injected."
+  echo "⚠️  SENTRY_AUTH_TOKEN secret not found. Sourcemaps will not be uploaded and Debug IDs will NOT be injected."
 fi
 
 # Verify environment variables are set before starting build

--- a/apps/web/scripts/docker/read-secrets.sh
+++ b/apps/web/scripts/docker/read-secrets.sh
@@ -92,9 +92,8 @@ if [ -f "/run/secrets/sentry_auth_token" ]; then
   # symbolicated. Uploading the same Debug IDs twice is idempotent and costs a little build
   # time; shipping an unsymbolicatable image is not a trade worth making.
   IFS= read -r SENTRY_AUTH_TOKEN < /run/secrets/sentry_auth_token || true
-  SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN%$'\n'}
   export SENTRY_AUTH_TOKEN
-  echo "✅ Sentry auth token found. Debug IDs will be injected and sourcemaps uploaded (${TARGETARCH:-unknown} platform)."
+  echo "✅ Sentry auth token found. Debug IDs will be injected (${TARGETARCH:-unknown} platform). Sourcemaps are uploaded only on a release build."
 else
   echo "⚠️  SENTRY_AUTH_TOKEN secret not found. Sourcemaps will not be uploaded and Debug IDs will NOT be injected."
 fi


### PR DESCRIPTION
Fixes ENG-2321

## What & why

Production source maps have never been applied. `apps/web/next.config.mjs` uploaded to project `formbricks-cloud`, which lives in the `formbricks-us` org (`us.sentry.io`), while `org` was set to `formbricks` (`de.sentry.io`) — not a valid combination, so the Sentry CLI rejected every upload with `One or more projects are invalid (http status: 400)`. `git log -S'formbricks-cloud'` dates the slug to 2023-07-31, so this has been broken for about two years. Every production stack trace, server and browser, stays minified and cannot be grounded to a `file:line`.

Fixing the slug alone would leave the same failure able to recur silently, and would newly break builds that are not ours. So:

- **`project: "formbricks"`** — the project production actually ingests into. `find_projects` on the `formbricks` org returns only `formbricks` and `license`; there is no `formbricks-cloud` there.
- **An `errorHandler` that rethrows on release builds.** The plugin's default logs the failure and leaves the build green. That is *why* a wrong slug survived two years: `silent: false` was already printing the 400 in every release build and nothing was watching.
- **`sourcemaps.deleteSourcemapsAfterUpload: true`.** The SDK documents this as defaulting to `true`, but it only applies that default inside the path that also turns `productionBrowserSourceMaps` on for you, and that path early-returns when the field is already set — which `next.config.mjs:57` always does. So the default never landed, and the `.map` files stayed in the image and are served publicly. This option is what closes that, not the slug fix.
- **Uploads scoped to release builds** via `sourcemaps.disable: "disable-upload"` when there is no release. Without this, a local or self-hosted build with `SENTRY_AUTH_TOKEN` set would upload into the *production* `formbricks` project under a release named after the local git SHA (with `create`/`finalize` defaulting to true), and the new `errorHandler` would hard-fail a build that was previously green. `"disable-upload"` skips the upload while still injecting Debug IDs; `true` would skip those too.
- **An explicit release**, derived from `apps/web/package.json` exactly the way the runtime `SENTRY_RELEASE` is derived in `lib/constants.ts`. CI bumps that file before the image build, so build-time and runtime releases agree, and it doubles as the "is this an official release build?" signal above. The real command previously ran `--release undefined`. Derived from the file rather than an env var, so no new env plumbing and no `turbo.json` change.
- **Export `SENTRY_AUTH_TOKEN` on every platform, not just amd64.** The arch gate existed to avoid duplicate uploads, but `next.config.mjs` only wraps the app in `withSentryConfig` when the token is set — so on arm64 the plugin never ran and **no Debug IDs were injected at all**, contradicting the script's own `Debug IDs will still be injected` message. Re-uploading identical Debug IDs is idempotent and costs a little build time; shipping an unsymbolicatable image is the worse trade.

Also drops `${SENTRY_AUTH_TOKEN%$'\n'}` (pre-existing, relocated by this PR): `read -r` already strips the delimiter, and the expression was the file's only shellcheck finding.

<details>
<summary>Hypotheses ruled out, recorded so they don't get reopened</summary>

- **Turbopack is not the problem.** Debug IDs are injected and maps are generated. Verified against live production: chunk `2j7l4be8fe5f4.js` carries `debugId=5910d473-…` and its `.map` carries the identical id with real `turbopack:///[project]/apps/web/...` sources. Only the upload half was missing.
- **Region / `sentryUrl` is not a blocker.** A 400 `projects are invalid` means auth and org already resolved; a wrong region returns 401/403/404. No `sentryUrl` change is needed.
- **`require()` in `.mjs` is fine here.** `next.config.mjs:11` already defines `const require = createRequire(import.meta.url)`.

</details>

## Breaking changes

- [ ] This PR contains breaking changes

None. Internal build configuration only — no API or SDK shape, endpoint, route, env var, config key, default or webhook payload changes. Note this was *nearly* breaking for self-hosters: an earlier revision made any build with `SENTRY_AUTH_TOKEN` set hard-fail on upload error, which would have broken self-hosted image builds whose token has no access to the `formbricks` org. The `disable: "disable-upload"` gate is what keeps it non-breaking.

## Migrations & env

- none. The release name is read from `apps/web/package.json`, so no new env var and no `turbo.json` `build.env` entry is required.

## How this was tested

**Coverage**

Verified end to end on a real release build: [run 32345497459](https://github.com/formbricks/formbricks/actions/runs/32345497459) (`Build Community Testing Images`, dispatched from this branch, `linux/amd64,linux/arm64`, **success**). Library-level probes against the installed `@sentry/nextjs@10.43.0` cover the option resolution underneath it.

| Behaviour | How | Outcome |
| --- | --- | --- |
| The bug reproduces in a real release build | manual | Run `31487401618` (5.3.4 `:production`, 2026-08-11): `One or more projects are invalid (http status: 400)` on `sourcemaps upload -p formbricks-cloud --release undefined`, twice per job — client (`Found 449 files`) and server (`Found 2704 files`) both bundle, both uploads rejected. `grep -c "Successfully uploaded source maps"` → **0**. Same in the older July run. |
| `formbricks-cloud` does not exist in the `formbricks` org | manual | `find_projects(formbricks, de.sentry.io)` → exactly `formbricks` and `license`. |
| Source maps are currently served publicly | manual | `https://app.formbricks.com/_next/static/chunks/27bydrymu7mm7.js.map` → `200`, 638 KB, full first-party `sourcesContent`. |
| The deletion default really never landed, so the option is required | manual | Probed the real SDK on the Turbopack path this build uses (`parseBundlerArgs({})` → `0`, `detectActiveBundler()` → `turbopack`). Without the option: `deleteSourcemapsAfterUpload = undefined`, `filesToDeleteAfterUpload = undefined`, and the real `deleteArtifacts()` no-op'd on its `filesToDelete !== void 0` guard. With it: the four `.next/static/**/*.{js,mjs,cjs,css}.map` globs and `WOULD DELETE`. Server maps are outside that glob. |
| `errorHandler` really fails the build, and only on release builds | manual | Drove the real `createSentryBuildPluginManager(...).uploadSourcemaps()` with an invalid token: stock SDK default resolves green (`handleRecoverableError(e, false)` = log-and-continue); with this `errorHandler` it is invoked once and throws, on the Turbopack `runAfterProductionCompile` path. With version `0.0.0` the handler resolves to `undefined` and nothing is attempted. |
| `"disable-upload"` skips the upload but keeps Debug IDs | manual | Three-way probe of the resolved options: `false` → Debug IDs ✓, upload ✓. `true` → upload skipped but **Debug IDs skipped too** (`handleRunAfterProductionCompile.js:54` and `constructTurbopackConfig.js:30` both guard on `!== true`). `"disable-upload"` → Debug IDs ✓, upload skipped ✓. This is why the value is a string and not `true`. |
| The removed shell expansion was dead code | manual | `IFS= read -r` leaves no trailing newline: identical output across 7 fixtures (LF, no-LF, CRLF, CR, literal `$\n`, multiline, empty) × 5 host shells, plus real BusyBox ash 1.36.1 and 1.37.0, plus the unmodified script run in Alpine against a real `/run/secrets` file. `shellcheck --shell=sh` goes from 1 finding (SC3003 — also present on `main`) to **0**. |
| Changed files parse | manual | `node --check apps/web/next.config.mjs` → clean. `sh -n apps/web/scripts/docker/read-secrets.sh` → clean. |
| **The upload now succeeds** | manual | Run 32345497459: `Successfully uploaded source maps to Sentry` ×2 (`grep -c` → **2**, was **0**), logged by `[@sentry/nextjs - After Production Compile]` — the Turbopack path. Client `Found 443 files` / `Analyzing 443 sources`, server `Found 2738 files` / `Analyzing 2738 sources`, both uploaded. Zero `projects are invalid`, zero `Source map upload was disabled`, zero `No auth token provided`. |
| The release name is real, not `undefined` | manual | Same run: `Release: 0.0.0-alpha-anshuman-eng-2321-…-1787211966`. Confirms the CI version bump reaches `next build`, so `sentryRelease` is set and the upload is not silently skipped by the `disable` gate — the one way this change could pass while doing nothing. |
| `SENTRY_AUTH_TOKEN` is scoped correctly | manual | Implied by the successful upload to `formbricks/formbricks`. |
| Debug IDs are injected on **both** architectures | manual | Same run, both legs: `Sentry auth token found. Debug IDs will be injected (amd64 platform)` and `… (arm64 platform)`. This is the arm64 fix observed rather than inferred. |
| Browser source maps are no longer served publicly | manual | Pulled the resulting image (`ghcr.io/formbricks/formbricks-experimental:0.0.0-alpha-…`) and counted `.map` files: **`.next/static/` → 0**, `public/` → 0, `.next/server/` → 188, `node_modules` → 2401. The two publicly served paths are clean. The surviving server maps are empty stubs (`{"version":3,"sources":[],"sections":[]}`, no `sourcesContent`) and `.next/server` is not served; the `node_modules` maps are vendor-shipped and pre-existing. |

**Open gaps**

- **Not yet confirmed on production.** The verification above ran on an experimental image, not a prod deploy. Whether previously unreadable issues become groundable still needs the next real release — `FORMBRICKS-183` / ENG-2259 is the first to re-check.
- **Deletion was not probed on the no-release path.** The image check above covers the `disable: false` (release) path, which is the one that produces our production image. Whether `deleteArtifacts()` still fires when the upload is skipped was never executed; at worst that path is unchanged from today.
- **The experimental run created a junk release** (`0.0.0-alpha-anshuman-eng-2321-…`) in the production `formbricks` Sentry project, with its artifacts. Harmless, but worth deleting.
- Out of scope, surfaced by this run: the build logs `DEPRECATION WARNING: disableLogger is deprecated … (Not supported with Turbopack.)`. `disableLogger: false` predates this PR and is already a no-op; removing it belongs in its own change.

**Risks**

- **This converts a silent failure into a loud one on release builds.** Any future upload problem now fails the release build instead of shipping a broken image. That is the intent, and it has been exercised once successfully (run 32345497459).
- **`"disable-upload"` is a string where `@sentry/nextjs` types the field as `boolean`.** It is honoured by the underlying bundler plugin and verified above, but it is the one thing here worth re-checking on an SDK upgrade. A regression would be silent (no upload on release builds), which the `Successfully uploaded source maps` check catches.
- **arm64 now uploads as well as x64.** Extra build time on multi-platform builds; uploads are duplicates and idempotent by Debug ID.
- Local, PR and self-hosted builds are unaffected: `0.0.0` means no release, so no upload and no rethrow, and without a token `withSentryConfig` is not applied at all.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.
