### PR TITLE
docs(pr-template): say how to look up the model and effort for the agent note

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ opens on demand (background, file audits, setup steps). Never fold the Coverage 
 Breaking changes — long media inside Coverage may still be folded. -->
 
 <!-- AI agents: no promotional footers, don't advertise yourself or any tool/service (e.g. "Generated
-by …"). The model note at the bottom is the one exception. -->
+by …"). The agent note at the bottom is the one exception. -->
 
 <!-- Complete the line below: `Fixes ENG-<id>`. A bare URL does NOT link the PR — the magic word has
 to come first. Use `Ref ENG-<id>` instead if this PR only partly addresses the ticket, so merging
@@ -90,7 +90,20 @@ to challenge this list, so an empty one is a claim rather than a formality. -->
 
 ---
 
-<!-- Fill in if an AI agent wrote code or this description; delete the note if none did. -->
+<!-- Fill in if an AI agent wrote code or this description; delete the note if none did.
+
+`<model>` is the exact model id the vendor serves — `claude-opus-5`, `gpt-5.1-codex` — not the
+product it runs in: Claude Code, Codex CLI and Cursor are harnesses, not models. Name the harness
+and its version in parentheses when it adds something: `claude-opus-5 (Claude Code 2.1.237)`.
+
+`<level>` is whatever reasoning knob that vendor exposes, in that vendor's own units: an effort
+level (`max`, `high`), a thinking budget (`32k tokens`), or `n/a` where there is no such setting.
+
+Read both values out of the tool rather than from memory. Claude Code reports them in `/status`,
+or as the session's `model` and `effort_level`; Codex CLI in `/model` or the line it prints at
+startup; other tools, whatever they report about themselves. A value you cannot look up is
+`unknown` — never a plausible-looking guess, and never the harness name standing in for the
+model. -->
 
 > [!NOTE]
 > **AI model used** — `<model>`, reasoning effort `<level>`.


### PR DESCRIPTION
No ticket — process fix for the PR template, prompted by getting this exact field wrong on #8932.

## What & why

The template ends with a note the author fills in:

```
**AI model used** — `<model>`, reasoning effort `<level>`.
```

The shape is fine. What was missing is any statement of *what those two values are* and *where to read them*, so both get filled from memory:

* **`<model>` reads as "what are you".** Two comments higher the template tells agents not to advertise their tooling, so an agent resolves "model" to the product it runs in and writes the harness name. On #8932 that produced `Claude Code, reasoning effort high` while the session was serving `claude-opus-5` at effort `max` — @itsjavi corrected it by hand.
* **"reasoning effort" is Claude-shaped.** Codex exposes a different knob, some tools expose none, and an agent with nothing to put there invents a plausible level rather than saying so.

**The rendered note is unchanged.** This PR only fills in the HTML comment above it, which never reaches the description:

* model is the vendor's exact model id (`claude-opus-5`, `gpt-5.1-codex`), not the harness — Claude Code, Codex CLI and Cursor are harnesses; the harness may follow in parentheses when it adds something;
* effort is that vendor's own knob in its own units — an effort level, a thinking budget, or `n/a` where there is no such setting;
* both are read out of the tool: `/status` or the session's `model` / `effort_level` in Claude Code, `/model` or the startup line in Codex CLI, whatever it reports about itself elsewhere;
* a value that cannot be looked up is `unknown`, never a plausible guess and never the harness standing in for the model.

Vendor-neutral on purpose: the answer differs per tool, not just per model, so the guidance has to hold for whatever opens the next PR.

The header comment's cross-reference is also renamed from "The model note at the bottom" to "The agent note at the bottom", so it names the block rather than one of its fields.

## Breaking changes

- [ ] This PR contains breaking changes

None — one HTML comment and one word in another. No API, SDK, route, env var, config key or emitted value, and nothing an integrator or self-hoster can observe.

## Migrations & env

- none

## How this was tested

Nothing executable changed. The risks are that something *parses* the note, that repo prose goes stale, or that the template stops rendering as intended — checked rather than assumed.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The rendered template is byte-identical to `main` | manual | `git diff origin/main -- .github/pull_request_template.md` touches only the HTML comment block and the word "model" → "agent" inside another comment. The `> [!NOTE] **AI model used** — …` line is unchanged, so every future PR description renders exactly as it does today. An earlier revision of this PR restructured that visible line into four bullets; that is reverted |
| Nothing parses the note | manual | `grep -rn "AI model\|reasoning effort\|ai_model" .github/ .coderabbit.yaml` returns one hit — the unchanged template line. `pr-label-sync.yml` reads only the Breaking-changes checkbox; `.coderabbit.yaml`'s `pre_merge_checks.description` is `mode: warning` with no requirements, and its three `custom_checks` (breaking-changes, magic-word, coverage) don't reference the note |
| No repo prose describes the old wording | manual | `grep -rn "AI model\|model note\|agent note\|reasoning effort"` over `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `docs/` and `.claude/` finds only the unrelated `AI_MODEL` env-var row in `docs/self-hosting/…/environment-variables.mdx`. AGENTS.md refers to the template generically, which stays true; the one in-file cross-reference is updated here |
| The guidance actually produces the right answer | manual | Followed it on this PR: `get_session` returns `session_context.model` `claude-opus-5` and `effort_level` `max`, which is what the note below says. That is the same lookup the comment now points at, and the value I failed to check on #8932 |
| Prettier cannot reflow this file, so the comment's wrapping is safe | manual | `.prettierignore:24` exempts `.github/pull_request_template.md` (for the intentional empty list items). Stated because it cuts both ways: it means Prettier can't strip a blockquote marker or re-wrap the comment — and it means **`pnpm format:check` never inspects this file**, so citing that check as evidence here would be vacuous. `npx prettier --check` on the path prints "All matched files use Prettier code style!" precisely because zero files matched. Verified by reading `.prettierignore`, not by running the check — thanks to @kiln-agent for catching that an earlier revision of this description made exactly that vacuous claim |

**Open gaps**

* Honour-system either way — nothing can verify that a filled-in model id is the one that actually served the turn. This only removes the excuses for getting it wrong.
* Lookup instructions are concrete for Claude Code and Codex CLI, generic for everything else. Whoever first fills this in from Cursor or Copilot Workspace should add that tool's incantation.
* The comment's `claude-opus-5 (Claude Code 2.1.237)` example pins a patch version that will age. Kept because the version *is* the thing being illustrated, and it sits inside the same comment that says to read the value from the tool — but it is an example an inattentive agent could copy.

**Risks**

* The comment is longer than the one it replaces, but it is a comment: it costs template-reading agents a few lines and costs the rendered description nothing.
* If a workflow ever wants to parse authorship, it should key on the visible `**AI model used**` label, which this PR deliberately leaves alone.

---

> [!NOTE]
> **AI model used** — `claude-opus-5 (Claude Code 2.1.237)`, reasoning effort `max`.