### PR TITLE
chore: add consistent UTM tags to all outbound formbricks.com links

### DIFF
--- a/apps/web/app/(app)/account/settings/profile/page.tsx
+++ b/apps/web/app/(app)/account/settings/profile/page.tsx
@@ -76,7 +76,7 @@ const Page = async () => {
                     text: t("common.learn_more"),
                     href: IS_FORMBRICKS_CLOUD
                       ? billingUpgradeHref
-                      : "https://formbricks.com/learn-more-self-hosting-license",
+                      : "https://formbricks.com/learn-more-self-hosting-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=ee_lock_two_factor",
                   },
                 ]}
               />

--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -325,7 +325,7 @@ export const MainNavigation = ({
         text: t("workspace.settings.billing.upgrade"),
         href: isLicenseActive
           ? `/organizations/${organization.id}/settings/enterprise`
-          : "https://formbricks.com/upgrade-self-hosted-license",
+          : "https://formbricks.com/upgrade-self-hosted-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=upgrade_prompt_nav",
       },
       {
         text: t("common.cancel"),

--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/workspace-breadcrumb.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/workspace-breadcrumb.tsx
@@ -124,7 +124,7 @@ export const WorkspaceBreadcrumb = ({
         text: t("workspace.settings.billing.upgrade"),
         href: isLicenseActive
           ? `/organizations/${currentOrganizationId}/settings/enterprise`
-          : "https://formbricks.com/upgrade-self-hosted-license",
+          : "https://formbricks.com/upgrade-self-hosted-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=upgrade_prompt_breadcrumb",
       },
       {
         text: t("common.cancel"),

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/components/SecurityListTip.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/components/SecurityListTip.tsx
@@ -13,7 +13,7 @@ export const SecurityListTip = () => {
         <p className="text-sm">
           {t("workspace.settings.general.security_list_tip")}{" "}
           <Link
-            href="https://formbricks.com/security#stay-informed-with-formbricks-security-updates"
+            href="https://formbricks.com/security?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=security_tip#stay-informed-with-formbricks-security-updates"
             target="_blank"
             rel="noopener noreferrer"
             className="underline hover:text-blue-700">

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/personal-links-tab.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/personal-links-tab.tsx
@@ -177,7 +177,7 @@ export const PersonalLinksTab = ({
             text: t("common.learn_more"),
             href: isFormbricksCloud
               ? `/organizations/${workspace?.organizationId}/settings/billing`
-              : "https://formbricks.com/learn-more-self-hosting-license",
+              : "https://formbricks.com/learn-more-self-hosting-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=ee_lock_personal_links",
           },
         ]}
       />

--- a/apps/web/app/lib/survey-builder.ts
+++ b/apps/web/app/lib/survey-builder.ts
@@ -84,7 +84,8 @@ export const getDefaultEndingCard = (languages: TSurveyLanguage[], t: TFunction)
     headline: createI18nString(t("templates.default_ending_card_headline"), languageCodes),
     subheader: createI18nString(t("templates.default_ending_card_subheader"), languageCodes),
     buttonLabel: createI18nString(t("templates.default_ending_card_button_label"), languageCodes),
-    buttonLink: "https://formbricks.com",
+    buttonLink:
+      "https://formbricks.com?utm_source=formbricks-app&utm_medium=survey&utm_campaign=default_ending_cta",
   };
 };
 

--- a/apps/web/app/lib/templates.ts
+++ b/apps/web/app/lib/templates.ts
@@ -571,7 +571,8 @@ const churnSurvey = (t: TFunction): TTemplate => {
               subheader: t("templates.churn_survey_question_3_html"),
               headline: t("templates.churn_survey_question_3_headline"),
               required: false,
-              buttonUrl: "https://formbricks.com",
+              buttonUrl:
+                "https://formbricks.com?utm_source=formbricks-app&utm_medium=survey&utm_campaign=template_cta_churn_survey",
               buttonExternal: true,
               ctaButtonLabel: t("templates.churn_survey_question_3_button_label"),
             }),
@@ -1000,7 +1001,8 @@ const improveTrialConversion = (t: TFunction): TTemplate => {
               subheader: t("templates.improve_trial_conversion_question_4_html"),
               headline: t("templates.improve_trial_conversion_question_4_headline"),
               required: false,
-              buttonUrl: "https://formbricks.com/github",
+              buttonUrl:
+                "https://formbricks.com/github?utm_source=formbricks-app&utm_medium=survey&utm_campaign=template_cta_trial_conversion",
               buttonExternal: true,
               ctaButtonLabel: t("templates.improve_trial_conversion_question_4_button_label"),
             }),
