### PR TITLE
docs: state that we do not offer bug bounties

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Let's have a chat about your survey needs and get you started.
 
 ## 🔒 Security
 
-We take security very seriously. If you come across any security vulnerabilities, please disclose them by sending an email to security@formbricks.com. We appreciate your help in making our platform as secure as possible and are committed to working with you to resolve any issues quickly and efficiently. See [`SECURITY.md`](./SECURITY.md) for more information.
+We take security very seriously. If you come across any security vulnerabilities, please disclose them by sending an email to security@formbricks.com. We appreciate your help in making our platform as secure as possible and are committed to working with you to resolve any issues quickly and efficiently. Please note that we do not offer bug bounties or any other payment for security reports, but we are happy to credit you in the release notes for the fix. See [`SECURITY.md`](./SECURITY.md) for more information.
 
 <a id="license"></a>
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Let's have a chat about your survey needs and get you started.
 
 ## 🔒 Security
 
-We take security very seriously. If you come across any security vulnerabilities, please disclose them by sending an email to security@formbricks.com. We appreciate your help in making our platform as secure as possible and are committed to working with you to resolve any issues quickly and efficiently. Please note that we do not offer bug bounties or any other payment for security reports, but we are happy to credit you in the release notes for the fix. See [`SECURITY.md`](./SECURITY.md) for more information.
+We take security very seriously. If you come across any security vulnerabilities, please disclose them by sending an email to security@formbricks.com. We appreciate your help in making our platform as secure as possible and are committed to working with you to resolve any issues quickly and efficiently. Please note that we do not offer bug bounties or any other payment for security reports, but we are happy to credit you in the release notes for the fix on request. See [`SECURITY.md`](./SECURITY.md) for more information.
 
 <a id="license"></a>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,8 @@ To understand and bolster our security stature, Formbricks undertakes:
 
 Please do not use attacks on physical security, social engineering, distributed denial of service, spam or applications of third parties.
 
