### PR TITLE
fix(storage): delete uploaded files when a survey's responses are reset

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/delete-response-files.mock.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/delete-response-files.mock.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest";
+
+/**
+ * Storage boundary for the survey-reset tests. Kept in `__mocks__` (per AGENTS.md) so the `vi.mock`
+ * call is hoisted by the import order rather than by a bare `vi.mock` inside each spec.
+ */
+export const deleteResponseFileUrls = vi.fn<(fileUrls: string[], workspaceId?: string) => Promise<void>>();
+
+vi.mock("@/modules/storage/lib/delete-response-files", () => ({
+  deleteResponseFileUrls,
+}));

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/survey-reset.mock.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/survey-reset.mock.ts
@@ -1,0 +1,51 @@
+import { TResponseData } from "@formbricks/types/responses";
+import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
+import { TSurveyElementTypeEnum, TSurveyFileUploadElement } from "@formbricks/types/surveys/elements";
+import { TSurvey } from "@formbricks/types/surveys/types";
+
+export const surveyId = "clq5n7p1q0000m7z0h5p6g3r2";
+export const workspaceId = "u8qa6u0tlxb6160pi2jb8s4p";
+
+export const fileUploadElement: TSurveyFileUploadElement = {
+  id: "y3ydd3td2iq09wa599cxo1me",
+  type: TSurveyElementTypeEnum.FileUpload,
+  headline: { default: "Upload your file" },
+  required: false,
+  allowMultipleFiles: true,
+};
+
+export const fileUploadBlock: TSurveyBlock = {
+  id: "wq0m4wvvvhmzrxmnzmr6mkuz",
+  name: "File upload block",
+  elements: [fileUploadElement],
+};
+
+/**
+ * `collectSurveyResponseFileUrls` reads exactly these three fields off the survey, so the fixtures
+ * declare only those — fully typed, so a wrong block or element shape fails typecheck. The single cast
+ * to `TSurvey` lives in the mock helper that hands them to `getSurvey`.
+ */
+export type SurveyFileUploadFields = Pick<TSurvey, "blocks" | "questions" | "workspaceId">;
+
+export const surveyWithFileUpload: SurveyFileUploadFields = {
+  blocks: [fileUploadBlock],
+  questions: [],
+  workspaceId,
+};
+
+export const surveyWithoutFileUpload: SurveyFileUploadFields = {
+  blocks: [],
+  questions: [],
+  workspaceId,
+};
+
+export const storageUrl = (fileName: string) =>
+  `https://example.com/storage/${workspaceId}/private/${fileName}`;
+
+/** One response row as `collectSurveyResponseFileUrls` selects it (`id` + `data` only). */
+export type ScannedResponse = { id: string; data: TResponseData };
+
+export const responseWithFiles = (id: string, fileNames: string[]): ScannedResponse => ({
+  id,
+  data: { [fileUploadElement.id]: fileNames.map(storageUrl) },
+});

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/survey-reset.mock.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/survey-reset.mock.ts
@@ -42,10 +42,14 @@ export const surveyWithoutFileUpload: SurveyFileUploadFields = {
 export const storageUrl = (fileName: string) =>
   `https://example.com/storage/${workspaceId}/private/${fileName}`;
 
-/** One response row as `collectSurveyResponseFileUrls` selects it (`id` + `data` only). */
-export type ScannedResponse = { id: string; data: TResponseData };
+/** One response row as `collectSurveyResponseFileUrls` selects it (`id`, `createdAt`, `data`). */
+export type ScannedResponse = { id: string; createdAt: Date; data: TResponseData };
 
-export const responseWithFiles = (id: string, fileNames: string[]): ScannedResponse => ({
+/** Fixed epoch offsets keep the fixtures deterministic and the keyset order predictable. */
+export const scanTimestamp = (index: number) => new Date(Date.UTC(2026, 0, 1) + index * 1000);
+
+export const responseWithFiles = (id: string, fileNames: string[], index = 0): ScannedResponse => ({
   id,
+  createdAt: scanTimestamp(index),
   data: { [fileUploadElement.id]: fileNames.map(storageUrl) },
 });

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/survey-service.mock.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/survey-service.mock.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest";
+
+/**
+ * Survey-read boundary for the survey-reset tests. Kept in `__mocks__` (per AGENTS.md) so the
+ * `vi.mock` call is hoisted by import order rather than by a bare `vi.mock` in each spec.
+ */
+export const getSurvey = vi.fn();
+
+vi.mock("@/lib/survey/service", () => ({
+  getSurvey,
+}));

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/survey-service.mock.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/__mocks__/survey-service.mock.ts
@@ -1,10 +1,12 @@
 import { vi } from "vitest";
+import type { getSurvey as getSurveyImpl } from "@/lib/survey/service";
 
 /**
  * Survey-read boundary for the survey-reset tests. Kept in `__mocks__` (per AGENTS.md) so the
- * `vi.mock` call is hoisted by import order rather than by a bare `vi.mock` in each spec.
+ * `vi.mock` call is hoisted by import order rather than by a bare `vi.mock` in each spec. Typed off
+ * the real export, so `mockResolvedValue` is checked against `Promise<TSurvey | null>`.
  */
-export const getSurvey = vi.fn();
+export const getSurvey = vi.fn<typeof getSurveyImpl>();
 
 vi.mock("@/lib/survey/service", () => ({
   getSurvey,

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.test.ts
@@ -4,6 +4,7 @@ import {
   SurveyFileUploadFields,
   fileUploadElement,
   responseWithFiles,
+  scanTimestamp,
   storageUrl,
   surveyId,
   surveyWithFileUpload,
@@ -78,6 +79,7 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
       mockResponsePages([
         {
           id: "response-1",
+          createdAt: scanTimestamp(0),
           data: {
             [fileUploadElement.id]: [storageUrl("file1.png"), storageUrl("file2.pdf")],
             "other-element": "not a file",
@@ -124,9 +126,9 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
       // A full first page (500) forces a second cursor-based query; the file on the later page must
       // still reach storage cleanup.
       const firstPage = Array.from({ length: 500 }, (_, index) =>
-        responseWithFiles(`response-${index}`, [`page1-${index}.png`])
+        responseWithFiles(`response-${index}`, [`page1-${index}.png`], index)
       );
-      const secondPage = [responseWithFiles("response-500", ["page2.png"])];
+      const secondPage = [responseWithFiles("response-500", ["page2.png"], 500)];
 
       mockSurvey(surveyWithFileUpload);
       mockResponsePages(firstPage, secondPage);
@@ -138,11 +140,22 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
       // so exactly two queries are expected here.
       expect(prisma.response.findMany).toHaveBeenCalledTimes(2);
 
-      // The second query pages past the last id of the first page.
-      expect(vi.mocked(prisma.response.findMany).mock.calls[1][0]).toMatchObject({
-        skip: 1,
-        cursor: { id: "response-499" },
+      // The second query pages past the last row of the first page with a (createdAt, id) keyset, and
+      // orders by createdAt so it can use the existing (surveyId, createdAt) index.
+      const secondQuery = vi.mocked(prisma.response.findMany).mock.calls[1][0];
+      expect(secondQuery).toMatchObject({
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        where: {
+          surveyId,
+          OR: [
+            { createdAt: { gt: scanTimestamp(499) } },
+            { createdAt: scanTimestamp(499), id: { gt: "response-499" } },
+          ],
+        },
       });
+      // Keyset paging replaces cursor/skip entirely — a leftover offset would double-read rows.
+      expect(secondQuery).not.toHaveProperty("skip");
+      expect(secondQuery).not.toHaveProperty("cursor");
 
       const deletedUrls = deleteResponseFileUrls.mock.calls.flatMap(([urls]) => urls);
       expect(deletedUrls).toHaveLength(501);
@@ -187,9 +200,13 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
     test("Ignores non-array answers stored under a file-upload element id", async () => {
       mockSurvey(surveyWithFileUpload);
       mockResponsePages([
-        { id: "response-1", data: { [fileUploadElement.id]: "not-an-array" } },
+        { id: "response-1", createdAt: scanTimestamp(0), data: { [fileUploadElement.id]: "not-an-array" } },
         // Numbers and nulls inside the array are dropped rather than cast to a delete target.
-        { id: "response-2", data: { [fileUploadElement.id]: [42, null] as unknown as string[] } },
+        {
+          id: "response-2",
+          createdAt: scanTimestamp(1),
+          data: { [fileUploadElement.id]: [42, null] as unknown as string[] },
+        },
       ]);
       vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 2 }, { count: 0 }]);
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.test.ts
@@ -1,66 +1,54 @@
+import { deleteResponseFileUrls } from "./__mocks__/delete-response-files.mock";
+import {
+  ScannedResponse,
+  SurveyFileUploadFields,
+  fileUploadElement,
+  responseWithFiles,
+  storageUrl,
+  surveyId,
+  surveyWithFileUpload,
+  surveyWithoutFileUpload,
+  workspaceId,
+} from "./__mocks__/survey-reset.mock";
+import { getSurvey } from "./__mocks__/survey-service.mock";
+import { prisma } from "@/lib/__mocks__/database";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
+import { logger } from "@formbricks/logger";
 import { DatabaseError } from "@formbricks/types/errors";
-import { deleteResponseFileUrls } from "@/modules/storage/lib/delete-response-files";
+import { TSurvey } from "@formbricks/types/surveys/types";
 import { deleteResponsesAndDisplaysForSurvey, getQuotasSummary } from "./survey";
 
-// Mock prisma
-vi.mock("@formbricks/database", () => ({
-  prisma: {
-    response: {
-      deleteMany: vi.fn(),
-      findMany: vi.fn(),
-    },
-    display: {
-      deleteMany: vi.fn(),
-    },
-    survey: {
-      findUnique: vi.fn(),
-    },
-    $transaction: vi.fn(),
-    surveyQuota: {
-      findMany: vi.fn(),
-    },
-  },
-}));
+/**
+ * The fixtures declare only the three fields the service reads, so the hand-off to `getSurvey` (typed
+ * `TSurvey | null`) is cast once here. The fixture fields themselves stay typed against
+ * `@formbricks/types`, so a wrong block or element shape still fails typecheck.
+ */
+const mockSurvey = (survey: SurveyFileUploadFields | null) => {
+  getSurvey.mockResolvedValue(survey as TSurvey | null);
+};
 
-vi.mock("@/modules/storage/lib/delete-response-files", () => ({
-  deleteResponseFileUrls: vi.fn(),
-}));
-
-const surveyId = "clq5n7p1q0000m7z0h5p6g3r2";
-const workspaceId = "u8qa6u0tlxb6160pi2jb8s4p";
-const fileUploadElementId = "y3ydd3td2iq09wa599cxo1me";
-
-const fileUploadSurvey = {
-  workspaceId,
-  questions: [],
-  blocks: [
-    {
-      id: "block-1",
-      elements: [{ id: fileUploadElementId, type: "fileUpload" }],
-    },
-  ],
+const mockResponsePages = (...pages: ScannedResponse[][]) => {
+  const findMany = vi.mocked(prisma.response.findMany);
+  findMany.mockReset();
+  for (const page of pages) {
+    findMany.mockResolvedValueOnce(page as never);
+  }
+  // Anything past the configured pages reads as "no more rows".
+  findMany.mockResolvedValue([] as never);
 };
 
 beforeEach(() => {
-  vi.resetModules();
-  vi.resetAllMocks();
   // Default: a survey with no file-upload element, so the response scan is skipped.
-  vi.mocked(prisma.survey.findUnique).mockResolvedValue({
-    workspaceId,
-    questions: [],
-    blocks: [],
-  } as any);
+  mockSurvey(surveyWithoutFileUpload);
+  deleteResponseFileUrls.mockReset();
+  deleteResponseFileUrls.mockResolvedValue(undefined);
 });
 
 describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
   describe("Happy Path", () => {
     test("Deletes all responses and displays for a survey", async () => {
-      const { prisma } = await import("@formbricks/database");
-
       // Mock $transaction to return the results directly
       vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 5 }, { count: 3 }]);
 
@@ -74,8 +62,6 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
     });
 
     test("Handles case with no responses or displays to delete", async () => {
-      const { prisma } = await import("@formbricks/database");
-
       // Mock $transaction to return zero counts
       vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 0 }, { count: 0 }]);
 
@@ -88,33 +74,24 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
     });
 
     test("Deletes the uploaded files held by the deleted responses", async () => {
-      vi.mocked(prisma.survey.findUnique).mockResolvedValue(fileUploadSurvey as any);
-      vi.mocked(prisma.response.findMany).mockResolvedValue([
+      mockSurvey(surveyWithFileUpload);
+      mockResponsePages([
         {
           id: "response-1",
           data: {
-            [fileUploadElementId]: [
-              `https://example.com/storage/${workspaceId}/private/file1.png`,
-              `https://example.com/storage/${workspaceId}/private/file2.pdf`,
-            ],
+            [fileUploadElement.id]: [storageUrl("file1.png"), storageUrl("file2.pdf")],
             "other-element": "not a file",
           },
         },
-        {
-          id: "response-2",
-          data: { [fileUploadElementId]: [`https://example.com/storage/${workspaceId}/private/file3.png`] },
-        },
-      ] as any);
+        responseWithFiles("response-2", ["file3.png"]),
+      ]);
       vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 2 }, { count: 0 }]);
 
       await deleteResponsesAndDisplaysForSurvey(surveyId);
 
+      expect(deleteResponseFileUrls).toHaveBeenCalledTimes(1);
       expect(deleteResponseFileUrls).toHaveBeenCalledWith(
-        [
-          `https://example.com/storage/${workspaceId}/private/file1.png`,
-          `https://example.com/storage/${workspaceId}/private/file2.pdf`,
-          `https://example.com/storage/${workspaceId}/private/file3.png`,
-        ],
+        [storageUrl("file1.png"), storageUrl("file2.pdf"), storageUrl("file3.png")],
         workspaceId
       );
     });
@@ -122,29 +99,70 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
     test("Reads the file-upload answers before the responses are deleted", async () => {
       const callOrder: string[] = [];
 
-      vi.mocked(prisma.survey.findUnique).mockResolvedValue(fileUploadSurvey as any);
-      vi.mocked(prisma.response.findMany).mockImplementation((async () => {
+      mockSurvey(surveyWithFileUpload);
+      vi.mocked(prisma.response.findMany).mockReset();
+      vi.mocked(prisma.response.findMany).mockImplementation((() => {
         callOrder.push("scan");
-        return [
-          {
-            id: "response-1",
-            data: { [fileUploadElementId]: [`https://example.com/storage/${workspaceId}/private/f.png`] },
-          },
-        ];
-      }) as any);
-      vi.mocked(prisma.$transaction).mockImplementation((async () => {
+        return Promise.resolve([responseWithFiles("response-1", ["f.png"])]) as never;
+      }) as never);
+      vi.mocked(prisma.$transaction).mockImplementation((() => {
         callOrder.push("delete");
-        return [{ count: 1 }, { count: 0 }];
-      }) as any);
-      vi.mocked(deleteResponseFileUrls).mockImplementation((async () => {
+        return Promise.resolve([{ count: 1 }, { count: 0 }]) as never;
+      }) as never);
+      deleteResponseFileUrls.mockImplementation(async () => {
         callOrder.push("storage");
-      }) as any);
+      });
 
       await deleteResponsesAndDisplaysForSurvey(surveyId);
 
       // The scan must precede the row delete (the URLs live in response.data), and storage cleanup must
       // follow it so files are never removed while their responses survive.
       expect(callOrder).toEqual(["scan", "delete", "storage"]);
+    });
+
+    test("Collects files from every page when responses span the scan page size", async () => {
+      // A full first page (500) forces a second cursor-based query; the file on the later page must
+      // still reach storage cleanup.
+      const firstPage = Array.from({ length: 500 }, (_, index) =>
+        responseWithFiles(`response-${index}`, [`page1-${index}.png`])
+      );
+      const secondPage = [responseWithFiles("response-500", ["page2.png"])];
+
+      mockSurvey(surveyWithFileUpload);
+      mockResponsePages(firstPage, secondPage);
+      vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 501 }, { count: 0 }]);
+
+      await deleteResponsesAndDisplaysForSurvey(surveyId);
+
+      // Third call returns [] and ends the loop: 500 == page size, then 1 < page size would stop it,
+      // so exactly two queries are expected here.
+      expect(prisma.response.findMany).toHaveBeenCalledTimes(2);
+
+      // The second query pages past the last id of the first page.
+      expect(vi.mocked(prisma.response.findMany).mock.calls[1][0]).toMatchObject({
+        skip: 1,
+        cursor: { id: "response-499" },
+      });
+
+      const deletedUrls = deleteResponseFileUrls.mock.calls.flatMap(([urls]) => urls);
+      expect(deletedUrls).toHaveLength(501);
+      expect(deletedUrls).toContain(storageUrl("page1-0.png"));
+      expect(deletedUrls).toContain(storageUrl("page2.png"));
+    });
+
+    test("Issues storage deletes in bounded chunks", async () => {
+      const responses = Array.from({ length: 250 }, (_, index) =>
+        responseWithFiles(`response-${index}`, [`file-${index}.png`])
+      );
+
+      mockSurvey(surveyWithFileUpload);
+      mockResponsePages(responses);
+      vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 250 }, { count: 0 }]);
+
+      await deleteResponsesAndDisplaysForSurvey(surveyId);
+
+      // 250 URLs at a chunk size of 100 => 100 + 100 + 50, so no single storage fan-out exceeds 100.
+      expect(deleteResponseFileUrls.mock.calls.map(([urls]) => urls.length)).toEqual([100, 100, 50]);
     });
 
     test("Skips the response scan when the survey has no file-upload element", async () => {
@@ -156,12 +174,23 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
       expect(deleteResponseFileUrls).not.toHaveBeenCalled();
     });
 