@@ -1119,7 +1121,8 @@ const reviewPrompt = (t: TFunction): TTemplate => {
               subheader: t("templates.review_prompt_question_2_html"),
               headline: t("templates.review_prompt_question_2_headline"),
               required: false,
-              buttonUrl: "https://formbricks.com/github",
+              buttonUrl:
+                "https://formbricks.com/github?utm_source=formbricks-app&utm_medium=survey&utm_campaign=template_cta_review_prompt",
               buttonExternal: true,
               ctaButtonLabel: t("templates.review_prompt_question_2_button_label"),
             }),
@@ -3952,7 +3955,8 @@ const improveNewsletterContent = (t: TFunction): TTemplate => {
               subheader: t("templates.improve_newsletter_content_question_3_html"),
               headline: t("templates.improve_newsletter_content_question_3_headline"),
               required: false,
-              buttonUrl: "https://formbricks.com",
+              buttonUrl:
+                "https://formbricks.com?utm_source=formbricks-app&utm_medium=survey&utm_campaign=template_cta_newsletter",
               buttonExternal: true,
               ctaButtonLabel: t("templates.improve_newsletter_content_question_3_button_label"),
             }),

--- a/apps/web/modules/auth/components/form-wrapper.tsx
+++ b/apps/web/modules/auth/components/form-wrapper.tsx
@@ -10,7 +10,10 @@ export const FormWrapper = ({ children }: FormWrapperProps) => {
     <div className="mx-auto flex flex-1 flex-col justify-center px-4 py-12 sm:px-6 lg:flex-none lg:px-20 xl:px-24">
       <div className="mx-auto w-full max-w-sm rounded-xl bg-white p-8 shadow-2xl lg:w-96">
         <div className="mb-8 text-center">
-          <Link target="_blank" href="https://formbricks.com?utm_source=ce" rel="noopener noreferrer">
+          <Link
+            target="_blank"
+            href="https://formbricks.com?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=auth_logo"
+            rel="noopener noreferrer">
             <Logo className="mx-auto w-3/4" />
           </Link>
         </div>

--- a/apps/web/modules/ee/contacts/components/contacts-page-layout.tsx
+++ b/apps/web/modules/ee/contacts/components/contacts-page-layout.tsx
@@ -59,7 +59,7 @@ export const ContactsPageLayout = async ({
                 text: t("common.learn_more"),
                 href: IS_FORMBRICKS_CLOUD
                   ? organizationBillingPath
-                  : "https://formbricks.com/learn-more-self-hosting-license",
+                  : "https://formbricks.com/learn-more-self-hosting-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=ee_lock_contacts",
               },
             ]}
           />

--- a/apps/web/modules/ee/feedback-directory/page.tsx
+++ b/apps/web/modules/ee/feedback-directory/page.tsx
@@ -46,7 +46,7 @@ export const FeedbackDirectoriesPage = async (props: { params: Promise<{ organiz
                 text: t("common.learn_more"),
                 href: IS_FORMBRICKS_CLOUD
                   ? getOrganizationBillingPath(params.organizationId, IS_FORMBRICKS_CLOUD)
-                  : "https://formbricks.com/learn-more-self-hosting-license",
+                  : "https://formbricks.com/learn-more-self-hosting-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=ee_lock_feedback_directory",
               },
             ]}
           />

--- a/apps/web/modules/ee/quotas/components/quotas-card.tsx
+++ b/apps/web/modules/ee/quotas/components/quotas-card.tsx
@@ -183,7 +183,7 @@ export const QuotasCard = ({
                     text: t("common.learn_more"),
                     href: isFormbricksCloud
                       ? `/organizations/${workspace?.organizationId}/settings/billing`
-                      : "https://formbricks.com/learn-more-self-hosting-license",
+                      : "https://formbricks.com/learn-more-self-hosting-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=ee_lock_quotas",
                   },
                 ]}
               />

