### PR TITLE
perf(ci): halve the e2e test step and drop the dead docker build cache

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -53,6 +53,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      # NOTE: deliberately no `cache-from`/`cache-to: type=gha`. Measured over four runs, exporting
+      # the cache cost 222-407s per run while the layers it could restore add up to 12s of work: the
+      # only steps that ever reported CACHED were the apk/corepack prelude, because `COPY . .` sits
+      # ahead of `pnpm install` in apps/web/Dockerfile and invalidates everything after it on any
+      # diff. Nothing populates a cache scope this job can read either — no workflow runs on pushes
+      # to main, and merge_group runs write to throwaway `gh-readonly-queue/...` scopes. Restoring
+      # the cache is worth revisiting only together with both halves of the fix: reorder the
+      # Dockerfile so the install layer survives a source change, and give the cache a producer PRs
+      # can read (a push-to-main build, or a registry cache, which is not branch-scoped).
       - name: Build Docker Image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         env:
@@ -63,8 +72,6 @@ jobs:
           push: false
           load: true
           tags: formbricks-test:${{ env.GITHUB_SHA }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           secrets: |
             database_url=${{ secrets.DUMMY_DATABASE_URL }}
             encryption_key=${{ secrets.DUMMY_ENCRYPTION_KEY }}

--- a/apps/web/modules/survey/editor/components/add-element-button.tsx
+++ b/apps/web/modules/survey/editor/components/add-element-button.tsx
@@ -93,7 +93,11 @@ export const AddElementButton = ({ addElement, workspace, isCxMode }: AddElement
         "group w-full overflow-hidden rounded-lg border border-slate-300 bg-white duration-200 hover:cursor-pointer hover:bg-slate-50"
       )}>
       <Collapsible.CollapsibleTrigger asChild className="group h-full w-full">
-        <div className="inline-flex">
+        {/* data-testid: the trigger is a `div` (Radix `asChild`), so it exposes no button role for
+            tests to target. Without a stable hook, E2E had to match it by its rendered text through
+            a positional `locator("div").nth(1)`, which re-resolved to a different node on every
+            editor re-render and produced "element detached from the DOM" flakes. */}
+        <div className="inline-flex" data-testid="add-element-trigger">
           <div className="flex w-10 items-center justify-center rounded-l-[7px] bg-brand-dark group-aria-expanded:rounded-br group-aria-expanded:rounded-bl-none">
             <PlusIcon className="size-5 text-white" />
           </div>

--- a/apps/web/modules/survey/editor/components/add-element-button.tsx
+++ b/apps/web/modules/survey/editor/components/add-element-button.tsx
@@ -92,12 +92,13 @@ export const AddElementButton = ({ addElement, workspace, isCxMode }: AddElement
         open ? "shadow-lg" : "shadow-md",
         "group w-full overflow-hidden rounded-lg border border-slate-300 bg-white duration-200 hover:cursor-pointer hover:bg-slate-50"
       )}>
-      <Collapsible.CollapsibleTrigger asChild className="group h-full w-full">
-        {/* data-testid: the trigger is a `div` (Radix `asChild`), so it exposes no button role for
-            tests to target. Without a stable hook, E2E had to match it by its rendered text through
-            a positional `locator("div").nth(1)`, which re-resolved to a different node on every
-            editor re-render and produced "element detached from the DOM" flakes. */}
-        <div className="inline-flex" data-testid="add-element-trigger">
+      {/* Not `asChild` with a `div`: Radix forwards the click handler and aria state to the child but
+          adds no role and no tabIndex, so the control was unreachable by keyboard — a user could not
+          open the element picker at all. Letting Radix render its own `<button>` fixes that and
+          gives tests a real button role; the data-testid keeps them off the rendered copy, which
+          also appears in the live preview. */}
+      <Collapsible.CollapsibleTrigger className="group h-full w-full" data-testid="add-element-trigger">
+        <div className="inline-flex">
           <div className="flex w-10 items-center justify-center rounded-l-[7px] bg-brand-dark group-aria-expanded:rounded-br group-aria-expanded:rounded-bl-none">
             <PlusIcon className="size-5 text-white" />
           </div>
@@ -109,7 +110,9 @@ export const AddElementButton = ({ addElement, workspace, isCxMode }: AddElement
           </div>
         </div>
       </Collapsible.CollapsibleTrigger>
-      <Collapsible.CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+      <Collapsible.CollapsibleContent
+        data-testid="add-element-picker"
+        className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
         <div className="grid grid-cols-1 gap-x-6 px-3 pb-3 sm:grid-cols-2">
           <div>{visibleCategories.filter((category) => category.column === 1).map(renderCategory)}</div>
           <div>{visibleCategories.filter((category) => category.column === 2).map(renderCategory)}</div>

--- a/apps/web/playwright/storage-smoke.spec.ts
+++ b/apps/web/playwright/storage-smoke.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "./lib/fixtures";
 import { gotoSurveyList } from "./lib/utils";
 import {
+  addElement,
   createSurveyFromScratch,
   fillRichTextEditor,
   uploadImageChoicesForPictureSelection,
@@ -22,13 +23,7 @@ test.describe("Storage Smoke @storage-smoke", () => {
 
     await fillRichTextEditor(page, "Question*", "Storage smoke question");
 
-    const addBlock = "Add BlockChoose the first question on your Block";
-    await page
-      .locator("div")
-      .filter({ hasText: new RegExp(`^${addBlock}$`) })
-      .nth(1)
-      .click();
-    await page.getByRole("button", { name: "Picture Selection" }).click();
+    await addElement(page, "Picture Selection");
     await fillRichTextEditor(page, "Question*", "Storage smoke picture choice");
     await page.getByRole("button", { name: "Add description" }).click();
     await fillRichTextEditor(page, "Description", "Storage smoke description");

--- a/apps/web/playwright/survey.spec.ts
+++ b/apps/web/playwright/survey.spec.ts
@@ -10,17 +10,6 @@ import {
   uploadImageChoicesForPictureSelection,
 } from "./utils/helper";
 
-// NOTE: slowMo paces every action in this spec's heavy survey-editor flows.
-// It is load-bearing: without it, the question-builder interactions (matrix
-// columns, ranking options) hit "element detached from the DOM" races and the
-// tests fail. Removing it requires first hardening those waits in
-// createSurvey/createSurveyWithLogic (utils/helper.ts). Tracked as a follow-up.
-test.use({
-  launchOptions: {
-    slowMo: 150,
-  },
-});
-
 test.beforeEach(async ({ page }) => {
   await helper.mockStorageUploads(page);
 });
@@ -77,10 +66,7 @@ test.describe("Survey Create & Submit Response without logic", async () => {
       await page.getByRole("button", { name: "Save as draft", exact: true }).click();
       await expect(page.getByText("Changes saved.")).toBeVisible();
 
-      await Promise.all([
-        page.waitForURL(/\/workspaces\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/, { timeout: 120000 }),
-        page.getByRole("button", { name: "Publish", exact: true }).click(),
-      ]);
+      await helper.publishSurvey(page);
       await page.getByLabel("Copy survey link to clipboard").click();
       url = await page.evaluate("navigator.clipboard.readText()");
     });
@@ -325,29 +311,15 @@ test.describe("Multi Language Survey Create", async () => {
     await page.locator("#welcome-toggle").click();
 
     // Add questions in default language
-    await page.getByText("Add Block").click();
-    await page.getByRole("button", { name: "Single-Select" }).click();
+    await helper.addElement(page, "Single-Select");
     await helper.fillRichTextEditor(page, "Question*", surveys.createAndSubmit.singleSelectQuestion.question);
-    await page.getByPlaceholder("Option 1").fill(surveys.createAndSubmit.singleSelectQuestion.options[0]);
-    await page.getByPlaceholder("Option 2").fill(surveys.createAndSubmit.singleSelectQuestion.options[1]);
+    await helper.fillChoiceOptions(page, surveys.createAndSubmit.singleSelectQuestion.options);
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^Add BlockChoose the first question on your Block$/ })
-      .nth(1)
-      .click();
-    await page.getByRole("button", { name: "Multi-Select", exact: true }).click();
+    await helper.addElement(page, "Multi-Select", { exact: true });
     await helper.fillRichTextEditor(page, "Question*", surveys.createAndSubmit.multiSelectQuestion.question);
-    await page.getByPlaceholder("Option 1").fill(surveys.createAndSubmit.multiSelectQuestion.options[0]);
-    await page.getByPlaceholder("Option 2").fill(surveys.createAndSubmit.multiSelectQuestion.options[1]);
-    await page.getByPlaceholder("Option 3").fill(surveys.createAndSubmit.multiSelectQuestion.options[2]);
+    await helper.fillChoiceOptions(page, surveys.createAndSubmit.multiSelectQuestion.options);
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^Add BlockChoose the first question on your Block$/ })
-      .nth(1)
-      .click();
-    await page.getByRole("button", { name: "Picture Selection" }).click();
+    await helper.addElement(page, "Picture Selection");
     await helper.fillRichTextEditor(
       page,
       "Question*",
@@ -356,75 +328,28 @@ test.describe("Multi Language Survey Create", async () => {
 
     await uploadImageChoicesForPictureSelection(page);
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^Add BlockChoose the first question on your Block$/ })
-      .nth(1)
-      .click();
-    await page.getByRole("button", { name: "Rating" }).click();
+    await helper.addElement(page, "Rating");
     await helper.fillRichTextEditor(page, "Question*", surveys.createAndSubmit.ratingQuestion.question);
     await page.getByPlaceholder("Not good").fill(surveys.createAndSubmit.ratingQuestion.lowLabel);
     await page.getByPlaceholder("Very satisfied").fill(surveys.createAndSubmit.ratingQuestion.highLabel);
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^Add BlockChoose the first question on your Block$/ })
-      .nth(1)
-      .click();
-    await page.getByRole("button", { name: "Net Promoter Score (NPS)" }).click();
+    await helper.addElement(page, "Net Promoter Score (NPS)");
     await helper.fillRichTextEditor(page, "Question*", surveys.createAndSubmit.npsQuestion.question);
     await page.getByLabel("Lower label").fill(surveys.createAndSubmit.npsQuestion.lowLabel);
     await page.getByLabel("Upper label").fill(surveys.createAndSubmit.npsQuestion.highLabel);
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^Add BlockChoose the first question on your Block$/ })
-      .nth(1)
-      .click();
-    await page.getByRole("button", { name: "Date" }).click();
+    await helper.addElement(page, "Date");
     await helper.fillRichTextEditor(page, "Question*", surveys.createAndSubmit.dateQuestion.question);
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^Add BlockChoose the first question on your Block$/ })
-      .nth(1)
-      .click();
-    await page.getByRole("button", { name: "File Upload" }).click();
+    await helper.addElement(page, "File Upload");
     await helper.fillRichTextEditor(page, "Question*", surveys.createAndSubmit.fileUploadQuestion.question);
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^Add BlockChoose the first question on your Block$/ })
-      .nth(1)
-      .click();
-
-    await page.getByRole("button", { name: "Matrix" }).scrollIntoViewIfNeeded();
-    await page.getByRole("button", { name: "Matrix" }).click();
+    await helper.addElement(page, "Matrix");
     await helper.fillRichTextEditor(page, "Question*", surveys.createAndSubmit.matrix.question);