+> **Formbricks does not offer bug bounties.** We do not pay for vulnerability reports of any kind. Public credit for your finding is available on request — see [D. Bug Bounties and Credit](#d-bug-bounties-and-credit).
+
 ### **A. When to Report a Vulnerability**
 
 We invite you to report if:
@@ -64,6 +66,18 @@ In the interest of responsibly managing vulnerabilities, please adhere to the fo
 3. **Ongoing Communication**:
    - A project maintainer may engage with you for additional details or clarification.
    - We appreciate your patience as we explore the reported item, verify its authenticity, and ascertain the existence of a vulnerability.
+
+### **D. Bug Bounties and Credit**
+
+Formbricks does not run a bug bounty program, and we want to be upfront about that before you invest your time:
+
+- We do not pay bounties, rewards, gift cards, or goodwill payments for security reports. There are no exceptions, and this is not decided case by case.
+- We have offered both a bounty and one-off payments in the past. The result was a sharp increase in low-quality and automated reports rather than better ones, so we stopped. It is a settled policy rather than a question of budget.
+- Please do not attach an invoice, a payment request, or a payment condition to a report. We will still read and act on the report, but the answer on payment will be no.
+
+What we do offer is **credit**. If you would like to be named, tell us in your report or at any point before the fix ships, and we will mention you in the release notes for the fix.
+
+None of this changes how seriously we treat your report. A well-written vulnerability report is real work, and we are genuinely grateful for it — we simply pay it back in credit and a fast fix rather than in money.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy of Formbricks
 
-This is Formbrick's security policy. Please report vulnerabilities
+This is the Formbricks security policy. Please report vulnerabilities
 privately via <security@formbricks.com> rather than in public.
 
 ## Introduction

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,6 +84,6 @@ None of this changes how seriously we treat your report. A well-written vulnerab
 ### Please Read the below carefully
 
 If you have followed the instructions above, we will **not** take any legal action against you in regard to the report,
-We will handle your report with strict confidentiality, and not pass on your personal details to third parties without your permission, We will keep you informed of the progress towards resolving the problem, In the public information concerning the problem reported, we will give your name as the discoverer of the problem (unless you desire otherwise).
+We will handle your report with strict confidentiality, and not pass on your personal details to third parties without your permission, We will keep you informed of the progress towards resolving the problem, In the public information concerning the problem reported, we will name you as the discoverer of the problem if you have asked to be credited, and stay silent about your identity if you have not.
 
 We, at Formbricks, wish to express our gratitude towards all individuals who assist us in fortifying our security posture. Your responsible disclosure and cooperation enable us to elevate our security protocols, safeguarding our platform and data therein.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy of Formbricks
 
-This is Formbrick's security policy. Please reach out to us
-on Github or, if privately, via <security@formbricks.com>
+This is Formbrick's security policy. Please report vulnerabilities
+privately via <security@formbricks.com> rather than in public.
 
 ## Introduction
 
@@ -53,7 +53,8 @@ In the interest of responsibly managing vulnerabilities, please adhere to the fo
 > Do not reveal the problem to others until it has been resolved.
 
 1. **Send a Detailed Report**:
-   - Raise a security report on [Github](https://github.com/formbricks/formbricks/issues/new/choose) or send an email to [security@formbricks.com](mailto:security@formbricks.com).
+   - Send an email to [security@formbricks.com](mailto:security@formbricks.com).
+   - Please do not open a GitHub issue for a vulnerability. The issue tracker is public, so filing there discloses the problem before a fix exists — which is what the line above asks you to avoid.
    - Include:
      - Problem description.
      - Detailed, reproducible steps, with screenshots where possible.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,7 +83,7 @@ None of this changes how seriously we treat your report. A well-written vulnerab
 
 ### Please Read the below carefully
 
-If you have followed the instructions above, we will **not** take any legal action against you in regard to the report,
-We will handle your report with strict confidentiality, and not pass on your personal details to third parties without your permission, We will keep you informed of the progress towards resolving the problem, In the public information concerning the problem reported, we will name you as the discoverer of the problem if you have asked to be credited, and stay silent about your identity if you have not.
+If you have followed the instructions above, we will **not** take any legal action against you in regard to the report.
+We will handle your report with strict confidentiality and will not pass on your personal details to third parties without your permission. We will keep you informed of the progress towards resolving the problem. In the public information concerning the problem reported, we will name you as the discoverer of the problem only if you have asked to be credited. Otherwise, we will not publish your identity.
 
 We, at Formbricks, wish to express our gratitude towards all individuals who assist us in fortifying our security posture. Your responsible disclosure and cooperation enable us to elevate our security protocols, safeguarding our platform and data therein.


### PR DESCRIPTION
Ref FOU-5

## What & why

Our policy on paying for security reports is settled internally (no bounties, no goodwill payments, credit on request) but nothing a reporter can read says so. `SECURITY.md` was silent on payment, so people find out only after they have written the report and asked — which is the worst moment to say no, and it has produced repeat negotiation threads. Reviewing it surfaced two further contradictions in the same document, both about what we promise a reporter; those are fixed here too.

**The bounty policy**

- `SECURITY.md`: a short blockquote at the top of *III. Vulnerability Reporting and Management*, before the "when to report" lists, so it lands before anyone starts work. It links down to the detail.
- `SECURITY.md`: new subsection **D. Bug Bounties and Credit** — no bounties/rewards/gift cards/goodwill payments, no exceptions and not case-by-case; the reason on record (both were tried and produced more low-quality reports, so it is policy rather than budget); a request not to attach an invoice or payment condition, with the report still getting read either way; then the credit that *is* on offer — a release-notes mention on request. Firm on substance, warm in delivery, and deliberately unhedged, since an ambiguous answer is what invites the negotiation.
- `README.md`: one sentence in the Security section, since that is where most people land first — including the "on request" condition, so the summary most people read cannot promise credit the policy withholds.

**Contradictions the review surfaced**

- Credit consent: the closing legal section promised to name the discoverer in public information *unless they objected*, while the new section D only names people who ask. Settled on affirmative consent — we name you only if you asked to be credited, otherwise we do not publish your identity — which is what the policy already is. Timing is stated once, in D. That paragraph's comma splices became sentence boundaries, since the attribution condition was otherwise buried in a run-on with the confidentiality and progress promises.
- Reporting channel: step 1 offered a GitHub issue as an alternative to email, three lines after "do not reveal the problem to others until it has been resolved" — and there is no private option behind that route (`blank_issues_enabled: true`, no security template, and private vulnerability reporting disabled on the repo), so following the doc literally published the vulnerability. Email is now the only channel, with a plain sentence on why a GitHub issue is the wrong place. The header offered the same public route and changes with it.

Docs only — no code, config or dependency changes.

## Breaking changes

- [ ] This PR contains breaking changes

None — the diff touches two Markdown files and no API, SDK, env var, route or default.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| In-doc link from the section III blockquote to the new subsection resolves | manual | Fetched the rendered `SECURITY.md` from the pushed branch: heading id is `user-content-d-bug-bounties-and-credit`, matching the link target `#d-bug-bounties-and-credit`. Worth checking because the heading carries bold markers (`**D. …**`) that the slug drops. |
| Every statement of the credit rule says the same thing | manual | Read all four against each other on `5b1c8d0` — the section III blockquote, section D, the closing paragraph, and the README sentence: credit is published only when the reporter asks, and the timing condition appears only in D. Two of these disagreed before `04fffd2` and `d2ad142`. |
| The document names one place to send a report, and it is private | manual | Header and step 1 both say email `security@formbricks.com` on `5b1c8d0`; the only remaining GitHub pointer is Discussions for hardening help, which is not a vulnerability channel. Verified the route being removed really was public: `blank_issues_enabled: true`, no security template in `.github/ISSUE_TEMPLATE/`, and `GET /repos/formbricks/formbricks/private-vulnerability-reporting` → `{"enabled": false}`. |
| Both files render as intended (blockquote, list, subsection nesting under III) | manual | Reviewed the rendered branch output; the new subsection sits between C and the closing legal section, and the README sentence reads in place. |

**Open gaps**

- The security@ auto-response still does not mention payment. It lives outside this repo, so it is not in this diff — hence `Ref` rather than `Fixes`, leaving the ticket open for it. That auto-response is the other half of heading these threads off before they start.
- The internal copies of the rule (the security-report-triage skill's "Standing answers", and step 7 of the Notion vulnerability process) were not read while writing this, so the public wording has not been diffed against them. Worth confirming the credit promise matches — this text commits specifically to a release-notes mention.
- `.github/ISSUE_TEMPLATE/config.yml` is untouched: someone can still file a vulnerability as a blank public issue, whatever this document says. GitHub surfaces a `SECURITY.md` link on the new-issue chooser, which is why a second contact link was not added, but the only real fix is enabling private vulnerability reporting — a repo setting, not a diff.

**Risks**

- The wording is a public commitment, so it is worth reading as a policy statement rather than as docs. One line was deliberately cut from the draft: an offer to confirm findings in writing for CVE requests or portfolios. It is plausible and cheap, but it is not part of the settled policy, so it should be a decision rather than something inherited from a draft.
- Two promises that predate this PR changed: credit went from opt-out to opt-in, and GitHub is no longer offered as a reporting channel. Both are the privacy-safer direction and both were reviewer-flagged, but they are deliberate changes to what we tell reporters, not typo fixes.
- The second bullet of D asserts a fact about our history rather than a policy. It is the rationale that keeps the rule from being relitigated, but it is also the one sentence a reporter can argue with, and it is permanent once published.
