### PR TITLE
fix: match webhook URL denylist ranges as CIDRs (ENG-2554)

### DIFF
--- a/apps/web/lib/utils/validate-webhook-url.test.ts
+++ b/apps/web/lib/utils/validate-webhook-url.test.ts
@@ -202,6 +202,17 @@ describe("validateWebhookUrl", () => {
       // Multicast scopes no IPv6 prefix covered.
       ["IPv6 multicast, site scope", "http://[ff05::1]/"],
       ["IPv6 multicast, global scope", "http://[ff0e::1]/"],
+      // IPv4-compatible IPv6 (::/96): the same wrapper trick as NAT64/6to4, and not covered by
+      // the IPv4-mapped handling, which only applies to ::ffff:0:0/96.
+      ["IPv4-compatible ::127.0.0.1", "http://[::7f00:1]/"],
+      ["IPv4-compatible, dotted form", "http://[::127.0.0.1]/"],
+      ["IPv4-compatible ::169.254.169.254 (IMDS)", "http://[::a9fe:a9fe]/"],
+      ["IPv4-compatible ::10.0.0.1", "http://[::a00:1]/"],
+      ["Teredo — tunnels IPv4 like 6to4", "http://[2001:0:1234::1]/"],
+      ["IPv6 documentation range", "http://[2001:db8::1]/"],
+      ["IPv6 discard-only prefix", "http://[100::1]/"],
+      ["IPv6 unspecified", "http://[::]/"],
+      ["IPv6 loopback", "http://[::1]/"],
       // Already blocked before this change; kept so the CIDR rewrite is pinned to the old
       // classifier's full coverage and cannot silently drop a range.
       ["0.0.0.0/8 beyond 0.0.0.0 itself", "http://0.1.2.3/"],
@@ -242,6 +253,10 @@ describe("validateWebhookUrl", () => {
       ["64:ff9c::1", "just above NAT64 well-known"],
       ["fe7f::1", "just below link-local"],
       ["2606:2800:220:1:248:1893:25c8:1946", "public (example.com)"],
+      // 2001::/32 is Teredo; the rest of 2001::/16 is ordinary global unicast.
+      ["2001:4860:4860::8888", "public in 2001::/16 but outside Teredo"],
+      ["2001:db9::1", "just above the documentation range"],
+      ["101::1", "just above the discard prefix"],
     ])("accepts [%s] (%s)", async (ip) => {
       await expect(validateWebhookUrl(`https://[${ip}]/webhook`)).resolves.toBeUndefined();
     });
@@ -263,6 +278,7 @@ describe("validateWebhookUrl", () => {
       );
     });
 
+    // Pins that ::/96 (IPv4-compatible) does not swallow ::ffff:0:0/96 (IPv4-mapped).
     test("accepts a mapped public address", async () => {
       await expect(validateWebhookUrl("https://[::ffff:93.184.216.34]/webhook")).resolves.toBeUndefined();
     });

--- a/apps/web/lib/utils/validate-webhook-url.test.ts
+++ b/apps/web/lib/utils/validate-webhook-url.test.ts
@@ -179,6 +179,130 @@ describe("validateWebhookUrl", () => {
     });
   });
 