-    await page.locator("#row-0").click();
-    await page.locator("#row-0").fill(surveys.createAndSubmit.matrix.rows[0]);
-    await page.locator("#row-1").click();
-    await page.locator("#row-1").fill(surveys.createAndSubmit.matrix.rows[1]);
-    await page.getByRole("button", { name: "Add row" }).click();
-    await expect(page.locator("#row-2")).toBeEditable();
-    await page.locator("#row-2").fill(surveys.createAndSubmit.matrix.rows[2]);
-    await page.locator("#column-0").click();
-    await page.locator("#column-0").fill(surveys.createAndSubmit.matrix.columns[0]);
-    await page.locator("#column-1").click();
-    await page.locator("#column-1").fill(surveys.createAndSubmit.matrix.columns[1]);
-    await page.getByRole("button", { name: "Add column" }).click();
-    await expect(page.locator("#column-2")).toBeEditable();
-    await page.locator("#column-2").fill(surveys.createAndSubmit.matrix.columns[2]);
-    await page.getByRole("button", { name: "Add column" }).click();
-    await expect(page.locator("#column-3")).toBeEditable();
-    await page.locator("#column-3").fill(surveys.createAndSubmit.matrix.columns[3]);
+    await helper.fillMatrixLabels(page, "row", surveys.createAndSubmit.matrix.rows);
+    await helper.fillMatrixLabels(page, "column", surveys.createAndSubmit.matrix.columns);
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^Add BlockChoose the first question on your Block$/ })
-      .nth(1)
-      .click();
-    await page.getByRole("button", { name: "Address" }).click();
+    await helper.addElement(page, "Address");
     await helper.fillRichTextEditor(page, "Question*", surveys.createAndSubmit.address.question);
     await page.getByRole("row", { name: "Address Line 2" }).getByRole("switch").nth(1).click();
     await page.getByRole("row", { name: "City" }).getByRole("cell").nth(2).click();