--- a/apps/web/modules/ee/unify-feedback/sources/page.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/page.tsx
@@ -62,7 +62,7 @@ export const UnifyFeedbackSourcesPage = async (
                 text: t("common.learn_more"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/organizations/${organization.id}/settings/billing`
-                  : "https://formbricks.com/learn-more-self-hosting-license",
+                  : "https://formbricks.com/learn-more-self-hosting-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=ee_lock_unify_sources",
               },
             ]}
           />

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/page.tsx
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/page.tsx
@@ -52,7 +52,7 @@ export const UnifyTopicsSubtopicsPage = async (
                 text: t("common.learn_more"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/organizations/${organization.id}/settings/billing`
-                  : "https://formbricks.com/learn-more-self-hosting-license",
+                  : "https://formbricks.com/learn-more-self-hosting-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=ee_lock_unify_topics",
               },
             ]}
           />

--- a/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
+++ b/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
@@ -194,7 +194,7 @@ export const EmailCustomizationSettings = ({
       text: t("common.learn_more"),
       href: isFormbricksCloud
         ? `/organizations/${organization.id}/settings/billing`
-        : "https://formbricks.com/learn-more-self-hosting-license",
+        : "https://formbricks.com/learn-more-self-hosting-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=ee_lock_email_whitelabel",
     },
   ];
 