+    test("Skips storage cleanup when the survey no longer exists", async () => {
+      mockSurvey(null);
+      vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 0 }, { count: 0 }]);
+
+      await deleteResponsesAndDisplaysForSurvey(surveyId);
+
+      expect(prisma.response.findMany).not.toHaveBeenCalled();
+      expect(deleteResponseFileUrls).not.toHaveBeenCalled();
+    });
+
     test("Ignores non-array answers stored under a file-upload element id", async () => {
-      vi.mocked(prisma.survey.findUnique).mockResolvedValue(fileUploadSurvey as any);
-      vi.mocked(prisma.response.findMany).mockResolvedValue([
-        { id: "response-1", data: { [fileUploadElementId]: "not-an-array" } },
-        { id: "response-2", data: { [fileUploadElementId]: [42, null] } },
-      ] as any);
+      mockSurvey(surveyWithFileUpload);
+      mockResponsePages([
+        { id: "response-1", data: { [fileUploadElement.id]: "not-an-array" } },
+        // Numbers and nulls inside the array are dropped rather than cast to a delete target.
+        { id: "response-2", data: { [fileUploadElement.id]: [42, null] as unknown as string[] } },
+      ]);
       vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 2 }, { count: 0 }]);
 
       await deleteResponsesAndDisplaysForSurvey(surveyId);