@@ -432,26 +357,9 @@ test.describe("Multi Language Survey Create", async () => {
     await page.getByRole("row", { name: "Zip" }).getByRole("cell").nth(2).click();
     await page.getByRole("row", { name: "Country" }).getByRole("switch").nth(1).click();
 
-    await page
-      .locator("div")
-      .filter({ hasText: /^Add BlockChoose the first question on your Block$/ })
-      .nth(1)
-      .click();
-    await page.getByRole("button", { name: "Ranking" }).click();
+    await helper.addElement(page, "Ranking");
     await helper.fillRichTextEditor(page, "Question*", surveys.createAndSubmit.ranking.question);
-    await page.getByPlaceholder("Option 1").click();
-    await page.getByPlaceholder("Option 1").fill(surveys.createAndSubmit.ranking.choices[0]);
-    await page.getByPlaceholder("Option 2").click();
-    await page.getByPlaceholder("Option 2").fill(surveys.createAndSubmit.ranking.choices[1]);
-    await page.getByRole("button", { name: "Add option" }).click();
-    await page.getByPlaceholder("Option 3").click();
-    await page.getByPlaceholder("Option 3").fill(surveys.createAndSubmit.ranking.choices[2]);
-    await page.getByRole("button", { name: "Add option" }).click();
-    await page.getByPlaceholder("Option 4").click();
-    await page.getByPlaceholder("Option 4").fill(surveys.createAndSubmit.ranking.choices[3]);
-    await page.getByRole("button", { name: "Add option" }).click();
-    await page.getByPlaceholder("Option 5").click();
-    await page.getByPlaceholder("Option 5").fill(surveys.createAndSubmit.ranking.choices[4]);
+    await helper.fillChoiceOptions(page, surveys.createAndSubmit.ranking.choices);
 
     // Navigate to Language tab to enable translations and add German
     await page.getByText("Language").click();
@@ -747,10 +655,7 @@ test.describe("Multi Language Survey Create", async () => {
     await page.getByRole("button", { name: "Save as draft", exact: true }).click();
     await expect(page.getByText("Changes saved.")).toBeVisible();
 
-    await Promise.all([
-      page.waitForURL(/\/workspaces\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/, { timeout: 120000 }),
-      page.getByRole("button", { name: "Publish", exact: true }).click(),
-    ]);
+    await helper.publishSurvey(page);
     await page.getByLabel("Select Language").click();
     await page.getByText("German").click();
     await page.getByLabel("Copy survey link to clipboard").click();
@@ -791,10 +696,7 @@ test.describe("Testing Survey with advanced logic", async () => {
       await page.getByRole("button", { name: "Save as draft", exact: true }).click();
       await expect(page.getByText("Changes saved.")).toBeVisible();
 
-      await Promise.all([
-        page.waitForURL(/\/workspaces\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/, { timeout: 120000 }),
-        page.getByRole("button", { name: "Publish", exact: true }).click(),
-      ]);
+      await helper.publishSurvey(page);
 
       // Get URL
       await page.getByLabel("Copy survey link to clipboard").click();

--- a/apps/web/playwright/utils/helper.ts
+++ b/apps/web/playwright/utils/helper.ts
@@ -424,14 +424,19 @@ export const signupUsingInviteToken = async (page: Page, name: string, email: st
 };
 
 /**
- * Wait for React to commit and paint whatever the previous interaction changed.
+ * Wait for the previous interaction to reach the survey state, then for a frame after it.
  *
- * The survey editor's "add" handlers (`handleAddLabel`, `addChoice`, `addElement`, the "Add
- * description"/"Add “Other”" buttons) each build their payload from the `element`/`survey` prop of
- * the render they were created in. A structural click that lands before the previous edit has been
- * committed therefore writes a stale array back and silently drops that edit — which is what the
- * spec-wide `slowMo: 150` was really paying for. Two animation frames are enough to guarantee the
- * commit has painted, at ~30ms a seam instead of 150ms on every single action.
+ * `ElementFormInput` pushes edits upstream through `debounce(handleUpdate, 100)`
+ * (apps/web/modules/survey/components/element-form-input/index.tsx), and the editor's add handlers
+ * (`handleAddLabel`, `updateChoice`, `addElement`, the "Add description"/"Add “Other”" buttons) each
+ * build their payload from the `element`/`survey` prop of the render they were created in. A
+ * structural click that lands before that debounce has fired writes a stale array back and silently
+ * drops the edit — what the spec-wide `slowMo: 150` was really paying for.
+ *
+ * Order matters: the sleep clears the 100ms debounce, and the two animation frames then confirm the
+ * resulting commit has painted. Frames first would resolve at ~16/32ms — before the debounce had
+ * even run — and guarantee nothing. Cost is ~180ms at each of the ~40 structural seams, against
+ * 150ms on every one of the spec's 726 actions.
  */
 const RENDER_SETTLE_MS = 150;
 
@@ -439,11 +444,9 @@ const flushRender = async (page: Page): Promise<void> => {
   await page.evaluate(
     (settleMs) =>
       new Promise<void>((resolve) => {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            setTimeout(resolve, settleMs);
-          });
-        });
+        setTimeout(() => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }, settleMs);
       }),
     RENDER_SETTLE_MS
   );
@@ -535,7 +538,12 @@ export const addElement = async (page: Page, elementType: string, options: { exa
   // for a timeout to expire.
   await expect(trigger).toHaveAttribute("data-state", "open");
 
-  const option = page.getByRole("button", { name: elementType, exact: options.exact ?? false });
+  // Scoped to the picker panel: the editor renders a card per existing element plus its settings, so
+  // an unscoped non-exact name ("Date", "Rating") can match several buttons late in a build and fail
+  // strict mode.
+  const option = page
+    .getByTestId("add-element-picker")
+    .getByRole("button", { name: elementType, exact: options.exact ?? false });
   await expect(option).toBeVisible();
   // The picker is a two-column grid that overflows on shorter viewports (e.g. "Matrix").
   await option.scrollIntoViewIfNeeded();
@@ -544,22 +552,6 @@ export const addElement = async (page: Page, elementType: string, options: { exa
   // The picker closes itself from `handleAddElement`, so a collapsed trigger is the signal that
   // the element was committed to the survey and the new card is rendering.
   await expect(trigger).toHaveAttribute("data-state", "closed");
-};
-
-/**
- * Fill one matrix row/column label and wait for the value to be committed.
- *
- * `handleAddLabel` and `updateMatrixLabel` in matrix-element-form.tsx both rebuild the whole label
- * array from the `element` prop of the render they were created in, so an add that lands while an
- * edit is still in flight overwrites it — the edited label reverts to "" and the new label is lost.
- * Every label is therefore added first (see `ensureMatrixLabelCount`) and only then filled.
- */
-export const fillMatrixLabel = async (page: Page, type: "row" | "column", index: number, value: string) => {
-  const field = page.locator(`#${type}-${index}`);
-  await expect(field).toBeEditable();
-  await field.fill(value);
-  await expect(field).toHaveValue(value);
-  await flushRender(page);
 };
 
 /**
@@ -605,22 +597,32 @@ const fillLabelsUntilCommitted = async (
 /**
  * Click "Add row"/"Add column" until the matrix has `total` labels.
  *
- * A retry rather than one click per label: on a survey with a dozen elements the editor
- * occasionally drops the click (same stale-array hazard as above). The `count < total` guard means
- * a retry can never overshoot, and `toHaveCount` pins the exact expected length.
+ * One click per pass, each verified by the count growing by exactly one. Waiting for the *final*
+ * count instead would burn the whole timeout on every intermediate pass, and could not keep its
+ * promise not to overshoot: if a commit outlasted the wait, the next pass would still read the
+ * pre-click count and click again, pushing the list past `total` with no way back.
  */
 export const ensureMatrixLabelCount = async (page: Page, type: "row" | "column", total: number) => {
   const labels = page.locator(`input[id^="${type}-"]`);
   const addButton = page.getByRole("button", { name: type === "row" ? "Add row" : "Add column" });
 
-  await expect(async () => {
-    if ((await labels.count()) < total) {
-      await flushRender(page);
-      await expect(addButton).toBeEnabled();
-      await addButton.click();
-    }
-    await expect(labels).toHaveCount(total, { timeout: 2000 });
-  }).toPass({ timeout: 30000 });
+  // One label per iteration, each add retried against its own target count. Driving the loop from
+  // the outside is what keeps it honest: a `toPass` that merely "added one" reports success and
+  // stops, and a `toPass` waiting for `total` burns its whole budget on every intermediate pass.
+  for (let count = await labels.count(); count < total; count++) {
+    const target = count + 1;
+
+    await expect(async () => {
+      if ((await labels.count()) < target) {
+        await flushRender(page);
+        await expect(addButton).toBeEnabled();
+        await addButton.click();
+      }
+      await expect(labels).toHaveCount(target, { timeout: 2000 });
+    }).toPass({ timeout: 20000 });
+  }
+
+  await expect(labels).toHaveCount(total);
 };
 
 /** Add every matrix label, then fill them — see fillLabelsUntilCommitted for the ordering reason. */
@@ -629,30 +631,45 @@ export const fillMatrixLabels = async (page: Page, type: "row" | "column", value
   await fillLabelsUntilCommitted(page, values, (index) => page.locator(`#${type}-${index}`));
 };
 
-/** Fill one "Option N" choice input and confirm the input accepted it. */
-export const fillChoiceOption = async (page: Page, optionNumber: number, value: string) => {
-  const field = page.getByPlaceholder(`Option ${optionNumber}`);
-  await expect(field).toBeEditable();
-  await field.fill(value);
-  await expect(field).toHaveValue(value);
-  await flushRender(page);
-};
-
-/** Click "Add option" until the choice list holds `total` inputs (same rationale as the matrix). */
+/**
+ * Click until the choice list holds `total` inputs, one added per pass.
+ *
+ * Two different controls, because the forms disagree: the ranking form renders a single "Add option"
+ * button (ranking-element-form.tsx), while the multiple-choice forms only offer the per-row
+ * "Add choice below" icon (element-option-choice.tsx). Whichever exists is used, so this works for
+ * select and ranking elements alike — with the select presets currently matching the fixtures, the
+ * select path would otherwise only be exercised the day a fixture grew an option.
+ */
 export const ensureChoiceCount = async (page: Page, total: number) => {
   // Counting by placeholder, not by `id^="choice-"`: the "Other" and "None of the above" choices
   // share that id prefix, so an id-based count would never match the number of real options.
   const choices = page.locator('input[placeholder^="Option "]');
-  const addButton = page.getByRole("button", { name: "Add option" });
+  const addOption = page.getByRole("button", { name: "Add option" });
+  const addChoiceBelow = page.getByRole("button", { name: "Add choice below" });
 
-  await expect(async () => {
-    if ((await choices.count()) < total) {
-      await flushRender(page);
-      await expect(addButton).toBeEnabled();
-      await addButton.click();
-    }
-    await expect(choices).toHaveCount(total, { timeout: 2000 });
-  }).toPass({ timeout: 30000 });
+  // One choice per iteration, each add retried against its own target count — see
+  // ensureMatrixLabelCount for why the loop lives outside the retry.
+  for (let count = await choices.count(); count < total; count++) {
+    const target = count + 1;
+
+    await expect(async () => {
+      if ((await choices.count()) < target) {
+        await flushRender(page);
+
+        if (await addOption.count()) {
+          await expect(addOption).toBeEnabled();
+          await addOption.click();
+        } else {
+          const lastRowAdd = addChoiceBelow.last();
+          await expect(lastRowAdd).toBeEnabled();
+          await lastRowAdd.click();
+        }
+      }
+      await expect(choices).toHaveCount(target, { timeout: 2000 });
+    }).toPass({ timeout: 20000 });
+  }
+
+  await expect(choices).toHaveCount(total);
 };
 
 /** Add every choice, then fill them — see fillLabelsUntilCommitted for the ordering reason. */
@@ -661,38 +678,60 @@ export const fillChoiceOptions = async (page: Page, values: string[]) => {
   await fillLabelsUntilCommitted(page, values, (index) => page.getByPlaceholder(`Option ${index + 1}`));
 };
 
+const publishButtonOf = (page: Page): Locator => page.getByRole("button", { name: "Publish", exact: true });
+
 /**
  * Publish the survey being edited and wait for the summary page.
  *
- * The editor validates client-side and reports problems only through a toast that auto-dismisses,
- * so a failed publish otherwise shows up as an opaque `waitForURL` timeout. This polls for the
- * toast alongside the navigation and fails with the message the editor actually gave.
+ * The editor validates client-side and reports problems only through a toast that auto-dismisses, so
+ * a failed publish otherwise surfaces as an opaque `waitForURL` timeout. This watches for the
+ * navigation and collects error toasts alongside it, then fails with the message the editor actually
+ * gave — or says plainly that none was shown, which points at a slow publish rather than a rejected
+ * one.
  */
 export const publishSurvey = async (page: Page): Promise<void> => {
-  const publishButton = page.getByRole("button", { name: "Publish", exact: true });
+  // Matches the per-test timeout in playwright.config.ts, and the `waitForURL` timeout every call
+  // site used before this helper existed. Publishing the 13-element survey is the slowest step in
+  // the suite; a shorter budget would turn a slow-but-passing run red.
+  const publishTimeoutMs = 120000;
   const summaryUrl = /\/workspaces\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/;
-  // react-hot-toast renders every toast into a role="status" container.
-  const toasts = page.locator('div[role="status"]');
+  // Scoped to react-hot-toast's own error class (set in modules/ui/components/toaster-client) rather
+  // than `role="status"`, which the shared `Alert` also uses — several of those are on screen in the
+  // editor and would be reported as publish failures.
+  const errorToasts = page.locator(".formbricks__toast__error");
 
-  await expect(publishButton).toBeEnabled();
-  await publishButton.click();
+  await expect(publishButtonOf(page)).toBeEnabled();
+  await publishButtonOf(page).click();
+
+  const navigated = page
+    .waitForURL(summaryUrl, { timeout: publishTimeoutMs })
+    .then(() => true)
+    .catch(() => false);
 
   const seen = new Set<string>();
-  const deadline = Date.now() + 60000;
 
-  while (Date.now() < deadline) {
-    if (summaryUrl.test(page.url())) return;
+  for (;;) {
+    // Racing the navigation keeps the toast reads off a destroyed execution context: once the
+    // summary page starts loading, `navigated` wins and no further query is issued.
+    const settled = await Promise.race([navigated, page.waitForTimeout(250).then(() => null)]);
 
-    for (const text of await toasts.allInnerTexts()) {
+    if (settled === true) return;
+    if (settled === false) break;
+
+    // The publish may still navigate between the race above and this read.
+    for (const text of await errorToasts.allInnerTexts().catch(() => [])) {
       const message = text.trim();
-      if (message && message !== "Formbricks") seen.add(message);
+      if (message) seen.add(message);
     }
-
-    await page.waitForTimeout(250);
   }
 
+  const reported =
+    seen.size > 0
+      ? `Editor reported: ${JSON.stringify([...seen])}`
+      : "No validation toast was shown, so this is a slow publish rather than a rejected one";
+
   throw new Error(
-    `Publish did not reach the summary page. Editor reported: ${JSON.stringify([...seen])} (url: ${page.url()})`
+    `Publish did not reach the summary page within ${publishTimeoutMs}ms. ${reported} (url: ${page.url()})`
   );
 };
 

--- a/apps/web/playwright/utils/helper.ts
+++ b/apps/web/playwright/utils/helper.ts
@@ -424,6 +424,32 @@ export const signupUsingInviteToken = async (page: Page, name: string, email: st
 };
 
 /**
+ * Wait for React to commit and paint whatever the previous interaction changed.
+ *
+ * The survey editor's "add" handlers (`handleAddLabel`, `addChoice`, `addElement`, the "Add
+ * description"/"Add “Other”" buttons) each build their payload from the `element`/`survey` prop of
+ * the render they were created in. A structural click that lands before the previous edit has been
+ * committed therefore writes a stale array back and silently drops that edit — which is what the
+ * spec-wide `slowMo: 150` was really paying for. Two animation frames are enough to guarantee the
+ * commit has painted, at ~30ms a seam instead of 150ms on every single action.
+ */
+const RENDER_SETTLE_MS = 150;
+
+const flushRender = async (page: Page): Promise<void> => {
+  await page.evaluate(
+    (settleMs) =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            setTimeout(resolve, settleMs);
+          });
+        });
+      }),
+    RENDER_SETTLE_MS
+  );
+};
+
+/**
  * Helper function to fill content into a rich text editor (contenteditable div).
  * The rich text editor uses a contenteditable div with class "editor-input" instead of a regular input.
  *
@@ -437,12 +463,18 @@ export const fillRichTextEditor = async (page: Page, labelText: string, content:
   const editorContainer = label.locator("..").locator("..");
   const editor = editorContainer.locator(".editor-input").first();
 
-  await editor.click();
-  // Clear existing content by selecting all and deleting
-  await editor.press("Meta+a"); // Cmd+A on Mac, Ctrl+A is handled automatically by Playwright
-  await editor.press("Backspace");
-  // Type the new content
-  await editor.pressSequentially(content, { delay: 50 });
+  // Waiting for the editor before touching it is what lets this run without a global `slowMo`: the
+  // element card mounts its form asynchronously after an element is added, so an unguarded action
+  // used to resolve against the outgoing render and fail as a detached node.
+  await expect(editor).toBeVisible();
+  // `fill` on the contenteditable, not `pressSequentially`. One `insertText` replaces the whole
+  // value, where per-key typing raced Lexical's own re-render and truncated the text ("Picture
+  // Select Question" landing as "Picture S") unless every keystroke was paced by `slowMo`.
+  await editor.fill(content);
+  // Confirms the editor settled before the caller's next action — this assertion, not a delay, is
+  // what keeps the following interactions off a mid-render tree.
+  await expect(editor).toHaveText(content);
+  await flushRender(page);
 };
 
 /**
@@ -463,15 +495,208 @@ export const fillModalRichTranslation = async (page: Page, path: string, text: s
   const row = page.locator(`[data-testid="translation-row-${path}"]`);
   await row.scrollIntoViewIfNeeded();
   const editor = row.locator(".editor-input").first();
-  await editor.click();
-  await editor.press("Meta+a");
-  await editor.press("Backspace");
-  await editor.pressSequentially(text, { delay: 50 });
+  await expect(editor).toBeVisible();
+  await editor.fill(text);
+  await expect(editor).toHaveText(text);
+};
+
+/** Reveal an element's description field. Structural, so the pending edit is flushed first. */
+const addDescription = async (page: Page, options: { exact?: boolean } = {}) => {
+  await flushRender(page);
+  await page.getByRole("button", { name: "Add description", exact: options.exact ?? false }).click();
+  await expect(page.locator('label:has-text("Description")').first()).toBeVisible();
+};
+
+/** Append the "Other" choice to a select element. Structural, so flush first. */
+const addOtherChoice = async (page: Page) => {
+  await flushRender(page);
+  await page.getByRole("button", { name: "Add “Other”", exact: true }).click();
+  await expect(page.getByPlaceholder("Other", { exact: true })).toBeVisible();
+};
+
+/**
+ * Add an element to the survey via the editor's "Add Block" collapsible.
+ *
+ * Every step asserts the state it depends on, which is what replaced the spec-wide `slowMo: 150`:
+ * the collapsible animates open and shut (`animate-collapsible-down`/`-up`) while the new element
+ * card mounts, so an unguarded "click trigger, click type" pair raced the animation and the React
+ * commit, and failed with "element detached from the DOM".
+ */
+export const addElement = async (page: Page, elementType: string, options: { exact?: boolean } = {}) => {
+  const trigger = page.getByTestId("add-element-trigger");
+
+  // The add rebuilds the element list from the current render — let the previous edit commit first.
+  await flushRender(page);
+  await expect(trigger).toBeVisible();
+  await trigger.scrollIntoViewIfNeeded();
+  await trigger.click();
+
+  // Radix flips `data-state` on the trigger, so this waits for the panel to be open rather than
+  // for a timeout to expire.
+  await expect(trigger).toHaveAttribute("data-state", "open");
+
+  const option = page.getByRole("button", { name: elementType, exact: options.exact ?? false });
+  await expect(option).toBeVisible();
+  // The picker is a two-column grid that overflows on shorter viewports (e.g. "Matrix").
+  await option.scrollIntoViewIfNeeded();
+  await option.click();
+
+  // The picker closes itself from `handleAddElement`, so a collapsed trigger is the signal that
+  // the element was committed to the survey and the new card is rendering.
+  await expect(trigger).toHaveAttribute("data-state", "closed");
+};
+
+/**
+ * Fill one matrix row/column label and wait for the value to be committed.
+ *
+ * `handleAddLabel` and `updateMatrixLabel` in matrix-element-form.tsx both rebuild the whole label
+ * array from the `element` prop of the render they were created in, so an add that lands while an
+ * edit is still in flight overwrites it — the edited label reverts to "" and the new label is lost.
+ * Every label is therefore added first (see `ensureMatrixLabelCount`) and only then filled.
+ */
+export const fillMatrixLabel = async (page: Page, type: "row" | "column", index: number, value: string) => {
+  const field = page.locator(`#${type}-${index}`);
+  await expect(field).toBeEditable();
+  await field.fill(value);
+  await expect(field).toHaveValue(value);
+  await flushRender(page);
+};
+
+/**
+ * The editor's live preview, which renders from the committed survey state.
+ *
+ * The label inputs keep their own local state, so an input can still show text that the survey no
+ * longer holds — exactly what happens when a later edit overwrites an earlier one from a stale
+ * array. Asserting against the preview is therefore the only reliable proof that an edit landed.
+ */
+const surveyPreview = (page: Page): Locator => page.locator("#survey-preview");
+
+/**
+ * Fill a list of label inputs until every value is present in the live preview at the same time.
+ *
+ * `updateChoice`/`updateMatrixLabel` rebuild their whole array from the props of the render they
+ * were created in, so two quick edits overwrite each other — filling "Option 2" reverts "Option 1"
+ * to "". Re-filling whatever the preview is still missing converges on the intended state without
+ * pacing every action, which is what the spec-wide `slowMo: 150` used to do.
+ */
+const fillLabelsUntilCommitted = async (
+  page: Page,
+  values: string[],
+  fieldFor: (index: number) => Locator
+): Promise<void> => {
+  const preview = surveyPreview(page);
+
+  await expect(async () => {
+    for (const [index, value] of values.entries()) {
+      const field = fieldFor(index);
+      if ((await field.inputValue()) !== value) {
+        await expect(field).toBeEditable();
+        await field.fill(value);
+        await flushRender(page);
+      }
+    }
+
+    for (const value of values) {
+      await expect(preview.getByText(value, { exact: true }).first()).toBeVisible({ timeout: 2000 });
+    }
+  }).toPass({ timeout: 60000 });
+};
+
+/**
+ * Click "Add row"/"Add column" until the matrix has `total` labels.
+ *
+ * A retry rather than one click per label: on a survey with a dozen elements the editor
+ * occasionally drops the click (same stale-array hazard as above). The `count < total` guard means
+ * a retry can never overshoot, and `toHaveCount` pins the exact expected length.
+ */
+export const ensureMatrixLabelCount = async (page: Page, type: "row" | "column", total: number) => {
+  const labels = page.locator(`input[id^="${type}-"]`);
+  const addButton = page.getByRole("button", { name: type === "row" ? "Add row" : "Add column" });
+
+  await expect(async () => {
+    if ((await labels.count()) < total) {
+      await flushRender(page);
+      await expect(addButton).toBeEnabled();
+      await addButton.click();
+    }
+    await expect(labels).toHaveCount(total, { timeout: 2000 });
+  }).toPass({ timeout: 30000 });
+};
+
+/** Add every matrix label, then fill them — see fillLabelsUntilCommitted for the ordering reason. */
+export const fillMatrixLabels = async (page: Page, type: "row" | "column", values: string[]) => {
+  await ensureMatrixLabelCount(page, type, values.length);
+  await fillLabelsUntilCommitted(page, values, (index) => page.locator(`#${type}-${index}`));
+};
+
+/** Fill one "Option N" choice input and confirm the input accepted it. */
+export const fillChoiceOption = async (page: Page, optionNumber: number, value: string) => {
+  const field = page.getByPlaceholder(`Option ${optionNumber}`);
+  await expect(field).toBeEditable();
+  await field.fill(value);
+  await expect(field).toHaveValue(value);
+  await flushRender(page);
+};
+
+/** Click "Add option" until the choice list holds `total` inputs (same rationale as the matrix). */
+export const ensureChoiceCount = async (page: Page, total: number) => {
+  // Counting by placeholder, not by `id^="choice-"`: the "Other" and "None of the above" choices
+  // share that id prefix, so an id-based count would never match the number of real options.
+  const choices = page.locator('input[placeholder^="Option "]');
+  const addButton = page.getByRole("button", { name: "Add option" });
+
+  await expect(async () => {
+    if ((await choices.count()) < total) {
+      await flushRender(page);
+      await expect(addButton).toBeEnabled();
+      await addButton.click();
+    }
+    await expect(choices).toHaveCount(total, { timeout: 2000 });
+  }).toPass({ timeout: 30000 });
+};
+
+/** Add every choice, then fill them — see fillLabelsUntilCommitted for the ordering reason. */
+export const fillChoiceOptions = async (page: Page, values: string[]) => {
+  await ensureChoiceCount(page, values.length);
+  await fillLabelsUntilCommitted(page, values, (index) => page.getByPlaceholder(`Option ${index + 1}`));
+};
+
+/**
+ * Publish the survey being edited and wait for the summary page.
+ *
+ * The editor validates client-side and reports problems only through a toast that auto-dismisses,
+ * so a failed publish otherwise shows up as an opaque `waitForURL` timeout. This polls for the
+ * toast alongside the navigation and fails with the message the editor actually gave.
+ */
+export const publishSurvey = async (page: Page): Promise<void> => {
+  const publishButton = page.getByRole("button", { name: "Publish", exact: true });
+  const summaryUrl = /\/workspaces\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/;
+  // react-hot-toast renders every toast into a role="status" container.
+  const toasts = page.locator('div[role="status"]');
+
+  await expect(publishButton).toBeEnabled();
+  await publishButton.click();
+
+  const seen = new Set<string>();
+  const deadline = Date.now() + 60000;
+
+  while (Date.now() < deadline) {
+    if (summaryUrl.test(page.url())) return;
+
+    for (const text of await toasts.allInnerTexts()) {
+      const message = text.trim();
+      if (message && message !== "Formbricks") seen.add(message);
+    }
+
+    await page.waitForTimeout(250);
+  }
+
+  throw new Error(
+    `Publish did not reach the summary page. Editor reported: ${JSON.stringify([...seen])} (url: ${page.url()})`
+  );
 };
 
 export const createSurvey = async (page: Page, params: CreateSurveyParams) => {
-  const addBlock = "Add BlockChoose the first question on your Block";
-
   await createSurveyFromScratch(page);
 
   // Welcome Card
@@ -489,71 +714,45 @@ export const createSurvey = async (page: Page, params: CreateSurveyParams) => {
   await page.getByRole("main").getByText("What would you like to know?").click();
 
   await fillRichTextEditor(page, "Question*", params.openTextQuestion.question);
-  await page.getByRole("button", { name: "Add description" }).click();
+  await addDescription(page);
   await fillRichTextEditor(page, "Description", params.openTextQuestion.description);
   await page.getByLabel("Placeholder").fill(params.openTextQuestion.placeholder);
 
   await page.locator("h3").filter({ hasText: params.openTextQuestion.question }).click();
 
   // Single Select Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Single-Select" }).click();
+  await addElement(page, "Single-Select");
   await fillRichTextEditor(page, "Question*", params.singleSelectQuestion.question);
-  await page.getByRole("button", { name: "Add description" }).click();
+  await addDescription(page);
   await fillRichTextEditor(page, "Description", params.singleSelectQuestion.description);
-  await page.getByPlaceholder("Option 1").fill(params.singleSelectQuestion.options[0]);
-  await page.getByPlaceholder("Option 2").fill(params.singleSelectQuestion.options[1]);
-  await page.getByRole("button", { name: "Add “Other”", exact: true }).click();
+  // "Other" is added before the labels are filled: the add rebuilds the choice array and would
+  // otherwise wipe whatever had just been typed into Option 1/2.
+  await addOtherChoice(page);
+  await fillChoiceOptions(page, params.singleSelectQuestion.options);
 
   // Multi Select Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Multi-Select", exact: true }).click();
+  await addElement(page, "Multi-Select", { exact: true });
   await fillRichTextEditor(page, "Question*", params.multiSelectQuestion.question);
-  await page.getByRole("button", { name: "Add description", exact: true }).click();
+  await addDescription(page, { exact: true });
   await fillRichTextEditor(page, "Description", params.multiSelectQuestion.description);
-  await page.getByPlaceholder("Option 1").fill(params.multiSelectQuestion.options[0]);
-  await page.getByPlaceholder("Option 2").fill(params.multiSelectQuestion.options[1]);
-  await page.getByPlaceholder("Option 3").fill(params.multiSelectQuestion.options[2]);
+  await fillChoiceOptions(page, params.multiSelectQuestion.options);
 
   // Rating Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Rating" }).click();
+  await addElement(page, "Rating");
   await fillRichTextEditor(page, "Question*", params.ratingQuestion.question);
-  await page.getByRole("button", { name: "Add description", exact: true }).click();
+  await addDescription(page, { exact: true });
   await fillRichTextEditor(page, "Description", params.ratingQuestion.description);
   await page.getByPlaceholder("Not good").fill(params.ratingQuestion.lowLabel);
   await page.getByPlaceholder("Very satisfied").fill(params.ratingQuestion.highLabel);
 
   // NPS Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Net Promoter Score (NPS)" }).click();
+  await addElement(page, "Net Promoter Score (NPS)");
   await fillRichTextEditor(page, "Question*", params.npsQuestion.question);
   await page.getByLabel("Lower label").fill(params.npsQuestion.lowLabel);
   await page.getByLabel("Upper label").fill(params.npsQuestion.highLabel);
 
   // CTA Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Statement (Call to Action)" }).click();
+  await addElement(page, "Statement (Call to Action)");
   await fillRichTextEditor(page, "Question*", params.ctaQuestion.question);
 
   // Enable external button and fill URL
@@ -562,72 +761,32 @@ export const createSurvey = async (page: Page, params: CreateSurveyParams) => {
   await page.getByPlaceholder("Finish").fill(params.ctaQuestion.buttonLabel);
 
   // Consent Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Consent" }).click();
+  await addElement(page, "Consent");
   await fillRichTextEditor(page, "Question*", params.consentQuestion.question);
   await page.getByPlaceholder("I agree to the terms and").fill(params.consentQuestion.checkboxLabel);
 
   // Picture Select Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Picture Selection" }).click();
+  await addElement(page, "Picture Selection");
   await fillRichTextEditor(page, "Question*", params.pictureSelectQuestion.question);
-  await page.getByRole("button", { name: "Add description" }).click();
+  await addDescription(page);
   await fillRichTextEditor(page, "Description", params.pictureSelectQuestion.description);
 
   await uploadImageChoicesForPictureSelection(page);
 
   // File Upload Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "File Upload" }).click();
+  await addElement(page, "File Upload");
   await fillRichTextEditor(page, "Question*", params.fileUploadQuestion.question);
 
   // Matrix Upload Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Matrix" }).click();
+  await addElement(page, "Matrix");
   await fillRichTextEditor(page, "Question*", params.matrix.question);
-  await page.getByRole("button", { name: "Add description", exact: true }).click();
+  await addDescription(page, { exact: true });
   await fillRichTextEditor(page, "Description", params.matrix.description);
-  await page.locator("#row-0").click();
-  await page.locator("#row-0").fill(params.matrix.rows[0]);
-  await page.locator("#row-1").click();
-  await page.locator("#row-1").fill(params.matrix.rows[1]);
-  await page.getByRole("button", { name: "Add row" }).click();
-  await expect(page.locator("#row-2")).toBeEditable();
-  await page.locator("#row-2").fill(params.matrix.rows[2]);
-  await page.locator("#column-0").click();
-  await page.locator("#column-0").fill(params.matrix.columns[0]);
-  await page.locator("#column-1").click();
-  await page.locator("#column-1").fill(params.matrix.columns[1]);
-  await page.getByRole("button", { name: "Add column" }).click();
-  await expect(page.locator("#column-2")).toBeEditable();
-  await page.locator("#column-2").fill(params.matrix.columns[2]);
-  await page.getByRole("button", { name: "Add column" }).click();
-  await expect(page.locator("#column-3")).toBeEditable();
-  await page.locator("#column-3").fill(params.matrix.columns[3]);
+  await fillMatrixLabels(page, "row", params.matrix.rows);
+  await fillMatrixLabels(page, "column", params.matrix.columns);
 
   // Fill Address Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Address" }).click();
+  await addElement(page, "Address");
   await fillRichTextEditor(page, "Question*", params.address.question);
   await page.getByRole("row", { name: "Address Line 2" }).getByRole("switch").nth(1).click();
   await page.getByRole("row", { name: "City" }).getByRole("cell").nth(2).click();
@@ -636,12 +795,7 @@ export const createSurvey = async (page: Page, params: CreateSurveyParams) => {
   await page.getByRole("row", { name: "Country" }).getByRole("switch").nth(1).click();
 
   // Fill Contact Info Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Contact Info" }).click();
+  await addElement(page, "Contact Info");
   await fillRichTextEditor(page, "Question*", params.contactInfo.question);
   await page.getByRole("row", { name: "Last Name" }).getByRole("switch").nth(1).click();
   await page.getByRole("row", { name: "Email" }).getByRole("switch").nth(1).click();
@@ -649,26 +803,9 @@ export const createSurvey = async (page: Page, params: CreateSurveyParams) => {
   await page.getByRole("row", { name: "Company" }).getByRole("switch").nth(1).click();
 
   // Fill Ranking question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Ranking" }).click();
+  await addElement(page, "Ranking");
   await fillRichTextEditor(page, "Question*", params.ranking.question);
-  await page.getByPlaceholder("Option 1").click();
-  await page.getByPlaceholder("Option 1").fill(params.ranking.choices[0]);
-  await page.getByPlaceholder("Option 2").click();
-  await page.getByPlaceholder("Option 2").fill(params.ranking.choices[1]);
-  await page.getByRole("button", { name: "Add option" }).click();
-  await page.getByPlaceholder("Option 3").click();
-  await page.getByPlaceholder("Option 3").fill(params.ranking.choices[2]);
-  await page.getByRole("button", { name: "Add option" }).click();
-  await page.getByPlaceholder("Option 4").click();
-  await page.getByPlaceholder("Option 4").fill(params.ranking.choices[3]);
-  await page.getByRole("button", { name: "Add option" }).click();
-  await page.getByPlaceholder("Option 5").click();
-  await page.getByPlaceholder("Option 5").fill(params.ranking.choices[4]);
+  await fillChoiceOptions(page, params.ranking.choices);
 };
 
 /**
@@ -684,8 +821,6 @@ const editorElementHeading = (page: Page, name: string): Locator =>
   page.getByRole("main").getByRole("heading", { name });
 
 export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWithLogicParams) => {
-  const addBlock = "Add BlockChoose the first question on your Block";
-
   await createSurveyFromScratch(page);
 
   // Add variables
@@ -717,133 +852,65 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
   await page.getByRole("main").getByText("What would you like to know?").click();
 
   await fillRichTextEditor(page, "Question*", params.openTextQuestion.question);
-  await page.getByRole("button", { name: "Add description" }).click();
+  await addDescription(page);
   await fillRichTextEditor(page, "Description", params.openTextQuestion.description);
   await page.getByLabel("Placeholder").fill(params.openTextQuestion.placeholder);
 
   await page.locator("h3").filter({ hasText: params.openTextQuestion.question }).click();
 
   // Single Select Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Single-Select" }).click();
+  await addElement(page, "Single-Select");
   await fillRichTextEditor(page, "Question*", params.singleSelectQuestion.question);
-  await page.getByRole("button", { name: "Add description" }).click();
+  await addDescription(page);
   await fillRichTextEditor(page, "Description", params.singleSelectQuestion.description);
-  await page.getByPlaceholder("Option 1").fill(params.singleSelectQuestion.options[0]);
-  await page.getByPlaceholder("Option 2").fill(params.singleSelectQuestion.options[1]);
-  await page.getByRole("button", { name: "Add “Other”", exact: true }).click();
+  // "Other" is added before the labels are filled: the add rebuilds the choice array and would
+  // otherwise wipe whatever had just been typed into Option 1/2.
+  await addOtherChoice(page);
+  await fillChoiceOptions(page, params.singleSelectQuestion.options);
 
   // Multi Select Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Multi-Select", exact: true }).click();
+  await addElement(page, "Multi-Select", { exact: true });
   await fillRichTextEditor(page, "Question*", params.multiSelectQuestion.question);
-  await page.getByRole("button", { name: "Add description" }).click();
+  await addDescription(page);
   await fillRichTextEditor(page, "Description", params.multiSelectQuestion.description);
-  await page.getByPlaceholder("Option 1").fill(params.multiSelectQuestion.options[0]);
-  await page.getByPlaceholder("Option 2").fill(params.multiSelectQuestion.options[1]);
-  await page.getByPlaceholder("Option 3").fill(params.multiSelectQuestion.options[2]);
+  await fillChoiceOptions(page, params.multiSelectQuestion.options);
 
   // Picture Select Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Picture Selection" }).click();
+  await addElement(page, "Picture Selection");
   await fillRichTextEditor(page, "Question*", params.pictureSelectQuestion.question);
-  await page.getByRole("button", { name: "Add description" }).click();
+  await addDescription(page);
   await fillRichTextEditor(page, "Description", params.pictureSelectQuestion.description);
   await uploadImageChoicesForPictureSelection(page);
 
   // Rating Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Rating" }).click();
+  await addElement(page, "Rating");
   await fillRichTextEditor(page, "Question*", params.ratingQuestion.question);
-  await page.getByRole("button", { name: "Add description" }).click();
+  await addDescription(page);
   await fillRichTextEditor(page, "Description", params.ratingQuestion.description);
   await page.getByPlaceholder("Not good").fill(params.ratingQuestion.lowLabel);
   await page.getByPlaceholder("Very satisfied").fill(params.ratingQuestion.highLabel);
 
   // NPS Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Net Promoter Score (NPS)" }).click();
+  await addElement(page, "Net Promoter Score (NPS)");
   await fillRichTextEditor(page, "Question*", params.npsQuestion.question);
   await page.getByLabel("Lower label").fill(params.npsQuestion.lowLabel);
   await page.getByLabel("Upper label").fill(params.npsQuestion.highLabel);
 
   // Fill Ranking question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Ranking" }).click();
+  await addElement(page, "Ranking");
   await fillRichTextEditor(page, "Question*", params.ranking.question);
-  await page.getByPlaceholder("Option 1").click();
-  await page.getByPlaceholder("Option 1").fill(params.ranking.choices[0]);
-  await page.getByPlaceholder("Option 2").click();
-  await page.getByPlaceholder("Option 2").fill(params.ranking.choices[1]);
-  await page.getByRole("button", { name: "Add option" }).click();
-  await page.getByPlaceholder("Option 3").click();
-  await page.getByPlaceholder("Option 3").fill(params.ranking.choices[2]);
-  await page.getByRole("button", { name: "Add option" }).click();
-  await page.getByPlaceholder("Option 4").click();
-  await page.getByPlaceholder("Option 4").fill(params.ranking.choices[3]);
-  await page.getByRole("button", { name: "Add option" }).click();
-  await page.getByPlaceholder("Option 5").click();
-  await page.getByPlaceholder("Option 5").fill(params.ranking.choices[4]);
+  await fillChoiceOptions(page, params.ranking.choices);
 
   // Matrix Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Matrix" }).click();
+  await addElement(page, "Matrix");
   await fillRichTextEditor(page, "Question*", params.matrix.question);
-  await page.getByRole("button", { name: "Add description" }).click();
+  await addDescription(page);
   await fillRichTextEditor(page, "Description", params.matrix.description);
-  await page.locator("#row-0").click();
-  await page.locator("#row-0").fill(params.matrix.rows[0]);
-  await page.locator("#row-1").click();
-  await page.locator("#row-1").fill(params.matrix.rows[1]);
-  await page.getByRole("button", { name: "Add row" }).click();
-  await expect(page.locator("#row-2")).toBeEditable();
-  await page.locator("#row-2").fill(params.matrix.rows[2]);
-  await page.locator("#column-0").click();
-  await page.locator("#column-0").fill(params.matrix.columns[0]);
-  await page.locator("#column-1").click();
-  await page.locator("#column-1").fill(params.matrix.columns[1]);
-  await page.getByRole("button", { name: "Add column" }).click();
-  await expect(page.locator("#column-2")).toBeEditable();
-  await page.locator("#column-2").fill(params.matrix.columns[2]);
-  await page.getByRole("button", { name: "Add column" }).click();
-  await expect(page.locator("#column-3")).toBeEditable();
-  await page.locator("#column-3").fill(params.matrix.columns[3]);
+  await fillMatrixLabels(page, "row", params.matrix.rows);
+  await fillMatrixLabels(page, "column", params.matrix.columns);
 
   // CTA Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Statement (Call to Action)" }).click();
+  await addElement(page, "Statement (Call to Action)");
   await fillRichTextEditor(page, "Question*", params.ctaQuestion.question);
 
   // Enable external button and fill URL
@@ -852,49 +919,24 @@ export const createSurveyWithLogic = async (page: Page, params: CreateSurveyWith
   await page.getByPlaceholder("Finish").fill(params.ctaQuestion.buttonLabel);
 
   // Consent Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Consent" }).click();
+  await addElement(page, "Consent");
   await fillRichTextEditor(page, "Question*", params.consentQuestion.question);
   await page.getByPlaceholder("I agree to the terms and").fill(params.consentQuestion.checkboxLabel);
 
   // File Upload Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "File Upload" }).click();
+  await addElement(page, "File Upload");
   await fillRichTextEditor(page, "Question*", params.fileUploadQuestion.question);
 
   // Date Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Date" }).click();
+  await addElement(page, "Date");
   await fillRichTextEditor(page, "Question*", params.date.question);
 
   // Cal Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Schedule a meeting" }).click();
+  await addElement(page, "Schedule a meeting");
   await fillRichTextEditor(page, "Question*", params.cal.question);
 
   // Fill Address Question
-  await page
-    .locator("div")
-    .filter({ hasText: new RegExp(`^${addBlock}$`) })
-    .nth(1)
-    .click();
-  await page.getByRole("button", { name: "Address" }).click();
+  await addElement(page, "Address");
   await fillRichTextEditor(page, "Question*", params.address.question);
   await page.getByRole("row", { name: "Address Line 2" }).getByRole("switch").nth(1).click();
   await page.getByRole("row", { name: "City" }).getByRole("cell").nth(2).click();


### PR DESCRIPTION
Ref ENG-2006

## What & why

E2E and Docker Build Validation are the two jobs that decide how long a PR takes; every other check finishes in under 6 min. This PR takes a measured chunk out of each: **E2E 12m43s → 10m30s** (its test step 598s → 288s) and **Docker Build Validation 12–17m → 8.7m**.

**1. `survey.spec.ts` paced every action with `launchOptions.slowMo: 150`**, with a comment saying it was load-bearing and that removing it needed hardened waits first (the leftover of ENG-2006).

- E2E median was **12m43s**, worst **16m29s** over 14 runs; next-longest job 5m.
- Of its 598s test step in run [32447746140](https://github.com/formbricks/formbricks/actions/runs/32447746140), `survey.spec.ts` was **876s of the suite's 1799s CPU-seconds in 3 tests** — and with 10 Azure workers the wall clock is bounded by the longest single test, not the total.
- The trace of the retried test shows 726 actions / 171s, ~110s of it slowMo sleep, plus 25 `pressSequentially` calls averaging 2756ms because `delay: 50` and slowMo both apply per keystroke.

Removing the sleep meant fixing the two editor behaviours it was hiding:

- **Text has to be entered in one operation.** `pressSequentially` at full speed races Lexical's re-render and truncates (`"Picture Select Question"` arriving as `"Picture S"`). `fill()` replaces the value with a single `insertText`; verified it commits by saving the draft and reloading.
- **Structural clicks drop in-flight edits.** `handleAddLabel` (matrix), `updateChoice` (multiple-choice), the element add, and the "Add description" / "Add “Other”" buttons each rebuild their array from the `element`/`survey` prop of the render they were created in. A click landing before the previous edit committed writes a stale array back, silently reverting it — surfacing as `Choice 1 in question 1 of block 2 is missing` blocking Publish. Adds are now separated from fills, the fills converge against the **live preview** (the only surface reflecting committed state — the label inputs keep their own), and the ~40 structural seams pace themselves instead of all 726 actions.

Two cleanups fell out. The add-block trigger was a Radix `asChild` `div`, so specs matched it positionally via `locator("div").filter({hasText}).nth(1)` — a match that re-resolves to a different node on every editor re-render. Review surfaced that the `div` was also an **accessibility bug**: `asChild` forwards the click handler and aria state but adds no role and no `tabIndex`, so the control was unreachable by keyboard and a keyboard-only user could not add a block at all. Dropping `asChild` lets Radix render its own `<button>`, which fixes that and gives the specs a real button; the `data-testid` stays because the live preview renders a second copy of the block text. And `publishSurvey` reports the editor's auto-dismissing `react-hot-toast` validation message instead of failing as an opaque `waitForURL` timeout — which is how the stale-write symptom was identified at all.

**2. `docker-build-validation.yml` exported a BuildKit layer cache that costs far more than it restores.** Decomposing one 10.4 min run ([32452739610](https://github.com/formbricks/formbricks/actions/runs/32452739610)):

| BuildKit step | Time |
| --- | --- |
| `pnpm install` | 34s |
| build `@formbricks/database` | 33s |
| build `@formbricks/web...` | 239s |
| exporting to docker image format | 45s |
| importing to docker (`load: true`) | 28s |
| **exporting to GitHub Actions Cache** | **222s** |
| base image, apk, ~106 runner layers | ~30s |

That export was 222s here, 286s in [32449834984](https://github.com/formbricks/formbricks/actions/runs/32449834984) and 407s in [32453148066](https://github.com/formbricks/formbricks/actions/runs/32453148066). What the cache can restore is **12s** of work: three of four runs reported `CACHED` on nothing, and the one that hit (8 steps) hit only the apk/corepack prelude, measured at 12s cold. Two independent reasons it cannot do better as written, both recorded in a comment at the step:

- `COPY . .` precedes `pnpm install` in `apps/web/Dockerfile`, so any diff invalidates every layer after it — only the prelude is ever reusable.
- GHA caches are branch-scoped. A PR may read its own scope and `main`'s, but no workflow runs on pushes to `main`, and `merge_group` runs write to throwaway `gh-readonly-queue/...` scopes, so the readable scope is never populated.

Making it pay needs both halves — reorder the Dockerfile so the install layer survives a source change, *and* give the cache a producer PRs can read (a push-to-main build, or a registry cache, which isn't branch-scoped). Until then, paying 222–407s to save 12s is worse than not caching. No other workflow uses `type=gha`, so nothing else is affected.

**The two jobs on a PR's critical path, before and after:**

| Job | Before | After |
| --- | --- | --- |
| `Run E2E Tests` | <img width="430" alt="Run E2E Tests — Successful in 12m" src="https://github.com/user-attachments/assets/a618e74a-dee2-4efa-bd47-9051fac929e5" /> | <img width="430" alt="Run E2E Tests — Successful in 10m" src="https://github.com/user-attachments/assets/bd349626-aaea-4bdf-b94d-bc25188e3a38" /> |
| `Validate Docker Build` | <img width="430" alt="Validate Docker Build — Successful in 18m" src="https://github.com/user-attachments/assets/8c13a94c-8bfb-4153-bdfc-7f58a3032be1" /> | <img width="430" alt="Validate Docker Build — Successful in 8m" src="https://github.com/user-attachments/assets/0b2cbec7-b71b-40af-a87b-8b86a1c8ae5f" /> |

The two run in parallel, so a PR waits on the slower of them: 18m before, 10m after.

## Breaking changes

- [ ] This PR contains breaking changes

None — test-side changes, two `data-testid` attributes, a keyboard-reachability fix on the add-block trigger (a `div` becomes the `<button>` Radix renders by default, same classes and layout), and one workflow step's caching options. No API, SDK or config surface changes; the image plus every validation run against it are unchanged.

## Migrations & env

- none

## How this was tested

E2E was verified locally against the full stack (Postgres, Valkey, RustFS, `pnpm build` + `pnpm start` in `NODE_ENV=test`, `E2E_TESTING=1`) — the same config CI uses. Baselines come from `git stash`ing the spec changes and re-running the identical command, so both sides ran against the same build and machine. The docker change is evidenced by measurement of existing runs; its check is the job on this PR, which must stay green and get faster.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `survey.spec.ts` passes without `slowMo`, on CI | e2e | Two green runs on this branch: test step **303s** then **288s**, against 598s on the run analysed above; E2E job 10m54s / 10m30s against a 12m43s median. Local, 2 workers: 3 passed in 151s vs 286s baseline — longest test 198s → 114s, which is what bounds CI wall clock. |
| Rich-text entry commits, not just renders | e2e | Probe spec typed via `fill()`, saved the draft, reloaded: value persisted. Same probe with `pressSequentially` (no delay) failed on truncation — this is why `fill()` and not merely faster typing. |
| Matrix rows/columns and choice options survive to Publish | e2e | Covered by the two `survey.spec.ts` tests that build the 13-element survey and publish it; before the converge-loop fix these failed with `Choice 1 in question 1 of block 2 is missing` and a missing `#column-3`. |
| Other specs using the changed helpers | e2e | `storage-smoke.spec.ts` + `survey-editor-rich-text-tabs.spec.ts` → 3 passed (12.0s). The only other specs importing `fillRichTextEditor` / `createSurvey` / the add-block pattern. |
| Add-block trigger is keyboard reachable | manual | `asChild` dropped, so Radix renders a `<button>`: the control now takes focus and opens the picker from the keyboard, where the `div` took no focus at all. Layout is unchanged (same classes, same inner markup). |
| Review round re-verified end to end | e2e | After the review fixes: `survey.spec.ts` 3 passed in **144s** (37.4s / 28.3s / 108s), `storage-smoke` + `survey-editor-rich-text-tabs` 3 passed in 12.8s, against the rebuilt app. The first attempt at the per-item add loop failed here with `Expected 4, Received 3` — a single `toPass` stops at the first successful add — which is why the loop is now driven from outside the retry. |
| `data-testid` reaches the rendered editor | manual | Rebuilt and grepped the emitted chunk for `add-element-trigger`; the spec's `getByTestId` resolves against the running app. A first run against a stale build failed here, which is how the check earned its place. |
| Docker image still builds and passes every validation step, faster | e2e | This PR's `Validate Docker Build` run: **pass, job 8.7m / build step 7.1m**, against 12–17m / 10.4–15.3m across the previous six runs. Same steps throughout (npm-exclusion check, env-rejection cases, Compose migration validation, startup-migration skip, health check) — only the cache options are gone. |
| The removed docker cache was a net loss | manual | Four runs via `gh run view <id> --log`: `CACHED` counts 0/0/0/8, cache export 222s / 286s / 407s, and the cold cost of the only ever-cached steps (apk, corepack ×3, chmod, WORKDIR, runner apk) summing to 12s. `grep -rn "type=gha\|cache-from\|cache-to" .github/workflows/` matches only this workflow. |

**Open gaps**

- Both savings are measured over one or two runs, not a distribution: docker export time varied 222–407s before this change, so the 8.7m job is one sample of a range rather than a new ceiling.
- The rest of the e2e suite (the other 25 specs) was not run locally — they don't import the changed helpers, so this PR's own E2E run is the check.
- Local e2e numbers are single runs on one machine, not repeated samples. The previously flaky `Multi Language Survey Create` needs several runs before its flake rate can be called improved.
- The underlying editor bug is untouched: fast successive edits can still drop a label for a real user. The specs work around it rather than fixing it — worth its own ticket.
- The address rows in `survey.spec.ts` still use positional `getByRole("cell").nth(2)` / `getByRole("switch").nth(1)` locators (raised in review). Those lines are unchanged by this diff; fixing them means giving the address switches accessible names in `address-element-form.tsx`, which belongs with the editor-bug ticket rather than here.
- Three larger docker costs are left alone: the 239s `apps/web` build (built again in the E2E job, with no Turbo remote cache anywhere in the repo to share it), the 45s image export, and the ~106-layer runner stage built from `COPY` + `RUN chown -R` + `RUN chmod -R` triples.

**Risks**

- The converge loops assert against `#survey-preview`. If a future change stops rendering an element type's labels there, those helpers spin until their 60s cap rather than failing fast.
- Structural adds retry while the expected input count is short. The `count < total` guard cannot overshoot, but a genuinely stuck add now surfaces after the `toPass` timeout instead of immediately.
- `RENDER_SETTLE_MS = 150` in `helper.ts` still paces the ~40 structural seams — the residue of the old global pacing, and now deliberately sized against the editor's `debounce(handleUpdate, 100)`. If CI proves slower than local, that constant is the first knob.
- `ensureChoiceCount` picks its control by which one exists ("Add option" in the ranking form, else the per-row "Add choice below"). A form that renders both would take the ranking path.
- If someone later adds a push-to-main build that populates the docker cache scope, its removal becomes the wrong default; the comment at the step says so, with what has to change first.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.