--- a/apps/web/modules/email/components/preview-email-template.tsx
+++ b/apps/web/modules/email/components/preview-email-template.tsx
@@ -1049,7 +1049,7 @@ function EmailFooter({
     <Container className="mx-auto mt-8 text-center">
       <Link
         className="text-signature-color text-xs"
-        href="https://formbricks.com?utm_source=email_branding"
+        href="https://formbricks.com?utm_source=formbricks-app&utm_medium=email&utm_campaign=powered_by_badge"
         style={{ ...getForcedColorStyle(signatureColor), fontFamily }}
         target={PREVIEW_LINK_TARGET}>
         {t("common.powered_by_formbricks")}

--- a/apps/web/modules/email/embed-survey-preview-email.test.ts
+++ b/apps/web/modules/email/embed-survey-preview-email.test.ts
@@ -81,7 +81,8 @@ const expectSharedPreviewSignals = (html: string) => {
   expect(html).toContain(
     `${EMBED_SURVEY_PREVIEW_QUESTION_ID}=${encodeURIComponent(EMBED_SURVEY_PREVIEW_CHOICE_IDS.pineapples)}`
   );
-  expect(html).toContain("utm_source=email_branding");
+  expect(html).toContain("utm_source=formbricks-app");
+  expect(html).toContain("utm_campaign=powered_by_badge");
 };
 
 const expectPreviewFragmentBaseSignals = (html: string) => {

--- a/apps/web/modules/survey/editor/components/end-screen-form.tsx
+++ b/apps/web/modules/survey/editor/components/end-screen-form.tsx
@@ -119,7 +119,8 @@ export const EndScreenForm = ({
               } else {
                 updateSurvey({
                   buttonLabel: { default: t("workspace.surveys.edit.create_your_own_survey") },
-                  buttonLink: "https://formbricks.com",
+                  buttonLink:
+                    "https://formbricks.com?utm_source=formbricks-app&utm_medium=survey&utm_campaign=default_ending_cta",
                 });
               }
               setshowEndingCardCTA(!showEndingCardCTA);

--- a/apps/web/modules/survey/editor/components/targeting-locked-card.tsx
+++ b/apps/web/modules/survey/editor/components/targeting-locked-card.tsx
@@ -58,7 +58,7 @@ export const TargetingLockedCard = ({
                 text: t("common.learn_more"),
                 href: isFormbricksCloud
                   ? organizationBillingPath
-                  : "https://formbricks.com/learn-more-self-hosting-license",
+                  : "https://formbricks.com/learn-more-self-hosting-license?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=ee_lock_targeting",
               },
             ]}
           />

--- a/apps/web/modules/survey/link/components/survey-completed-message.tsx
+++ b/apps/web/modules/survey/link/components/survey-completed-message.tsx
@@ -30,7 +30,7 @@ export const SurveyCompletedMessage = async ({
       </div>
       {(!workspace || workspace.linkSurveyBranding) && (
         <div>
-          <Link href="https://formbricks.com">
+          <Link href="https://formbricks.com?utm_source=formbricks-app&utm_medium=survey&utm_campaign=survey_completed">
             <Image src={footerLogo} alt="Brand logo" className="mx-auto w-40" />
           </Link>
         </div>

--- a/apps/web/modules/survey/link/components/survey-inactive.tsx
+++ b/apps/web/modules/survey/link/components/survey-inactive.tsx
@@ -65,13 +65,15 @@ export const SurveyInactive = async ({
         <p className="text-lg leading-10 text-slate-500">{description}</p>
         {showCTA && (
           <Button className="mt-2" asChild>
-            <Link href="https://formbricks.com">{t("s.create_your_own")}</Link>
+            <Link href="https://formbricks.com?utm_source=formbricks-app&utm_medium=survey&utm_campaign=create_your_own_cta">
+              {t("s.create_your_own")}
+            </Link>
           </Button>
         )}
       </div>
       {(!workspace || workspace.linkSurveyBranding) && (
         <div>
-          <Link href="https://formbricks.com">
+          <Link href="https://formbricks.com?utm_source=formbricks-app&utm_medium=survey&utm_campaign=powered_by_badge">
             <Image src={footerLogo} alt="Brand logo" className="mx-auto w-40" />
           </Link>
         </div>

--- a/apps/web/playwright/survey-email-preview.spec.ts
+++ b/apps/web/playwright/survey-email-preview.spec.ts
@@ -109,7 +109,10 @@ test.describe("Survey Email Preview", () => {
     await expect(firstChoiceLink).toHaveAttribute("target", "_blank");
 
     const poweredByLink = previewFrame.getByRole("link", { name: "Powered by Formbricks" });
-    await expect(poweredByLink).toHaveAttribute("href", "https://formbricks.com?utm_source=email_branding");
+    await expect(poweredByLink).toHaveAttribute(
+      "href",
+      "https://formbricks.com?utm_source=formbricks-app&utm_medium=email&utm_campaign=powered_by_badge"
+    );
   });
 
   test("keeps non-option email previews clickable in the summary modal", async ({ page, users }) => {

--- a/packages/email/src/components/email-template.tsx
+++ b/packages/email/src/components/email-template.tsx
@@ -3,7 +3,7 @@ import { TEmailTemplateLegalProps } from "../types/email";
 import { TFunction } from "../types/translations";
 
 const fbLogoUrl = "https://app.formbricks.com/logo-transparent.png";
-const logoLink = "https://formbricks.com?utm_source=email_header&utm_medium=email";
+const logoLink = "https://formbricks.com?utm_source=formbricks-app&utm_medium=email&utm_campaign=email_logo";
 const FORCE_LIGHT_COLOR_SCHEME = "only light";
 
 interface EmailTemplateProps extends TEmailTemplateLegalProps {
@@ -68,7 +68,7 @@ export function EmailTemplate({
           <Section className="mt-4 text-center text-sm">
             <Link
               className="m-0 text-sm font-normal text-slate-500"
-              href="https://formbricks.com/?utm_source=email_header&utm_medium=email"
+              href="https://formbricks.com/?utm_source=formbricks-app&utm_medium=email&utm_campaign=email_footer_text"
               target="_blank"
               rel="noopener noreferrer">
               {t("emails.email_template_text_1")}

--- a/packages/email/src/lib/fixtures/embed-survey-preview-email-html.ts
+++ b/packages/email/src/lib/fixtures/embed-survey-preview-email-html.ts
@@ -126,7 +126,7 @@ export const embedSurveyPreviewEmailHtml = `
             <tr style="width:100%">
               <td>
                 <a
-                  href="https://formbricks.com?utm_source=email_branding"
+                  href="https://formbricks.com?utm_source=formbricks-app&amp;utm_medium=email&amp;utm_campaign=powered_by_badge"
                   style="color:#4c545f !important;text-decoration-line:none;font-size:0.75rem;line-height:1.3333333333333333;color-scheme:only light;font-family:Inter, Helvetica, Arial, sans-serif"
                   target="_blank"
                   >Powered by Formbricks</a

--- a/packages/surveys/src/components/general/formbricks-branding.tsx
+++ b/packages/surveys/src/components/general/formbricks-branding.tsx
@@ -4,7 +4,10 @@ export function FormbricksBranding() {
   const { t } = useTranslation();
   return (
     <span className="flex justify-center">
-      <a href="https://formbricks.com?utm_source=survey_branding" target="_blank" rel="noopener">
+      <a
+        href="https://formbricks.com?utm_source=formbricks-app&utm_medium=survey&utm_campaign=powered_by_badge"
+        target="_blank"
+        rel="noopener">
         <p className="text-signature text-xs">
           {t("common.powered_by")}{" "}
           <b>


### PR DESCRIPTION
<!-- No ticket for this one — it came out of an ad hoc audit of outbound links, not a Linear issue. -->

## What & why

The app links out to `formbricks.com` from ~20 places — the "Powered by Formbricks" badge on surveys and emails, the login page logo, EE upgrade/upsell prompts, the security settings tip, and the default CTA URLs baked into new surveys and survey templates. Some already carried a UTM tag, but the scheme was inconsistent (`utm_source=survey_branding`, `utm_source=email_branding`, `utm_source=ce`, `utm_source=email_header`, one with `utm_medium` but no `utm_campaign`), and several links — the EE "learn more" upsell links, the two "upgrade to self-hosted license" prompts, the security tip, and the default survey/template CTA URLs — had no UTM at all. That makes it impossible to tell, from formbricks.com's analytics, which in-app surface actually drove a given visit.

This PR puts every one of them on one scheme: `utm_source=formbricks-app&utm_medium={survey|email|webapp}&utm_campaign=<unique_placement>`, so each link can be attributed to its exact surface.

<details>
<summary>Full list of links touched (24 files)</summary>

- `packages/surveys/.../formbricks-branding.tsx` — survey "Powered by" badge → `utm_campaign=powered_by_badge`
- `apps/web/.../survey-completed-message.tsx` — link-survey completed page → `utm_campaign=survey_completed`
- `apps/web/.../survey-inactive.tsx` — "create your own" CTA and footer logo → `utm_campaign=create_your_own_cta` / `powered_by_badge`
- `packages/email/.../email-template.tsx` — email header logo link and footer text link → `utm_campaign=email_logo` / `email_footer_text`
- `apps/web/.../preview-email-template.tsx` — embed-survey email "Powered by" → `utm_campaign=powered_by_badge`
- `apps/web/.../form-wrapper.tsx` — login/signup page logo → `utm_campaign=auth_logo`
- `MainNavigation.tsx` / `workspace-breadcrumb.tsx` — "upgrade to self-hosted license" prompts → `utm_campaign=upgrade_prompt_nav` / `upgrade_prompt_breadcrumb`
- `SecurityListTip.tsx` — security settings tip → `utm_campaign=security_tip`
- 9 EE-gated "learn more" upsell links (profile 2FA, personal links, contacts, feedback directory, quotas, unify-feedback sources/topics, email whitelabel, survey targeting) → one unique `utm_campaign=ee_lock_*` each
- `survey-builder.ts` / `end-screen-form.tsx` — default "Ending" screen CTA on new surveys → `utm_campaign=default_ending_cta`
- `templates.ts` — 4 built-in survey templates' default CTA button URLs → `utm_campaign=template_cta_*`

</details>

## Breaking changes

- [ ] This PR contains breaking changes

None — only query parameters are added/changed on outbound links; no route, API, or payload shape changes.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Embed-survey preview email "Powered by Formbricks" link carries the new UTM params and still renders/matches the static fixture | unit (guard) — `apps/web/modules/email/embed-survey-preview-email.test.ts` | Pass — updated the fixture (`packages/email/src/lib/fixtures/embed-survey-preview-email-html.ts`) and assertions to the new href; full suite green |
| Same link, rendered in a real preview iframe | e2e (guard) — `apps/web/playwright/survey-email-preview.spec.ts` → "keeps the powered-by link's UTM tag intact" | Pass — updated the expected `href` |
| Every other touched link (survey branding badge, login logo, upgrade prompts, EE upsell links, default template/ending CTAs) | manual — read diff, grepped for remaining bare `formbricks.com` occurrences outside test/mock/fixture/seed files | Confirmed only the intended 24 files changed; no leftover unparameterized links |
| No regressions elsewhere | `pnpm build --filter=@formbricks/web^...` then `pnpm --filter=@formbricks/web test` (627 files / 8289 tests) and `pnpm typecheck` on `apps/web`, `packages/email`, `packages/surveys` | All green |

**Open gaps**

- none

**Risks**

- Low. Purely additive query-string changes to outbound links; no behavior change for anything other than the destination URL's tracking params.

---

> [!NOTE]
> **AI model used** — Claude Sonnet 5, reasoning effort medium.