@@ -172,26 +201,44 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
 
   describe("Sad Path", () => {
     test("Throws DatabaseError on PrismaClientKnownRequestError occurrence", async () => {
-      const { prisma } = await import("@formbricks/database");
-
       const mockErrorMessage = "Mock error message";
       const errToThrow = new Prisma.PrismaClientKnownRequestError(mockErrorMessage, {
         code: PrismaErrorType.UniqueConstraintViolation,
         clientVersion: "0.0.1",
       });
 
+      mockSurvey(surveyWithFileUpload);
+      mockResponsePages([responseWithFiles("response-1", ["file1.png"])]);
       vi.mocked(prisma.$transaction).mockRejectedValue(errToThrow);
 
       await expect(deleteResponsesAndDisplaysForSurvey(surveyId)).rejects.toThrow(DatabaseError);
+
+      // The converse of the ordering guarantee: if the rows survive, their files must survive too.
+      expect(deleteResponseFileUrls).not.toHaveBeenCalled();
     });
 
     test("Throws a generic Error for other exceptions", async () => {
-      const { prisma } = await import("@formbricks/database");
-
       const mockErrorMessage = "Mock error message";
       vi.mocked(prisma.$transaction).mockRejectedValue(new Error(mockErrorMessage));
 
       await expect(deleteResponsesAndDisplaysForSurvey(surveyId)).rejects.toThrow(Error);
+    });
+
+    test("Reports the reset as successful when storage cleanup fails", async () => {
+      mockSurvey(surveyWithFileUpload);
+      mockResponsePages([responseWithFiles("response-1", ["file1.png"])]);
+      vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 1 }, { count: 0 }]);
+      deleteResponseFileUrls.mockRejectedValue(new Error("storage down"));
+      const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+
+      // The rows are already committed as deleted, so a storage failure must not surface as a failed
+      // reset the caller would retry — it is logged and the counts still come back.
+      const result = await deleteResponsesAndDisplaysForSurvey(surveyId);
+
+      expect(result).toEqual({ deletedResponsesCount: 1, deletedDisplaysCount: 0 });
+      expect(loggerSpy).toHaveBeenCalled();
+
+      loggerSpy.mockRestore();
     });
   });
 });
