### PR TITLE
docs(agents): tell agents when an e2e test is warranted

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -86,15 +86,20 @@ reviews:
   path_instructions:
     - path: "**/*.test.tsx"
       instructions: |
-        AGENTS.md forbids React component unit tests in this repo — components are covered by
-        Playwright specs in `apps/web/playwright/`. If this file is newly added, say so and ask for
-        the coverage to move to a Playwright `.spec.ts` instead. Do not raise this on edits to the
-        handful of `.test.tsx` files that already exist.
+        AGENTS.md forbids React component unit tests in this repo. If this file is newly added, say
+        so and ask for the logic under test to move into a `.ts` module with a unit test. Do not ask
+        for a Playwright spec instead: deleting a `.test.tsx` creates no E2E obligation, and a
+        component is not an E2E subject. Do not raise this on edits to the handful of `.test.tsx`
+        files that already exist.
 
     - path: "**/*.tsx"
       instructions: |
-        - Never suggest adding unit tests for `.tsx` files. AGENTS.md forbids them; UI behaviour is
-          covered by Playwright specs in `apps/web/playwright/`. Suggesting an E2E spec is fine.
+        - Never suggest adding unit tests for `.tsx` files — AGENTS.md forbids them, and their
+          absence is not a coverage gap to fill somewhere else. Ask for a Playwright spec only when
+          the diff changes a feature's happy path or a journey across several surfaces, and then ask
+          for it in that feature's existing spec. Never ask for one to cover component detail (a
+          label, a breadcrumb, an ARIA attribute, a keystroke inside one widget, a field's
+          validation message) — that belongs in a `.ts` unit test or in manual QA.
         - New client data flows go through an `/api/v3` route with TanStack Query, not a new Server
           Action. Server data lives in the query cache only — flag it being mirrored into
           `useState` or Jotai, and flag `router.refresh()` used as a data-refresh mechanism.
@@ -122,9 +127,24 @@ reviews:
 
     - path: "apps/web/playwright/**/*.spec.ts"
       instructions: |