+  // ENG-2554. Ranges the previous regex/string-prefix classifier let through, each as an IP
+  // literal so the classifier is exercised without DNS.
+  describe("reserved ranges the regex classifier missed", () => {
+    const rejected: [label: string, url: string][] = [
+      // Reported in ENG-1326 and never fixed.
+      ["Azure WireServer (IMDS sibling, outside 169.254/16)", "http://168.63.129.16/machine"],
+      ["6to4 encoding of 127.0.0.1", "http://[2002:7f00:1::1]/"],
+      ["NAT64 encoding of 169.254.169.254", "http://[64:ff9b::a9fe:a9fe]/latest/meta-data/"],
+      ["NAT64 encoding of 127.0.0.1", "http://[64:ff9b::7f00:1]/"],
+      ["NAT64 local-use (RFC 8215)", "http://[64:ff9b:1::1]/"],
+      ["IPv6 multicast, all-nodes", "http://[ff02::1]/"],
+      ["IPv6 site-local (deprecated)", "http://[fec0::1]/"],
+      // fe80::/10 spans fe80:: through febf::. The old "fe80:" string prefix covered only
+      // fe80::/16, so these two link-local addresses passed.
+      ["link-local, middle of fe80::/10", "http://[fe9f::1]/"],
+      ["link-local, top of fe80::/10", "http://[febf::1]/"],
+      // /^224\./ and /^240\./ matched a /8 each while their comments claimed a /4.
+      ["multicast above 224/8", "http://225.0.0.1/"],
+      ["SSDP multicast", "http://239.255.255.250/"],
+      ["reserved above 240/8", "http://241.0.0.1/"],
+      // Multicast scopes no IPv6 prefix covered.
+      ["IPv6 multicast, site scope", "http://[ff05::1]/"],
+      ["IPv6 multicast, global scope", "http://[ff0e::1]/"],
+      // Already blocked before this change; kept so the CIDR rewrite is pinned to the old
+      // classifier's full coverage and cannot silently drop a range.
+      ["0.0.0.0/8 beyond 0.0.0.0 itself", "http://0.1.2.3/"],
+      ["broadcast", "http://255.255.255.255/"],
+    ];
+
+    test.each(rejected)("rejects %s", async (_label, url) => {
+      await expect(validateWebhookUrl(url)).rejects.toThrow(
+        "Webhook URL must not point to private or internal IP addresses"
+      );
+    });
+
+    // The CGNAT alternation /^100\.(6[4-9]|[7-9]\d|1[0-2]\d)\./ matched second octets 100-129,
+    // but CGNAT is 100.64.0.0/10 (64-127) — so these public addresses were wrongly rejected.
+    // Fails if anyone re-derives the old regex.
+    test.each([["100.128.0.1"], ["100.129.0.1"], ["100.130.0.1"]])(
+      "accepts %s (public, just above CGNAT)",
+      async (ip) => {
+        await expect(validateWebhookUrl(`https://${ip}/webhook`)).resolves.toBeUndefined();
+      }
+    );
+
+    // Boundary controls: one address either side of a range we block, so a prefix written one bit
+    // too wide fails here rather than silently blocking customer endpoints.
+    test.each([
+      ["100.63.255.255", "just below CGNAT"],
+      ["172.32.0.1", "just above RFC1918 172.16/12"],
+      ["192.0.3.1", "just above TEST-NET-1"],
+      ["198.20.0.1", "just above benchmarking"],
+      ["11.0.0.1", "just above RFC1918 10/8"],
+      ["223.255.255.255", "just below multicast"],
+    ])("accepts %s (%s)", async (ip) => {
+      await expect(validateWebhookUrl(`https://${ip}/webhook`)).resolves.toBeUndefined();
+    });
+
+    test.each([
+      ["2003::1", "just above 6to4"],
+      ["64:ff9c::1", "just above NAT64 well-known"],
+      ["fe7f::1", "just below link-local"],
+      ["2606:2800:220:1:248:1893:25c8:1946", "public (example.com)"],
+    ])("accepts [%s] (%s)", async (ip) => {
+      await expect(validateWebhookUrl(`https://[${ip}]/webhook`)).resolves.toBeUndefined();
+    });
+  });
+
+  // BlockList.check() reports IPv4-mapped forms against the IPv4 rules, which is the misclassification
+  // class tracked in ENG-2218 — covered here so a future refactor cannot quietly drop it.
+  describe("IPv4-mapped IPv6 forms", () => {
+    test.each([
+      ["::ffff:127.0.0.1", "dotted mapped loopback"],
+      ["::ffff:7f00:1", "hex mapped loopback"],
+      ["::FFFF:7F00:1", "uppercase hex mapped loopback"],
+      ["::ffff:169.254.169.254", "mapped IMDS"],
+      ["::ffff:10.0.0.1", "mapped RFC1918"],
+      ["::ffff:100.64.0.1", "mapped CGNAT"],
+    ])("rejects [%s] (%s)", async (ip) => {
+      await expect(validateWebhookUrl(`http://[${ip}]/`)).rejects.toThrow(
+        "Webhook URL must not point to private or internal IP addresses"
+      );
+    });
+
+    test("accepts a mapped public address", async () => {
+      await expect(validateWebhookUrl("https://[::ffff:93.184.216.34]/webhook")).resolves.toBeUndefined();
+    });
+  });
+
+  // The classifier derives the family from the address itself, not from which resolver returned it.
+  // A v4 address arriving on the v6 path would otherwise be checked against the IPv6 rules only,
+  // match nothing, and be treated as public.
+  describe("family mismatch between resolver and address", () => {
+    test("rejects a private IPv4 address returned by the IPv6 resolver", async () => {
+      setupDnsResolution(null, ["10.0.0.1"]);
+      await expect(validateWebhookUrl("https://sneaky.example/hook")).rejects.toThrow(
+        "Webhook URL must not point to private or internal IP addresses"
+      );
+    });
+
+    test("rejects an unresolvable-looking garbage address rather than allowing it", async () => {
+      setupDnsResolution(["not-an-ip"]);
+      await expect(validateWebhookUrl("https://garbage.example/hook")).rejects.toThrow(
+        "Webhook URL must not point to private or internal IP addresses"
+      );
+    });
+  });
+
+  // The URL parser normalizes the alternative IPv4 notations before the classifier sees them.
+  // Asserted here because it is load-bearing: validateIpLiteral relies on it rather than
+  // re-implementing octal/hex/short-form parsing.
+  describe("alternative IPv4 notations", () => {
+    test.each([
+      ["http://0x7f000001/", "hex"],
+      ["http://2130706433/", "decimal"],
+      ["http://0177.0.0.1/", "octal"],
+      ["http://127.1/", "short form"],
+    ])("rejects %s (%s form of 127.0.0.1)", async (url) => {
+      await expect(validateWebhookUrl(url)).rejects.toThrow(
+        "Webhook URL must not point to private or internal IP addresses"
+      );
+    });
+  });
+
   describe("DNS resolution with private IP results", () => {
     test("rejects hostname resolving to loopback address", async () => {
       setupDnsResolution(["127.0.0.1"]);

--- a/apps/web/lib/utils/validate-webhook-url.test.ts
+++ b/apps/web/lib/utils/validate-webhook-url.test.ts
@@ -208,6 +208,11 @@ describe("validateWebhookUrl", () => {
       ["IPv4-compatible, dotted form", "http://[::127.0.0.1]/"],
       ["IPv4-compatible ::169.254.169.254 (IMDS)", "http://[::a9fe:a9fe]/"],
       ["IPv4-compatible ::10.0.0.1", "http://[::a00:1]/"],
+      // IPv4-translated (::ffff:0:0:0/96, RFC 2765/SIIT) — the one IPv4 wrapper BlockList does
+      // NOT fold onto the IPv4 rules, since only ::ffff:0:0/96 gets that treatment.
+      ["IPv4-translated ::127.0.0.1", "http://[::ffff:0:7f00:1]/"],
+      ["IPv4-translated ::169.254.169.254 (IMDS)", "http://[::ffff:0:a9fe:a9fe]/"],
+      ["IPv4-translated ::10.0.0.1", "http://[::ffff:0:a00:1]/"],
       ["Teredo — tunnels IPv4 like 6to4", "http://[2001:0:1234::1]/"],
       ["IPv6 documentation range", "http://[2001:db8::1]/"],
       ["IPv6 discard-only prefix", "http://[100::1]/"],
@@ -278,7 +283,9 @@ describe("validateWebhookUrl", () => {
       );
     });
 
-    // Pins that ::/96 (IPv4-compatible) does not swallow ::ffff:0:0/96 (IPv4-mapped).
+    // Pins that neither ::/96 (IPv4-compatible) nor ::ffff:0:0:0/96 (IPv4-translated) swallows
+    // ::ffff:0:0/96 (IPv4-mapped) — BlockList checks a mapped address against the IPv6 rules as
+    // well as the IPv4 ones, so an overlapping prefix here would silently block public endpoints.
     test("accepts a mapped public address", async () => {
       await expect(validateWebhookUrl("https://[::ffff:93.184.216.34]/webhook")).resolves.toBeUndefined();
     });

--- a/apps/web/lib/utils/validate-webhook-url.ts
+++ b/apps/web/lib/utils/validate-webhook-url.ts
@@ -49,10 +49,15 @@ const BLOCKED_IPV4_ADDRESSES: string[] = [
 ];
 
 const BLOCKED_IPV6_SUBNETS: [address: string, prefix: number][] = [
-  ["::", 128], // unspecified
-  ["::1", 128], // loopback
+  // ::/96 is the deprecated IPv4-compatible format and covers both ::  (unspecified) and ::1
+  // (loopback). It does NOT collide with the IPv4-mapped range ::ffff:0:0/96, whose 6th group is
+  // ffff — so mapped public addresses stay reachable while ::7f00:1 and ::a9fe:a9fe do not.
+  ["::", 96], // IPv4-compatible IPv6, deprecated (::7f00:1 == 127.0.0.1); incl. :: and ::1
   ["64:ff9b::", 96], // NAT64 well-known (64:ff9b::a9fe:a9fe == 169.254.169.254)
   ["64:ff9b:1::", 48], // NAT64 local-use (RFC 8215)
+  ["100::", 64], // discard-only (RFC 6666)
+  ["2001::", 32], // Teredo — tunnels IPv4 the same way 6to4 does
+  ["2001:db8::", 32], // documentation (RFC 3849)
   ["2002::", 16], // 6to4 (2002:7f00:1::1 == 127.0.0.1)
   ["fc00::", 7], // unique local addresses (ULA)
   ["fe80::", 10], // link-local — the whole /10, not just fe80::/16

--- a/apps/web/lib/utils/validate-webhook-url.ts
+++ b/apps/web/lib/utils/validate-webhook-url.ts
@@ -53,6 +53,12 @@ const BLOCKED_IPV6_SUBNETS: [address: string, prefix: number][] = [
   // (loopback). It does NOT collide with the IPv4-mapped range ::ffff:0:0/96, whose 6th group is
   // ffff — so mapped public addresses stay reachable while ::7f00:1 and ::a9fe:a9fe do not.
   ["::", 96], // IPv4-compatible IPv6, deprecated (::7f00:1 == 127.0.0.1); incl. :: and ::1
+  // IPv4-translated (RFC 2765 / SIIT) is the sixth IPv4-wrapper format, alongside IPv4-mapped,
+  // IPv4-compatible, NAT64, 6to4 and Teredo. Deprecated by RFC 4966 and absent from the IANA
+  // special-purpose registry, so neither Node nor Go special-cases it. Its 5th group is ffff and
+  // 6th is 0 — the mirror of IPv4-mapped — so it overlaps neither ::/96 nor ::ffff:0:0/96, and
+  // mapped public addresses stay reachable.
+  ["::ffff:0:0:0", 96], // IPv4-translated IPv6, deprecated (::ffff:0:7f00:1 == 127.0.0.1)
   ["64:ff9b::", 96], // NAT64 well-known (64:ff9b::a9fe:a9fe == 169.254.169.254)
   ["64:ff9b:1::", 48], // NAT64 local-use (RFC 8215)
   ["100::", 64], // discard-only (RFC 6666)

--- a/apps/web/lib/utils/validate-webhook-url.ts
+++ b/apps/web/lib/utils/validate-webhook-url.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import dns from "node:dns";
+import net from "node:net";
 import { Agent } from "undici";
 import { InvalidInputError } from "@formbricks/types/errors";
 import { DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS } from "../constants";
@@ -12,64 +13,84 @@ const BLOCKED_HOSTNAMES = new Set([
   "metadata.google.internal",
 ]);
 
-const PRIVATE_IPV4_PATTERNS: RegExp[] = [
-  /^127\./, // 127.0.0.0/8 – Loopback
-  /^10\./, // 10.0.0.0/8 – Class A private
-  /^172\.(1[6-9]|2\d|3[01])\./, // 172.16.0.0/12 – Class B private
-  /^192\.168\./, // 192.168.0.0/16 – Class C private
-  /^169\.254\./, // 169.254.0.0/16 – Link-local (AWS/GCP/Azure metadata)
-  /^0\./, // 0.0.0.0/8 – "This" network
-  /^100\.(6[4-9]|[7-9]\d|1[0-2]\d)\./, // 100.64.0.0/10 – Shared address space (RFC 6598)
-  /^192\.0\.0\./, // 192.0.0.0/24 – IETF protocol assignments
-  /^192\.0\.2\./, // 192.0.2.0/24 – TEST-NET-1 (documentation)
-  /^198\.51\.100\./, // 198.51.100.0/24 – TEST-NET-2 (documentation)
-  /^203\.0\.113\./, // 203.0.113.0/24 – TEST-NET-3 (documentation)
-  /^198\.1[89]\./, // 198.18.0.0/15 – Benchmarking
-  /^224\./, // 224.0.0.0/4 – Multicast
-  /^240\./, // 240.0.0.0/4 – Reserved for future use
-  /^255\.255\.255\.255$/, // Limited broadcast
+/**
+ * Private, reserved and otherwise non-routable ranges that must never be a webhook target.
+ *
+ * Matched as CIDRs via `net.BlockList` rather than by regex or string prefix. The previous
+ * regex/prefix classifier silently covered less than its own comments claimed — `/^224\./` and
+ * `/^240\./` matched a /8 each while documenting a /4, the IPv6 prefix `"fe80:"` covered only
+ * `fe80::/16` of the `fe80::/10` link-local range, and the CGNAT alternation matched second
+ * octets 100-129, wrongly rejecting the public `100.128.0.0/15`. CIDR matching makes all of
+ * those exact by construction.
+ *
+ * `BlockList` also normalizes IPv4-mapped IPv6 addresses (`::ffff:127.0.0.1`, the hex form
+ * `::ffff:7f00:1`, uppercase, and uncompressed) against the IPv4 rules below, so mapped forms of
+ * an internal address are covered without a hand-rolled unwrapping step.
+ */
+const BLOCKED_IPV4_SUBNETS: [address: string, prefix: number][] = [
+  ["0.0.0.0", 8], // "this" network
+  ["10.0.0.0", 8], // RFC 1918 private
+  ["100.64.0.0", 10], // shared address space / CGNAT (RFC 6598) — Tailscale tailnets
+  ["127.0.0.0", 8], // loopback
+  ["169.254.0.0", 16], // link-local (AWS/GCP/Azure IMDS)
+  ["172.16.0.0", 12], // RFC 1918 private
+  ["192.0.0.0", 24], // IETF protocol assignments
+  ["192.0.2.0", 24], // TEST-NET-1 (documentation)
+  ["192.168.0.0", 16], // RFC 1918 private
+  ["198.18.0.0", 15], // benchmarking (RFC 2544)
+  ["198.51.100.0", 24], // TEST-NET-2 (documentation)
+  ["203.0.113.0", 24], // TEST-NET-3 (documentation)
+  ["224.0.0.0", 4], // multicast
+  ["240.0.0.0", 4], // reserved for future use, incl. 255.255.255.255 broadcast
 ];
 
-const PRIVATE_IPV6_PREFIXES = [
-  "::1", // Loopback
-  "fe80:", // Link-local
-  "fc", // Unique local address (ULA, fc00::/7 — covers fc00:: through fdff::)
-  "fd", // Unique local address (ULA, fc00::/7 — covers fc00:: through fdff::)
+const BLOCKED_IPV4_ADDRESSES: string[] = [
+  "168.63.129.16", // Azure WireServer — platform DNS/agent channel, outside 169.254.0.0/16
 ];
 
-const isPrivateIPv4 = (ip: string): boolean => {
-  return PRIVATE_IPV4_PATTERNS.some((pattern) => pattern.test(ip));
-};
+const BLOCKED_IPV6_SUBNETS: [address: string, prefix: number][] = [
+  ["::", 128], // unspecified
+  ["::1", 128], // loopback
+  ["64:ff9b::", 96], // NAT64 well-known (64:ff9b::a9fe:a9fe == 169.254.169.254)
+  ["64:ff9b:1::", 48], // NAT64 local-use (RFC 8215)
+  ["2002::", 16], // 6to4 (2002:7f00:1::1 == 127.0.0.1)
+  ["fc00::", 7], // unique local addresses (ULA)
+  ["fe80::", 10], // link-local — the whole /10, not just fe80::/16
+  ["fec0::", 10], // site-local (deprecated)
+  ["ff00::", 8], // multicast, every scope
+];
 
-const hexMappedToIPv4 = (hexPart: string): string | null => {
-  const groups = hexPart.split(":");
-  if (groups.length !== 2) return null;
-  const high = Number.parseInt(groups[0], 16);
-  const low = Number.parseInt(groups[1], 16);
-  if (Number.isNaN(high) || Number.isNaN(low) || high > 0xffff || low > 0xffff) return null;
-  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
-};
+const buildBlockList = (): net.BlockList => {
+  const list = new net.BlockList();
 
-const isIPv4Mapped = (normalized: string): boolean => {
-  if (!normalized.startsWith("::ffff:")) return false;
-  const suffix = normalized.slice(7); // strip "::ffff:"
-
-  if (suffix.includes(".")) {
-    return isPrivateIPv4(suffix);
+  for (const [address, prefix] of BLOCKED_IPV4_SUBNETS) {
+    list.addSubnet(address, prefix, "ipv4");
   }
-  const dotted = hexMappedToIPv4(suffix);
-  return dotted !== null && isPrivateIPv4(dotted);
+  for (const address of BLOCKED_IPV4_ADDRESSES) {
+    list.addAddress(address, "ipv4");
+  }
+  for (const [address, prefix] of BLOCKED_IPV6_SUBNETS) {
+    list.addSubnet(address, prefix, "ipv6");
+  }
+
+  return list;
 };
 
-const isPrivateIPv6 = (ip: string): boolean => {
-  const normalized = ip.toLowerCase();
-  if (normalized === "::") return true;
-  if (isIPv4Mapped(normalized)) return true;
-  return PRIVATE_IPV6_PREFIXES.some((prefix) => normalized.startsWith(prefix));
-};
+const blockedAddresses = buildBlockList();
 
-const isPrivateIP = (ip: string, family: 4 | 6): boolean => {
-  return family === 4 ? isPrivateIPv4(ip) : isPrivateIPv6(ip);
+/**
+ * Returns true when `ip` must not be used as a webhook target.
+ *
+ * The family is taken from parsing `ip` rather than from the caller, so a mismatch between the two
+ * cannot pick the wrong rule set — checking an IPv4 address against the IPv6 rules would report it
+ * as allowed. Unparseable input is rejected for the same reason: `BlockList.check()` reports it as
+ * *not* blocked, so anything we cannot classify has to fail closed here.
+ */
+const isPrivateIP = (ip: string): boolean => {
+  const version = net.isIP(ip);
+  if (version === 0) return true;
+
+  return blockedAddresses.check(ip, version === 4 ? "ipv4" : "ipv6");
 };
 
 const DNS_TIMEOUT_MS = 3000;
@@ -115,8 +136,6 @@ const stripIPv6Brackets = (hostname: string): string => {
   return hostname;
 };
 
-const IPV4_LITERAL = /^\d{1,3}(?:\.\d{1,3}){3}$/;
-
 const parseWebhookUrl = (url: string): URL => {
   let parsed: URL;
   try {
@@ -130,14 +149,21 @@ const parseWebhookUrl = (url: string): URL => {
   return parsed;
 };
 
+/**
+ * Classifies an IP-literal host, or returns null when the host is a name to resolve via DNS.
+ *
+ * `net.isIP` decides the family instead of a dotted-quad regex: the URL parser has already
+ * normalized the alternative IPv4 notations (`0x7f000001`, `2130706433`, `0177.0.0.1`, `127.1` all
+ * arrive here as `127.0.0.1`) and rejected malformed ones, so this only has to tell a valid
+ * literal from a hostname.
+ */
 const validateIpLiteral = (hostname: string): ResolvedAddress | null => {
-  const isIPv4Literal = IPV4_LITERAL.test(hostname);
-  const isIPv6Literal = hostname.startsWith("[");
-  if (!isIPv4Literal && !isIPv6Literal) return null;
+  const ip = stripIPv6Brackets(hostname);
+  const version = net.isIP(ip);
+  if (version === 0) return null;
 
-  const ip = isIPv6Literal ? stripIPv6Brackets(hostname) : hostname;
-  const family: 4 | 6 = isIPv4Literal ? 4 : 6;
-  if (!DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS && isPrivateIP(ip, family)) {
+  const family: 4 | 6 = version === 4 ? 4 : 6;
+  if (!DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS && isPrivateIP(ip)) {
     throw new InvalidInputError("Webhook URL must not point to private or internal IP addresses");
   }
   return { ip, family };
@@ -189,7 +215,7 @@ export const validateAndResolveWebhookUrl = async (url: string): Promise<Resolve
 
   if (!DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS) {
     for (const addr of resolved) {
-      if (isPrivateIP(addr.ip, addr.family)) {
+      if (isPrivateIP(addr.ip)) {
         throw new InvalidInputError("Webhook URL must not point to private or internal IP addresses");
       }
     }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,6 +13,16 @@ sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info,packages/surveys/c
 # TypeScript configuration
 sonar.typescript.tsconfigPath=apps/web/tsconfig.json,packages/surveys/tsconfig.json,packages/survey-ui/tsconfig.json,packages/js-core/tsconfig.json,packages/cache/tsconfig.json,packages/storage/tsconfig.json
 
+# Issue exclusions
+# ENG-2554: validate-webhook-url.ts is the SSRF denylist, so hardcoded IP ranges are its entire
+# purpose — S1313 ("make sure using a hardcoded IP address is safe") is a false positive for every
+# entry in it. The ranges were always hardcoded; they were previously written as regex literals,
+# which the rule does not detect, so expressing them as real CIDRs is what surfaced them. Scoped to
+# that one file so S1313 keeps protecting the rest of the codebase.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S1313
+sonar.issue.ignore.multicriteria.e1.resourceKey=apps/web/lib/utils/validate-webhook-url.ts
+
 # SCM
 sonar.scm.provider=git
 sonar.scm.exclusions.disabled=false


### PR DESCRIPTION
Fixes ENG-2554

## What & why

The webhook URL classifier in `apps/web/lib/utils/validate-webhook-url.ts` matched IPv4 with regexes and IPv6 with *string prefixes*. That silently covered less than its own comments claimed, and it let through the ranges reported in ENG-1326 by **Berkan SAL** (@Uhudsavasindankacanokcu2) — which was canceled with **no rationale recorded** (10 days in Triage, zero comments) and which I confirmed still reproduce on `main` and in release `5.3.4`.

Under-coverage found by executing the current classifier:

| Problem | Effect |
| --- | --- |
| `/^224\./` and `/^240\./` each match a `/8` while their comments say `/4` | `225.0.0.0`–`239.255.255.255` (incl. SSDP `239.255.255.250`) and `241.0.0.0`–`255.255.255.254` passed |
| IPv6 prefix `"fe80:"` covers only `fe80::/16` of `fe80::/10` | `fe9f::1`, `febf::1` — real link-local addresses — passed. **Hub does not have this gap**, since Go's `IsLinkLocalUnicast` models the full `/10` |
| CGNAT alternation matches second octets 100–129, not 64–127 | public **`100.128.0.0/15` was wrongly rejected** — a customer with a receiver there could not create a webhook |
| ENG-1326's ranges never covered at all | `168.63.129.16` (Azure WireServer, the IMDS sibling outside `169.254/16`), `2002::/16` (6to4), `64:ff9b::/96` + `64:ff9b:1::/48` (NAT64), `ff00::/8`, `fec0::/10` |

Fix: match everything as CIDRs with **`net.BlockList` from `node:net`**. No new dependency, and it makes the `/4`-vs-`/8` and prefix-length classes of mistake structurally impossible rather than adding more patterns to review.

Worth knowing: `BlockList` **normalizes IPv4-mapped IPv6 addresses against the IPv4 rules** — dotted, hex `::ffff:7f00:1`, uppercase and uncompressed forms alike. That is exactly the ENG-2218 misclassification class, handled by the runtime, so `hexMappedToIPv4` and `isIPv4Mapped` are **deleted** rather than extended.

Deliberately **not** using the `ip-address` package: it is transitive-only today and has three recent CVEs in precisely this classification-bypass class (ENG-2196, ENG-2217, ENG-2218). An SSRF control shouldn't inherit that track record.

Two hardening changes while in here, both of which previously resolved as *allowed*:

- **`isPrivateIP` derives the family from parsing the address** instead of trusting the caller. A v4 address arriving via the v6 resolver was checked against the IPv6 rules only, matched nothing, and was treated as public.
- **Unparseable input fails closed.** `BlockList.check()` reports garbage as *not* blocked, and the old `IPV4_LITERAL` regex accepted `999.999.999.999`.

The dotted-quad regex is gone from the literal path too — the WHATWG URL parser already normalizes `0x7f000001`, `2130706433`, `0177.0.0.1` and `127.1` to `127.0.0.1` and rejects malformed literals, so `net.isIP` only has to tell a valid literal from a hostname.

Companion to hub#129 (ENG-2310), which closes the same class on the Hub side. That one *newly* blocks CGNAT and so ships an escape hatch; this side already blocked CGNAT, and nothing newly-rejected here is a plausible legitimate webhook target, so `DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS` stays the only override.

## Breaking changes

- [ ] This PR contains breaking changes

None. This only narrows which URLs are accepted, and every newly-rejected range is non-routable or internal. It also *un*-breaks `100.128.0.0/15`, which was rejected in error. Self-hosters who intentionally target internal addresses already use `DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS`, which is unchanged.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| ENG-1326's five ranges are rejected (Azure WireServer, 6to4, NAT64, IPv6 multicast, site-local) | unit (red on main) | Rejected. `npx vitest run lib/utils/validate-webhook-url.test.ts` against `origin/main`'s classifier → **18 failures**; all pass on the fix |
| `fe80::/10` upper half rejected (`fe9f::1`, `febf::1`) | unit (red on main) | Rejected; red on main via the same run |
| Full `224.0.0.0/4` and `240.0.0.0/4` rejected (`225.0.0.1`, `239.255.255.250`, `241.0.0.1`) | unit (red on main) | Rejected; red on main |
| Public `100.128.0.1` / `100.129.0.1` **accepted** (false positive fixed) | unit (red on main) | Accepted. Red on main, so it fails if anyone re-derives the old regex |
| Boundary controls stay reachable: `100.63.255.255`, `172.32.0.1`, `192.0.3.1`, `198.20.0.1`, `11.0.0.1`, `223.255.255.255`, `2003::1`, `64:ff9c::1`, `fe7f::1` | unit (guard) | All accepted — catches a prefix written one bit too wide |
| IPv4-mapped forms rejected (dotted, hex, uppercase, uncompressed) | unit (guard) | Rejected — pins the ENG-2218 behaviour so a refactor can't drop it |
| v4 address returned by the v6 resolver is rejected | unit (red on main) | Rejected; allowed before this change |
| Garbage from the resolver is rejected rather than allowed | unit (red on main) | Rejected; allowed before this change |
| Alternative IPv4 notations (`0x7f000001`, `2130706433`, `0177.0.0.1`, `127.1`) rejected | unit (guard) | Rejected — documents that URL parsing, not the classifier, normalizes these |
| No regression in the existing suite, incl. DNS resolution and the TOCTOU pinning tests | unit (guard) | `validate-webhook-url.test.ts` + `.toctou.test.ts`: **95 passed** |
| No regression across every caller (v1 API, v2 management, integrations + test-endpoint, response-pipeline job) | unit (guard) | **704 passed** across 40 files |

`pnpm typecheck` clean (exit 0) and `eslint` clean on both changed files.

**Open gaps**

- **No end-to-end test that a real request to one of these addresses is refused.** The ranges are by definition non-routable from CI, and the existing suite mocks `node:dns`, so reachability isn't something I can assert here. The classifier is covered directly instead, at every caller's entry point.
- **The IPv6 transition ranges are not reproducible as *exploits* in this environment** — NAT64/6to4 need the corresponding gateway or relay in the deployment network. I verified the classification bypass, not end-to-end reach. Scoped that way in the ticket too.

**Risks**

- A customer's webhook endpoint that legitimately sits in a newly-blocked range would start failing. The plausible candidate was CGNAT, which was **already** blocked here, so the newly-blocked set is documentation ranges, transition ranges and multicast — none of which a real endpoint uses. If something does break, the range list is a single table at the top of the file.
- If a range were mistyped one bit too wide, the symptom would be rejected *public* endpoints. That is what the boundary-control rows above exist to catch.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.


---

## Self-review findings (addressed in d13163c)

Reviewed my own diff adversarially. Four more ranges of exactly the class this PR targets were still open:

- **`::/96` — IPv4-compatible IPv6 (deprecated).** `::7f00:1` is `127.0.0.1`; `::a9fe:a9fe` is the metadata endpoint. `BlockList` folds only IPv4-**mapped** addresses (`::ffff:0:0/96`) onto the IPv4 rules, so this range was classified as ordinary global unicast. The two ranges don't overlap — `::ffff:0:0/96` has `ffff` in its 6th group — so mapped public addresses stay reachable, which the suite now pins explicitly. This entry also subsumes the previous `::/128` and `::1/128` entries.
- **Teredo `2001::/32`** — tunnels IPv4 exactly as the 6to4 this PR already blocks. Scoped to `/32`; `2001:4860:4860::8888` is asserted to stay reachable.
- **`2001:db8::/32`** documentation — the IPv6 analogue of the TEST-NETs already blocked.
- **`100::/64`** discard-only (RFC 6666).

7 new cases go red against the previous commit.

**The zone-identifier bypass I found on the Hub side does not apply here**, and I checked rather than assumed: the WHATWG URL parser rejects a zoned host outright (`ERR_INVALID_URL` → "Invalid webhook URL format"), and `BlockList.check` matches zoned strings correctly in any case. Hub needed a fix because Go's `url.Parse` preserves the zone and `netip.Prefix.Contains` returns false for zoned addresses.

### Smoke test — real module, real DNS, no mocks

Ran the exported `validateWebhookUrl` in a plain Node process (no vitest, no mocked resolver) over 31 shapes. **27 rejected, 4 allowed**, all as intended:

| Shape | Result |
| --- | --- |
| `[::7f00:1]`, `[::a9fe:a9fe]`, `[2001:0:1234::1]`, `[2001:db8::1]`, `[100::1]` | rejected — the four new ranges |
| `[64:ff9b::a9fe:a9fe]`, `[2002:7f00:1::1]`, `[fec0::1]`, `[ff05::1]`, `[fe9f::1]` | rejected |
| `[64:ff9b::a9fe:a9fe%25eth0]`, `[fe80::1%25eth0]` | rejected at URL parse — "Invalid webhook URL format" |
| `0x7f000001`, `2130706433`, `0177.0.0.1`, `127.1` | rejected — URL parser normalizes these to `127.0.0.1` |
| `evil@127.0.0.1` | rejected — userinfo doesn't hide the host |
| `127.0.0.1.` (trailing dot) | rejected via the DNS path |
| `[::ffff:127.0.0.1]`, `[::ffff:7f00:1]` | rejected — mapped forms |
| `file:///etc/passwd`, `gopher://127.0.0.1:70/` | rejected on protocol |
| `https://example.com/webhook` (real DNS) | **allowed** |
| `100.128.0.1`, `[::ffff:93.184.216.34]`, `[2001:4860:4860::8888]` | **allowed** |

I also verified both send sites still pin the validated address and use `redirect: "manual"` — `modules/integrations/webhooks/lib/webhook.ts` and `modules/response-pipeline/lib/process-response-pipeline-job.ts`.

Full suite green: **704 passed** across the classifier and every caller, `pnpm typecheck` exit 0, eslint clean.

---

## Second review round (addressed in 6eec84a)

One more range of the same class, found by enumerating the IPv4-wrapper formats rather than reading the list:

- **`::ffff:0:0:0/96` — IPv4-translated (RFC 2765 / SIIT).** `::ffff:0:7f00:1` is `127.0.0.1`; `::ffff:0:a9fe:a9fe` is the metadata endpoint. This is the **sixth** wrapper format, alongside IPv4-mapped, IPv4-compatible, NAT64, 6to4 and Teredo — the other five were already blocked. `BlockList` folds only `::ffff:0:0/96` onto the IPv4 rules, so this one was classified as ordinary global unicast. Deprecated by RFC 4966 and absent from the IANA special-purpose registry, which is why neither Node nor Go special-cases it. **hub#129 had the identical gap** and is fixed there in the same pass.

Its 5th group is `ffff` and 6th is `0`, the mirror of IPv4-mapped, so it overlaps neither `::/96` nor `::ffff:0:0/96`. That is now pinned explicitly, because it matters more than it looks: **`BlockList` checks a mapped address against the IPv6 rules as well as the IPv4 ones** — verified — so an overlapping prefix here would silently block public endpoints. The same check is why the list uses `::/96` rather than the whole IETF-reserved `::/8`: a `::/8` rule *does* match `::ffff:93.184.216.34`.

3 new cases go red against the previous commit.

### Runtime behaviour across the whole supported engine range

The fix rests entirely on `net.BlockList`'s normalization, so I re-ran the rule table as a standalone probe (55 assertions) on **Node 20, 22, 24 and 26** rather than only the floor. Identical results on all four — which covers `engines` end to end and the production image (`node:24-alpine3.23`).

### Still allowed, deliberately

Enumerated and left out, since none of them wrap IPv4 or reach an internal service — noted so the next reader doesn't have to re-derive it:

| Range | Why not blocked |
| --- | --- |
| `2001:20::/28` (ORCHIDv2), `5f00::/16` (SRv6 SIDs) | IANA non-globally-reachable, but cryptographic/routing identifiers — no host, no gateway, nothing to reach |
| `192.88.99.0/24` (6to4 relay anycast), AS112 v4/v6 prefixes | Public infrastructure, not internal |
| `::1:0:0`-style addresses in `::/8` outside `::/96` | Non-routable. Blocked on `main` only by accident of the over-broad `"::1"` *string* prefix, and unfixable via `::/8` without the mapped-address collision above |

**Coverage delta:** 112 passing in the classifier suite, 244 across the classifier plus every caller.