@@ -208,7 +255,6 @@ describe("Tests for getQuotasSummary service", () => {
         },
       } as unknown as Awaited<ReturnType<typeof prisma.surveyQuota.findMany>>[number],
     ]);
-
     const result = await getQuotasSummary(surveyId);
     expect(result).toEqual([
       {
@@ -220,7 +266,6 @@ describe("Tests for getQuotasSummary service", () => {
       },
     ]);
   });
-
   test("Returns 0 percentage if limit is 0", async () => {
     vi.mocked(prisma.surveyQuota.findMany).mockResolvedValue([
       {
@@ -232,7 +277,6 @@ describe("Tests for getQuotasSummary service", () => {
         },
       } as unknown as Awaited<ReturnType<typeof prisma.surveyQuota.findMany>>[number],
     ]);
-
     const result = await getQuotasSummary(surveyId);
     expect(result).toEqual([
       {
@@ -244,25 +288,17 @@ describe("Tests for getQuotasSummary service", () => {
       },
     ]);
   });
-
   test("Throws DatabaseError on PrismaClientKnownRequestError occurrence", async () => {
-    const { prisma } = await import("@formbricks/database");
-
     vi.mocked(prisma.surveyQuota.findMany).mockRejectedValue(
       new Prisma.PrismaClientKnownRequestError("Database error", {
         code: PrismaErrorType.UniqueConstraintViolation,
         clientVersion: "0.0.1",
       })
     );
-
     await expect(getQuotasSummary(surveyId)).rejects.toThrow(DatabaseError);
   });
-
   test("Throws a generic Error for other exceptions", async () => {
-    const { prisma } = await import("@formbricks/database");
-
     vi.mocked(prisma.surveyQuota.findMany).mockRejectedValue(new Error("Database error"));
-
     await expect(getQuotasSummary(surveyId)).rejects.toThrow(Error);
   });
 });

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.test.ts
@@ -3,6 +3,7 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { DatabaseError } from "@formbricks/types/errors";
+import { deleteResponseFileUrls } from "@/modules/storage/lib/delete-response-files";
 import { deleteResponsesAndDisplaysForSurvey, getQuotasSummary } from "./survey";
 
 // Mock prisma
@@ -10,9 +11,13 @@ vi.mock("@formbricks/database", () => ({
   prisma: {
     response: {
       deleteMany: vi.fn(),
+      findMany: vi.fn(),
     },
     display: {
       deleteMany: vi.fn(),
+    },
+    survey: {
+      findUnique: vi.fn(),
     },
     $transaction: vi.fn(),
     surveyQuota: {
@@ -21,11 +26,34 @@ vi.mock("@formbricks/database", () => ({
   },
 }));
 
+vi.mock("@/modules/storage/lib/delete-response-files", () => ({
+  deleteResponseFileUrls: vi.fn(),
+}));
+
 const surveyId = "clq5n7p1q0000m7z0h5p6g3r2";
+const workspaceId = "u8qa6u0tlxb6160pi2jb8s4p";
+const fileUploadElementId = "y3ydd3td2iq09wa599cxo1me";
+
+const fileUploadSurvey = {
+  workspaceId,
+  questions: [],
+  blocks: [
+    {
+      id: "block-1",
+      elements: [{ id: fileUploadElementId, type: "fileUpload" }],
+    },
+  ],
+};
 
 beforeEach(() => {
   vi.resetModules();
   vi.resetAllMocks();
+  // Default: a survey with no file-upload element, so the response scan is skipped.
+  vi.mocked(prisma.survey.findUnique).mockResolvedValue({
+    workspaceId,
+    questions: [],
+    blocks: [],
+  } as any);
 });
 
 describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
@@ -57,6 +85,88 @@ describe("Tests for deleteResponsesAndDisplaysForSurvey service", () => {
         deletedResponsesCount: 0,
         deletedDisplaysCount: 0,
       });
+    });
+
+    test("Deletes the uploaded files held by the deleted responses", async () => {
+      vi.mocked(prisma.survey.findUnique).mockResolvedValue(fileUploadSurvey as any);
+      vi.mocked(prisma.response.findMany).mockResolvedValue([
+        {
+          id: "response-1",
+          data: {
+            [fileUploadElementId]: [
+              `https://example.com/storage/${workspaceId}/private/file1.png`,
+              `https://example.com/storage/${workspaceId}/private/file2.pdf`,
+            ],
+            "other-element": "not a file",
+          },
+        },
+        {
+          id: "response-2",
+          data: { [fileUploadElementId]: [`https://example.com/storage/${workspaceId}/private/file3.png`] },
+        },
+      ] as any);
+      vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 2 }, { count: 0 }]);
+
+      await deleteResponsesAndDisplaysForSurvey(surveyId);
+
+      expect(deleteResponseFileUrls).toHaveBeenCalledWith(
+        [
+          `https://example.com/storage/${workspaceId}/private/file1.png`,
+          `https://example.com/storage/${workspaceId}/private/file2.pdf`,
+          `https://example.com/storage/${workspaceId}/private/file3.png`,
+        ],
+        workspaceId
+      );
+    });
+
+    test("Reads the file-upload answers before the responses are deleted", async () => {
+      const callOrder: string[] = [];
+
+      vi.mocked(prisma.survey.findUnique).mockResolvedValue(fileUploadSurvey as any);
+      vi.mocked(prisma.response.findMany).mockImplementation((async () => {
+        callOrder.push("scan");
+        return [
+          {
+            id: "response-1",
+            data: { [fileUploadElementId]: [`https://example.com/storage/${workspaceId}/private/f.png`] },
+          },
+        ];
+      }) as any);
+      vi.mocked(prisma.$transaction).mockImplementation((async () => {
+        callOrder.push("delete");
+        return [{ count: 1 }, { count: 0 }];
+      }) as any);
+      vi.mocked(deleteResponseFileUrls).mockImplementation((async () => {
+        callOrder.push("storage");
+      }) as any);
+
+      await deleteResponsesAndDisplaysForSurvey(surveyId);
+
+      // The scan must precede the row delete (the URLs live in response.data), and storage cleanup must
+      // follow it so files are never removed while their responses survive.
+      expect(callOrder).toEqual(["scan", "delete", "storage"]);
+    });
+
+    test("Skips the response scan when the survey has no file-upload element", async () => {
+      vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 3 }, { count: 1 }]);
+
+      await deleteResponsesAndDisplaysForSurvey(surveyId);
+
+      expect(prisma.response.findMany).not.toHaveBeenCalled();
+      expect(deleteResponseFileUrls).not.toHaveBeenCalled();
+    });
+
+    test("Ignores non-array answers stored under a file-upload element id", async () => {
+      vi.mocked(prisma.survey.findUnique).mockResolvedValue(fileUploadSurvey as any);
+      vi.mocked(prisma.response.findMany).mockResolvedValue([
+        { id: "response-1", data: { [fileUploadElementId]: "not-an-array" } },
+        { id: "response-2", data: { [fileUploadElementId]: [42, null] } },
+      ] as any);
+      vi.mocked(prisma.$transaction).mockResolvedValue([{ count: 2 }, { count: 0 }]);
+
+      await deleteResponsesAndDisplaysForSurvey(surveyId);
+
+      expect(deleteResponseFileUrls).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
@@ -1,18 +1,27 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
+import { logger } from "@formbricks/logger";
 import { DatabaseError } from "@formbricks/types/errors";
-import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
-import { TSurveyQuestion } from "@formbricks/types/surveys/types";
 import { convertFloatTo2Decimal } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/utils";
+import { getSurvey } from "@/lib/survey/service";
 import { deleteResponseFileUrls } from "@/modules/storage/lib/delete-response-files";
 import { getSurveyFileUploadConfigs } from "@/modules/storage/utils";
 
 /**
- * Responses are scanned in pages so resetting a survey with a large response count never loads every
- * response's data into memory at once.
+ * Responses are scanned in pages so resetting a survey with a large response count never holds every
+ * `response.data` blob at once. Note this bounds only the blobs: the collected URLs still accumulate
+ * across pages, which is what STORAGE_DELETE_CHUNK_SIZE bounds on the way out.
  */
 const RESPONSE_FILE_SCAN_PAGE_SIZE = 500;
+
+/**
+ * Storage deletes are issued in bounded chunks. `deleteResponseFileUrls` fans out with `Promise.all`
+ * over every URL it is handed, so passing a whole survey's worth at once would open one storage
+ * request per uploaded file. Chunking caps the in-flight requests no matter how many files the scan
+ * collected.
+ */
+const STORAGE_DELETE_CHUNK_SIZE = 100;
 
 /**
  * Collects the storage URLs a survey's file-upload answers point at, so they can be deleted once the
@@ -29,20 +38,20 @@ const RESPONSE_FILE_SCAN_PAGE_SIZE = 500;
 const collectSurveyResponseFileUrls = async (
   surveyId: string
 ): Promise<{ fileUrls: string[]; workspaceId: string | undefined }> => {
-  const survey = await prisma.survey.findUnique({
-    where: { id: surveyId },
-    select: { blocks: true, questions: true, workspaceId: true },
-  });
+  // getSurvey is reactCache'd and the reset action fetches the same survey immediately before calling
+  // this, so it resolves from the request cache rather than issuing a second round-trip — and it hands
+  // back typed blocks/questions instead of raw JSON columns needing a cast. This is also the source the
+  // single-response cleanup path reads the survey from.
+  const survey = await getSurvey(surveyId);
 
   if (!survey) {
     return { fileUrls: [], workspaceId: undefined };
   }
 
   const fileUploadElementIds = new Set(
-    getSurveyFileUploadConfigs({
-      blocks: survey.blocks as TSurveyBlock[],
-      questions: survey.questions as TSurveyQuestion[],
-    }).map((config) => config.id)
+    getSurveyFileUploadConfigs({ blocks: survey.blocks, questions: survey.questions }).map(
+      (config) => config.id
+    )
   );
 
   // A survey with no file-upload element can have no uploads to clean up, so skip the response scan.
@@ -112,10 +121,22 @@ export const deleteResponsesAndDisplaysForSurvey = async (
     ]);
 
     // Runs after the rows are gone so a storage failure can never delete files whose responses
-    // survived. deleteResponseFileUrls logs and swallows per-file errors, so a storage outage does not
-    // fail the reset — it leaves objects behind, which is the pre-existing behaviour, not a new one.
-    if (fileUrls.length > 0) {
-      await deleteResponseFileUrls(fileUrls, workspaceId);
+    // survived, and chunked so the number of concurrent storage requests stays bounded.
+    //
+    // The responses are already committed as deleted at this point, so cleanup must not turn a
+    // successful reset into a failed one: deleteResponseFileUrls already logs and swallows per-file
+    // errors, and this guard covers an unexpected throw. The cost of failing here is objects left in
+    // storage — the pre-existing behaviour — not a reset the caller has to retry.
+    for (let i = 0; i < fileUrls.length; i += STORAGE_DELETE_CHUNK_SIZE) {
+      const chunk = fileUrls.slice(i, i + STORAGE_DELETE_CHUNK_SIZE);
+      try {
+        await deleteResponseFileUrls(chunk, workspaceId);
+      } catch (error) {
+        logger.error(
+          { error, surveyId, workspaceId, fileCount: chunk.length },
+          "Failed to delete response files after resetting a survey"
+        );
+      }
     }
 
     return {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
@@ -2,12 +2,100 @@ import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
+import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
+import { TSurveyQuestion } from "@formbricks/types/surveys/types";
 import { convertFloatTo2Decimal } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/utils";
+import { deleteResponseFileUrls } from "@/modules/storage/lib/delete-response-files";
+import { getSurveyFileUploadConfigs } from "@/modules/storage/utils";
+
+/**
+ * Responses are scanned in pages so resetting a survey with a large response count never loads every
+ * response's data into memory at once.
+ */
+const RESPONSE_FILE_SCAN_PAGE_SIZE = 500;
+
+/**
+ * Collects the storage URLs a survey's file-upload answers point at, so they can be deleted once the
+ * responses themselves are gone.
+ *
+ * Must run *before* the responses are deleted: the URLs only exist inside `response.data`, so once the
+ * rows are gone there is nothing left to tell storage which objects are now unreferenced.
+ *
+ * Mirrors the single-response delete path (`findAndDeleteUploadedFilesInResponse` in
+ * lib/response/service.ts): the id set comes from the union of `blocks` and `questions` via
+ * `getSurveyFileUploadConfigs`, because a survey holds file uploads in either shape and keying off one
+ * of them silently skips the other.
+ */
+const collectSurveyResponseFileUrls = async (
+  surveyId: string
+): Promise<{ fileUrls: string[]; workspaceId: string | undefined }> => {
+  const survey = await prisma.survey.findUnique({
+    where: { id: surveyId },
+    select: { blocks: true, questions: true, workspaceId: true },
+  });
+
+  if (!survey) {
+    return { fileUrls: [], workspaceId: undefined };
+  }
+
+  const fileUploadElementIds = new Set(
+    getSurveyFileUploadConfigs({
+      blocks: survey.blocks as TSurveyBlock[],
+      questions: survey.questions as TSurveyQuestion[],
+    }).map((config) => config.id)
+  );
+
+  // A survey with no file-upload element can have no uploads to clean up, so skip the response scan.
+  if (fileUploadElementIds.size === 0) {
+    return { fileUrls: [], workspaceId: survey.workspaceId };
+  }
+
+  const fileUrls: string[] = [];
+  let cursor: string | undefined;
+
+  for (;;) {
+    const responses = await prisma.response.findMany({
+      where: { surveyId },
+      select: { id: true, data: true },
+      orderBy: { id: "asc" },
+      take: RESPONSE_FILE_SCAN_PAGE_SIZE,
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+    });
+
+    if (responses.length === 0) {
+      break;
+    }
+
+    for (const response of responses) {
+      for (const [elementId, answer] of Object.entries(response.data ?? {})) {
+        // Only file-upload answers hold storage URLs, and they are always stored as an array. Anything
+        // else under the same key is skipped rather than cast, so malformed data cannot produce a
+        // bogus delete target.
+        if (!fileUploadElementIds.has(elementId) || !Array.isArray(answer)) {
+          continue;
+        }
+
+        fileUrls.push(...answer.filter((url): url is string => typeof url === "string"));
+      }
+    }
+
+    if (responses.length < RESPONSE_FILE_SCAN_PAGE_SIZE) {
+      break;
+    }
+
+    cursor = responses[responses.length - 1].id;
+  }
+
+  return { fileUrls, workspaceId: survey.workspaceId };
+};
 
 export const deleteResponsesAndDisplaysForSurvey = async (
   surveyId: string
 ): Promise<{ deletedResponsesCount: number; deletedDisplaysCount: number }> => {
   try {
+    // Read the file-upload answers while the responses still exist (see collectSurveyResponseFileUrls).
+    const { fileUrls, workspaceId } = await collectSurveyResponseFileUrls(surveyId);
+
     // Delete all responses for this survey
 
     const [deletedResponsesCount, deletedDisplaysCount] = await prisma.$transaction([
@@ -22,6 +110,13 @@ export const deleteResponsesAndDisplaysForSurvey = async (
         },
       }),
     ]);
+
+    // Runs after the rows are gone so a storage failure can never delete files whose responses
+    // survived. deleteResponseFileUrls logs and swallows per-file errors, so a storage outage does not
+    // fail the reset — it leaves objects behind, which is the pre-existing behaviour, not a new one.
+    if (fileUrls.length > 0) {
+      await deleteResponseFileUrls(fileUrls, workspaceId);
+    }
 
     return {
       deletedResponsesCount: deletedResponsesCount.count,

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
@@ -23,6 +23,33 @@ const RESPONSE_FILE_SCAN_PAGE_SIZE = 500;
  */
 const STORAGE_DELETE_CHUNK_SIZE = 100;
 
+/** One response row as the scan below selects it. */
+type ScannedResponseRow = { id: string; data: Prisma.JsonValue };
+
+/**
+ * Pulls the storage URLs out of one page of scanned responses.
+ *
+ * Only file-upload answers hold storage URLs, and they are always stored as an array of strings.
+ * Anything else under the same key is skipped rather than cast, so malformed data cannot produce a
+ * bogus delete target.
+ */
+const collectFileUrlsFromPage = (
+  responses: ScannedResponseRow[],
+  fileUploadElementIds: Set<string>
+): string[] => {
+  const fileUrls: string[] = [];
+
+  for (const response of responses) {
+    for (const [elementId, answer] of Object.entries(response.data ?? {})) {
+      if (fileUploadElementIds.has(elementId) && Array.isArray(answer)) {
+        fileUrls.push(...answer.filter((url): url is string => typeof url === "string"));
+      }
+    }
+  }
+
+  return fileUrls;
+};
+
 /**
  * Collects the storage URLs a survey's file-upload answers point at, so they can be deleted once the
  * responses themselves are gone.
@@ -75,24 +102,16 @@ const collectSurveyResponseFileUrls = async (
       break;
     }
 
-    for (const response of responses) {
-      for (const [elementId, answer] of Object.entries(response.data ?? {})) {
-        // Only file-upload answers hold storage URLs, and they are always stored as an array. Anything
-        // else under the same key is skipped rather than cast, so malformed data cannot produce a
-        // bogus delete target.
-        if (!fileUploadElementIds.has(elementId) || !Array.isArray(answer)) {
-          continue;
-        }
+    fileUrls.push(...collectFileUrlsFromPage(responses, fileUploadElementIds));
 
-        fileUrls.push(...answer.filter((url): url is string => typeof url === "string"));
-      }
-    }
-
-    if (responses.length < RESPONSE_FILE_SCAN_PAGE_SIZE) {
+    // A short page means the last one. The `lastId` check only guards the cursor from going undefined
+    // and re-reading the same page forever; a full page always has a last row.
+    const lastId = responses.at(-1)?.id;
+    if (responses.length < RESPONSE_FILE_SCAN_PAGE_SIZE || !lastId) {
       break;
     }
 
-    cursor = responses[responses.length - 1].id;
+    cursor = lastId;
   }
 
   return { fileUrls, workspaceId: survey.workspaceId };

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
@@ -24,7 +24,23 @@ const RESPONSE_FILE_SCAN_PAGE_SIZE = 500;
 const STORAGE_DELETE_CHUNK_SIZE = 100;
 
 /** One response row as the scan below selects it. */
-type ScannedResponseRow = { id: string; data: Prisma.JsonValue };
+type ScannedResponseRow = { id: string; createdAt: Date; data: Prisma.JsonValue };
+
+/** Keyset position in the scan: the last row read, ordered by (createdAt, id). */
+type ResponseScanCursor = { createdAt: Date; id: string };
+
+/**
+ * Keyset predicate for "strictly after this row" in (createdAt, id) order.
+ *
+ * The scan orders by createdAt rather than id alone so it can ride the existing
+ * `@@index([surveyId, createdAt])` on Response. Ordering by `id` would have no supporting index —
+ * `(surveyId, id)` does not exist — leaving the planner to either sort the survey's whole response set
+ * on every page or scan by primary key across the entire table. `id` is only the tiebreaker that makes
+ * the order total, so responses sharing a createdAt are neither skipped nor read twice.
+ */
+const afterCursor = (cursor: ResponseScanCursor) => ({
+  OR: [{ createdAt: { gt: cursor.createdAt } }, { createdAt: cursor.createdAt, id: { gt: cursor.id } }],
+});
 
 /**
  * Pulls the storage URLs out of one page of scanned responses.
@@ -81,21 +97,25 @@ const collectSurveyResponseFileUrls = async (
     )
   );
 
-  // A survey with no file-upload element can have no uploads to clean up, so skip the response scan.
+  // No file-upload element in the survey's *current* definition, so there is no key this scan would
+  // match — skip it. Note this is about today's blocks/questions, not the response history: answers
+  // left by an upload element that was since deleted sit under an id no longer in the set, and are not
+  // cleaned up here or by the single-response path. Widening the match to "any answer shaped like a
+  // storage URL" is deliberately not the fix — see the PR's Open gaps for why that would let one
+  // survey's reset delete another's live files.
   if (fileUploadElementIds.size === 0) {
     return { fileUrls: [], workspaceId: survey.workspaceId };
   }
 
   const fileUrls: string[] = [];
-  let cursor: string | undefined;
+  let cursor: ResponseScanCursor | undefined;
 
   for (;;) {
     const responses = await prisma.response.findMany({
-      where: { surveyId },
-      select: { id: true, data: true },
-      orderBy: { id: "asc" },
+      where: { surveyId, ...(cursor ? afterCursor(cursor) : {}) },
+      select: { id: true, createdAt: true, data: true },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
       take: RESPONSE_FILE_SCAN_PAGE_SIZE,
-      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
     });
 
     if (responses.length === 0) {
@@ -104,14 +124,14 @@ const collectSurveyResponseFileUrls = async (
 
     fileUrls.push(...collectFileUrlsFromPage(responses, fileUploadElementIds));
 
-    // A short page means the last one. The `lastId` check only guards the cursor from going undefined
+    // A short page means the last one. The `lastRow` check only guards the cursor from going undefined
     // and re-reading the same page forever; a full page always has a last row.
-    const lastId = responses.at(-1)?.id;
-    if (responses.length < RESPONSE_FILE_SCAN_PAGE_SIZE || !lastId) {
+    const lastRow = responses.at(-1);
+    if (responses.length < RESPONSE_FILE_SCAN_PAGE_SIZE || !lastRow) {
       break;
     }
 
-    cursor = lastId;
+    cursor = { createdAt: lastRow.createdAt, id: lastRow.id };
   }
 
   return { fileUrls, workspaceId: survey.workspaceId };


### PR DESCRIPTION
<!-- No Linear ticket. Found while investigating a customer bug report about
DELETE /api/v1/management/responses/<id> leaving storage files behind. That
report's own path was already fixed by #8861 (merged, unreleased); this is the
same leak on the survey-reset path, still present on main. -->

## What & why

A customer asked whether deleting a response through the management API is
supposed to leave its uploaded files in storage — theirs stayed downloadable
with an API key. Chasing that down turned up a related leak that is still
live on `main`.

`deleteResponsesAndDisplaysForSurvey` — the "delete all responses" / reset
action on the survey summary page — wipes every response row for a survey with
`prisma.response.deleteMany` and never touches storage. Every file-upload
answer in those responses becomes an orphaned object: no longer referenced by
any response, still served by `/storage/...` to anyone with an API key. This is
the bulk counterpart of the single-response cleanup that
`findAndDeleteUploadedFilesInResponse` has always done in
`lib/response/service.ts`, and that #8861 just hardened.

The fix:

- Collect the file URLs **before** the rows are deleted — they only exist
  inside `response.data`, so after `deleteMany` there is nothing left to tell
  storage which objects went unreferenced.
- Hand them to `deleteResponseFileUrls` (added in #8861) **after** the delete
  commits, so a storage failure can never remove files whose responses
  survived, and so workspace scoping is enforced there rather than re-derived
  here.
- Build the file-upload id set from the union of `blocks` and `questions` via
  `getSurveyFileUploadConfigs`, matching the single-response path — keying off
  one shape silently skips surveys stored in the other.
- Page the response scan (500 at a time) so resetting a survey with a large
  response count doesn't hold every `data` blob at once, and skip the scan
  entirely when the survey has no file-upload element. Ordering is
  `(createdAt, id)` with an explicit keyset predicate rather than a cursor on
  `id`, so the scan rides the existing `@@index([surveyId, createdAt])` — there
  is no `(surveyId, id)` index, and ordering by `id` alone would have made the
  paging cost grow with the very input it was added to bound.
- Issue the storage deletes in chunks of 100. `deleteResponseFileUrls` fans out
  with `Promise.all` over everything it is handed and this is its first bulk
  caller, so an unchunked call on a survey with many uploads would open one
  storage request per file. Paging bounds the response blobs; chunking bounds
  the fan-out they feed.
- Read the survey through the `reactCache`d `getSurvey` rather than a second raw
  `findUnique`: the reset action fetched the same survey immediately before, so
  this is a cache hit, and it returns typed `blocks`/`questions` instead of raw
  JSON columns needing a cast.
- Log and continue if cleanup throws. The rows are already committed as deleted
  by then, so a storage problem must not surface as a failed reset the caller
  would retry.

Non-array values under a file-upload key are skipped rather than cast, so
malformed data can't produce a bogus delete target.

## Breaking changes

- [ ] This PR contains breaking changes

Not breaking: no API shape, route, env var or default changes. The reset action
returns the same counts as before; only the storage side effect is added.

## Migrations & env

- none

Note this does not retroactively clean objects orphaned by past resets — it
only stops new ones. Existing orphans would need a separate sweep.

## How this was tested

All rows are in
`apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.test.ts`.
Rerun one with `cd apps/web && pnpm vitest run "app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.test.ts" -t "<test name>"`.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Uploaded files of all deleted responses reach storage cleanup | unit (red on main) | `Deletes the uploaded files held by the deleted responses` — asserts the exact URL list and workspace id |
| Scan precedes the row delete, storage cleanup follows it | unit (red on main) | `Reads the file-upload answers before the responses are deleted` — asserts the exact `["scan", "delete", "storage"]` order |
| Files on a later page are still collected, via an index-friendly keyset | unit (red on main) | `Collects files from every page when responses span the scan page size` — full 500-row first page forces a second query; asserts the `(createdAt, id)` keyset `where`, the `orderBy`, the absence of `skip`/`cursor`, and that all 501 URLs arrive |
| Storage fan-out stays bounded | unit (red on main) | `Issues storage deletes in bounded chunks` — 250 URLs arrive as `[100, 100, 50]`, so no single fan-out exceeds the chunk size |
| A committed reset is not failed by broken storage | unit (red on main) | `Reports the reset as successful when storage cleanup fails` — counts still return, error is logged |
| A failed row delete leaves storage untouched | unit (guard) | `Throws DatabaseError on PrismaClientKnownRequestError occurrence` — now also asserts `deleteResponseFileUrls` was never called, locking the converse of the ordering guarantee |
| No file-upload element → no response scan, no storage call | unit (guard) | `Skips the response scan when the survey has no file-upload element` |
| Missing survey → no scan, no storage call | unit (guard) | `Skips storage cleanup when the survey no longer exists` |
| Non-array answer under a file-upload id is ignored | unit (guard) | `Ignores non-array answers stored under a file-upload element id` — `"not-an-array"` and `[42, null]` produce no storage call |
| Existing reset behaviour (counts, error mapping) | unit (guard) | `Deletes all responses and displays for a survey`, `Handles case with no responses or displays to delete`, `Throws a generic Error for other exceptions` — pre-existing, still green |

Red-on-main verified by restoring `origin/main`'s `survey.ts` under the new test
file: **5 failed / 11 passed**. With the fix: **16 passed**. Full `apps/web`
suite: **627 files, 8297 tests passed**. `tsc --noEmit` clean on the changed
files, eslint and prettier clean.

**Open gaps**

- Not exercised against a live S3/MinIO bucket — `deleteResponseFileUrls` is
  mocked at the module boundary, so this PR proves the URLs reach it with the
  right workspace id, not that the objects disappear. That helper's own S3
  behaviour is covered by `delete-response-files.test.ts` from #8861.
- No e2e coverage of the reset button itself.
- **A file-upload element deleted from a live survey still orphans its files.**
  Its answers stay in `response.data` but its id is gone from
  `getSurveyFileUploadConfigs`, so a later reset skips them (and the
  no-file-upload fast path skips the scan entirely). This is parity with the
  single-response path, not a regression introduced here. Worth stating that
  broadening the key set to "any answer that parses as a storage URL" is *not*
  the fix: `delete-response-files.ts` validates workspace, not survey, so a
  respondent could plant another survey's file URL in a text answer and have an
  admin's reset delete a live file. The narrow keying is deliberate.
- The extraction rule ("build the id set, pull the URLs out of `data`") now
  exists in three places — this file, `lib/response/service.ts` and
  `modules/api/v2/management/responses/[responseId]/lib/utils.ts` — and they have
  already drifted: the two older copies do a bare `elementResponse as string[]`
  with no array guard, so a malformed non-array answer that this file skips still
  reaches storage through them. Extracting one
  `collectResponseFileUrls(data, survey)` next to `deleteResponseFileUrls` would
  fix the drift and give the older paths the guard. Deliberately left out of this
  diff so the leak fix does not carry a refactor of two working paths; happy to
  do it as an immediate follow-up.
- Chunking bounds concurrent storage requests, not total wall-clock. A reset on
  a survey with a very large number of uploads still issues one `DeleteObject`
  per file and could outlive a platform timeout, leaving orphans with no retry
  path. S3's `DeleteObjects` (1000 keys per request) or a durable cleanup queue
  is the real answer at that scale; both are larger changes than this fix and
  neither is needed to close the leak.

**Risks**

- The scan adds a `getSurvey` call (request-cache hit in the action's flow) plus,
  for surveys that actually have a file-upload element, a paged
  `response.findMany` before the delete. Surveys without file uploads add no
  queries beyond the cached survey read. If a reset on a very large survey feels
  slower, `RESPONSE_FILE_SCAN_PAGE_SIZE` and `STORAGE_DELETE_CHUNK_SIZE` are the
  knobs.
- Responses created between the scan and the `deleteMany` have their rows
  deleted but their files kept — the same narrow race the single-response path
  has, and it fails toward keeping files rather than deleting live ones.

## Related, not fixed here

`deleteSurvey` (`modules/survey/lib/surveys.ts`) hard-deletes a survey and
cascades its responses without any storage cleanup, so permanently deleting a
survey — including via the archive purge cron — orphans the same files. Left
out to keep this diff to the response-deletion path; happy to follow up if you
want it in the same cycle.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `medium`.