### PR TITLE
fix(surveys): keep mount autofocus from painting an option as hovered or selected [ENG-2288]

### DIFF
--- a/packages/survey-ui/src/components/elements/multi-select.tsx
+++ b/packages/survey-ui/src/components/elements/multi-select.tsx
@@ -92,7 +92,9 @@ const getOptionContainerClassName = (isSelected: boolean, isDisabled: boolean): 
     "relative flex flex-col border transition-colors outline-none",
     "rounded-option px-option-x py-option-y",
     isSelected ? "bg-option-selected-bg border-brand" : "bg-option-bg border-option-border",
-    "focus-within:border-brand focus-within:bg-option-selected-bg",
+    // No focus-within fill: it repainted the option in the *selected* colors, so the card's
+    // mount autofocus made option 1 look answered (ENG-2288). Focus has its own uniform ring
+    // on the option label, from survey-ui's globals.css.
     "hover:bg-option-hover-bg",
     isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"
   );

--- a/packages/survey-ui/src/components/elements/nps.tsx
+++ b/packages/survey-ui/src/components/elements/nps.tsx
@@ -60,6 +60,10 @@ function NPS({
 }: Readonly<NPSProps>): React.JSX.Element {
   const errorAria = getElementErrorAria(inputId, errorMessage);
 
+  // Pointer-only hover preview: driving this from onFocus too made the card's mount autofocus
+  // (focusFirstControl in block-conditional.tsx) paint 0 with the grey hover fill before the
+  // respondent had touched anything (ENG-2288). Keyboard focus is indicated on its own by the
+  // uniform focus ring in survey-ui's globals.css.
   const [hoveredValue, setHoveredValue] = React.useState<number | null>(null);
 
   // Ensure value is within valid range (0-10)
@@ -123,14 +127,6 @@ function NPS({
           }
         }}
         onMouseLeave={() => {
-          setHoveredValue(null);
-        }}
-        onFocus={() => {
-          if (!disabled) {
-            setHoveredValue(number);
-          }
-        }}
-        onBlur={() => {
           setHoveredValue(null);
         }}>
         {colorCoding ? (

--- a/packages/survey-ui/src/components/elements/nps.tsx
+++ b/packages/survey-ui/src/components/elements/nps.tsx
@@ -60,10 +60,6 @@ function NPS({
 }: Readonly<NPSProps>): React.JSX.Element {
   const errorAria = getElementErrorAria(inputId, errorMessage);
 
-  // Pointer-only hover preview: driving this from onFocus too made the card's mount autofocus
-  // (focusFirstControl in block-conditional.tsx) paint 0 with the grey hover fill before the
-  // respondent had touched anything (ENG-2288). Keyboard focus is indicated on its own by the
-  // uniform focus ring in survey-ui's globals.css.
   const [hoveredValue, setHoveredValue] = React.useState<number | null>(null);
 
   // Ensure value is within valid range (0-10)
@@ -80,13 +76,18 @@ function NPS({
   // decoupled from arrow-key focus moves because selecting can trigger
   // auto-progress (see useRovingRadioGroup).
   const npsValues = Array.from({ length: 11 }, (_, i) => String(i));
-  const { getRadioProps } = useRovingRadioGroup({
+  const { getRadioProps, keyboardValue } = useRovingRadioGroup({
     values: npsValues,
     selectedValue: currentValue === undefined ? undefined : String(currentValue),
     onSelect: (v) => {
       handleSelect(Number(v));
     },
   });
+
+  // Pointer hover, or the cell the respondent arrowed to — but never the card's mount autofocus,
+  // which painted 0 with the grey hover fill before the respondent had touched anything (ENG-2288).
+  // See `keyboardValue` in useRovingRadioGroup, and the same comment in rating.tsx.
+  const previewValue = hoveredValue ?? (keyboardValue === null ? null : Number(keyboardValue));
 
   // Get NPS option color for color coding
   const getNPSOptionColor = (idx: number): string => {
@@ -98,7 +99,7 @@ function NPS({
   // Render NPS option (0-10)
   const renderNPSOption = (number: number): React.JSX.Element => {
     const isSelected = currentValue === number;
-    const isHovered = hoveredValue === number;
+    const isHovered = previewValue === number;
     const isLast = number === 10; // Last option is 10
     const isFirst = number === 0; // First option is 0
 

--- a/packages/survey-ui/src/components/elements/ranking.tsx
+++ b/packages/survey-ui/src/components/elements/ranking.tsx
@@ -80,7 +80,10 @@ function RankingItem({
       className={cn(
         "rounded-option flex h-12 cursor-pointer items-center border px-3 transition-all",
         "bg-option-bg border-option-border",
-        "hover:bg-option-hover-bg focus-within:border-brand focus-within:bg-option-selected-bg focus-within:shadow-sm",
+        // No focus-within fill: it repainted the item in the *ranked* colors, so the card's mount
+        // autofocus made the first item look already ranked (ENG-2288). Focus has its own uniform
+        // ring, painted on the item's button by survey-ui's globals.css.
+        "hover:bg-option-hover-bg",
         isRanked && "bg-option-selected-bg border-brand",
         disabled && "cursor-not-allowed opacity-50"
       )}>

--- a/packages/survey-ui/src/components/elements/rating.tsx
+++ b/packages/survey-ui/src/components/elements/rating.tsx
@@ -174,6 +174,11 @@ function Rating({
 }: Readonly<RatingProps>): React.JSX.Element {
   const errorAria = getElementErrorAria(inputId, errorMessage);
 
+  // Pointer-only hover preview. The player autofocuses a card's first control on mount
+  // (focusFirstControl in block-conditional.tsx), so driving this from onFocus too painted
+  // option 1 as hovered — grey fill on the number scale, a filled star/smiley — before the
+  // respondent had touched anything (ENG-2288). Keyboard focus is indicated on its own by the
+  // uniform focus ring in survey-ui's globals.css.
   const [hoveredValue, setHoveredValue] = React.useState<number | null>(null);
 
   // Ensure value is within valid range
@@ -247,14 +252,6 @@ function Rating({
         }}
         onMouseLeave={() => {
           setHoveredValue(null);
-        }}
-        onFocus={() => {
-          if (!disabled) {
-            setHoveredValue(number);
-          }
-        }}
-        onBlur={() => {
-          setHoveredValue(null);
         }}>
         {colorCoding ? (
           <div
@@ -301,14 +298,6 @@ function Rating({
             }
           }}
           onMouseLeave={() => {
-            setHoveredValue(null);
-          }}
-          onFocus={() => {
-            if (!disabled) {
-              setHoveredValue(number);
-            }
-          }}
-          onBlur={() => {
             setHoveredValue(null);
           }}>
           <input
@@ -358,14 +347,6 @@ function Rating({
             }
           }}
           onMouseLeave={() => {
-            setHoveredValue(null);
-          }}
-          onFocus={() => {
-            if (!disabled) {
-              setHoveredValue(number);
-            }
-          }}
-          onBlur={() => {
             setHoveredValue(null);
           }}>
           <input

--- a/packages/survey-ui/src/components/elements/rating.tsx
+++ b/packages/survey-ui/src/components/elements/rating.tsx
@@ -174,11 +174,6 @@ function Rating({
 }: Readonly<RatingProps>): React.JSX.Element {
   const errorAria = getElementErrorAria(inputId, errorMessage);
 
-  // Pointer-only hover preview. The player autofocuses a card's first control on mount
-  // (focusFirstControl in block-conditional.tsx), so driving this from onFocus too painted
-  // option 1 as hovered — grey fill on the number scale, a filled star/smiley — before the
-  // respondent had touched anything (ENG-2288). Keyboard focus is indicated on its own by the
-  // uniform focus ring in survey-ui's globals.css.
   const [hoveredValue, setHoveredValue] = React.useState<number | null>(null);
 
   // Ensure value is within valid range
@@ -195,13 +190,22 @@ function Rating({
   // the focusable control), but selection is decoupled from arrow-key focus
   // moves because selecting can trigger auto-progress (see useRovingRadioGroup).
   const ratingValues = Array.from({ length: range }, (_, i) => String(i + 1));
-  const { getRadioProps } = useRovingRadioGroup({
+  const { getRadioProps, keyboardValue } = useRovingRadioGroup({
     values: ratingValues,
     selectedValue: currentValue === undefined ? undefined : String(currentValue),
     onSelect: (v) => {
       handleSelect(Number(v));
     },
   });
+
+  // The value the scale previews before anything is selected: the pointer first, otherwise the
+  // option the respondent arrowed to. Deliberately NOT every focus: cards autofocus their first
+  // control on mount (focusFirstControl in block-conditional.tsx), and previewing that painted
+  // option 1 as hovered — grey on the number scale, a filled star or smiley — on a card nobody had
+  // touched yet (ENG-2288). `keyboardValue` is only set by an explicit arrow/Home/End move, so the
+  // preview a pointer user gets on hover is the one a keyboard user gets on arrow, and mount focus
+  // gets none (it is marked by the focus ring in survey-ui's globals.css, like every other card).
+  const previewValue = hoveredValue ?? (keyboardValue === null ? null : Number(keyboardValue));
 
   // Get number option color for color coding
   const getRatingNumberOptionColor = (ratingRange: number, idx: number): string => {
@@ -222,7 +226,7 @@ function Rating({
   // Render number scale option
   const renderNumberOption = (number: number, totalLength: number): React.JSX.Element => {
     const isSelected = currentValue === number;
-    const isHovered = hoveredValue === number;
+    const isHovered = previewValue === number;
     const isLast = totalLength === number;
     const isFirst = number === 1;
 
@@ -279,8 +283,8 @@ function Rating({
   // Render star scale option
   const renderStarOption = (number: number): React.JSX.Element => {
     const isSelected = currentValue === number;
-    // Fill all stars up to the hovered value (if hovering) or selected value
-    const activeValue = hoveredValue ?? currentValue ?? 0;
+    // Fill all stars up to the previewed value (pointer or arrow key) or the selected value
+    const activeValue = previewValue ?? currentValue ?? 0;
     const isActive = number <= activeValue;
 
     return (
@@ -328,8 +332,7 @@ function Rating({
   // Render smiley scale option
   const renderSmileyOption = (number: number, index: number): React.JSX.Element => {
     const isSelected = currentValue === number;
-    const isHovered = hoveredValue === number;
-    const isActive = isSelected || isHovered;
+    const isActive = isSelected || previewValue === number;
 
     return (
       // The flex-1 wrapper keeps the even column layout; the label is sized to the icon so the

--- a/packages/survey-ui/src/components/elements/single-select.tsx
+++ b/packages/survey-ui/src/components/elements/single-select.tsx
@@ -373,7 +373,9 @@ function getOptionContainerClassName(isSelected: boolean, disabled: boolean): st
     "relative flex cursor-pointer flex-col border transition-colors outline-none",
     "rounded-option px-option-x py-option-y",
     isSelected ? "bg-option-selected-bg border-brand" : "bg-option-bg border-option-border",
-    "focus-within:border-brand focus-within:bg-option-selected-bg",
+    // No focus-within fill: it repainted the option in the *selected* colors, so the card's
+    // mount autofocus made option 1 look answered (ENG-2288). Focus has its own uniform ring
+    // on the option label, from survey-ui's globals.css.
     "hover:bg-option-hover-bg",
     disabled && "cursor-not-allowed opacity-50"
   );

--- a/packages/survey-ui/src/lib/use-roving-radio-group.ts
+++ b/packages/survey-ui/src/lib/use-roving-radio-group.ts
@@ -20,6 +20,9 @@ interface RovingRadioProps {
  * - Home/End jump to the first/last option.
  * - Space (native) or Enter selects the focused option.
  *
+ * `keyboardValue` reports the roving position for those explicit key moves only, so a consumer can
+ * preview a value on arrow-key navigation without also previewing on the card's mount autofocus.
+ *
  * Spread the returned props onto every radio `<input>` of the group, in the
  * same order as `values`.
  */
@@ -36,17 +39,32 @@ export function useRovingRadioGroup({
   onSelect: (value: string) => void;
 }): {
   getRadioProps: (value: string) => RovingRadioProps;
+  /** The option the respondent moved focus to with a key, or null. See the state's comment. */
+  keyboardValue: string | null;
 } {
   const inputRefs = React.useRef<Map<string, HTMLInputElement>>(new Map());
   // The roving position while focus is inside the group; null = follow selection.
   const [focusedValue, setFocusedValue] = React.useState<string | null>(null);
+  // The same position, but only while the respondent is the one who moved it, with a key. Focus
+  // that arrives any other way — the card's mount autofocus, a pointer click — leaves this null,
+  // so a consumer can drive a value *preview* from it (the star scale's cumulative fill) without
+  // painting an answer onto a card the respondent has not touched yet (ENG-2288).
+  const [keyboardValue, setKeyboardValue] = React.useState<string | null>(null);
+  // True only for the synchronous .focus() inside focusValue, which is reached from the arrow /
+  // Home / End handlers alone. A ref, not state: the focus event fires during that same call.
+  const isKeyMove = React.useRef(false);
 
   const rovingValue =
     focusedValue ?? (selectedValue && values.includes(selectedValue) ? selectedValue : values[0]);
 
   const focusValue = (value: string): void => {
     setFocusedValue(value);
+    isKeyMove.current = true;
     inputRefs.current.get(value)?.focus();
+    isKeyMove.current = false;
+    // Also set here, not only from the focus handler: focusing the already-focused option (Home at
+    // the first option, an arrow in a one-option group) fires no focus event.
+    setKeyboardValue(value);
   };
 
   const handleKeyDown = (value: string) => (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -94,7 +112,10 @@ export function useRovingRadioGroup({
     // at the selected option, matching native radio-group behavior.
     const next = e.relatedTarget;
     const leavingGroup = !next || ![...inputRefs.current.values()].includes(next as HTMLInputElement);
-    if (leavingGroup) setFocusedValue(null);
+    if (leavingGroup) {
+      setFocusedValue(null);
+      setKeyboardValue(null);
+    }
   };
 
   const getRadioProps = (value: string): RovingRadioProps => ({
@@ -106,9 +127,12 @@ export function useRovingRadioGroup({
     onKeyDown: handleKeyDown(value),
     onFocus: () => {
       setFocusedValue(value);
+      // Mount autofocus, a click, or Tab entering the group: no preview, and no stale one left
+      // behind from an earlier key move (clicking option 5 after arrowing to 3).
+      setKeyboardValue(isKeyMove.current ? value : null);
     },
     onBlur: handleBlur,
   });
 
-  return { getRadioProps };
+  return { getRadioProps, keyboardValue };
 }

--- a/packages/surveys/src/components/general/block-conditional.tsx
+++ b/packages/surveys/src/components/general/block-conditional.tsx
@@ -27,13 +27,23 @@ const FOCUSABLE_CONTROL_SELECTOR = [
   "textarea:not(:disabled)",
   "select:not(:disabled)",
   "button:not(:disabled)",
-  "a[href]",
-  '[tabindex="0"]',
+  '[tabindex="0"]:not(a)',
 ].join(", ");
 
 /**
+ * Links are focusable but are not what a card asks of the respondent: a headline or subheader may
+ * carry one in its prose (a consent element pointing at a privacy policy), and that link sits
+ * *before* the element's own control in the DOM. Focusing it on mount opened the card with a ring
+ * around a word in the question text, reading as a highlighted suggestion (ENG-2415), and gave a
+ * screen-reader user "Privacy Policy, link" as their orientation instead of the question's control.
+ * Kept as a fallback so a card that really has nothing else still receives focus.
+ */
+const FOCUSABLE_LINK_SELECTOR = "a[href]";
+
+/**
  * Focuses the first interactive control inside `root`. With `preferInvalid`,
- * controls flagged aria-invalid win.
+ * controls flagged aria-invalid win; a prose link is only a fallback (see
+ * FOCUSABLE_LINK_SELECTOR).
  *
  * Scrolling is always left to the caller. The first control can sit *below* the card's content — a
  * CTA block has no input of its own, so its first control is the Next button rendered after the
@@ -46,7 +56,10 @@ const focusFirstControl = (root: HTMLElement, preferInvalid = false): void => {
         ':is(input, textarea, select)[aria-invalid="true"]:not([tabindex="-1"]):not(:disabled)'
       )
     : null;
-  const target = invalidTarget ?? root.querySelector<HTMLElement>(FOCUSABLE_CONTROL_SELECTOR);
+  const target =
+    invalidTarget ??
+    root.querySelector<HTMLElement>(FOCUSABLE_CONTROL_SELECTOR) ??
+    root.querySelector<HTMLElement>(FOCUSABLE_LINK_SELECTOR);
   target?.focus({ preventScroll: true });
 };
 

--- a/packages/surveys/src/components/general/block-conditional.tsx
+++ b/packages/surveys/src/components/general/block-conditional.tsx
@@ -22,6 +22,17 @@ import { getFirstErrorMessage, validateBlockResponses } from "@/lib/validation/e
 
 const AUTO_PROGRESS_SUBMIT_DELAY_MS = 350;
 
+/**
+ * Anchors are deliberately absent: they are focusable, but a link is never what a card asks of the
+ * respondent. A headline or subheader may carry one in its prose (a consent element pointing at a
+ * privacy policy), and that link sits *before* the element's own control in the DOM — so mount
+ * focus landed on a word in the question text, ringed, reading as a highlighted suggestion
+ * (ENG-2415), and gave a screen-reader user "Privacy Policy, link" as their orientation instead of
+ * the question's control. Excluding `a` from `[tabindex="0"]` too keeps that uniform for an anchor
+ * made focusable by hand. Nothing is left unfocused by the exclusion: every block renders its
+ * Submit and/or Back button inside `root`, and the only shape without one (an auto-progress
+ * element on the first block) is a radio group.
+ */
 const FOCUSABLE_CONTROL_SELECTOR = [
   'input:not([type="hidden"]):not([tabindex="-1"]):not(:disabled)',
   "textarea:not(:disabled)",
@@ -31,19 +42,9 @@ const FOCUSABLE_CONTROL_SELECTOR = [
 ].join(", ");
 
 /**
- * Links are focusable but are not what a card asks of the respondent: a headline or subheader may
- * carry one in its prose (a consent element pointing at a privacy policy), and that link sits
- * *before* the element's own control in the DOM. Focusing it on mount opened the card with a ring
- * around a word in the question text, reading as a highlighted suggestion (ENG-2415), and gave a
- * screen-reader user "Privacy Policy, link" as their orientation instead of the question's control.
- * Kept as a fallback so a card that really has nothing else still receives focus.
- */
-const FOCUSABLE_LINK_SELECTOR = "a[href]";
-
-/**
  * Focuses the first interactive control inside `root`. With `preferInvalid`,
- * controls flagged aria-invalid win; a prose link is only a fallback (see
- * FOCUSABLE_LINK_SELECTOR).
+ * controls flagged aria-invalid win. Prose links are not candidates at all (see
+ * FOCUSABLE_CONTROL_SELECTOR).
  *
  * Scrolling is always left to the caller. The first control can sit *below* the card's content — a
  * CTA block has no input of its own, so its first control is the Next button rendered after the
@@ -56,10 +57,7 @@ const focusFirstControl = (root: HTMLElement, preferInvalid = false): void => {
         ':is(input, textarea, select)[aria-invalid="true"]:not([tabindex="-1"]):not(:disabled)'
       )
     : null;
-  const target =
-    invalidTarget ??
-    root.querySelector<HTMLElement>(FOCUSABLE_CONTROL_SELECTOR) ??
-    root.querySelector<HTMLElement>(FOCUSABLE_LINK_SELECTOR);
+  const target = invalidTarget ?? root.querySelector<HTMLElement>(FOCUSABLE_CONTROL_SELECTOR);
   target?.focus({ preventScroll: true });
 };
 


### PR DESCRIPTION
Fixes formbricks/formbricks#8786

Ref [ENG-2415](https://linear.app/formbricks/issue/ENG-2415/rating-scale-numbers-first-option-shows-grey-hover-background-on-load)

## What & why

A survey card moves focus to its first control when it mounts (`focusFirstControl`, there on purpose for keyboard and screen-reader users). Several elements treated that focus as a pointer hover, or styled it exactly like a chosen answer — so a card opened looking as if it had already been answered, before the respondent touched anything:

* **rating (number) and NPS** — `onFocus` set the same `hoveredValue` state as `onMouseEnter`, so option 1 (NPS 0) opened carrying the grey hover fill. This is the reported bug.
* **rating (star, smiley)** — same coupling, louder: star 1 opened *filled yellow*, smiley 1 filled and brand-stroked, reading as a 1-star rating already given.
* **single-select, multi-select, ranking** — each option row carried `focus-within:bg-option-selected-bg focus-within:border-brand`, which is character-for-character its `isSelected` styling, so the first choice opened looking answered (the checkbox screenshot on [ENG-2415](https://linear.app/formbricks/issue/ENG-2415/rating-scale-numbers-first-option-shows-grey-hover-background-on-load)).
* **any element with a link in its prose** — `focusFirstControl` accepted `a[href]`, and a link inside the question text sits *before* the element's own control in the DOM. The card opened with a ring around "Privacy Policy" (the second screenshot on [ENG-2415](https://linear.app/formbricks/issue/ENG-2415/rating-scale-numbers-first-option-shows-grey-hover-background-on-load)), and a screen reader announced that link instead of the question's control.

The fix separates *the respondent previewing a value* from *focus landing somewhere*:

* **the scales preview from** `hoveredValue ?? keyboardValue`**.** `useRovingRadioGroup` already owns the explicit arrow / Home / End moves in `focusValue`, which a card's mount autofocus never goes through, so the hook now reports that position as `keyboardValue`. Pointer hover and arrow keys preview identically; mount focus, a pointer click and Tab entering the group all leave it null, and a click after arrowing clears the preview instead of stranding it.
* **the option rows** in `single-select.tsx`, `multi-select.tsx` and `ranking.tsx` no longer restyle themselves on `:focus-within` — that rule painted the *selected* colours for any focus, whatever its origin.
* `focusFirstControl` **never targets a link.** Anchors are excluded from the candidate selector, so the block's own control wins; a prose link in a headline or subheader is no longer what a card opens on.

Focus itself is unchanged everywhere: the same kind of element receives it, and survey-ui's uniform ring (`globals.css`: `label:has(input:focus-visible)`, `label[data-fb-scale-cell]`, `button:focus-visible`) still marks it. What is gone is a *preview that nobody asked for* — the same confusion formbricks/formbricks#8566 removed when it decoupled selection from arrow-key focus.

**Deliberately unchanged:** the focus ring still appears on load, because that entry point is what formbricks/formbricks#8566 added for keyboard and screen-reader users. [ENG-2415](https://linear.app/formbricks/issue/ENG-2415/rating-scale-numbers-first-option-shows-grey-hover-background-on-load) asks more broadly for nothing to look highlighted on load, so it is referenced rather than closed: after this PR the first option no longer looks *answered*, but it does still carry a focus ring. Dropping that is a separate decision about the autofocus itself — see the first Open gap, which is the same decision from the other side.

## Before / after

> Rendered from the **compiled** `@formbricks/surveys` **bundle**, not from a real `/s/{surveyId}` page: no Docker daemon here, so no database to boot the app against. Both sides are real compiled bundles driven in Chromium — the "before" side built from `main`'s version of the changed files, the "after" side from this branch — same fixture, same 720×560 viewport at 2× scale, one block per case so the element under test is the card's first control. Every capture is **the card on load: no click, no keypress, no pointer movement.** The ring on the first option is the autofocus this PR keeps. (GitHub strips `<details>` from descriptions written through the API, so the remaining nine figures are linked rather than embedded, to keep this readable.)

**Rating, number scale** — the reported bug. Option 1 opens filled grey, as if hovered or picked; after, it is the same colour as 2–5 and only the focus ring marks it.

![Rating number scale, before and after, on load](https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/pair-rating-number.png)

**Multi-select** — the customer's own screenshot on [ENG-2415](https://linear.app/formbricks/issue/ENG-2415/rating-scale-numbers-first-option-shows-grey-hover-background-on-load), reproduced and fixed. "Writing new content" opened in the selected colours with a brand border, next to four unanswered options.

![Multi-select, before and after, on load](https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/pair-multi-select.png)

**A card with links in its prose** — the other [ENG-2415](https://linear.app/formbricks/issue/ENG-2415/rating-scale-numbers-first-option-shows-grey-hover-background-on-load) screenshot. A non-external CTA contributes no control of its own, so mount focus used to ring "Privacy Policy" mid-sentence; now it goes to the card's own button.

![CTA card with prose links, before and after, on load](https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/pair-cta-links.png)

The same capture for every other affected element, on load with no interaction:  <br>[star scale](<https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/pair-rating-star.png>) (a filled yellow star 1 is not "focused", it is a 1-star review) ·  <br>[smiley scale](<https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/pair-rating-smiley.png>) ·  <br>[NPS](<https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/pair-nps.png>) ·  <br>[single-select](<https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/pair-single-select.png>) ·  <br>[ranking](<https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/pair-ranking.png>) (the first item opened in the *ranked* colours while its rank badge was still empty) ·  <br>[consent](<https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/pair-consent.png>) (focus moves from the prose link to the checkbox)

## Breaking changes

- [ ] This PR contains breaking changes

None. No API, SDK, prop, route, env var or emitted value changes. `useRovingRadioGroup` gains a returned field (`keyboardValue`); it is an internal hook of `@formbricks/survey-ui`, and its existing consumers destructure `getRadioProps` only.

## Migrations & env

* none

## How this was tested

Same harness as the figures above (compiled bundle in Chromium, before side built from `main`). Captures are on load with no interaction unless a row says otherwise; computed values come from `getComputedStyle`.

**Coverage**

<!-- linear:table-colwidths:266,266,266 -->
| Behaviour | How | Outcome |
| -- | -- | -- |
| Rating, number scale: option 1 is idle on load | manual | Option 1's background `bg-input-selected-bg` **→** `bg-input-bg` (`color(srgb 0.882941 0.894118 0.927647)` → `rgb(237, 240, 249)`, identical to options 2–5). Focus still lands on `input[aria-label="Rate 1 out of 5"]`, ringed. First figure above |
| Rating, star scale: star 1 is not pre-filled on load | manual | Star 1's fill **yellow-400 → slate-300** (`oklch(0.852 0.199 91.936)` → `oklch(0.869 0.022 252.894)`); all five idle. Star figure linked above |
| Rating, smiley scale: smiley 1 is not pre-filled on load | manual | Smiley 1 opens outline-only instead of filled yellow with the brand stroke. Figure linked above |
| NPS: 0 is idle on load | manual | Cell 0 `bg-input-selected-bg` **→** `bg-input-bg`. Figure linked above |
| Single-select and multi-select: the first option does not look answered | manual | Option 1 `bg-option-selected-bg` **+** `border-brand` **→** `bg-option-bg` **+** `border-option-border` (`rgb(30, 64, 175)` border gone). Second figure above |
| Ranking: the first item does not look already ranked, and still shows focus | manual | Item 1 `bg-option-selected-bg` **+** `border-brand` **→ idle**, while the brand ring is still painted on the item's button (`#fbjs button:focus-visible` in `globals.css`) — WCAG 2.4.7 intact, visible in the ranking walk linked below |
| Consent: mount focus goes to the checkbox, not to a link in the question text | manual | `document.activeElement` on load `a` **"Privacy Policy" → the consent checkbox** `button`; both prose links render unringed. Figure linked above |
| **A card whose element contributes no control of its own, with links in its prose** | manual | The shape that lost the `a[href]` fallback. Non-external CTA (renders no control — see `cta.tsx`) with two links in its subheader: `document.activeElement` on load `a` **"Privacy Policy" →** `button` **"Finish"**, the block's own nav button. Third figure above. A card with *no* control at all is not constructible through the survey schema — every block renders Submit and/or Back — which is why the fallback was dead code; the hypothetical is in Risks |
| The pointer still previews exactly as before | manual | Pointer over option 4 → 4 takes the hover fill and 1 stays idle (before: 1 *and* 4 were grey, focus and pointer painting the same thing); over star 4 → stars 1–4 fill; pointer away → all idle. Walk figures linked below |
| **The keyboard previews the same value the pointer does** | manual | `→ →` from mount focus: star scale fills **stars 1–3** with the ring on 3, number scale tints **cell 3**, NPS tints **cell 2** — i.e. arrow keys and hover paint the same thing, which is what the first revision of this PR had lost. Walk figures linked below |
| …but only for a move the respondent made | manual | Mount focus: **all five idle** (`fill: oklch(0.869 0.022 252.894)` on every star). Tab entering the group: still idle. Tab out: preview cleared, selection kept. Clicking option 5 after arrowing to 3: cell 3 returns to `rgb(237, 240, 249)` and only 5 is painted — no stranded preview |
| Selection is untouched | manual | `Space` on the focused option still checks it (`input:checked`) and paints the selected styling: number cell → `bg-brand-20` + brand border, stars → 1–3 filled, ranking → item ranked and its button becomes "Remove Price from ranking" |
| A card reached by a **pointer** click on Next paints no focus indicator | manual | Measured on both bundles, two-block fixture, real mouse click on Next: card 2's first option has `:focus` but **not** `:focus-visible`, so no ring on either side; before it still showed the `:focus-within` fill, after it shows nothing. `Space` then checks the option on **both** bundles. This is the first Open gap, not a fixed row |
| Nothing regressed in the two packages | unit (guard) | `pnpm test --filter=@formbricks/surveys --filter=@formbricks/survey-ui` — 35 files, 829 tests, green |

Interaction walks on the **after** bundle — load, pointer over an option, two arrow presses, then Space, four moments per figure:  <br>[star scale](<https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/walk-rating-star.png>) (hover previews 1–4, arrows preview 1–3, Space commits) ·  <br>[number scale](<https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/walk-rating-number.png>) (the grey follows the pointer and the arrow keys, but not the card opening) ·  <br>[ranking](<https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8932/walk-ranking.png>) (no fill on focus, ring still on the item's button; ranking has no roving group, so arrows are a no-op)

**Open gaps**

* **A card reached by a pointer click on Next shows no focus indicator at all** — measured above, and worth a decision that is bigger than this PR. `:focus-within` matched any focus; the ring is `:focus-visible`, which Chromium and WebKit withhold from a script `focus()` when the last input modality was a pointer. So after a mouse-driven Next, focus sits on option 1 invisibly, and a Space press (a plausible "scroll the card" reflex) checks it — on **both** bundles, so the footgun is not introduced here, but this PR removes the misleading paint that used to mark the target. Every remedy cuts against something: a modality-independent mount ring is exactly the "first option looks highlighted on load" that [ENG-2415](https://linear.app/formbricks/issue/ENG-2415/rating-scale-numbers-first-option-shows-grey-hover-background-on-load) asks us to stop doing; skipping mount autofocus for pointer navigation would strand VoiceOver/TalkBack users, whose navigation *is* pointer-driven (the regression formbricks/formbricks#8566 fixed); focusing the card container (`tabindex="-1"`, already ring-exempt) on the pointer path looks best to me and is still a change to the autofocus model. It belongs to the [ENG-2415](https://linear.app/formbricks/issue/ENG-2415/rating-scale-numbers-first-option-shows-grey-hover-background-on-load) decision, with this data attached — discussion is on the open `multi-select.tsx` thread.
* **No automated regression guard ships with this fix.** The repo rules out component unit tests for `.tsx`, and the behaviour is real-browser paint and focus, which jsdom/happy-dom cannot observe. A Playwright spec would be the right guard, but there is no database here to run one against, and shipping a spec I could not run would be worse than none. Repro recipe: open any rating/NPS/choice card as the first card and read the first option's `backgroundColor` (or star 1's `fill`) before touching anything.
* The media comes from the surveys bundle rendered standalone, so it proves the elements' own behaviour, not the full link-survey page around them. A pass on a real link survey is still owed by a human — including a touch device, where `onMouseEnter` can fire on tap.
* `picture-select` and `matrix` also consume `useRovingRadioGroup`; they ignore `keyboardValue` and have no focus/selection coupling, so they are unchanged by inspection, not by capture.
* Consent's own `focus-within:border-ring` on the checkbox box is left alone — it is a focus affordance on that element's single control, not a "this is selected" look.

**Risks**

* `useRovingRadioGroup` is shared (rating, NPS, single-select, picture-select). The change is additive — a new returned field plus one extra state write per focus event — and `focusValue` still sets the roving position first, so the tabindex model is untouched. If a scale ever previews the wrong option, the suspect is `isKeyMove`: it is a ref that is true only for the synchronous `.focus()` inside `focusValue`.
* `focusFirstControl` is shared with the failed-submit path (`preferInvalid`), which is unchanged: it still targets `aria-invalid` inputs first, and those callers still scroll the field they focus into view themselves. `apps/web/playwright/survey-keyboard.spec.ts` covers that path; its fixtures have no prose links, so the anchor exclusion cannot touch them.
* Anchors are now excluded from mount focus with no fallback. That is safe because every block renders its Submit and/or Back button inside the focus root — the shape with neither (an auto-progress element on the first block) is always a radio group. A future card type with no control and only a link would receive no focus at all; the guard against that is `FOCUSABLE_CONTROL_SELECTOR`'s docblock, which says so.

---

> [!NOTE]
> **AI model used** — Claude Opus 5, reasoning effort: Max.