### PR TITLE
perf(ci): drop the docker build cache that costs more than it restores

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -53,6 +53,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      # NOTE: deliberately no `cache-from`/`cache-to: type=gha`. Measured over four runs, exporting
+      # the cache cost 222-407s per run while the layers it could restore add up to 12s of work: the
+      # only steps that ever reported CACHED were the apk/corepack prelude, because `COPY . .` sits
+      # ahead of `pnpm install` in apps/web/Dockerfile and invalidates everything after it on any
+      # diff. Nothing populates a cache scope this job can read either — no workflow runs on pushes
+      # to main, and merge_group runs write to throwaway `gh-readonly-queue/...` scopes. Restoring
+      # the cache is worth revisiting only together with both halves of the fix: reorder the
+      # Dockerfile so the install layer survives a source change, and give the cache a producer PRs
+      # can read (a push-to-main build, or a registry cache, which is not branch-scoped).
       - name: Build Docker Image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         env:
@@ -63,8 +72,6 @@ jobs:
           push: false
           load: true
           tags: formbricks-test:${{ env.GITHUB_SHA }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           secrets: |
             database_url=${{ secrets.DUMMY_DATABASE_URL }}
             encryption_key=${{ secrets.DUMMY_ENCRYPTION_KEY }}


### PR DESCRIPTION
No Linear ticket — spun out of a CI wall-clock investigation while working on ENG-2006's leftover; small and self-contained enough that a ticket would only restate this description.

## What & why

`Validate Docker Build` is the longest job on a PR (12–17 min over the last six runs; its `Build Docker Image` step alone is 10.4–15.3 min). A measurable chunk of that is the layer cache it exports to the GitHub Actions cache — which is a net loss today, not an optimization.

Decomposing one 10.4 min run ([32452739610](https://github.com/formbricks/formbricks/actions/runs/32452739610)):

| BuildKit step | Time |
| --- | --- |
| `pnpm install` | 34s |
| build `@formbricks/database` | 33s |
| build `@formbricks/web...` | 239s |
| exporting to docker image format | 45s |
| importing to docker (`load: true`) | 28s |
| **exporting to GitHub Actions Cache** | **222s** |
| base image, apk, ~106 runner layers | ~30s |

The export was 222s here, 286s in [32449834984](https://github.com/formbricks/formbricks/actions/runs/32449834984) and 407s in [32453148066](https://github.com/formbricks/formbricks/actions/runs/32453148066). Against that, what the cache can restore is **12s** of work: three of the four runs reported `CACHED` on nothing at all, and the one that did hit (8 steps) hit only the apk/corepack prelude — measured at 12s total when cold.

Two independent reasons it cannot do better as written, both left in a comment at the step:

- `COPY . .` sits ahead of `pnpm install` in `apps/web/Dockerfile`, so any diff in the repo invalidates every layer after it. Only the prelude is ever reusable.
- GHA caches are branch-scoped: a PR may read its own scope and `main`'s, but no workflow runs on pushes to `main`, and `merge_group` runs write to throwaway `gh-readonly-queue/...` scopes. So the scope PRs are allowed to read is never populated.

Making the cache pay needs both halves — reorder the Dockerfile so the install layer survives a source change, *and* give the cache a producer PRs can read (a push-to-main build, or a registry cache, which isn't branch-scoped). Until someone does both, paying 222–407s a run to save 12s is strictly worse than not caching. No other workflow uses `type=gha`, so nothing else is affected.

## Breaking changes

- [ ] This PR contains breaking changes

None — CI-only change to one workflow step's caching options. The image built, and every validation run against it, are unchanged.

## Migrations & env

- none

## How this was tested

The evidence is measurement of existing runs rather than a new test; the check on this PR is the job itself, which must stay green and get faster.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Docker image still builds and passes every validation step | e2e | This PR's own `Validate Docker Build` run — same steps (npm-exclusion check, env-rejection cases, Compose migration validation, startup-migration skip, health check), only the cache options removed. |
| The removed cache was a net loss | manual | Four runs inspected via `gh run view <id> --log`: `CACHED` counts 0/0/0/8, cache export 222s / 286s / 407s, and the cold cost of the only ever-cached steps (apk, corepack ×3, chmod, WORKDIR, runner apk) summing to 12s. |
| Nothing else consumes this cache | manual | `grep -rn "type=gha\|cache-from\|cache-to" .github/workflows/` matches only this workflow. |

**Open gaps**

- The expected saving is inferred from the export timings above, not yet observed on this branch — the first run on this PR is what confirms it. Worth a second look after it lands, since export time varied 222–407s.
- The three larger costs are untouched: the 239s `apps/web` build (built a second time in the E2E job, with no Turbo remote cache anywhere in the repo to share it), the 45s image export, and the ~106-layer runner stage built from `COPY` + `RUN chown -R` + `RUN chmod -R` triples. Each is its own change.

**Risks**

- If someone later adds a push-to-main build that populates the cache scope, this removal becomes the wrong default — the comment at the step says so, with what has to change first.
- Build times become slightly more variable run-to-run without any cache, though at 12s of restorable work the effect is inside the noise of the 239s build.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.