-        - Flag timing hacks (`waitForTimeout`, arbitrary sleeps) and dependencies on data another
-          spec created — these are the repo's main source of flake.
-        - Specs must stay small and single-purpose; flag mega-specs. Slow suites need a `@slow` tag.
+        This suite is the critical path of every PR and every test is paid on every PR forever, so
+        cost is a review dimension here rather than a nit (AGENTS.md "Testing Guidelines"):
+        - A new spec file is a finding unless it opens a feature area the suite does not cover yet —
+          the default is assertions or a `test.step` added to that feature's existing spec. A spec
+          that asserts component-level detail (a label, a breadcrumb, a sidebar's link list, an ARIA
+          attribute, a keystroke inside one widget, a field's validation message) is a finding
+          whatever file it lands in: ask for a `.ts` unit test or manual QA instead.
+        - Flag variant matrices. A second viewport, theme, locale, role or layout needs its own
+          stated reason; "the adjacent spec does it" is not one. New a11y coverage extends
+          `survey-accessibility.spec.ts` rather than adding a per-ticket a11y spec.
+        - Flag state clicked into existence through the UI where Prisma or `/api/v3` could seed it
+          (`playwright/utils/accessibility.ts` is the pattern), and a per-test `users.create()` plus
+          login where a worker-scoped fixture would do.
+        - Flag timing hacks (`waitForTimeout`, arbitrary sleeps, `slowMo`) and dependencies on data
+          another spec created — these are the repo's main source of flake.
+        - Specs stay single-purpose per feature area: flag a spec that walks several unrelated
+          features, and a spec that exists for one detail of a covered one. `@slow` is metadata that
+          nothing reads, so a tag is not an answer to a cost finding.
 
     - path: "**/actions.ts"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -97,7 +97,9 @@ reviews:
         - Never suggest adding unit tests for `.tsx` files — AGENTS.md forbids them, and their
           absence is not a coverage gap to fill somewhere else. Ask for a Playwright spec only when
           the diff changes a feature's happy path or a journey across several surfaces, and then ask
-          for it in that feature's existing spec. Never ask for one to cover component detail (a
+          for it in that feature's existing spec — or, if the diff opens a feature area the suite does
+          not cover yet, for one happy-path spec named for that area. Never ask for one to cover
+          component detail (a
           label, a breadcrumb, an ARIA attribute, a keystroke inside one widget, a field's
           validation message) — that belongs in a `.ts` unit test or in manual QA.
         - New client data flows go through an `/api/v3` route with TanStack Query, not a new Server
@@ -129,14 +131,17 @@ reviews:
       instructions: |
         This suite is the critical path of every PR and every test is paid on every PR forever, so
         cost is a review dimension here rather than a nit (AGENTS.md "Testing Guidelines"):
-        - A new spec file is a finding unless it opens a feature area the suite does not cover yet —
-          the default is assertions or a `test.step` added to that feature's existing spec. A spec
+        - A new spec file is a finding unless it opens a feature area the suite does not cover yet
+          (the spec filenames in `apps/web/playwright/` are the inventory — check before claiming an
+          area is uncovered); the default is assertions or a `test.step` added to that feature's
+          existing spec. A spec
           that asserts component-level detail (a label, a breadcrumb, a sidebar's link list, an ARIA
           attribute, a keystroke inside one widget, a field's validation message) is a finding
           whatever file it lands in: ask for a `.ts` unit test or manual QA instead.
         - Flag variant matrices. A second viewport, theme, locale, role or layout needs its own
-          stated reason; "the adjacent spec does it" is not one. New a11y coverage extends
-          `survey-accessibility.spec.ts` rather than adding a per-ticket a11y spec.
+          stated reason; "the adjacent spec does it" is not one. A11y coverage for the rendered
+          survey extends `survey-accessibility.spec.ts`; elsewhere it belongs in that feature area's
+          own spec. Neither case is a per-ticket a11y spec.
         - Flag state clicked into existence through the UI where Prisma or `/api/v3` could seed it
           (`playwright/utils/accessibility.ts` is the pattern), and a per-test `users.create()` plus
           login where a worker-scoped fixture would do.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -71,6 +71,12 @@ existed; `unit (mutation)` — only fails if you break the fix, because the code
 Any red-on-main or mutation row must carry the command or the mutated `file:line`, so a reviewer can
 rerun it instead of taking the claim on trust. -->
 
+<!-- Pick the cheapest level that can fail on the behaviour (AGENTS.md "Testing Guidelines"): `unit`
+for logic and invariants, a route test for authorization/response shape/scoping, `e2e` only for a
+feature's happy path or a journey across several surfaces, and `manual` — with the screenshot — for
+UI detail inside a feature that already has an e2e. A `manual` row is a complete answer; a new e2e
+spec is paid on every PR forever, so "this row had no automated test" is not a reason to add one. -->
+
 | Behaviour | How | Outcome |
 | --- | --- | --- |
 |  | unit (red on main) / unit (mutation) / unit (guard) / e2e / manual |  |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ Every `packages/*` workspace therefore exposes the standard `lint` / `typecheck`
 `test:coverage` scripts (plus `build` where there is a compile step). Deliberate exceptions:
 `config-*` packages hold only config files (no scripts beyond `clean`); `types` has no runtime logic
 to test; `email`, `types`, and `vite-plugins` are consumed from source, so they have no `build`;
-`apps/storybook` has no unit tests by policy (UI is covered by Playwright). Keep new packages on this
-matrix or document the exception here.
+`apps/storybook` has no unit tests by policy (its components are exercised by the feature journeys in
+`apps/web/playwright`). Keep new packages on this matrix or document the exception here.
 
 ### Survey Packages Build & Cache
 
@@ -171,8 +171,9 @@ Principles:
 - Prove a behavior at the cheapest level that can fail on it. An E2E test is not a stronger unit test; it
   has a different subject — the journey, not the logic.
 - **An E2E test is paid on every PR, by everyone, forever.** The Playwright job is the critical path of the
-  PR gate (as of Aug 2026: ~13 min, ~30 browser-minutes across ~110 tests), and its wall clock can never
-  drop below its slowest single test. Weigh that before adding one — sometimes the right answer is no test
+  PR gate (as of Aug 2026: a ~13 min job, of which ~6 min is the Playwright step itself — the rest is
+  install, build and boot — over ~110 tests and ~30 browser-minutes), and its wall clock can never drop
+  below its slowest single test. Weigh that before adding one — sometimes the right answer is no test
   at this level.
 
 Which level, concretely:
@@ -187,10 +188,13 @@ Which level, concretely:
 A journey across several surfaces means something like survey list → editor → public survey → response,
 where the behavior only exists once browser, survey bundle, and server are wired together.
 
+The spec filenames in `apps/web/playwright/` are the inventory of covered areas — check there before
+concluding an area has no spec.
+
 This raises a floor as well as lowering a ceiling. Every feature area ships a happy-path E2E, and an area
 with none is a gap rather than a saving (Dashboards and Workflows are the current examples — ENG-2314). A
-bug fix inside a feature that already has one almost never needs a second spec: add an assertion to the
-existing spec, or prove it in a unit test.
+bug fix inside a feature that already has one almost never needs a second spec — the level still follows
+the table above: journey behavior extends that spec, logic goes to a unit test, UI detail to manual QA.
 
 Do:
 
@@ -223,8 +227,9 @@ Do not:
   none of these justify a browser, a login, and a seeded tenant.
 - Do not build a variant matrix. Cover the one case that carries the risk; a second viewport, theme,
   locale, role, or layout needs its own stated reason, and "the adjacent spec does it" is not one.
-  Accessibility work extends the existing axe gate (`survey-accessibility.spec.ts`) instead of adding a
-  per-ticket a11y spec.
+  Accessibility work on the rendered survey extends the existing axe gate
+  (`survey-accessibility.spec.ts`); elsewhere it becomes an assertion in that feature area's own spec.
+  Either way, not a per-ticket a11y spec.
 - Do not add coverage-driven or low-signal tests.
 - Do not write tests that lock implementation details, markup, snapshots, or create churn — an assertion on
   an exact list of nav labels is churn, not coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,33 +168,69 @@ Always mark React component props as `Readonly<>` (e.g., `({ children }: Readonl
 Principles:
 
 - Confidence over coverage. Test behavior and outcomes; avoid brittle implementation-detail tests.
+- Prove a behavior at the cheapest level that can fail on it. An E2E test is not a stronger unit test; it
+  has a different subject — the journey, not the logic.
+- **An E2E test is paid on every PR, by everyone, forever.** The Playwright job is the critical path of the
+  PR gate (as of Aug 2026: ~13 min, ~30 browser-minutes across ~110 tests), and its wall clock can never
+  drop below its slowest single test. Weigh that before adding one — sometimes the right answer is no test
+  at this level.
+
+Which level, concretely:
+
+| The change                                                                      | The level                                     |
+| ------------------------------------------------------------------------------- | --------------------------------------------- |
+| A new feature area, or a journey across several surfaces                        | One happy-path E2E + unit tests for its logic |
+| Business logic, invariants, validation, derivation, permissions — anything pure | Unit test on the `.ts`                        |
+| A route's authorization, response shape, or query scoping                       | Unit or integration test on that route        |
+| A UI detail inside a feature that already has a happy-path spec                 | Neither — verify manually, say so in the PR   |
+
+A journey across several surfaces means something like survey list → editor → public survey → response,
+where the behavior only exists once browser, survey bundle, and server are wired together.
+
+This raises a floor as well as lowering a ceiling. Every feature area ships a happy-path E2E, and an area
+with none is a gap rather than a saving (Dashboards and Workflows are the current examples — ENG-2314). A
+bug fix inside a feature that already has one almost never needs a second spec: add an assertion to the
+existing spec, or prove it in a unit test.
 
 Do:
 
-- E2E tests (Playwright): cover critical user flows and regression risks. Extend existing specs or add
-  focused new ones in `apps/web/playwright`, keep tests small and well-named, use descriptive filenames
-  such as `billing.spec.ts`, tag slow suites with `@slow`, and run the suite before opening a PR.
+- E2E tests (Playwright): one spec per **feature area**, not per ticket and not per component. Default to
+  adding assertions or a `test.step` to that area's existing spec in `apps/web/playwright`; a new
+  `*.spec.ts` is for a feature area that has none, and it takes the area's name (`billing.spec.ts`).
+  Follow the suite's own patterns — seed state through Prisma or `/api/v3` instead of clicking it into
+  existence (`playwright/utils/accessibility.ts`), one journey per test with `test.step` phases
+  (`settings-tags.spec.ts`), assertions at feature level (`survey-overview.spec.ts`) — and run the suite
+  before opening a PR.
 - Unit tests: cover stable, high-value logic in `.ts` files, such as validators, transformers,
   evaluators, calculations, and edge cases. Keep assertions on inputs and outputs, colocate specs with
   the code they exercise (`utility.test.ts`), and mock network and storage boundaries through helpers
   from `@formbricks/*`.
 - Manual QA, especially for releases: verify on staging and file bugs. If a bug is critical, backport and
-  re-test.
+  re-test. For UI detail below the journey level, manual verification plus a screenshot in the PR is the
+  expected answer, not a new spec.
 - Run `pnpm test` before opening a PR and `pnpm test:coverage` when touching critical flows.
+- Merging, narrowing, or deleting an E2E spec is legitimate work — record it in the PR's Coverage table
+  like any other change.
 
 Do not:
 
-- Do not write component or UI unit tests for `.tsx` files; React components are covered by Playwright E2E
-  tests instead.
+- Do not write component or UI unit tests for `.tsx` files. **This is not an instruction to write an E2E
+  test instead**: the absence of a component unit test creates no coverage obligation. If a component holds
+  logic worth proving, lift that logic into a `.ts` module and unit-test it there; the rendering is
+  exercised incidentally by the feature journeys that already cross it.
+- Do not E2E a component. A language selector, a breadcrumb, a sidebar's link list, an ARIA attribute on
+  one widget, a keystroke inside one editor, a field's validation message, a search box filtering a list —
+  none of these justify a browser, a login, and a seeded tenant.
+- Do not build a variant matrix. Cover the one case that carries the risk; a second viewport, theme,
+  locale, role, or layout needs its own stated reason, and "the adjacent spec does it" is not one.
+  Accessibility work extends the existing axe gate (`survey-accessibility.spec.ts`) instead of adding a
+  per-ticket a11y spec.
 - Do not add coverage-driven or low-signal tests.
-- Do not write tests that lock implementation details, markup, snapshots, or create churn.
-- Do not create mega or flaky E2E tests; avoid timing hacks and unstable dependencies.
-
-Heuristic:
-
-- User journey risk: E2E.
-- Pure logic or edge cases: unit test.
-- Release readiness: manual QA plus bug/backport loop.
+- Do not write tests that lock implementation details, markup, snapshots, or create churn — an assertion on
+  an exact list of nav labels is churn, not coverage.
+- Do not create mega or flaky E2E tests; avoid timing hacks (`waitForTimeout`, `slowMo`) and unstable
+  dependencies. `@slow` is triage metadata only: nothing in `playwright.config.ts` or CI reads it, so
+  tagging a spec does not make its cost go away.
 
 ## Documentation (apps/docs)
 

--- a/docs/development/standards/qa/testing-methodology.mdx
+++ b/docs/development/standards/qa/testing-methodology.mdx
@@ -34,9 +34,13 @@ We use Vitest as our primary testing framework. All unit tests follow these conv
    });
    ```
 
-3. **Coverage Requirements**
-   - Minimum 85% code coverage requirement 
-   - Coverage is tracked using V8 provider
+3. **Coverage**
+   - Coverage is measured, not targeted: confidence over coverage, and no test exists to move the
+     number (see `AGENTS.md`, "Testing Guidelines")
+   - The repo enforces exactly one Vitest threshold: `modules/auth/lib/**` at 80%
+     (`apps/web/vite.config.mts`). Everything else is reported — `pnpm test:coverage` emits lcov and
+     the SonarQube workflow uploads it, with the quality gate configured in SonarQube, not here
+   - Coverage is tracked using the V8 provider
    - Coverage reports include:
      - Text summaries
      - HTML reports
@@ -44,7 +48,22 @@ We use Vitest as our primary testing framework. All unit tests follow these conv
 
 ### End-to-End Testing with Playwright
 
-E2E tests are located in `apps/web/playwright/` and focus on critical user workflows.
+E2E tests are located in `apps/web/playwright/` and focus on critical user workflows. `AGENTS.md` is the
+source of truth for when one is warranted; the short version:
+
+1. **Level.** Prove a behavior at the cheapest level that can fail on it. A feature's happy path or a
+   journey across several surfaces is E2E. Business logic, invariants and anything pure is a unit test on
+   the `.ts`. A route's authorization, response shape or query scoping is a unit or integration test on
+   that route.
+2. **Unit of coverage.** One spec per feature area, not per ticket and not per component. Every feature
+   area ships a happy-path spec; a fix inside an area that already has one adds an assertion to that
+   spec rather than a new file.
+3. **Neither is an option.** A granular UI detail inside a covered feature — a label, a breadcrumb, an
+   ARIA attribute, a keystroke inside one widget, a field's validation message — is verified manually and
+   recorded in the PR. It does not get a spec.
+4. **Cost.** Every spec is paid on every PR by everyone, forever. The Playwright job is the critical path
+   of the PR gate and its wall clock can never drop below its slowest single test, so a new spec has to
+   buy risk coverage that nothing cheaper can.
 
 ## Testing Setup
 
@@ -124,6 +143,7 @@ Common test utilities are available in `vitestSetup.ts`:
    - Test results reporting
 
 2. **New Features**
-   - Must include corresponding unit tests
-   - Must maintain or improve coverage metrics
-   - Must include relevant E2E tests for user-facing features
+   - Must include unit tests for the logic they add
+   - A new user-facing feature area must include one happy-path E2E spec; a change inside an area that
+     already has one extends that spec, or is covered by a unit test or manual QA instead
+   - Must not add tests whose only purpose is to move a coverage metric

--- a/docs/development/standards/qa/testing-methodology.mdx
+++ b/docs/development/standards/qa/testing-methodology.mdx
@@ -56,8 +56,9 @@ source of truth for when one is warranted; the short version:
    the `.ts`. A route's authorization, response shape or query scoping is a unit or integration test on
    that route.
 2. **Unit of coverage.** One spec per feature area, not per ticket and not per component. Every feature
-   area ships a happy-path spec; a fix inside an area that already has one adds an assertion to that
-   spec rather than a new file.
+   area ships a happy-path spec, and a new spec file is for an area that has none. Inside an area that
+   already has one, the level still follows the behavior: journey behavior extends that spec, logic goes
+   to a `.ts` unit test, UI detail goes to manual QA (see 3) — never a second spec file.
 3. **Neither is an option.** A granular UI detail inside a covered feature — a label, a breadcrumb, an
    ARIA attribute, a keystroke inside one widget, a field's validation message — is verified manually and
    recorded in the PR. It does not get a spec.
@@ -69,19 +70,18 @@ source of truth for when one is warranted; the short version:
 
 ### Configuration
 
-Our Vitest configuration (`vite.config.ts`) includes:
+The web app's Vitest configuration (`apps/web/vite.config.mts`) includes:
 
 ```typescript
 test: {
-exclude: ['playwright/', 'node_modules/'],
-setupFiles: ['../../packages/lib/vitestSetup.ts'],
-coverage: {
-provider: 'v8',
-reporter: ['text', 'html', 'lcov'],
-reportsDirectory: './coverage',
-},
+  exclude: ["playwright/**", "node_modules/**", ".next/**", "**/*.integration.test.ts"],
+  setupFiles: ["./vitestSetup.ts"],
+  coverage: {
+    provider: "v8",
+    reporter: ["text", "html", "lcov"],
+    reportsDirectory: "./coverage",
+  },
 }
-
 ```
 
 ### Test Utilities
@@ -144,6 +144,7 @@ Common test utilities are available in `vitestSetup.ts`:
 
 2. **New Features**
    - Must include unit tests for the logic they add
-   - A new user-facing feature area must include one happy-path E2E spec; a change inside an area that
-     already has one extends that spec, or is covered by a unit test or manual QA instead
+   - A new user-facing feature area must include one happy-path E2E spec. Inside an area that already
+     has one, the level follows the behavior: journey behavior extends that spec, logic goes to a unit
+     test, UI detail is verified manually
    - Must not add tests whose only purpose is to move a coverage metric


### PR DESCRIPTION
Ref ENG-2517

## What & why

Agents have been adding granular e2e specs — a breadcrumb's visibility, a progress bar's `aria-valuenow`, a Tab keypress inside one editor — and the shared context is what asked for them. Six places pointed at Playwright, and one made it the only sanctioned home for UI behaviour:

- **`AGENTS.md`** banned `.tsx` unit tests and added *"React components are covered by Playwright E2E tests **instead**"*. The second clause reads as an instruction: component changed → unit test forbidden → write a spec.
- **`.coderabbit.yaml`** asked, on any newly added `.test.tsx`, for *"the coverage to move to a Playwright `.spec.ts`"*, and licensed the same on any `.tsx` diff (*"Suggesting an E2E spec is fine"*). The review bot was requesting specs.
- Its `playwright/**` rules policed *how* a spec is written (flake, mega-specs, `@slow`) and never *whether* it should exist, so a component-level spec passed review clean.
- **`testing-methodology.mdx`** made an e2e test a per-feature `Must`, read as per-ticket, and asserted an *"85% code coverage requirement"* that nothing enforces.
- **The PR template** asked for one row per behaviour with `e2e` among the options and no cost attached, so `e2e` looked like the strongest row available.

This states the rule instead, in the four places agents actually read:

- **Level.** Prove a behaviour at the cheapest level that can fail on it. Feature happy path or a journey across surfaces → e2e; logic, invariants, anything pure → unit; a route's authorization/response shape/scoping → a test on that route.
- **Unit of coverage.** One spec per **feature area**, not per ticket and not per component — and the spec filenames in `apps/web/playwright/` are named as the inventory, so "is this area covered?" is a lookup rather than a judgement call.
- **"Neither" is an option.** A granular UI detail inside a covered feature gets manual QA and a screenshot, not a spec — with named examples so it needs no judgement.
- **Cost, where the decision is made.** An e2e test is paid on every PR, by everyone, forever; the job is the gate's critical path and its wall clock can never drop below its slowest single test.
- **The floor moves with the ceiling.** Every feature area ships a happy-path e2e, and an area with none is a gap rather than a saving — Dashboards and Workflows named, pointing at ENG-2314. Without this the change would just read as "write fewer tests".

`.coderabbit.yaml` now mirrors the same rule from the reviewer's side: a new spec file is a finding unless it opens an uncovered feature area, component-level assertions and variant matrices are findings, and UI-clicked state that Prisma or `/api/v3` could seed is a finding.

Four factual corrections fall out of it: the only enforced coverage threshold is `modules/auth/lib/**` at 80% (`apps/web/vite.config.mts`), `@slow` is metadata no project or script reads, and the mdx's Configuration section named three things that do not exist — `vite.config.ts`, `packages/lib/vitestSetup.ts`, and a stale `exclude` list — now synced to the real config.

Docs and review-bot configuration only. No spec was trimmed here and no runtime code changed.

## Breaking changes

- [ ] This PR contains breaking changes

None. No API/SDK shape, endpoint, route, env var, config key, default or webhook payload is touched — the diff is four documentation and review-configuration files.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The cost figures in the new guidance (~13 min job of which ~6 min is the Playwright step, ~30 browser-minutes, ~110 tests, wall clock floored by the slowest test) | manual | From the Playwright HTML report of run [31204161814](https://github.com/formbricks/formbricks/actions/runs/31204161814) and its job steps: e2e job 13m02s vs unit 5m04s (so it is the critical path), Playwright step 6m58s, 78 tests / 1,474 s measured, single longest test 303 s, 35% worker utilisation. Independently re-derived by a reviewer on [32417433654](https://github.com/formbricks/formbricks/actions/runs/32417433654) at this PR's base: job 12m59s, Playwright step 6m03s. `apps/web/playwright` holds 41 spec files / 109 tests at this commit |
| `@slow` described as metadata nothing reads | manual | `grep -rn "slow" playwright.config.ts playwright.service.config.ts package.json .github/workflows/e2e.yml` returns no consumer — no project, `grep`/`grepInvert`, or CI step, while 7 spec files carry the tag |
| The one enforced coverage threshold | manual | The only `thresholds` block in the repo is `apps/web/vite.config.mts:140-144` (`modules/auth/lib/**` at 80%); no other vitest config sets one, and `sonarqube.yml` scans without a quality-gate step (the gate lives in SonarQube, which is what the doc now says). Sonar's own check on this PR passes with 0.0% coverage on new code, which is the same claim from the other direction |
| Every path named anywhere in the diff resolves | manual | `playwright/utils/accessibility.ts`, `settings-tags.spec.ts`, `survey-overview.spec.ts`, `survey-accessibility.spec.ts`, `apps/web/vite.config.mts` all exist. The three that did **not** (`vite.config.ts`, `packages/lib/vitestSetup.ts`, the stale `exclude` list) were the review finding fixed in 6efefc4 |
| The level rule reads the same in all three places it appears | manual | Re-read after 6efefc4: `AGENTS.md` table + floor paragraph, the mdx "Unit of coverage" item, and the mdx New Features bullet now all say journey → extend the existing spec, logic → `.ts` unit test, UI detail → manual QA. Before that commit the three gave three different fallbacks |
| The a11y route is reachable for non-survey surfaces | manual | `survey-accessibility.spec.ts` seeds a link survey and only visits `/s/<id>`, so the unconditional "extend the axe gate" wording was unfollowable for a billing or settings page. Now scoped to the rendered survey, with the feature-area spec named for everything else |
| `.coderabbit.yaml` stays valid after both rounds of edits | manual | YAML parses, 19 `path_instructions` entries; the `path_filters`-are-exclusions guard from `coderabbit-config-validation.yml` passes locally (4 entries, all exclusions) and the check is green on the PR. Only string values changed — no schema keys added or renamed |

**Open gaps**

- **The same instructions exist outside this repo and are untouched.** The installed agent skills carry them: the E2E Tester brief's *"cover the themes, viewports, keyboard paths, roles… that the acceptance criteria **or the adjacent suite** establish"* (the ratchet that produces variant matrices), `formbricks-rules.md`'s repeat of the `.tsx` substitution plus *"treat [the axe gate] as the bar for all product UI"*, and `pr-review`'s stale *"the 25 specs"* (41 now). Those need a separate PR in the robots repo; this PR cannot reach them.
- **Nothing enforces the rule mechanically.** No CI check notices the suite growing — it went from 78 to 109 tests in about two weeks unremarked. Wiring `@slow` into `pr` / `nightly` Playwright projects and adding a duration budget check belong with ENG-2006, not here.
- **The ticket's "done when" cannot be verified yet**: it asks for a week of agent-authored PRs with no e2e specs Javier would have removed.
- **The existing suite is untouched.** The per-file inventory (which specs to trim, merge, or move to nightly — starting with `survey.spec.ts` at 32% of all browser time and the 7-variant axe matrix) is analysis, not part of this diff. Two current specs — `survey-progress-a11y.spec.ts` and `survey-keyboard.spec.ts` — are close to literal instances of the new "do not" examples; the new rules only bite on new files, so they are the trim pass's first entries rather than this PR's problem.

**Risks**

- Lowering the e2e ceiling while `.tsx` unit tests stay banned could open a real gap if "neither" is read too liberally. The counterweight is that the table's "Neither" row is scoped to *a detail inside a feature that already has a happy-path spec* — the escape hatch is unavailable exactly where coverage is absent — plus the floor sentence naming Dashboards and Workflows.
- CodeRabbit `path_instructions` are prose fed to a model, so *"a new spec file is a finding unless it opens a feature area the suite does not cover"* will occasionally fire on a legitimate new-area spec (exactly the ENG-2314 work). 6efefc4 mitigates both halves: the `.tsx` bullet now has the same new-area escape as the `.spec.ts` one, and both point at the spec-filename inventory instead of leaving the bot to guess. If it still proves noisy, narrow the bullet rather than dropping the cost framing.
- The a11y rule routes new survey-a11y work into `survey-accessibility.spec.ts`, which is itself the suite's clearest variant matrix and a trim target. Extending still beats a new file on cost, so this is a deliberate choice, not an oversight — worth revisiting when ENG-2006 picks that file up.
- The cost figures are a dated snapshot ("as of Aug 2026") and will drift as the suite changes.
