### PR TITLE
fix(auth): stop paging on client-caused OAuth state rejections (ENG-2471)

### DIFF
--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -413,6 +413,8 @@ describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
   // expired, or no `state` arrived at all. Nothing to act on, so these must not page.
   test.each([
     ["state_mismatch", "State mismatch: verification not found"],
+    // Cookie-branch message, kept as a label only: the code is what the gate reads, and this variant
+    // is unreachable on our database strategy.
     ["state_mismatch", "State mismatch: auth state cookie not found"],
     ["state_mismatch", "Invalid state: request expired"],
     ["state_not_found", "State not found in OAuth callback"],
@@ -430,10 +432,12 @@ describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
   /**
    * The other three codes stay captured, and each for its own reason:
    * - `state_generation_error` — the adapter could not write the verification row: a real fault.
-   * - `state_invalid` — undecryptable state, which is what replicas running different
-   *   `BETTER_AUTH_SECRET` values look like. Suppressing it would bury an outage.
-   * - `state_security_mismatch` — the state does not match the stored one: the forged/mixed-up callback
-   *   shape. ENG-2471 defers judging it until the ENG-2259 `auth.path` tag has sized it.
+   * - `state_security_mismatch` — the state does not match the stored one, OR the signed state cookie
+   *   fails verification. That second half is where a cross-replica `BETTER_AUTH_SECRET` divergence
+   *   surfaces (a real outage) and also where the benign 5–10 minute cookie-expiry case lands, so it is
+   *   mixed and ENG-2471 defers judging it until the ENG-2259 `auth.path` tag has sized the split.
+   * - `state_invalid` — cookie-branch only, so unreachable on this configuration. Kept because
+   *   suppressing a code that never fires buys nothing.
    */
   test.each([
     ["state_generation_error", "Unable to create verification"],
@@ -447,6 +451,38 @@ describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
     expect(Sentry.captureException).toHaveBeenCalledWith(stateError, {
       tags: { component: "better-auth" },
     });
+  });
+
+  /**
+   * The log field is the whole justification for suppressing anything: a suppressed event survives only
+   * in the application log, so it has to be queryable by the same value that suppressed it. Without this
+   * test the field can be deleted and the suite stays green — verified, it did.
+   *
+   * Recorded for captured codes too, so one query covers the class rather than only its quiet half.
+   */
+  test.each([
+    ["state_mismatch", "suppressed"],
+    ["state_security_mismatch", "captured"],
+  ])("records %s on the log context (%s)", (code) => {
+    log("error", "State mismatch", new StateErrorLike("State mismatch", code));
+
+    expect(logger.withContext).toHaveBeenCalledWith({
+      source: "better-auth",
+      stateErrorCode: code,
+    });
+  });
+
+  // The raw `state` is a single-use credential for the in-flight flow and lives on the error's
+  // `details`. Only the code is ever read, so it cannot reach the log through this path.
+  test("never puts the raw state value on the log context", () => {
+    const stateError = new StateErrorLike("State mismatch: verification not found", "state_mismatch");
+    Object.assign(stateError, { details: { state: "super-secret-state-value" } });
+
+    log("error", "State mismatch: verification not found", stateError);
+
+    expect(JSON.stringify(vi.mocked(logger.withContext).mock.calls)).not.toContain(
+      "super-secret-state-value"
+    );
   });
 
   // The gate fails CLOSED: anything it cannot positively identify as one of the two suppressed codes is

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -437,11 +437,12 @@ describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
    *   mixed and ENG-2471 defers judging it until the ENG-2259 `auth.path` tag has sized the split.
    * - `state_invalid` — cookie-branch only, so unreachable on this configuration. Kept because
    *   suppressing a code that never fires buys nothing.
-   * - `state_not_found` — no `state` on the callback at all. A real flow cannot produce this (the IdP
-   *   echoes the state it was given), so it is either a bare scanner or something upstream dropping the
-   *   parameter — an IdP regression, a proxy, or a callback rewrite mishandling the query string. The
-   *   latter is a provider-wide sign-in outage and this is its canary, so it keeps paging. None of the
-   *   reported FORMBRICKS-16G events are this code.
+   * - `state_not_found` — a defensive entry rather than a live one. Verified against 1.7.0 that the
+   *   callback route short-circuits a missing `state` before any `StateError` is thrown, and logs it
+   *   with the OAuth `error` query param rather than an `Error` — so it reaches neither this gate nor
+   *   Sentry, and the assertion below is a contract for a shape the callback route does not currently
+   *   produce. Kept captured so that if upstream ever does route it through as a real `StateError`, it
+   *   pages instead of being dropped by a stale allow-list.
    */
   test.each([
     ["state_generation_error", "Unable to create verification"],

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -409,15 +409,14 @@ describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
     vi.clearAllMocks();
   });
 
-  // Client- or timing-caused: the state cookie expired, the verification record was purged, the request
-  // expired, or no `state` arrived at all. Nothing to act on, so these must not page.
+  // Client- or timing-caused: the verification record was purged or already consumed, or the parsed
+  // state is past its `expiresAt`. Nothing to act on, so these must not page.
   test.each([
     ["state_mismatch", "State mismatch: verification not found"],
     // Cookie-branch message, kept as a label only: the code is what the gate reads, and this variant
     // is unreachable on our database strategy.
     ["state_mismatch", "State mismatch: auth state cookie not found"],
     ["state_mismatch", "Invalid state: request expired"],
-    ["state_not_found", "State not found in OAuth callback"],
   ])("does not capture the client-caused %s (%s)", (code, message) => {
     const stateError = new StateErrorLike(message, code);
 
@@ -438,11 +437,17 @@ describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
    *   mixed and ENG-2471 defers judging it until the ENG-2259 `auth.path` tag has sized the split.
    * - `state_invalid` — cookie-branch only, so unreachable on this configuration. Kept because
    *   suppressing a code that never fires buys nothing.
+   * - `state_not_found` — no `state` on the callback at all. A real flow cannot produce this (the IdP
+   *   echoes the state it was given), so it is either a bare scanner or something upstream dropping the
+   *   parameter — an IdP regression, a proxy, or a callback rewrite mishandling the query string. The
+   *   latter is a provider-wide sign-in outage and this is its canary, so it keeps paging. None of the
+   *   reported FORMBRICKS-16G events are this code.
    */
   test.each([
     ["state_generation_error", "Unable to create verification"],
     ["state_invalid", "State invalid: Failed to decrypt or parse auth state"],
     ["state_security_mismatch", "State mismatch: OAuth state parameter does not match stored state"],
+    ["state_not_found", "State not found in OAuth callback"],
   ])("still captures %s", (code, message) => {
     const stateError = new StateErrorLike(message, code);
 

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -429,7 +429,7 @@ describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
   });
 
   /**
-   * The other three codes stay captured, and each for its own reason:
+   * The other four codes stay captured, and each for its own reason:
    * - `state_generation_error` — the adapter could not write the verification row: a real fault.
    * - `state_security_mismatch` — the state does not match the stored one, OR the signed state cookie
    *   fails verification. That second half is where a cross-replica `BETTER_AUTH_SECRET` divergence
@@ -491,8 +491,8 @@ describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
     );
   });
 
-  // The gate fails CLOSED: anything it cannot positively identify as one of the two suppressed codes is
-  // still captured. A wrong answer should add noise, never silence a fault.
+  // The gate fails CLOSED: anything it cannot positively identify as THE one suppressed code
+  // (`state_mismatch`) is still captured. A wrong answer should add noise, never silence a fault.
   test("captures a BetterAuthError carrying no code", () => {
     const bare = new BetterAuthError("something upstream broke");
 

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -1,4 +1,7 @@
+import { BetterAuthError } from "@better-auth/core/error";
 import * as Sentry from "@sentry/nextjs";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
 import { APIError } from "better-auth/api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
@@ -377,6 +380,171 @@ describe("betterAuthLogger (Sentry capture gating, ENG-2037)", () => {
 
     expect(Sentry.captureException).not.toHaveBeenCalled();
     expect(contextLoggerMock.info).toHaveBeenCalledWith("some info");
+  });
+});
+
+/**
+ * ENG-2471: `BetterAuthError: State mismatch: verification not found` cleared the ENG-2037 gate and
+ * paged — 52 events in 14 days. It is a third shape ENG-2037 never enumerated: not a bare string code,
+ * not an `APIError`, but a `StateError extends BetterAuthError` carrying a stable `code`.
+ *
+ * Mirrors the real shape rather than importing it: `StateError` is internal to
+ * `better-auth/dist/state.mjs`, and it extends `BetterAuthError` adding only `code`/`details`/`errorURL`
+ * — so a subclass carrying `code` is exactly what the gate sees. The codes below are the five that
+ * module throws, read from its throw sites.
+ */
+class StateErrorLike extends BetterAuthError {
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
+  const log = betterAuthLogger.log!;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Client- or timing-caused: the state cookie expired, the verification record was purged, the request
+  // expired, or no `state` arrived at all. Nothing to act on, so these must not page.
+  test.each([
+    ["state_mismatch", "State mismatch: verification not found"],
+    ["state_mismatch", "State mismatch: auth state cookie not found"],
+    ["state_mismatch", "Invalid state: request expired"],
+    ["state_not_found", "State not found in OAuth callback"],
+  ])("does not capture the client-caused %s (%s)", (code, message) => {
+    const stateError = new StateErrorLike(message, code);
+
+    log("error", message, stateError);
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    // Still visible in the application log — suppression is Sentry-only. A burst of these is how a
+    // Redis eviction would present, since verification records live in Redis only.
+    expect(contextLoggerMock.error).toHaveBeenCalledWith(message);
+  });
+
+  /**
+   * The other three codes stay captured, and each for its own reason:
+   * - `state_generation_error` — the adapter could not write the verification row: a real fault.
+   * - `state_invalid` — undecryptable state, which is what replicas running different
+   *   `BETTER_AUTH_SECRET` values look like. Suppressing it would bury an outage.
+   * - `state_security_mismatch` — the state does not match the stored one: the forged/mixed-up callback
+   *   shape. ENG-2471 defers judging it until the ENG-2259 `auth.path` tag has sized it.
+   */
+  test.each([
+    ["state_generation_error", "Unable to create verification"],
+    ["state_invalid", "State invalid: Failed to decrypt or parse auth state"],
+    ["state_security_mismatch", "State mismatch: OAuth state parameter does not match stored state"],
+  ])("still captures %s", (code, message) => {
+    const stateError = new StateErrorLike(message, code);
+
+    log("error", message, stateError);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(stateError, {
+      tags: { component: "better-auth" },
+    });
+  });
+
+  // The gate fails CLOSED: anything it cannot positively identify as one of the two suppressed codes is
+  // still captured. A wrong answer should add noise, never silence a fault.
+  test("captures a BetterAuthError carrying no code", () => {
+    const bare = new BetterAuthError("something upstream broke");
+
+    log("error", "something upstream broke", bare);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(bare, {
+      tags: { component: "better-auth" },
+    });
+  });
+
+  test("captures a look-alike that is not a BetterAuthError, even with a suppressed code", () => {
+    const impostor = Object.assign(new Error("State mismatch: verification not found"), {
+      name: "BetterAuthError",
+      code: "state_mismatch",
+    });
+
+    log("error", "State mismatch: verification not found", impostor);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(impostor, {
+      tags: { component: "better-auth" },
+    });
+  });
+});
+
+/**
+ * The contract test for the gate above, and the reason the `StateErrorLike` tests are not enough on
+ * their own: they assert against a stand-in we define here, so they would keep passing if the REAL
+ * `StateError` stopped satisfying the gate. `StateError` is internal to `better-auth/dist/state.mjs`
+ * and cannot be imported, so the only way to bind the real shape is to make Better Auth throw one.
+ *
+ * This drives a real `betterAuth` instance — configured with `betterAuthLogger` itself, so the whole
+ * production path runs — at an OAuth callback carrying a `state` with no verification record. That is
+ * exactly the reported failure (`State mismatch: verification not found`, FORMBRICKS-16G). If a future
+ * upgrade renames the code, changes the class, or stops routing it through the logger, this fails.
+ */
+describe("betterAuthLogger — the real Better Auth StateError (ENG-2471 contract)", () => {
+  const BASE_URL = "http://localhost:3000";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const provokeStateMismatch = async (): Promise<void> => {
+    const auth = betterAuth({
+      baseURL: BASE_URL,
+      secret: "eng-2471-contract-test-secret-0123456789abcdef",
+      // memoryAdapter declares its models up front; an empty `verification` table is the point — the
+      // state below resolves to no record, which is what throws.
+      database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+      logger: betterAuthLogger,
+      socialProviders: { google: { clientId: "contract-test", clientSecret: "contract-test" } },
+    });
+
+    await auth.handler(
+      new Request(`${BASE_URL}/api/auth/callback/google?state=no-such-state&code=irrelevant`)
+    );
+  };
+
+  test("is logged, so this suite is exercising the path at all", async () => {
+    await provokeStateMismatch();
+
+    // Anti-vacuity: if Better Auth stopped routing this through our logger, the assertion below would
+    // pass for the wrong reason — nothing captured because nothing happened.
+    expect(contextLoggerMock.error).toHaveBeenCalled();
+  });
+
+  // Pins the exact shape the gate depends on, so an upstream rename fails here loudly instead of
+  // quietly restoring the noise. Uses a capturing logger rather than `betterAuthLogger`, because the
+  // production logger deliberately forwards only the message to our logger, not the Error.
+  test("is a BetterAuthError carrying code state_mismatch", async () => {
+    const seen: unknown[] = [];
+    const auth = betterAuth({
+      baseURL: BASE_URL,
+      secret: "eng-2471-contract-test-secret-0123456789abcdef",
+      database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+      logger: { level: "error", log: (_level, _message, ...args) => seen.push(...args) },
+      socialProviders: { google: { clientId: "contract-test", clientSecret: "contract-test" } },
+    });
+
+    await auth.handler(
+      new Request(`${BASE_URL}/api/auth/callback/google?state=no-such-state&code=irrelevant`)
+    );
+
+    const stateError = seen.find((arg): arg is Error & { code?: unknown } => arg instanceof BetterAuthError);
+    expect(stateError).toBeDefined();
+    expect(stateError?.name).toBe("BetterAuthError");
+    expect(stateError?.code).toBe("state_mismatch");
+  });
+
+  test("is NOT captured to Sentry", async () => {
+    await provokeStateMismatch();
+
+    expect(contextLoggerMock.error).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -145,10 +145,21 @@ export const redactEmailsInLogMessage = (message: unknown): unknown =>
  * | code | thrown when (database strategy) | actionable? |
  * | --- | --- | --- |
  * | `state_mismatch` | no verification record for this `state` — purged after its 10-minute TTL, already consumed, or never issued — or the parsed state is past `expiresAt` | no — **suppressed** |
- * | `state_not_found` | the callback carried no `state` parameter at all (bots, truncated links) | no — **suppressed** |
+ * | `state_not_found` | the callback carried no `state` parameter at all | **yes**, kept — see below |
  * | `state_security_mismatch` | the state does not match the stored one, or the signed `state` cookie fails verification ("State not persisted correctly") | **yes**, kept |
  * | `state_generation_error` | the adapter could not write the verification row | **yes**, kept — a real fault |
  * | `state_invalid` | undecryptable state — **cookie branch only, unreachable on this config** | kept; suppressing a code that never fires buys nothing |
+ *
+ * `state_not_found` was in the first draft of this set and was deliberately taken back out. A real
+ * user-initiated flow cannot produce it: the IdP echoes the `state` it was given, so an absent `state`
+ * means either a bare scanner hitting the callback path, or something upstream dropping the parameter —
+ * an IdP regression, a proxy stripping the query string, or a callback-URL rewrite mishandling it (which
+ * is now a live concern: ENG-2343 rewrites every SSO callback through `legacy-sso-callback.ts`). That
+ * second class is a total-SSO-outage shape for the affected provider, and this code is the canary for
+ * it. Nothing in FORMBRICKS-16G is this code — the reported events are all `verification not found`,
+ * i.e. `state_mismatch` — so suppressing it would have traded an unmeasured amount of scanner noise for
+ * the loss of that canary, on no evidence. If it does turn out to be dominated by scanners once the
+ * `auth.path` tag is live, adding it then is a one-line change backed by data.
  *
  * `state_security_mismatch` carries the load this gate deliberately does not take on, and it is mixed:
  *
@@ -164,6 +175,13 @@ export const redactEmailsInLogMessage = (message: unknown): unknown =>
  * tag from ENG-2259 rather than guessing. Suppressing a signal before measuring it is how ENG-2037 left
  * this shape behind in the first place.
  *
+ * One security-visible consequence, stated rather than left implicit: a *replayed* callback — the same
+ * `state` presented again after the legitimate flow consumed it — also lands on `state_mismatch`, so
+ * replay attempts stop being visible in Sentry. That is judged acceptable because the replay fails
+ * closed (the record is single-use, and the authorization code is single-use at the IdP too), so this is
+ * a loss of visibility into a *failed* attempt, not of a control. The events remain in the application
+ * log with their `stateErrorCode`, which is where a campaign would show up as volume.
+ *
  * What suppression costs, stated narrowly: a Redis eviction, flush, or failover to an empty replica
  * drops in-flight verification records and yields `state_mismatch` for real login failures. A *hard*
  * Redis outage does not — `secondary-storage.ts` rethrows on connect failure, which is not a
@@ -171,7 +189,7 @@ export const redactEmailsInLogMessage = (message: unknown): unknown =>
  * `stateErrorCode` and the request's `authPath`, so they are greppable; note there is no log-based alert
  * rule for them today, so a burst is discoverable rather than announced.
  */
-const UNACTIONABLE_STATE_ERROR_CODES: ReadonlySet<string> = new Set(["state_mismatch", "state_not_found"]);
+const UNACTIONABLE_STATE_ERROR_CODES: ReadonlySet<string> = new Set(["state_mismatch"]);
 
 /**
  * The `StateError` code carried by a logged cause, or undefined when it is not one.
@@ -190,8 +208,8 @@ const getStateErrorCode = (cause: Error | undefined): string | undefined => {
 };
 
 /**
- * Fails CLOSED on purpose: anything not positively identified as one of the two unactionable codes is
- * still captured. A wrong answer here should add noise, never silence a genuine fault.
+ * Fails CLOSED on purpose: anything not positively identified as an unactionable code is still
+ * captured. A wrong answer here should add noise, never silence a genuine fault.
  */
 const isUnactionableStateError = (code: string | undefined): boolean =>
   code !== undefined && UNACTIONABLE_STATE_ERROR_CODES.has(code);

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { BetterAuthError } from "@better-auth/core/error";
 import * as Sentry from "@sentry/nextjs";
 import type { BetterAuthOptions } from "better-auth";
 import { isAPIError } from "better-auth/api";
@@ -130,6 +131,71 @@ export const redactEmailsInLogMessage = (message: unknown): unknown =>
   typeof message === "string" ? message.replace(EMAIL_IN_MESSAGE, "[redacted]@$1") : message;
 
 /**
+ * `StateError` codes whose events are client- or timing-caused, and so are not actionable in Sentry
+ * (ENG-2471). `StateError extends BetterAuthError` and carries a stable `code`, which is what we match
+ * on — never the message, which is not a contract.
+ *
+ * Read from the throw sites in `better-auth/dist/state.mjs`, **for the strategy we actually run**. That
+ * matters more than it sounds: the file has two branches that throw different codes for the same
+ * underlying cause, and reading the wrong one inverts the conclusions. `auth.ts` sets `secondaryStorage`,
+ * which makes Better Auth resolve `storeStateStrategy` to `"database"`, and `account:` sets no override —
+ * so the cookie branch never executes here.
+ *
+ * | code | thrown when (database strategy) | actionable? |
+ * | --- | --- | --- |
+ * | `state_mismatch` | no verification record for this `state` — purged after its 10-minute TTL, already consumed, or never issued — or the parsed state is past `expiresAt` | no — **suppressed** |
+ * | `state_not_found` | the callback carried no `state` parameter at all (bots, truncated links) | no — **suppressed** |
+ * | `state_security_mismatch` | the state does not match the stored one, or the signed `state` cookie fails verification ("State not persisted correctly") | **yes**, kept |
+ * | `state_generation_error` | the adapter could not write the verification row | **yes**, kept — a real fault |
+ * | `state_invalid` | undecryptable state — **cookie branch only, unreachable on this config**; kept for the cost of one Set entry | kept |
+ *
+ * `state_security_mismatch` carries the load this gate deliberately does not take on, and it is mixed:
+ *
+ * - The state cookie's `maxAge` is 300s while the verification record lives 10 minutes, so a user who
+ *   spends 5–10 minutes at the identity provider loses the cookie first and lands here. Benign, and
+ *   probably common — **so this change likely leaves residual noise behind**; it closes the reported
+ *   `verification not found` shape (FORMBRICKS-16G), not the whole class.
+ * - It is also where a `BETTER_AUTH_SECRET` divergence across replicas surfaces, because the signed
+ *   cookie cannot be verified with a different secret. That is a genuine outage and must keep paging.
+ * - And it is the shape a forged or mixed-up callback takes.
+ *
+ * Code cannot separate those three, which is exactly why ENG-2471 defers the decision to the `auth.path`
+ * tag from ENG-2259 rather than guessing. Suppressing a signal before measuring it is how ENG-2037 left
+ * this shape behind in the first place.
+ *
+ * What suppression costs, stated narrowly: a Redis eviction, flush, or failover to an empty replica
+ * drops in-flight verification records and yields `state_mismatch` for real login failures. A *hard*
+ * Redis outage does not — `secondary-storage.ts` rethrows on connect failure, which is not a
+ * `StateError` and still pages. The suppressed events remain at `error` in the application log carrying
+ * `stateErrorCode` and the request's `authPath`, so they are greppable; note there is no log-based alert
+ * rule for them today, so a burst is discoverable rather than announced.
+ */
+const UNACTIONABLE_STATE_ERROR_CODES: ReadonlySet<string> = new Set(["state_mismatch", "state_not_found"]);
+
+/**
+ * The `StateError` code carried by a logged cause, or undefined when it is not one.
+ *
+ * Extracted once and used for BOTH the log context and the Sentry gate, so a suppressed event stays
+ * queryable by the same value that suppressed it — the log is the only place these survive, and an
+ * upstream message string is not something to build an alert on.
+ *
+ * Deliberately reads only `code`, never the error's `details`, which holds the raw `state` value: that
+ * is a single-use credential for the in-flight OAuth flow and has no business in a log line.
+ */
+const getStateErrorCode = (cause: Error | undefined): string | undefined => {
+  if (!(cause instanceof BetterAuthError)) return undefined;
+  const { code } = cause as { code?: unknown };
+  return typeof code === "string" ? code : undefined;
+};
+
+/**
+ * Fails CLOSED on purpose: anything not positively identified as one of the two unactionable codes is
+ * still captured. A wrong answer here should add noise, never silence a genuine fault.
+ */
+const isUnactionableStateError = (code: string | undefined): boolean =>
+  code !== undefined && UNACTIONABLE_STATE_ERROR_CODES.has(code);
+
+/**
  * Route Better Auth's logger to @formbricks/logger and capture GENUINE internal faults to Sentry in
  * production — replaces auth.ts's placeholder logger (and the route's Sentry.captureException on auth
  * failures).
@@ -158,21 +224,26 @@ export const betterAuthLogger: NonNullable<BetterAuthOptions["logger"]> = {
     // construction, a server-side `auth.api.*` call). Already reduced to a safe label — never a raw
     // path, which on `/reset-password/:token` would be a live credential (better-auth-path-label.ts).
     const request = getBetterAuthRequestContext();
+    // BA usually passes the Error as a trailing arg, but a couple of sites pass it as `message`.
+    const cause = [...args, message].find((arg): arg is Error => arg instanceof Error);
+    const stateErrorCode = getStateErrorCode(cause);
     const contextLogger = logger.withContext({
       source: "better-auth",
       // Self-hosters have no Sentry, so the label has to reach the application log too — otherwise
       // their copy of this fault stays as untriageable as FORMBRICKS-183 was.
       ...(request && { authPath: request.path, httpMethod: request.method }),
+      // The suppressed state rejections survive only in the log, so the code has to be queryable there
+      // (ENG-2471). Recorded for every state error, not only the suppressed ones.
+      ...(stateErrorCode && { stateErrorCode }),
     });
     const safeMessage = redactEmailsInLogMessage(message);
     if (level === "error") {
       contextLogger.error(safeMessage);
       if (SENTRY_DSN && IS_PRODUCTION) {
-        // BA usually passes the Error as a trailing arg, but a couple of sites pass it as `message`.
-        const cause = [...args, message].find((arg): arg is Error => arg instanceof Error);
-        // Skip handled rejections: a bare string code (no Error) or a client-facing APIError. Capture
-        // only genuine internal faults so Sentry stays actionable (see the reason-split above).
-        if (cause && !isAPIError(cause)) {
+        // Skip handled rejections: a bare string code (no Error), a client-facing APIError, or a
+        // client/timing-caused OAuth `StateError` (ENG-2471). Capture only genuine internal faults so
+        // Sentry stays actionable (see the reason-split above and UNACTIONABLE_STATE_ERROR_CODES).
+        if (cause && !isAPIError(cause) && !isUnactionableStateError(stateErrorCode)) {
           // ENG-2259: Better Auth's router logs a non-APIError as `(e.name, e)` and discards the
           // endpoint (`better-auth/dist/api/index.mjs:210`), so a bare capture arrives with no
           // transaction, URL or route — which is why FORMBRICKS-183 sat at ~242 events untriageable.

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -145,21 +145,32 @@ export const redactEmailsInLogMessage = (message: unknown): unknown =>
  * | code | thrown when (database strategy) | actionable? |
  * | --- | --- | --- |
  * | `state_mismatch` | no verification record for this `state` — purged after its 10-minute TTL, already consumed, or never issued — or the parsed state is past `expiresAt` | no — **suppressed** |
- * | `state_not_found` | the callback carried no `state` parameter at all | **yes**, kept — see below |
+ * | `state_not_found` | the callback carried no `state` — **never reaches this gate on 1.7**, see below | kept |
  * | `state_security_mismatch` | the state does not match the stored one, or the signed `state` cookie fails verification ("State not persisted correctly") | **yes**, kept |
  * | `state_generation_error` | the adapter could not write the verification row | **yes**, kept — a real fault |
  * | `state_invalid` | undecryptable state — **cookie branch only, unreachable on this config** | kept; suppressing a code that never fires buys nothing |
  *
- * `state_not_found` was in the first draft of this set and was deliberately taken back out. A real
- * user-initiated flow cannot produce it: the IdP echoes the `state` it was given, so an absent `state`
- * means either a bare scanner hitting the callback path, or something upstream dropping the parameter —
- * an IdP regression, a proxy stripping the query string, or a callback-URL rewrite mishandling it (which
- * is now a live concern: ENG-2343 rewrites every SSO callback through `legacy-sso-callback.ts`). That
- * second class is a total-SSO-outage shape for the affected provider, and this code is the canary for
- * it. Nothing in FORMBRICKS-16G is this code — the reported events are all `verification not found`,
- * i.e. `state_mismatch` — so suppressing it would have traded an unmeasured amount of scanner noise for
- * the loss of that canary, on no evidence. If it does turn out to be dominated by scanners once the
- * `auth.path` tag is live, adding it then is a one-line change backed by data.
+ * `state_not_found` is kept out of the set, but on 1.7 that choice is **inert**, and the honest reason
+ * is worth recording because an earlier draft of this comment got it wrong in both directions.
+ *
+ * Verified live against 1.7.0: an OAuth callback with no `state` never produces a `StateError` at all.
+ * The callback route short-circuits before `parseGenericState` is reached
+ * (`better-auth/dist/api/routes/callback.mjs:72-76`):
+ *
+ * ```js
+ * if (!state) { c.context.logger.error("State not found", error); throw c.redirect(`…error=state_not_found`); }
+ * ```
+ *
+ * That second argument is the OAuth `error` *query parameter*, not an `Error`, so our `cause` lookup
+ * finds nothing, the Sentry gate's `cause &&` is already false, and the event is logged without a
+ * `stateErrorCode`. It was therefore never captured — this code is not part of the over-capture problem,
+ * and the `StateError` carrying it (`state.mjs:90`) is unreachable from this route. Listing it here or
+ * omitting it changes nothing today; it stays omitted so that if upstream ever routes it through the
+ * logger as a real `StateError`, it pages rather than being silently dropped by a stale allow-list.
+ *
+ * Worth knowing separately, because it is a gap this PR does not close: that makes an IdP which stops
+ * echoing `state` — a provider-wide sign-in outage — produce **no Sentry event whatsoever**, only that
+ * log line. Independent of this change, and not fixable from this gate.
  *
  * `state_security_mismatch` carries the load this gate deliberately does not take on, and it is mixed:
  *

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -193,12 +193,28 @@ export const redactEmailsInLogMessage = (message: unknown): unknown =>
  * a loss of visibility into a *failed* attempt, not of a control. The events remain in the application
  * log with their `stateErrorCode`, which is where a campaign would show up as volume.
  *
- * What suppression costs, stated narrowly: a Redis eviction, flush, or failover to an empty replica
- * drops in-flight verification records and yields `state_mismatch` for real login failures. A *hard*
- * Redis outage does not — `secondary-storage.ts` rethrows on connect failure, which is not a
- * `StateError` and still pages. The suppressed events remain at `error` in the application log carrying
- * `stateErrorCode` and the request's `authPath`, so they are greppable; note there is no log-based alert
- * rule for them today, so a burst is discoverable rather than announced.
+ * What suppression costs, stated narrowly. Two shapes produce `state_mismatch` for *real* login
+ * failures, and this gate hides both from Sentry:
+ *
+ * 1. **Runtime:** a Redis eviction, flush, or failover to an empty replica drops in-flight verification
+ *    records. Arrives as a trickle or a burst, mid-operation.
+ * 2. **Deploy-time, and the worse of the two:** replicas that do not share one Redis. The record is
+ *    written by the pod that started the flow and looked up by whichever pod serves the callback, and
+ *    that lookup is the *first* check in the database branch — before the signed-cookie check. So a
+ *    split-Redis deployment fails 100% of SSO sign-ins while the state cookie still verifies perfectly
+ *    (the secret is shared even when the store is not), which keeps it off `state_security_mismatch` and
+ *    squarely on the code we suppress. It also lands exactly when someone is watching Sentry rather than
+ *    the logs.
+ *
+ * A *hard* Redis outage is not in this class — `secondary-storage.ts` rethrows on connect failure, which
+ * is not a `StateError`, so it still pages.
+ *
+ * The suppressed events stay at `error` in the application log with `stateErrorCode` and the request's
+ * `authPath`, so they are greppable — and `stateErrorCode` is load-bearing rather than convenient here,
+ * because upstream logs every state error under the same "Failed to parse state" message. What is
+ * missing is the alert: there is no log-based rule on that field today, so a burst is discoverable
+ * rather than announced, which for shape 2 means a total outage nobody is paged for. Tracked separately;
+ * this gate cannot fix it.
  */
 const UNACTIONABLE_STATE_ERROR_CODES: ReadonlySet<string> = new Set(["state_mismatch"]);
 

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -137,9 +137,10 @@ export const redactEmailsInLogMessage = (message: unknown): unknown =>
  *
  * Read from the throw sites in `better-auth/dist/state.mjs`, **for the strategy we actually run**. That
  * matters more than it sounds: the file has two branches that throw different codes for the same
- * underlying cause, and reading the wrong one inverts the conclusions. `auth.ts` sets `secondaryStorage`,
- * which makes Better Auth resolve `storeStateStrategy` to `"database"`, and `account:` sets no override —
- * so the cookie branch never executes here.
+ * underlying cause, and reading the wrong one inverts the conclusions. Better Auth picks the strategy
+ * from `!!options.database || !!options.secondaryStorage`, and `auth.ts` sets BOTH — so it resolves to
+ * `"database"` and the cookie branch never executes here. Noted as both deliberately: dropping Redis
+ * alone would not flip it back.
  *
  * | code | thrown when (database strategy) | actionable? |
  * | --- | --- | --- |
@@ -147,7 +148,7 @@ export const redactEmailsInLogMessage = (message: unknown): unknown =>
  * | `state_not_found` | the callback carried no `state` parameter at all (bots, truncated links) | no — **suppressed** |
  * | `state_security_mismatch` | the state does not match the stored one, or the signed `state` cookie fails verification ("State not persisted correctly") | **yes**, kept |
  * | `state_generation_error` | the adapter could not write the verification row | **yes**, kept — a real fault |
- * | `state_invalid` | undecryptable state — **cookie branch only, unreachable on this config**; kept for the cost of one Set entry | kept |
+ * | `state_invalid` | undecryptable state — **cookie branch only, unreachable on this config** | kept; suppressing a code that never fires buys nothing |
  *
  * `state_security_mismatch` carries the load this gate deliberately does not take on, and it is mixed:
  *


### PR DESCRIPTION
<!-- AI agents: no promotional footers. -->

Fixes ENG-2471

## What & why

`BetterAuthError: State mismatch: verification not found` cleared the ENG-2037 gate and pages — 52 Sentry events in 14 days, 25 of them on `5.3.4` (`FORMBRICKS-16G`). ENG-2037 enumerated two shapes of expected-but-logged-at-error rejection (bare string codes, `APIError`s); this is a third it never covered — a `StateError extends BetterAuthError`, which `isAPIError()` is false for, so it clears `if (cause && !isAPIError(cause))` and reaches Sentry.

The gate now also skips a `StateError` whose `code` is client- or timing-caused, matching on **`code`** rather than the message — the message is not a contract. **Exactly one of the five qualifies:**

| code | thrown when (our strategy) | verdict |
| --- | --- | --- |
| `state_mismatch` | no verification record for this `state` — purged after its 10-minute TTL, already consumed, or never issued — or the parsed state is past `expiresAt` | **suppressed** |
| `state_not_found` | the callback carried no `state` — **never reaches this gate on 1.7** | kept (inert) |
| `state_security_mismatch` | the state does not match the stored one, or the signed `state` cookie fails verification | kept |
| `state_generation_error` | the adapter could not write the verification row | kept — a real fault |
| `state_invalid` | undecryptable state — cookie branch only, **unreachable on this config** | kept |

Everything still logs at `error`. The gate fails **closed**: anything not positively identified as an unactionable code is still captured.

### `state_not_found` — kept out of the set, and on 1.7 that is inert

Two earlier drafts of this section were wrong in opposite directions, so here is what the running code actually does. Smoke-tested against 1.7.0 on the rebased branch: **an OAuth callback with no `state` never produces a `StateError` at all.** The callback route short-circuits before `parseGenericState` (`better-auth/dist/api/routes/callback.mjs:72-76`):

```js
if (!state) { c.context.logger.error("State not found", error); throw c.redirect(`…error=state_not_found`); }
```

That second argument is the OAuth `error` **query parameter**, not an `Error`, so our `cause` lookup finds nothing, the Sentry gate's `cause &&` is already false, and the event is logged with no `stateErrorCode`. It was never captured, so it was never part of the over-capture problem, and the `StateError` carrying that code (`state.mjs:90`) is unreachable from this route.

Listing it or omitting it therefore changes nothing today. It stays omitted so that a future upstream change routing it through as a real `StateError` pages, rather than being dropped by a stale allow-list — and the test asserting that is labelled as the defensive contract it is.

**One gap this does not close, found the same way:** because that path carries no `Error`, an IdP that stops echoing `state` — a provider-wide sign-in outage — produces **no Sentry event at all**, only a log line. Independent of this change and not fixable from this gate.

### Replay visibility, stated rather than implied

A *replayed* callback — the same `state` presented again after the real flow consumed it — also lands on `state_mismatch`, so replay attempts stop appearing in Sentry. Accepted: the replay fails closed (the verification record and the IdP's authorization code are both single-use), so this is visibility into a *failed* attempt, not a control. The events stay in the log with their code, which is where a campaign shows up as volume.

## Read the right branch — this is where the first draft was wrong

`better-auth/dist/state.mjs` has two branches that throw *different codes for the same underlying cause*, and `auth.ts` sets `secondaryStorage`, so Better Auth resolves `storeStateStrategy` to `"database"` — the cookie branch never executes here. Two conclusions changed once that was checked against the throw sites rather than assumed:

- **`state_invalid` is unreachable**, so justifying its capture by a cross-replica `BETTER_AUTH_SECRET` divergence was wrong. That divergence actually surfaces as `state_security_mismatch`, because the signed state cookie cannot be verified with a different secret. It is a genuine outage, so that code keeps paging.
- **The dominant benign case is not suppressed.** The state cookie's `maxAge` is 300s against the record's 10 minutes, so a user who spends 5–10 minutes at the identity provider loses the cookie first and also lands on `state_security_mismatch`. So **this likely leaves residual noise** — it closes the reported shape, not the whole class. Code cannot separate that from a forged callback, which is why the decision is deferred to the `auth.path` tag from ENG-2259 rather than guessed. Suppressing a signal before measuring it is how ENG-2037 left this shape behind in the first place.

The state code now reaches the log context as `stateErrorCode`, extracted once and used for both the log and the gate. Without it the "still visible in logs" justification was hollow — only upstream's message text distinguished a Redis-eviction burst from anything else. It is never widened to the error's `details`, which holds the raw single-use `state`.

## Breaking changes

- [ ] This PR contains breaking changes

None — a Sentry capture filter. No API, schema, env or config surface.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The one client-caused code is not captured | unit | One code path, asserted with the three real message literals upstream throws for it (verification not found, cookie-branch label, request expired). The gate reads `code`, so those messages are documentation rather than three behaviours — the behavioural assertion is that each is still logged at `error`, i.e. suppression is Sentry-only |
| The other four still are | unit | `state_invalid`, `state_security_mismatch`, `state_generation_error` and `state_not_found` each assert a `captureException` with the `component: "better-auth"` tag. The last two are defensive contracts, not live paths — `state_invalid` is cookie-branch-only and `state_not_found` never arrives as a `StateError` (above) |
| The gate fails closed | unit | A `BetterAuthError` with no `code`, and a look-alike carrying `name: "BetterAuthError"` + `code: "state_mismatch"` that is not one — both still captured |
| **The REAL `StateError` is suppressed** | unit (real instance) | `StateError` is internal to `better-auth/dist/state.mjs` and unimportable, so the stand-in tests would keep passing if the real shape drifted. A real `betterAuth` (memoryAdapter, `logger: betterAuthLogger`) is driven at `/api/auth/callback/google?state=no-such-state` — the reported failure — and asserted not captured, plus an anti-vacuity assertion that it was logged at all |
| The real error's shape is pinned | unit (real instance) | Same throw captured through a recording logger: asserts `name === "BetterAuthError"` and `code === "state_mismatch"`, so an upstream rename fails loudly instead of quietly restoring the noise |
| The guards bind | manual | Mutation-tested: removing the gate fails **4** tests including the contract test; suppressing all five codes fails **4**; and putting `state_not_found` back into the suppressed set fails **1**, so the narrowing above is itself pinned rather than a comment |
| Runs on 1.7.0, which is now `main` | manual, live | #8835 has merged, so this branch is rebased onto 1.7.0 and re-verified there rather than on the 1.6.23 it was written against. Re-read the throw sites on 1.7.0: `state_invalid` is still inside `if (storeStateStrategy === "cookie")` (`state.mjs:108` in `:93`), the strategy default is unchanged, and the cited `api/index.mjs:210` context-discarding `logger?.error` is still exactly there. Suite 59/59 on 1.7.0, including the contract test that provokes a real `StateError` |
| The gate through #8835's pinned legacy callback | manual, live | A combination neither PR could test alone. A bogus `state` sent to the **pinned** `/api/auth/oauth2/callback/openid` — which `legacy-sso-callback.ts` rewrites — still logs `authPath: "/callback/*"`, `stateErrorCode: "state_mismatch"`. Confirms the external/internal path split holds end to end: observability keys off the internal `/callback/`, not the external `/oauth2/`, exactly as #8835 documents |
| Both codes end to end through the real route | manual, live | The contract test drives a real `betterAuth`, but nothing covered the two request-scoped contexts *composing* through our own route handler. Ran the app: `?state=no-such-state&code=…` → `302 …error=state_mismatch`, logged `ERROR … authPath: "/callback/*" httpMethod: GET stateErrorCode: "state_mismatch"`; `?code=…` with no `state` → same shape with `state_not_found`. That is the justification for suppressing anything — a suppressed event stays queryable by the value that suppressed it — holding live, with ENG-2259's `authPath` and this PR's `stateErrorCode` on one line. Also confirms `authPath` is the *parameterized* label, never a raw path |

`pnpm test` (this suite 59/59, full suite 8311 uncached), `pnpm typecheck` (27/27), `pnpm lint` (0 errors), `pnpm format:check` all green.

**Open gaps**

- **No measurement of the genuine-failure fraction.** ENG-2037's step 1 was never run for this shape and still has not been — I cannot read Sentry. Everything above is reasoning from the throw sites plus tests, not from event data. This is why only the two codes I can justify from code are suppressed, and why `state_security_mismatch` is explicitly left paging.
- **Residual noise is expected**, per the section above. The follow-up is to size `state_security_mismatch` once ENG-2259's `auth.path` tag has produced a few days of tagged events, then decide. Not this PR.
- **That follow-up is gated on a deploy, not a merge.** ENG-2537 shows with `git merge-base` that #8907 is not in production — prod has been on `5.3.4` since Aug 11, #8907 merged Aug 19 — so the `auth.path` tag is producing no data yet and the deferred decision cannot be taken until a release carries it. Flagged so it does not quietly never happen.
- No log-based alert rule exists for `stateErrorCode`, so a suppressed burst is discoverable rather than announced. **Now tracked as ENG-2551**, filed off this review — which also surfaced a sharper case than the eviction one this PR had: replicas that do not share one Redis fail **100% of SSO sign-ins** onto the suppressed code, because the record lookup precedes the signed-cookie check and the shared `BETTER_AUTH_SECRET` keeps the cookie valid. That is a deploy-time total outage with no Sentry event. The docblock now names it; the alert is out of scope here.
- Not exercised against a deployed image — this is a logger gate with no request surface, so a staging pass adds little beyond what the real-instance test covers.

**Risks**

- A *hard* Redis outage does not hide behind this: `secondary-storage.ts` rethrows on connect failure, which is not a `StateError` and still pages. Only a reachable-but-empty Redis (eviction, flush, failover to an empty replica) yields `state_mismatch`, and those are real login failures now visible only in the log.
- The three kept codes reach Sentry with no stack — `BetterAuthError` sets `this.stack = ""`. Pre-existing, not introduced here, but it caps how actionable those captures are.




