### PR TITLE
fix(embedded-data): teach every reserved-field consumer to read the catalog [ENG-2538]

### DIFF
--- a/apps/web/app/api/v3/surveys/reference-validation.test.ts
+++ b/apps/web/app/api/v3/surveys/reference-validation.test.ts
@@ -108,7 +108,13 @@ describe("validateV3SurveyReferences", () => {
       ],
     } as unknown as typeof validSurvey;
 
-    expect(() => validateV3SurveyReferences(withReservedOperands)).not.toThrow();
+    // Asserted on the returned value, not with `.not.toThrow()`: this function returns a result and
+    // never throws (`assertValidV3SurveyReferences` is the throwing wrapper), so the old form could
+    // not fail even if every reserved operand were rejected.
+    const result = validateV3SurveyReferences(withReservedOperands);
+
+    expect(result.ok).toBe(true);
+    expect(result.invalidParams).toStrictEqual([]);
   });
 
   test("accepts a survey with consistent stable identifiers", () => {

--- a/apps/web/app/api/v3/surveys/reference-validation.test.ts
+++ b/apps/web/app/api/v3/surveys/reference-validation.test.ts
@@ -67,6 +67,50 @@ const validSurvey = ZV3CreateSurveyBody.parse({
 });
 
 describe("validateV3SurveyReferences", () => {
+  test("a RESERVED operand is not validated against the catalog, on either side", () => {
+    // Pinned rather than left to be inferred from the absence of an arm (ENG-2538's audit). A
+    // reserved operand names a `RESERVED_FIELD_CATALOG` entry — a static list in code, not anything
+    // declared on the survey — so there are no references to dangle against. Refusing an unknown one
+    // would also contradict `ZDynamicReservedField`, which validates the name as non-empty only so a
+    // survey authored against a newer catalog still round-trips through an older deployment.
+    // Spread over the already-parsed fixture rather than re-parsed: `validSurvey` is schema OUTPUT,
+    // whose translatable fields carry the internal `default` key the input schema refuses.
+    const withReservedOperands = {
+      ...validSurvey,
+      blocks: [
+        {
+          ...validSurvey.blocks[0],
+          logic: [
+            {
+              id: "cllog123456789012345678902",
+              conditions: {
+                id: "clgrp123456789012345678902",
+                connector: "and",
+                conditions: [
+                  {
+                    id: "clcon123456789012345678902",
+                    leftOperand: { type: "reserved", value: "notInAnyCatalog" },
+                    operator: "equals",
+                    rightOperand: { type: "reserved", value: "alsoNotInAnyCatalog" },
+                  },
+                ],
+              },
+              actions: [
+                {
+                  id: "clact123456789012345678902",
+                  objective: "jumpToEnding",
+                  target: "clend123456789012345678901",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as typeof validSurvey;
+
+    expect(() => validateV3SurveyReferences(withReservedOperands)).not.toThrow();
+  });
+
   test("accepts a survey with consistent stable identifiers", () => {
     expect(
       validateV3SurveyReferences({

--- a/apps/web/app/api/v3/surveys/reference-validation.ts
+++ b/apps/web/app/api/v3/surveys/reference-validation.ts
@@ -219,6 +219,14 @@ function validateDynamicOperand(
       missingId: operand.value,
     });
   }
+
+  // `reserved` has no arm on purpose, and it is checked by a test rather than left to be inferred
+  // from the absence of code (ENG-2538). A reserved operand names a `RESERVED_FIELD_CATALOG` entry,
+  // which is a static list in code rather than anything declared on the survey — so there are no
+  // references to dangle against. Validating it against the catalog would also be actively wrong:
+  // `ZDynamicReservedField` deliberately checks the name as non-empty only, so that a survey
+  // authored against a newer catalog still round-trips through an older self-hosted deployment.
+  // An operand naming an entry that does not exist resolves as unset, exactly like a stale variable.
 }
 
 function validateConditionGroup(

--- a/apps/web/lib/responses.test.ts
+++ b/apps/web/lib/responses.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { parseRecallInfo } from "@/lib/utils/recall";
 import { convertResponseValue, getElementResponseMapping, processResponseData } from "./responses";
 
 // Mock the recall and i18n utils
@@ -311,6 +312,19 @@ describe("Response Processing", () => {
         element: "Question 2",
         response: "Option 1; Option 2",
         type: TSurveyElementTypeEnum.MultipleChoiceMulti,
+      });
+    });
+
+    test("recall receives the response's variables, which the value map cannot carry", () => {
+      // A variable is stored outside `response.data` and addressed by its id, so it is absent from
+      // the merged reserved+answers map. Omitting this argument left a headline recalling a variable
+      // rendering its fallback in the notification email while the same token resolved in the body.
+      vi.mocked(parseRecallInfo).mockClear();
+
+      getElementResponseMapping(mockSurvey, { ...mockResponse, variables: { var1: "gold" } });
+
+      expect(vi.mocked(parseRecallInfo)).toHaveBeenCalledWith("Question 1", expect.anything(), {
+        var1: "gold",
       });
     });
 

--- a/apps/web/lib/responses.ts
+++ b/apps/web/lib/responses.ts
@@ -65,7 +65,13 @@ export const getElementResponseMapping = (
 
     elementResponseMapping.push({
       element: getTextContent(
-        parseRecallInfo(getLocalizedValue(element.headline, responseLanguageCode ?? "default"), recallValues)
+        parseRecallInfo(
+          getLocalizedValue(element.headline, responseLanguageCode ?? "default"),
+          recallValues,
+          // Variables live outside `response.data`, so the map above cannot carry them and a headline
+          // recalling one rendered its fallback while the same token resolved in the email body.
+          response.variables
+        )
       ),
       response: convertResponseValue(answer, element),
       type: element.type,

--- a/apps/web/lib/responses.ts
+++ b/apps/web/lib/responses.ts
@@ -2,11 +2,20 @@ import { TResponse, TResponseDataValue } from "@formbricks/types/responses";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
+import { buildServerEmbeddedValues } from "@/lib/surveyLogic/utils";
 import { parseRecallInfo } from "@/lib/utils/recall";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { getLanguageCode, getLocalizedValue } from "./i18n/utils";
 
-export type TElementResponseMappingSurvey = Pick<TSurvey, "blocks" | "languages">;
+/**
+ * `variables` / `hiddenFields` / `embeddedFields` are carried for {@link buildServerEmbeddedValues}:
+ * a reserved recall token must resolve here (ENG-2538), and knowing which names the survey declares
+ * itself is what stops the reserved read from winning where a declared field was left blank.
+ */
+export type TElementResponseMappingSurvey = Pick<
+  TSurvey,
+  "blocks" | "languages" | "variables" | "hiddenFields" | "embeddedFields"
+>;
 
 // function to convert response value of type string | number | string[] or Record<string, string> to string | string[]
 export const convertResponseValue = (
@@ -47,13 +56,16 @@ export const getElementResponseMapping = (
   const responseLanguageCode = getLanguageCode(survey.languages, response.language);
 
   const elements = getElementsFromBlocks(survey.blocks);
+  // ENG-2538: `response.data` alone left a reserved recall token rendering its fallback here, and
+  // this function feeds exports, the response-finished email and the integrations' element labels.
+  const recallValues = buildServerEmbeddedValues(response, survey);
 
   for (const element of elements) {
     const answer = response.data[element.id];
 
     elementResponseMapping.push({
       element: getTextContent(
-        parseRecallInfo(getLocalizedValue(element.headline, responseLanguageCode ?? "default"), response.data)
+        parseRecallInfo(getLocalizedValue(element.headline, responseLanguageCode ?? "default"), recallValues)
       ),
       response: convertResponseValue(answer, element),
       type: element.type,

--- a/apps/web/lib/survey/reserved-logic-operands.test.ts
+++ b/apps/web/lib/survey/reserved-logic-operands.test.ts
@@ -118,7 +118,6 @@ describe("a logic condition on a reserved field saves", () => {
 
   test("QUESTIONS path: the legacy validator carried the identical bug", () => {
     const questions = [...mockSurvey.questions] as Record<string, unknown>[];
-    const lastQuestionId = questions[questions.length - 1].id as string;
     questions[0] = {
       ...questions[0],
       logic: [
@@ -135,13 +134,27 @@ describe("a logic condition on a reserved field saves", () => {
               },
             ],
           },
-          actions: [{ id: "cd0000000000000000000004", objective: "jumpToQuestion", target: lastQuestionId }],
+          // Targets the ending, not a question: `mockSurvey` has exactly one question, so the previous
+          // `questions[questions.length - 1]` target was the rule's OWN question and the survey failed
+          // the cyclic-logic refinement — which the message-only assertion below could not see. The
+          // legacy path has no `jumpToEnding`, but it accepts an ending id as a `jumpToQuestion`
+          // target. Same reason `withBlockLogic` adds a second block.
+          actions: [
+            {
+              id: "cd0000000000000000000004",
+              objective: "jumpToQuestion",
+              target: "gt1yoaeb5a3istszxqbl08mk",
+            },
+          ],
         },
       ],
     };
 
     const result = ZSurvey.safeParse({ ...mockSurvey, followUps: [], questions });
 
+    // Asserted on `success` too, matching the BLOCKS test above: without it an unrelated refinement
+    // rejecting this fixture would leave the test green while the survey stays unsaveable.
     expect(JSON.stringify(result.error?.issues ?? [])).not.toContain("Hidden field ID timezone");
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/web/lib/survey/reserved-logic-operands.test.ts
+++ b/apps/web/lib/survey/reserved-logic-operands.test.ts
@@ -1,0 +1,147 @@
+import { mockSurvey } from "@/app/api/(internal)/pipeline/lib/__mocks__/survey-follow-up.mock";
+import { describe, expect, test } from "vitest";
+import type { TSurveyBlockLogic } from "@formbricks/types/surveys/blocks";
+import { ZSurvey } from "@formbricks/types/surveys/types";
+import { mockSurveyWithLogic } from "@/lib/survey/__mock__/survey.mock";
+
+/**
+ * ENG-2538, bug 2: a logic condition on a reserved field made the survey unsaveable.
+ *
+ * ENG-1840 added `reserved` as a fourth member of `ZDynamicLogicFieldValue`, but both left-operand
+ * validators in `packages/types/surveys/types.ts` ended their chain with a bare `else` commented
+ * `leftOperand.type === "hiddenField"`. The new member fell into it, was looked up in
+ * `survey.hiddenFields.fieldIds` and reported missing — so every one of the 16 reserved fields the
+ * picker offers produced `Conditional Logic: Hidden field ID <name> does not exist`, and the "usable
+ * in logic" half of ENG-1840 did not work at all.
+ *
+ * Red on main: `pnpm --filter=@formbricks/web test lib/survey/reserved-logic-operands.test.ts`.
+ *
+ * These live in apps/web rather than packages/types for the same reason as
+ * `legacy-field-names.test.ts` — packages/types cannot import from apps/web, and the complete
+ * `TSurvey` fixtures live here.
+ */
+describe("a logic condition on a reserved field saves", () => {
+  const secondBlock = {
+    id: "block2",
+    name: "Block 2",
+    elements: [
+      {
+        id: "q_block2",
+        type: "openText",
+        inputType: "text",
+        headline: { default: "Anything else?" },
+        required: false,
+        charLimit: { enabled: false },
+      },
+    ],
+    logic: [],
+    logicFallback: undefined,
+  };
+
+  /**
+   * `mockSurveyWithLogic` declares a `de` language its fixture headlines do not carry, and its
+   * follow-ups are validated against elements derived from `blocks`. Both fail refinements that have
+   * nothing to do with logic operands, so they are neutralised here to isolate what this file is
+   * about — the same reason `legacy-field-names.test.ts` drops `followUps`. A second block exists so
+   * the jump target is not the block carrying the rule, which is its own refinement.
+   */
+  const withBlockLogic = (logic: TSurveyBlockLogic[]) =>
+    ({
+      ...mockSurveyWithLogic,
+      languages: [],
+      endings: [],
+      followUps: [],
+      blocks: [{ ...mockSurveyWithLogic.blocks[0], logic, logicFallback: undefined }, secondBlock],
+    }) as unknown as Record<string, unknown>;
+
+  const reservedRule = (name: string) =>
+    ({
+      id: "cd0000000000000000000001",
+      conditions: {
+        id: "cd0000000000000000000002",
+        connector: "and",
+        conditions: [
+          {
+            id: "cd0000000000000000000003",
+            leftOperand: { type: "reserved", value: name },
+            operator: "isSet",
+          },
+        ],
+      },
+      actions: [{ id: "cd0000000000000000000004", objective: "jumpToBlock", target: "block2" }],
+    }) as unknown as TSurveyBlockLogic;
+
+  test("BLOCKS path: a reserved left operand is not reported as a missing hidden field", () => {
+    const result = ZSurvey.safeParse(withBlockLogic([reservedRule("timezone")]));
+
+    // Asserted on the message as well as on `success`, so an unrelated refinement failing in this
+    // fixture cannot make the test pass for the wrong reason.
+    expect(JSON.stringify(result.error?.issues ?? [])).not.toContain("Hidden field ID timezone");
+    expect(result.success).toBe(true);
+  });
+
+  test("BLOCKS path: every reserved name the picker can offer saves", () => {
+    // Names, not the catalog itself: the point is that the validator does not consult the catalog at
+    // all (`ZDynamicReservedField` checks non-empty only, so a survey authored against a newer
+    // catalog still parses on an older deployment). A name absent from today's catalog must save for
+    // exactly the same reason, which is what the last entry pins.
+    for (const name of ["url", "source", "action", "language", "timezone", "utmSource", "notInAnyCatalog"]) {
+      const result = ZSurvey.safeParse(withBlockLogic([reservedRule(name)]));
+
+      expect(result.success, `reserved operand "${name}"`).toBe(true);
+    }
+  });
+
+  test("a hidden-field operand naming nothing the survey declares is STILL reported", () => {
+    // The explicit `hiddenField` arm must keep doing its job: a fix that made the chain lenient for
+    // every unmatched type would pass the tests above while silently losing this.
+    const rule = {
+      ...reservedRule("ignored"),
+      conditions: {
+        id: "cd0000000000000000000002",
+        connector: "and",
+        conditions: [
+          {
+            id: "cd0000000000000000000003",
+            leftOperand: { type: "hiddenField", value: "no_such_field" },
+            operator: "isSet",
+          },
+        ],
+      },
+    } as unknown as TSurveyBlockLogic;
+
+    const result = ZSurvey.safeParse(withBlockLogic([rule]));
+
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues ?? [])).toContain("Hidden field ID no_such_field");
+  });
+
+  test("QUESTIONS path: the legacy validator carried the identical bug", () => {
+    const questions = [...mockSurvey.questions] as Record<string, unknown>[];
+    const lastQuestionId = questions[questions.length - 1].id as string;
+    questions[0] = {
+      ...questions[0],
+      logic: [
+        {
+          id: "cd0000000000000000000001",
+          conditions: {
+            id: "cd0000000000000000000002",
+            connector: "and",
+            conditions: [
+              {
+                id: "cd0000000000000000000003",
+                leftOperand: { type: "reserved", value: "timezone" },
+                operator: "isSet",
+              },
+            ],
+          },
+          actions: [{ id: "cd0000000000000000000004", objective: "jumpToQuestion", target: lastQuestionId }],
+        },
+      ],
+    };
+
+    const result = ZSurvey.safeParse({ ...mockSurvey, followUps: [], questions });
+
+    expect(JSON.stringify(result.error?.issues ?? [])).not.toContain("Hidden field ID timezone");
+  });
+});

--- a/apps/web/lib/surveyLogic/utils.test.ts
+++ b/apps/web/lib/surveyLogic/utils.test.ts
@@ -1678,7 +1678,7 @@ describe("reserved field operands, server engine (ENG-1840)", () => {
   } as unknown as TEmbeddedValueResponse;
 
   test("the full catalog resolves server-side, including server-only fields", () => {
-    const values = buildServerEmbeddedValues(response);
+    const values = buildServerEmbeddedValues(response, survey);
 
     expect(
       evaluateLogic(
@@ -1724,7 +1724,7 @@ describe("reserved field operands, server engine (ENG-1840)", () => {
   });
 
   test("a declared field of the same name still wins server-side", () => {
-    const values = buildServerEmbeddedValues({ ...response, data: { country: "Declared answer" } });
+    const values = buildServerEmbeddedValues({ ...response, data: { country: "Declared answer" } }, survey);
 
     expect(
       evaluateLogic(
@@ -1749,12 +1749,77 @@ describe("reserved field operands, server engine (ENG-1840)", () => {
   });
 
   test("an unknown reserved name and a missing map both read as unset", () => {
-    const values = buildServerEmbeddedValues(response);
+    const values = buildServerEmbeddedValues(response, survey);
 
     expect(evaluateLogic(survey, {}, {}, reservedGroup("notACatalogEntry", "isSet"), "en", values)).toBe(
       false
     );
     // Callers with no response in hand (quota screening) pass nothing and get unset, not a throw.
     expect(evaluateLogic(survey, {}, {}, reservedGroup("country", "isSet"), "en")).toBe(false);
+  });
+
+  test("THE GRANDFATHER RULE, ENG-2538: a DECLARED but EMPTY field still owns its name", () => {
+    // Red before ENG-2538. `mergeReservedValues`' spread only demotes the reserved value behind a key
+    // that *exists*, so a survey declaring an optional `url` resolved the page address for every
+    // response where the respondent left it blank — the normal case for a hidden field. The survey
+    // parameter is what lets `dropShadowedReservedEntries` remove the entry instead.
+    const declaringSurvey = {
+      ...survey,
+      hiddenFields: { enabled: true, fieldIds: ["url"] },
+      embeddedFields: [
+        { field: { name: "url", source: "ingested", dataType: "string" }, link: { storageKey: "url" } },
+      ],
+    } as unknown as TJsWorkspaceStateSurvey;
+
+    const values = buildServerEmbeddedValues(response, declaringSurvey);
+
+    // Not merely outranked — absent. A consumer that falls back on a missing key (recall renders the
+    // author's fallback text) must see nothing here, not the reserved value.
+    expect(values).not.toHaveProperty("url");
+    expect(evaluateLogic(survey, {}, {}, reservedGroup("url", "isSet"), "en", values)).toBe(false);
+    // Everything the survey does NOT declare keeps resolving.
+    expect(values.country).toBe("DE");
+    expect(values.source).toBe("link");
+  });
+
+  test("an ELEMENT id shadows a reserved name too, before the question is answered", () => {
+    const declaringSurvey = {
+      ...survey,
+      blocks: [{ id: "block1", name: "Block 1", elements: [{ id: "url", type: "openText" }] }],
+    } as unknown as TJsWorkspaceStateSurvey;
+
+    expect(buildServerEmbeddedValues(response, declaringSurvey)).not.toHaveProperty("url");
+  });
+
+  test("a number-typed variable compared against a NUMBER reserved right operand coerces", () => {
+    // Red before ENG-2538: the coercion arm listed only `hiddenField`, so a reserved value — always a
+    // string or number in the projected map — was compared against a number variable unconverted and
+    // the condition could never match. `durationSeconds` is 150 for this response.
+    const numberVariableSurvey = {
+      ...survey,
+      variables: [{ id: "var_duration", name: "duration", type: "number", value: 150 }],
+      embeddedFields: [
+        {
+          field: { name: "duration", source: "computed", dataType: "number" },
+          link: { storageKey: "var_duration" },
+        },
+      ],
+    } as unknown as TJsWorkspaceStateSurvey;
+
+    const values = buildServerEmbeddedValues(response, numberVariableSurvey);
+    const group: TConditionGroup = {
+      id: "group1",
+      connector: "and",
+      conditions: [
+        {
+          id: "condition1",
+          operator: "equals",
+          leftOperand: { type: "variable", value: "var_duration" },
+          rightOperand: { type: "reserved", value: "durationSeconds" },
+        },
+      ],
+    };
+
+    expect(evaluateLogic(numberVariableSurvey, {}, { var_duration: 150 }, group, "en", values)).toBe(true);
   });
 });

--- a/apps/web/lib/surveyLogic/utils.test.ts
+++ b/apps/web/lib/surveyLogic/utils.test.ts
@@ -1791,10 +1791,19 @@ describe("reserved field operands, server engine (ENG-1840)", () => {
     expect(buildServerEmbeddedValues(response, declaringSurvey)).not.toHaveProperty("url");
   });
 
-  test("a number-typed variable compared against a NUMBER reserved right operand coerces", () => {
-    // Red before ENG-2538: the coercion arm listed only `hiddenField`, so a reserved value — always a
-    // string or number in the projected map — was compared against a number variable unconverted and
-    // the condition could never match. `durationSeconds` is 150 for this response.
+  test("a NUMBER reserved entry reaches logic already typed, so no coercion is needed", () => {
+    // The invariant that makes the `reserved` coercion arm defensive rather than load-bearing: the
+    // catalog read seam runs `coerceToEmbeddedDataType`, so a number-dataType entry is a JS number
+    // here, never a numeric string. If this goes red the seam stopped coercing and that arm became
+    // load-bearing, which is the only reason it is worth pinning separately.
+    expect(typeof buildServerEmbeddedValues(response, survey).durationSeconds).toBe("number");
+  });
+
+  test("the coercion arm converts a reserved value that arrives as a string anyway", () => {
+    // `mergeReservedValues` overlays `response.data` on the projection unconditionally, so a reserved
+    // key that is also a response key carries that raw string past the seam above. The map is passed
+    // directly because no authoring flow produces that overlap today — the reserved-name guard
+    // refuses declaring one — so this pins the arm's behaviour rather than reproducing a bug.
     const numberVariableSurvey = {
       ...survey,
       variables: [{ id: "var_duration", name: "duration", type: "number", value: 150 }],
@@ -1806,7 +1815,6 @@ describe("reserved field operands, server engine (ENG-1840)", () => {
       ],
     } as unknown as TJsWorkspaceStateSurvey;
 
-    const values = buildServerEmbeddedValues(response, numberVariableSurvey);
     const group: TConditionGroup = {
       id: "group1",
       connector: "and",
@@ -1820,6 +1828,10 @@ describe("reserved field operands, server engine (ENG-1840)", () => {
       ],
     };
 
-    expect(evaluateLogic(numberVariableSurvey, {}, { var_duration: 150 }, group, "en", values)).toBe(true);
+    expect(
+      evaluateLogic(numberVariableSurvey, {}, { var_duration: 150 }, group, "en", {
+        durationSeconds: "150",
+      })
+    ).toBe(true);
   });
 });

--- a/apps/web/lib/surveyLogic/utils.ts
+++ b/apps/web/lib/surveyLogic/utils.ts
@@ -356,12 +356,12 @@ const evaluateSingleCondition = (
     if (
       condition.leftOperand.type === "variable" &&
       getComputedFieldDataType(computedFields, condition.leftOperand.value) === "number" &&
-      // `reserved` alongside `hiddenField` because both sides of the comparison are strings in their
-      // stored form: a reserved value is projected as `string | number` and every number-typed entry
-      // (`durationSeconds`, `viewportWidth`, `screenHeight`) therefore reached this comparison
-      // unconverted, so a number variable measured against one could never match (ENG-2538). The
-      // picker offers reserved right operands filtered by `dataType`, so this operand shape is
-      // reachable from the editor.
+      // `reserved` alongside `hiddenField` as defence in depth. A *projected* reserved value does not
+      // need it: the catalog read seam runs `coerceToEmbeddedDataType`, so `durationSeconds` and the
+      // other number-typed entries arrive here as JS numbers and `Number()` is a no-op. What this
+      // guards is the one shape the map can still hold as a string — `mergeReservedValues` overlays
+      // `response.data` on the projection unconditionally, so a reserved key that is also a response
+      // key carries that raw string past the seam.
       (condition.rightOperand?.type === "hiddenField" || condition.rightOperand?.type === "reserved")
     ) {
       rightValue = Number(rightValue as string);

--- a/apps/web/lib/surveyLogic/utils.ts
+++ b/apps/web/lib/surveyLogic/utils.ts
@@ -1,11 +1,15 @@
 import { createId } from "@paralleldrive/cuid2";
 import {
   RESERVED_FIELD_CATALOG,
+  type TEmbeddedFieldsSurvey,
   type TEmbeddedValueResponse,
+  dropShadowedReservedEntries,
   findComputedEmbeddedField,
   getComputedEmbeddedFields,
   getComputedFieldDataType,
   getLogicVariableValue,
+  getSurveyEmbeddedFields,
+  listShadowingNames,
   mergeReservedValues,
   projectReservedValues,
 } from "@formbricks/types/embedded-data-resolver";
@@ -237,17 +241,48 @@ export const getUpdatedActionBody = (
   }
 };
 
+/** The survey slice {@link buildServerEmbeddedValues} needs to know what the survey declares. */
+export type TServerEmbeddedValuesSurvey = TEmbeddedFieldsSurvey & {
+  blocks: TJsWorkspaceStateSurvey["blocks"];
+};
+
 /**
- * The reserved-field lookup map for a **persisted** response: the full catalog projected, then
- * shadowed by the response's own data so a declared field of the same name still wins
- * (`mergeReservedValues` is the single expression carrying that guarantee).
+ * The reserved-field lookup map for a **persisted** response: every catalog entry the survey does
+ * not declare itself, projected, then shadowed once more by the response's own data.
  *
  * Server-side every reserved field is knowable, so this reads `RESERVED_FIELD_CATALOG` whole rather
  * than the mid-survey subset — the renderer's `projectClientReservedValues` exists precisely because
  * that is *not* true in the browser.
+ *
+ * **The survey parameter is what makes the grandfather rule work at all (ENG-2538).** This used to
+ * take only a response, so it had nothing to filter by and leaned entirely on `mergeReservedValues`'s
+ * spread — which loses only to a key that *exists*. A survey declaring an optional `url` therefore
+ * resolved the reserved page URL for every response where the respondent left it blank, in quotas,
+ * in server-side logic and (once ENG-2538 wired them up) on every display surface. Passing the survey
+ * lets {@link dropShadowedReservedEntries} apply the same rule the pickers already applied.
+ *
+ * The declared names come from the **stored rows** rather than the legacy columns: every caller here
+ * holds a saved survey, whose rows and declarations agree because every write path reconciles them in
+ * the same transaction. The editor is the one context where they can diverge, and it does not call
+ * this.
  */
-export const buildServerEmbeddedValues = (response: TEmbeddedValueResponse): TResponseData =>
-  mergeReservedValues(projectReservedValues(RESERVED_FIELD_CATALOG, response), response.data);
+export const buildServerEmbeddedValues = (
+  response: TEmbeddedValueResponse,
+  survey: TServerEmbeddedValuesSurvey
+): TResponseData =>
+  mergeReservedValues(
+    projectReservedValues(
+      dropShadowedReservedEntries(
+        RESERVED_FIELD_CATALOG,
+        listShadowingNames(
+          getSurveyEmbeddedFields(survey),
+          getElementsFromBlocks(survey.blocks).map((element) => element.id)
+        )
+      ),
+      response
+    ),
+    response.data
+  );
 
 /**
  * @param embeddedValues Reserved-field values merged UNDER `data` by `mergeReservedValues` — what a
@@ -321,7 +356,13 @@ const evaluateSingleCondition = (
     if (
       condition.leftOperand.type === "variable" &&
       getComputedFieldDataType(computedFields, condition.leftOperand.value) === "number" &&
-      condition.rightOperand?.type === "hiddenField"
+      // `reserved` alongside `hiddenField` because both sides of the comparison are strings in their
+      // stored form: a reserved value is projected as `string | number` and every number-typed entry
+      // (`durationSeconds`, `viewportWidth`, `screenHeight`) therefore reached this comparison
+      // unconverted, so a number variable measured against one could never match (ENG-2538). The
+      // picker offers reserved right operands filtered by `dataType`, so this operand shape is
+      // reachable from the editor.
+      (condition.rightOperand?.type === "hiddenField" || condition.rightOperand?.type === "reserved")
     ) {
       rightValue = Number(rightValue as string);
     }

--- a/apps/web/lib/utils/recall.test.ts
+++ b/apps/web/lib/utils/recall.test.ts
@@ -576,6 +576,26 @@ describe("recall utility functions", () => {
       // string or an unrendered raw token, neither of which would prove the declared field won.
       expect(result).toBe("You are in your-country");
     });
+
+    test("A DECLARED FIELD WITH NO VALUE AT ALL still owns its name (ENG-2538)", () => {
+      // The bug this ticket exists for, at the layer it was visible from. Every test above passes a
+      // key that *exists* — the asymmetry that hid it through review, unit tests and E2E. An optional
+      // hidden field the respondent never filled has no key at all, so the spread had nothing to lose
+      // to and the reserved value survived into respondent-facing copy.
+      //
+      // The fix is upstream of this call: `buildServerEmbeddedValues` / the renderer's projection now
+      // drop an entry the survey declares, so the map handed here has no `url` key. Simulated by
+      // omitting it, which is exactly what those functions now produce.
+      const withoutDeclaredUrl = { country: "DE" };
+
+      const result = parseRecallInfo(
+        "url=#recall:url/fallback:FALLBACK-HIT#",
+        mergeReservedValues(withoutDeclaredUrl, {})
+      );
+
+      expect(result).toBe("url=FALLBACK-HIT");
+      expect(result).not.toContain("app.test");
+    });
   });
 
   describe("getFallbackValues", () => {

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/ElementSkip.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/ElementSkip.tsx
@@ -16,7 +16,13 @@ interface ElementSkipProps {
   status: string;
   elements: TSurveyElement[];
   isFirstElementAnswered?: boolean;
-  responseData: TResponseData;
+  /**
+   * Recall's lookup map, not the raw `response.data` this used to take (ENG-2538). Named for what it
+   * is because it is more than the response: the parent merges the survey's readable reserved-field
+   * values under the answers, so a headline recalling `country` or `url` resolves here instead of
+   * falling back. Used for nothing else in this component.
+   */
+  recallValues: TResponseData;
   locale: TUserLocale;
 }
 
@@ -25,7 +31,7 @@ export const ElementSkip = ({
   status,
   elements,
   isFirstElementAnswered,
-  responseData,
+  recallValues,
   locale,
 }: ElementSkipProps) => {
   const { t } = useTranslation();
@@ -86,7 +92,7 @@ export const ElementSkip = ({
                             },
                             "default"
                           ),
-                          responseData,
+                          recallValues,
                           undefined,
                           false,
                           locale,
@@ -129,7 +135,7 @@ export const ElementSkip = ({
                               },
                               "default"
                             ),
-                            responseData,
+                            recallValues,
                             undefined,
                             false,
                             locale,

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/ElementSkip.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/ElementSkip.tsx
@@ -36,7 +36,7 @@ export const ElementSkip = ({
   recallValues,
   variables,
   locale,
-}: ElementSkipProps) => {
+}: Readonly<ElementSkipProps>) => {
   const { t } = useTranslation();
   const dateFormats = getSurveyDateFormatMap(elements);
   return (

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/ElementSkip.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/ElementSkip.tsx
@@ -2,7 +2,7 @@
 
 import { CheckCircle2Icon, ChevronsDownIcon, XCircleIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { TResponseData } from "@formbricks/types/responses";
+import { TResponseData, TResponseVariables } from "@formbricks/types/responses";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { getTextContent } from "@formbricks/types/surveys/validation";
 import { TUserLocale } from "@formbricks/types/user";
@@ -23,6 +23,8 @@ interface ElementSkipProps {
    * falling back. Used for nothing else in this component.
    */
   recallValues: TResponseData;
+  /** Recall resolves variables ahead of `recallValues`, and they are not in it — see `parseRecallInfo`. */
+  variables: TResponseVariables;
   locale: TUserLocale;
 }
 
@@ -32,6 +34,7 @@ export const ElementSkip = ({
   elements,
   isFirstElementAnswered,
   recallValues,
+  variables,
   locale,
 }: ElementSkipProps) => {
   const { t } = useTranslation();
@@ -93,7 +96,7 @@ export const ElementSkip = ({
                             "default"
                           ),
                           recallValues,
-                          undefined,
+                          variables,
                           false,
                           locale,
                           dateFormats
@@ -136,7 +139,7 @@ export const ElementSkip = ({
                               "default"
                             ),
                             recallValues,
-                            undefined,
+                            variables,
                             false,
                             locale,
                             dateFormats

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
@@ -12,6 +12,7 @@ import { TSurvey } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
 import { TUserLocale } from "@formbricks/types/user";
 import { getLocalizedValue } from "@/lib/i18n/utils";
+import { buildServerEmbeddedValues } from "@/lib/surveyLogic/utils";
 import { getSurveyDateFormatMap } from "@/lib/utils/date-display";
 import { parseRecallInfo } from "@/lib/utils/recall";
 import { ResponseCardQuotas } from "@/modules/ee/quotas/components/single-response-card-quotas";
@@ -42,6 +43,10 @@ export const SingleResponseCardBody = ({
   const computedFields = getComputedEmbeddedFields(survey);
   const ingestedFields = getIngestedEmbeddedFields(survey);
   const dateFormats = getSurveyDateFormatMap(elements);
+  // ENG-2538: recall's lookup map, not `response.data` — a reserved token such as `#recall:country#`
+  // rendered its fallback on this card while resolving correctly in the live survey. Shared with
+  // `ElementSkip`, which recalls the same headlines for skipped elements.
+  const recallValues = buildServerEmbeddedValues(response, survey);
   const isFirstElementAnswered = elements[0] ? !!response.data[elements[0].id] : false;
   const { t } = useTranslation();
   const formatTextWithSlashes = (text: string) => {
@@ -73,7 +78,7 @@ export const SingleResponseCardBody = ({
           elements={elements}
           status={"welcomeCard"}
           isFirstElementAnswered={isFirstElementAnswered}
-          responseData={response.data}
+          recallValues={recallValues}
           locale={locale}
         />
       )}
@@ -110,7 +115,7 @@ export const SingleResponseCardBody = ({
                       getTextContent(
                         parseRecallInfo(
                           getLocalizedValue(question.headline, "default"),
-                          response.data,
+                          recallValues,
                           response.variables,
                           true,
                           locale,
@@ -134,7 +139,7 @@ export const SingleResponseCardBody = ({
                 <ElementSkip
                   skippedElements={skipped}
                   elements={elements}
-                  responseData={response.data}
+                  recallValues={recallValues}
                   locale={locale}
                   status={
                     response.finished ||

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
@@ -79,6 +79,7 @@ export const SingleResponseCardBody = ({
           status={"welcomeCard"}
           isFirstElementAnswered={isFirstElementAnswered}
           recallValues={recallValues}
+          variables={response.variables}
           locale={locale}
         />
       )}
@@ -140,6 +141,7 @@ export const SingleResponseCardBody = ({
                   skippedElements={skipped}
                   elements={elements}
                   recallValues={recallValues}
+                  variables={response.variables}
                   locale={locale}
                   status={
                     response.finished ||

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
@@ -36,7 +36,7 @@ export const SingleResponseCardBody = ({
   response,
   skippedQuestions,
   locale,
-}: SingleResponseCardBodyProps) => {
+}: Readonly<SingleResponseCardBodyProps>) => {
   const elements = getElementsFromBlocks(survey.blocks);
   // ENG-1837: both blocks below render the survey's Embedded Data definitions, resolved through the
   // tables with the legacy columns as fallback.

--- a/apps/web/modules/ee/quotas/lib/evaluation-service.ts
+++ b/apps/web/modules/ee/quotas/lib/evaluation-service.ts
@@ -65,13 +65,17 @@ export const evaluateResponseQuotas = async (input: QuotaEvaluationInput): Promi
       return { shouldEndSurvey: false };
     }
     const isDefaultLanguage = survey.languages.find((lang) => lang.default)?.language.code === language;
+    const jsSurvey = toJsWorkspaceStateSurvey(survey);
     const result = evaluateQuotas(
-      toJsWorkspaceStateSurvey(survey),
+      jsSurvey,
       data,
       variables,
       quotas,
       isDefaultLanguage ? "default" : language,
-      response ? buildServerEmbeddedValues(response) : {}
+      // The survey is what lets a declared field of the same name shadow the reserved read
+      // (ENG-2538); without it a quota on `url` counted the page address for every response whose
+      // declared `url` was left blank.
+      response ? buildServerEmbeddedValues(response, jsSurvey) : {}
     );
 
     const quotaFull = await handleQuotas(surveyId, responseId, result, responseFinished, prismaClient);

--- a/apps/web/modules/email/components/preview-email-template.tsx
+++ b/apps/web/modules/email/components/preview-email-template.tsx
@@ -287,6 +287,9 @@ export async function PreviewEmailTemplate({
   const questions = getElementsFromBlocks(survey.blocks);
   const firstQuestion = questions[0];
 
+  // No response exists for a preview, so every recall token — reserved ones included — renders its
+  // author-written fallback, which is the correct preview of an unfilled survey. ENG-2538 wired the
+  // reserved values into the surfaces that *have* a response; there is nothing to resolve here.
   const headline = parseRecallInfo(
     getLocalizedValue(firstQuestion.headline, defaultLanguageCode),
     undefined,

--- a/apps/web/modules/email/lib/survey-response-email.test.ts
+++ b/apps/web/modules/email/lib/survey-response-email.test.ts
@@ -135,15 +135,24 @@ describe("buildSurveyResponseEmailHtml", () => {
     // allowlist below permits `<a href>` for author-written body HTML, so without escaping a
     // respondent could smuggle a clickable link through an open-text answer into an owner-facing
     // email. The locale is passed explicitly so recalled date answers aren't formatted as en-US.
+    //
+    // The lookup map is `buildServerEmbeddedValues(response, survey)`, not `response.data`
+    // (ENG-2538): a reserved token in a notification body used to render its fallback here while
+    // resolving correctly in the live survey. Asserted as a superset — every answer still reachable,
+    // plus the reserved values — rather than a literal object, so a catalog addition (ENG-1858) does
+    // not fail this test for saying nothing about sanitization.
     expect(mockParseRecallInfo).toHaveBeenCalledWith(
       "#recall:name/fallback:there#",
-      response.data,
+      expect.objectContaining({ ...response.data, responseId: response.id, surveyId: response.surveyId }),
       response.variables,
       false,
       "en-US",
       undefined,
       true
     );
+    // The declared answers are not merely present, they still WIN: `name` is the respondent's, and
+    // nothing reserved may overwrite it.
+    expect(mockParseRecallInfo.mock.calls[0][1]).toMatchObject(response.data);
     const rendered = mockRenderFollowUpEmail.mock.calls[0][0];
     expect(rendered.body).toBe("<p>Hi Jane</p>");
     expect(rendered.body).not.toContain("<script>");

--- a/apps/web/modules/email/lib/survey-response-email.ts
+++ b/apps/web/modules/email/lib/survey-response-email.ts
@@ -14,6 +14,7 @@ import { TSurvey } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
 import { DEFAULT_LOCALE, IMPRINT_ADDRESS, IMPRINT_URL, PRIVACY_URL, TERMS_URL } from "@/lib/constants";
 import { getElementResponseMapping } from "@/lib/responses";
+import { buildServerEmbeddedValues } from "@/lib/surveyLogic/utils";
 import { parseRecallInfo } from "@/lib/utils/recall";
 import { getTranslate } from "@/lingodotdev/server";
 import { resolveStorageUrl } from "@/modules/storage/utils";
@@ -32,14 +33,17 @@ import { resolveStorageUrl } from "@/modules/storage/utils";
  * `ul`/`ol`/`li` are on the list because `sanitize-html` drops a disallowed tag but keeps its text:
  * without them the Body editor's list buttons produced items run together on one line, unnumbered.
  */
-const sanitizeBody = (body: string, response: TResponse, locale?: TUserLocale): string =>
+const sanitizeBody = (body: string, survey: TSurvey, response: TResponse, locale?: TUserLocale): string =>
   sanitizeHtml(
     // Pass the resolved locale rather than letting it default to "en-US": recall values include date
     // answers, which parseRecallInfo formats per locale, so defaulting would render US dates in an
     // otherwise correctly localized email.
     parseRecallInfo(
       body,
-      response.data,
+      // ENG-2538: the survey's readable reserved values merged under the answers, so a body
+      // recalling `country` or `durationSeconds` resolves instead of rendering its fallback. The
+      // values are escaped as they are substituted, exactly like an answer.
+      buildServerEmbeddedValues(response, survey),
       response.variables,
       false,
       locale ?? DEFAULT_LOCALE,
@@ -165,7 +169,7 @@ export const buildSurveyResponseEmailHtml = async ({
   const t = await getTranslate(locale ?? DEFAULT_LOCALE);
 
   return renderFollowUpEmail({
-    body: sanitizeBody(body, response, locale),
+    body: sanitizeBody(body, survey, response, locale),
     responseData: buildResponseData(survey, response, attachResponseData),
     variables: buildVariables(survey, response, attachResponseData, includeVariables),
     hiddenFields: buildHiddenFields(survey, response, attachResponseData, includeHiddenFields),

--- a/apps/web/modules/response-pipeline/lib/handle-integrations.ts
+++ b/apps/web/modules/response-pipeline/lib/handle-integrations.ts
@@ -355,6 +355,22 @@ const extractResponses = async (
 
   const ingestedStorageKeys = getIngestedStorageKeys(survey);
 
+  // Slack posts one message per response, so its labels are per-response text and recall is
+  // interpolated for real — including reserved fields, which used to render their fallback here
+  // (ENG-2538). Every other integration writes `elements` as the SHEET/TABLE HEADER, which has to
+  // read identically for every response, so the empty object stays: a header that interpolated this
+  // response's answers would rename the column on every write. Reserved values are per response too,
+  // so they belong on the Slack side only.
+  //
+  // Hoisted alongside `emptyResponseObject` because neither depends on the element: built inside the
+  // loop this re-projected the whole catalog and re-walked `survey.blocks` once per element, per
+  // response.
+  const responseDataForRecall =
+    integrationType === "slack"
+      ? buildServerEmbeddedValues(pipelineData.response, survey)
+      : emptyResponseObject;
+  const variablesForRecall = integrationType === "slack" ? pipelineData.response.variables : {};
+
   for (const elementId of elementIds) {
     // Check for ingested (hidden) field storage keys
     if (ingestedStorageKeys.includes(elementId)) {
@@ -379,18 +395,6 @@ const extractResponses = async (
 
     const responseValue = pipelineData.response.data[elementId];
     responses.push(processElementResponse(element, responseValue));
-
-    // Slack posts one message per response, so its labels are per-response text and recall is
-    // interpolated for real — including reserved fields, which used to render their fallback here
-    // (ENG-2538). Every other integration writes `elements` as the SHEET/TABLE HEADER, which has to
-    // read identically for every response, so the empty object stays: a header that interpolated
-    // this response's answers would rename the column on every write. Reserved values are per
-    // response too, so they belong on the Slack side only.
-    const responseDataForRecall =
-      integrationType === "slack"
-        ? buildServerEmbeddedValues(pipelineData.response, survey)
-        : emptyResponseObject;
-    const variablesForRecall = integrationType === "slack" ? pipelineData.response.variables : {};
 
     elements.push(
       parseRecallInfo(

--- a/apps/web/modules/response-pipeline/lib/handle-integrations.ts
+++ b/apps/web/modules/response-pipeline/lib/handle-integrations.ts
@@ -18,13 +18,31 @@ import { writeData as writeNotionData } from "@/lib/notion/service";
 import { processResponseData } from "@/lib/responses";
 import { writeDataToSlack } from "@/lib/slack/service";
 import { getElementsFromBlocks } from "@/lib/survey/utils";
+import { buildServerEmbeddedValues } from "@/lib/surveyLogic/utils";
 import { getFormattedDateTimeString } from "@/lib/utils/datetime";
 import { parseRecallInfo } from "@/lib/utils/recall";
 import { truncateText } from "@/lib/utils/strings";
 import { resolveStorageUrlAuto } from "@/modules/storage/utils";
 
 type TIntegrationPipelineData = {
-  response: Pick<TResponse, "createdAt" | "data" | "meta" | "variables" | "contactAttributes">;
+  // Widened from five keys to cover `TEmbeddedValueResponse` (ENG-2538): the Slack path resolves
+  // reserved recall values off the response, and the caller already hands us a whole
+  // `ZResponsePipelineJobResponse`, so this pick was under-declaring what is really there rather than
+  // guarding anything.
+  response: Pick<
+    TResponse,
+    | "id"
+    | "surveyId"
+    | "createdAt"
+    | "updatedAt"
+    | "finished"
+    | "language"
+    | "data"
+    | "meta"
+    | "variables"
+    | "ttc"
+    | "contactAttributes"
+  >;
   surveyId: string;
 };
 // `hiddenFields` / `variables` stay in the pick as the resolver's fallback; `embeddedFields` carries
@@ -362,8 +380,16 @@ const extractResponses = async (
     const responseValue = pipelineData.response.data[elementId];
     responses.push(processElementResponse(element, responseValue));
 
+    // Slack posts one message per response, so its labels are per-response text and recall is
+    // interpolated for real — including reserved fields, which used to render their fallback here
+    // (ENG-2538). Every other integration writes `elements` as the SHEET/TABLE HEADER, which has to
+    // read identically for every response, so the empty object stays: a header that interpolated
+    // this response's answers would rename the column on every write. Reserved values are per
+    // response too, so they belong on the Slack side only.
     const responseDataForRecall =
-      integrationType === "slack" ? pipelineData.response.data : emptyResponseObject;
+      integrationType === "slack"
+        ? buildServerEmbeddedValues(pipelineData.response, survey)
+        : emptyResponseObject;
     const variablesForRecall = integrationType === "slack" ? pipelineData.response.variables : {};
 
     elements.push(

--- a/apps/web/modules/survey/editor/lib/utils.tsx
+++ b/apps/web/modules/survey/editor/lib/utils.tsx
@@ -6,8 +6,10 @@ import {
   RESERVED_FIELD_CATALOG,
   type TReservedFieldCatalogEntry,
   getDeclaredComputedFields,
+  getDeclaredEmbeddedFields,
   getDeclaredIngestedStorageKeys,
   listMidSurveyReservedEntries,
+  listShadowingNames,
 } from "@formbricks/types/embedded-data-resolver";
 import { TI18nString } from "@formbricks/types/i18n";
 import { TSurveyQuota } from "@formbricks/types/quota";
@@ -172,11 +174,15 @@ const getComputedFieldOptions = (localSurvey: TSurvey): TComputedFieldOption[] =
  * because the merged value map spreads `responseData` (which is keyed by element id) over the
  * reserved projection.
  */
-const getDeclaredFieldNames = (localSurvey: TSurvey): string[] => [
-  ...getDeclaredIngestedStorageKeys(localSurvey),
-  ...getComputedFieldOptions(localSurvey).map((variable) => variable.id),
-  ...getElementsFromBlocks(localSurvey.blocks).map((element) => element.id),
-];
+const getDeclaredFieldNames = (localSurvey: TSurvey): string[] =>
+  // `listShadowingNames` so the picker and the two value maps (the renderer's and
+  // `buildServerEmbeddedValues`) agree on what "declared" means from one definition — ENG-2538 fixed
+  // the value maps by giving them this same list. `getDeclaredEmbeddedFields` rather than the stored
+  // rows because this is the editor: its working copy is stale from the first card edit until save.
+  listShadowingNames(
+    getDeclaredEmbeddedFields(localSurvey),
+    getElementsFromBlocks(localSurvey.blocks).map((element) => element.id)
+  );
 
 /** The reserved entries this survey may offer mid-survey, already availability- and shadow-filtered. */
 const getPickerReservedEntries = (localSurvey: TSurvey): TReservedFieldCatalogEntry[] =>

--- a/apps/web/playwright/survey-reserved-fields.spec.ts
+++ b/apps/web/playwright/survey-reserved-fields.spec.ts
@@ -1,4 +1,5 @@
 import { type Locator, type Page, expect } from "@playwright/test";
+import { prisma } from "@formbricks/database";
 import { test } from "./lib/fixtures";
 import { createSurveyFromScratch, fillRichTextEditor } from "./utils/helper";
 
@@ -20,6 +21,9 @@ import { createSurveyFromScratch, fillRichTextEditor } from "./utils/helper";
  */
 
 const QUESTION_HEADLINE = "What would you like to know?";
+
+/** Deliberately un-URL-like, so "the fallback rendered" and "a URL leaked" can never be confused. */
+const FALLBACK_MARKER = "FALLBACK-HIT";
 
 const editorPanel = (page: Page): Locator => page.getByRole("main");
 
@@ -62,6 +66,48 @@ const openRecallPicker = async (page: Page, labelText: string): Promise<void> =>
   await editable.press("End");
   await editable.pressSequentially("@");
   await expect(recallDropdown(page)).toBeVisible({ timeout: 15000 });
+};
+
+/**
+ * Picks a reserved field out of the recall dropdown and gives it a fallback.
+ *
+ * The fallback is not optional housekeeping: the editor refuses to publish a survey whose recall
+ * token has an empty fallback ("Fallback missing"), and the fallback is the *expected output* of the
+ * declared-field test below, so it has to be something unmistakable.
+ */
+const recallReservedFieldWithFallback = async (
+  page: Page,
+  reservedLabel: string,
+  fallback: string
+): Promise<void> => {
+  await openRecallPicker(page, "Question*");
+  await recallDropdown(page).getByText(reservedLabel, { exact: true }).click();
+  await expect(recallDropdown(page)).toBeHidden();
+
+  const fallbackInput = page.getByPlaceholder("Enter fallback value");
+  await expect(fallbackInput).toBeVisible();
+  await fallbackInput.fill(fallback);
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(fallbackInput).toBeHidden();
+};
+
+/** Switches the draft to a link survey, publishes it, and returns the public URL. */
+const publishAsLinkSurvey = async (page: Page): Promise<string> => {
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator("#howToSendCardTrigger").click();
+  await expect(page.locator("#howToSendCardOption-link")).toBeVisible();
+  await page.locator("#howToSendCardOption-link").click();
+
+  await page.getByRole("button", { name: "Save as draft", exact: true }).click();
+  await expect(page.getByText("Changes saved.")).toBeVisible();
+
+  await Promise.all([
+    page.waitForURL(/\/workspaces\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/, { timeout: 120000 }),
+    page.getByRole("button", { name: "Publish", exact: true }).click(),
+  ]);
+
+  await page.getByLabel("Copy survey link to clipboard").click();
+  return (await page.evaluate("navigator.clipboard.readText()")) as string;
 };
 
 test.describe("Reserved fields in recall and logic", () => {
@@ -122,37 +168,12 @@ test.describe("Reserved fields in recall and logic", () => {
       // which selects nothing on Linux/Chromium where CI runs. What matters here is that the recall
       // token that follows resolves, not what precedes it.
       await fillRichTextEditor(page, "Question*", "You came from ");
-      await openRecallPicker(page, "Question*");
-      await recallDropdown(page).getByText("Url", { exact: true }).click();
-      await expect(recallDropdown(page)).toBeHidden();
-
-      // Picking a recall item opens the fallback popover, and its Save button stays disabled until
-      // a fallback is entered. Skipping it leaves the survey with an empty fallback, which the
-      // editor refuses to publish ("Fallback missing") — so the survey would never go live.
-      const fallbackInput = page.getByPlaceholder("Enter fallback value");
-      await expect(fallbackInput).toBeVisible();
-      await fallbackInput.fill("somewhere");
-      await page.getByRole("button", { name: "Save", exact: true }).click();
-      await expect(fallbackInput).toBeHidden();
+      // Picking a recall item opens the fallback popover, and its Save button stays disabled until a
+      // fallback is entered. Skipping it leaves the survey unpublishable ("Fallback missing").
+      await recallReservedFieldWithFallback(page, "Url", "somewhere");
     });
 
-    const surveyUrl = await test.step("publish as a link survey", async () => {
-      await page.getByRole("button", { name: "Settings", exact: true }).click();
-      await page.locator("#howToSendCardTrigger").click();
-      await expect(page.locator("#howToSendCardOption-link")).toBeVisible();
-      await page.locator("#howToSendCardOption-link").click();
-
-      await page.getByRole("button", { name: "Save as draft", exact: true }).click();
-      await expect(page.getByText("Changes saved.")).toBeVisible();
-
-      await Promise.all([
-        page.waitForURL(/\/workspaces\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/, { timeout: 120000 }),
-        page.getByRole("button", { name: "Publish", exact: true }).click(),
-      ]);
-
-      await page.getByLabel("Copy survey link to clipboard").click();
-      return (await page.evaluate("navigator.clipboard.readText()")) as string;
-    });
+    const surveyUrl = await test.step("publish as a link survey", () => publishAsLinkSurvey(page));
 
     expect(surveyUrl).toBeTruthy();
 
@@ -169,5 +190,99 @@ test.describe("Reserved fields in recall and logic", () => {
       await expect(headline).toContainText(surveyUrl.split("?")[0]);
       await expect(headline).not.toContainText("#recall:");
     });
+  });
+
+  test("a survey DECLARING `url` renders the author's fallback when the field is empty", async ({
+    page,
+    users,
+  }) => {
+    // ENG-2538, bug 1 — the one this whole spec exists to keep fixed, and the only place it is
+    // provable. `mergeReservedValues` is a spread, and a spread only wins for keys that EXIST: an
+    // optional hidden field the respondent never filled overwrote nothing, so the reserved page URL
+    // survived into the headline. On a seeded fixture this rendered
+    // `url=http://localhost:3000/workspaces/<ws>/surveys/<id>/edit` where the author had written a
+    // fallback.
+    //
+    // Not a preview artefact: a respondent opening `/s/<id>` without the param takes the same path.
+    // Supplying the param is what makes it look correct, which is why the happy-path test above
+    // misses it — and why this test opens the link BOTH ways.
+    const user = await users.create();
+    await user.login();
+    await page.waitForURL(/\/workspaces\/[^/]+\/surveys/);
+
+    await createSurveyFromScratch(page);
+
+    await test.step("recall the url with an unmistakable fallback", async () => {
+      await openQuestionCard(page);
+      await fillRichTextEditor(page, "Question*", "url=");
+      await recallReservedFieldWithFallback(page, "Url", FALLBACK_MARKER);
+    });
+
+    const surveyUrl = await test.step("publish as a link survey", () => publishAsLinkSurvey(page));
+    expect(surveyUrl).toBeTruthy();
+
+    const surveyId = await test.step("declare a hidden field named `url`", async () => {
+      const id = /\/surveys\/([^/]+)\//.exec(page.url())?.[1];
+      expect(id, "the summary URL should carry the survey id").toBeTruthy();
+
+      const survey = await prisma.survey.findUniqueOrThrow({
+        where: { id },
+        select: { workspaceId: true },
+      });
+
+      // Written directly rather than through the editor because ENG-1839's guard refuses to CREATE a
+      // declared field named `url` — which is the point: the 195 surveys in production that already
+      // declare it are grandfathered, and they are exactly who this bug hurt. The rows are what the
+      // renderer reads (`getSurveyEmbeddedFields`), inlined onto the survey at load.
+      const field = await prisma.embeddedData.create({
+        data: {
+          name: "url",
+          source: "ingested",
+          dataType: "string",
+          workspaceId: survey.workspaceId,
+          surveyId: id,
+        },
+      });
+      await prisma.surveyEmbeddedData.create({
+        data: {
+          storageKey: "url",
+          order: 0,
+          surveyId: id!,
+          workspaceId: survey.workspaceId,
+          embeddedDataId: field.id,
+        },
+      });
+      // The legacy column too, so the survey is in the state a real grandfathered survey is in and
+      // nothing downstream can read it as undeclared.
+      await prisma.survey.update({
+        where: { id },
+        data: { hiddenFields: { enabled: true, fieldIds: ["url"] } },
+      });
+
+      return id!;
+    });
+
+    await test.step("WITHOUT the param, the headline shows the fallback and never a URL", async () => {
+      await page.goto(surveyUrl);
+
+      const headline = editorPanel(page).locator("p").filter({ hasText: "url=" }).first();
+      await expect(headline).toBeVisible({ timeout: 30000 });
+      await expect(headline).toContainText(`url=${FALLBACK_MARKER}`);
+      // The regression itself, asserted on the shape of the leaked value rather than on one URL:
+      // the reserved read is the page's own address, so any scheme reaching this headline is the bug.
+      await expect(headline).not.toContainText("http");
+      await expect(headline).not.toContainText("#recall:");
+    });
+
+    await test.step("WITH the param, the respondent's value wins — the grandfather rule", async () => {
+      await page.goto(`${surveyUrl}?url=SUPPLIED-BY-RESPONDENT`);
+
+      const headline = editorPanel(page).locator("p").filter({ hasText: "url=" }).first();
+      await expect(headline).toBeVisible({ timeout: 30000 });
+      await expect(headline).toContainText("url=SUPPLIED-BY-RESPONDENT");
+      await expect(headline).not.toContainText(FALLBACK_MARKER);
+    });
+
+    expect(surveyId).toBeTruthy();
   });
 });

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -3,7 +3,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks"
 import {
   RESERVED_FIELD_CATALOG,
   coerceToEmbeddedDataType,
+  dropShadowedReservedEntries,
   getComputedEmbeddedFields,
+  getSurveyEmbeddedFields,
+  listShadowingNames,
   mergeReservedValues,
   projectClientReservedValues,
 } from "@formbricks/types/embedded-data-resolver";
@@ -985,6 +988,33 @@ export function Survey({
   );
 
   /**
+   * The catalog entries this survey may resolve at all — everything the survey does not declare
+   * itself (ENG-2538).
+   *
+   * Without this filter the projection below carried a reserved value for every name in the catalog,
+   * and {@link mergeReservedValues}'s spread was the only thing keeping a declared field ahead of
+   * it. A spread only wins for keys that exist, so a survey declaring an optional `url` rendered the
+   * page's own address — an internal `/edit` URL in the editor's preview, the respondent's own link
+   * in production — wherever the respondent had not supplied the field. That is the normal case for
+   * a hidden field, and it reached respondent-facing copy.
+   *
+   * Element ids count as declarations here, which is why `questions` is in the list: a question with
+   * id `url` is absent from `responseData` until it is answered, so the reserved read would win for
+   * exactly as long as the respondent had not reached it.
+   */
+  const readableReservedEntries = useMemo(
+    () =>
+      dropShadowedReservedEntries(
+        RESERVED_FIELD_CATALOG,
+        listShadowingNames(
+          getSurveyEmbeddedFields(localSurvey),
+          questions.map((question) => question.id)
+        )
+      ),
+    [localSurvey, questions]
+  );
+
+  /**
    * Reserved-field values this renderer can resolve *right now* (ENG-1840).
    *
    * `projectClientReservedValues` drops every `server` catalog entry, so the map holds only what a
@@ -999,7 +1029,7 @@ export function Survey({
    */
   const reservedValues = useMemo(
     () =>
-      projectClientReservedValues(RESERVED_FIELD_CATALOG, {
+      projectClientReservedValues(readableReservedEntries, {
         surveyId: localSurvey.id,
         language:
           selectedLanguage === "default" ? (getDefaultLanguageCode(survey) ?? null) : selectedLanguage,
@@ -1008,10 +1038,23 @@ export function Survey({
         ttc,
         meta: { ...getWebSurveyMeta(), action },
       }),
-    [localSurvey.id, selectedLanguage, survey, responseData, currentVariables, ttc, getWebSurveyMeta, action]
+    [
+      readableReservedEntries,
+      localSurvey.id,
+      selectedLanguage,
+      survey,
+      responseData,
+      currentVariables,
+      ttc,
+      getWebSurveyMeta,
+      action,
+    ]
   );
 
-  /** Recall's lookup map: reserved values first, so a declared field of the same name still wins. */
+  /**
+   * Recall's lookup map. The reserved side is already shadow-filtered, so a declared field owns its
+   * name whether or not it has a value; the merge order is what still protects a stored `""` or `0`.
+   */
   const recallValues = useMemo(
     () => mergeReservedValues(reservedValues, responseData),
     [reservedValues, responseData]

--- a/packages/surveys/src/lib/logic.test.ts
+++ b/packages/surveys/src/lib/logic.test.ts
@@ -1894,6 +1894,43 @@ describe("reserved field operands (ENG-1840)", () => {
   const evaluate = (conditions: TConditionGroup, embeddedValues: TResponseData): boolean =>
     evaluateLogic(buildSurvey(), {}, {}, conditions, "default", embeddedValues);
 
+  test("a number-typed variable compared against a NUMBER reserved right operand coerces", () => {
+    // Red before ENG-2538: the pre-switch coercion arm listed `hiddenField` only, so a reserved value
+    // — always `string | number` in the projected map — reached the comparison unconverted and a
+    // number variable could never match one. The picker filters reserved right operands by
+    // `dataType`, so this operand shape is reachable from the editor. Both engines carried the same
+    // arm; `apps/web/lib/surveyLogic/utils.test.ts` pins the server twin.
+    const numberVariableSurvey = {
+      ...buildSurvey(),
+      variables: [{ id: "var_duration", name: "duration", type: "number", value: 150 }],
+      embeddedFields: [
+        {
+          field: { name: "duration", source: "computed", dataType: "number" },
+          link: { storageKey: "var_duration" },
+        },
+      ],
+    } as unknown as TJsWorkspaceStateSurvey;
+
+    const conditions: TConditionGroup = {
+      id: "group1",
+      connector: "and",
+      conditions: [
+        {
+          id: "condition1",
+          operator: "equals",
+          leftOperand: { type: "variable", value: "var_duration" },
+          rightOperand: { type: "reserved", value: "durationSeconds" },
+        },
+      ],
+    };
+
+    expect(
+      evaluateLogic(numberVariableSurvey, {}, { var_duration: 150 }, conditions, "default", {
+        durationSeconds: "150",
+      })
+    ).toBe(true);
+  });
+
   test("a reserved left operand evaluates against the projected value", () => {
     const values = { country: "DE" };
 

--- a/packages/surveys/src/lib/logic.test.ts
+++ b/packages/surveys/src/lib/logic.test.ts
@@ -1895,11 +1895,10 @@ describe("reserved field operands (ENG-1840)", () => {
     evaluateLogic(buildSurvey(), {}, {}, conditions, "default", embeddedValues);
 
   test("a number-typed variable compared against a NUMBER reserved right operand coerces", () => {
-    // Red before ENG-2538: the pre-switch coercion arm listed `hiddenField` only, so a reserved value
-    // — always `string | number` in the projected map — reached the comparison unconverted and a
-    // number variable could never match one. The picker filters reserved right operands by
-    // `dataType`, so this operand shape is reachable from the editor. Both engines carried the same
-    // arm; `apps/web/lib/surveyLogic/utils.test.ts` pins the server twin.
+    // Pins the `reserved` coercion arm, which is defence in depth rather than a bug that was seen:
+    // the catalog read seam types `durationSeconds` as a number, so the string below is the overlay
+    // shape `mergeReservedValues` can still produce, passed directly. Both engines carry the same
+    // arm; `apps/web/lib/surveyLogic/utils.test.ts` pins the server twin and that read-seam invariant.
     const numberVariableSurvey = {
       ...buildSurvey(),
       variables: [{ id: "var_duration", name: "duration", type: "number", value: 150 }],

--- a/packages/surveys/src/lib/logic.ts
+++ b/packages/surveys/src/lib/logic.ts
@@ -251,7 +251,13 @@ const evaluateSingleCondition = (
     if (
       condition.leftOperand.type === "variable" &&
       getComputedFieldDataType(computedFields, condition.leftOperand.value) === "number" &&
-      condition.rightOperand?.type === "hiddenField"
+      // `reserved` alongside `hiddenField` because both sides of the comparison are strings in their
+      // stored form: a reserved value is projected as `string | number` and every number-typed entry
+      // (`durationSeconds`, `viewportWidth`, `screenHeight`) therefore reached this comparison
+      // unconverted, so a number variable measured against one could never match (ENG-2538). The
+      // picker offers reserved right operands filtered by `dataType`, so this operand shape is
+      // reachable from the editor.
+      (condition.rightOperand?.type === "hiddenField" || condition.rightOperand?.type === "reserved")
     ) {
       rightValue = Number(rightValue as string);
     }

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -10,6 +10,7 @@ import {
   type TReservedFieldCatalogEntry,
   coerceToEmbeddedDataType,
   deriveLegacyEmbeddedData,
+  dropShadowedReservedEntries,
   findComputedEmbeddedField,
   getComputedEmbeddedFields,
   getComputedFieldDataType,
@@ -22,6 +23,7 @@ import {
   getSurveyEmbeddedFields,
   listMidSurveyReservedEntries,
   listReadableFields,
+  listShadowingNames,
   mergeReservedValues,
   projectClientReservedValues,
   projectReservedValues,
@@ -1612,6 +1614,77 @@ describe("mergeReservedValues", () => {
 
     expect(reserved).toStrictEqual({ country: "DE" });
     expect(responseData).toStrictEqual({ q1: "answer" });
+  });
+});
+
+describe("dropShadowedReservedEntries", () => {
+  const names = (declared: string[]): string[] =>
+    dropShadowedReservedEntries(RESERVED_FIELD_CATALOG, declared).map((entry) => entry.name);
+
+  test("THE GRANDFATHER RULE, first half: a declared name removes the entry outright", () => {
+    // The point of ENG-2538. `mergeReservedValues` only demotes a reserved value behind a key that
+    // *exists*, so the entry has to be gone from the projection for a declared-but-empty field to
+    // win. Asserting absence here, and the consequence — no key in the projected map — below.
+    expect(names(["url"])).not.toContain("url");
+    expect(names(["url"])).toContain("source");
+  });
+
+  test("unlike the picker, it keeps server-derived entries", () => {
+    // The only difference between this and `listMidSurveyReservedEntries`, and the reason they are
+    // two functions: the server value map needs `country` and `durationSeconds`, the picker must not
+    // offer them.
+    expect(names([])).toContain("country");
+    expect(names([])).toContain("durationSeconds");
+    expect(names([])).toStrictEqual(RESERVED_FIELD_CATALOG.map((entry) => entry.name));
+  });
+
+  test("shadowing is per name, not a blanket opt-out", () => {
+    const offered = names(["url", "country"]);
+
+    expect(offered).not.toContain("url");
+    expect(offered).not.toContain("country");
+    expect(offered).toContain("timezone");
+    expect(offered).toHaveLength(RESERVED_FIELD_CATALOG.length - 2);
+  });
+
+  test("matching is case-sensitive, because the read namespace is", () => {
+    // `response.data["Country"]` and a reserved `country` are different keys, so a survey holding a
+    // legacy `Country` field still resolves the reserved `country` — dropping the entry would lose a
+    // value that resolves today. New declarations are refused under any casing by
+    // RESERVED_FIELD_NAMES, so this only ever concerns names that predate that guard.
+    expect(names(["Country"])).toContain("country");
+  });
+
+  test("a name no catalog entry uses changes nothing", () => {
+    expect(names(["plan", "some_element_id"])).toStrictEqual(names([]));
+  });
+});
+
+describe("listShadowingNames", () => {
+  const link = (storageKey: string): TLinkedEmbeddedField =>
+    ({ field: { name: storageKey }, link: { storageKey } }) as unknown as TLinkedEmbeddedField;
+
+  test("counts declared field storage keys and element ids alike", () => {
+    expect(listShadowingNames([link("plan"), link("cm_var_1")], ["q1", "url"])).toStrictEqual([
+      "plan",
+      "cm_var_1",
+      "q1",
+      "url",
+    ]);
+  });
+
+  test("element ids are in the list, which is the easy half to forget", () => {
+    // A question with id `url` is absent from `response.data` until it is answered, so without this
+    // the reserved read would win for exactly as long as the respondent had not reached it.
+    expect(
+      dropShadowedReservedEntries(RESERVED_FIELD_CATALOG, listShadowingNames([], ["url"])).map(
+        (entry) => entry.name
+      )
+    ).not.toContain("url");
+  });
+
+  test("empty inputs yield an empty list rather than undefined", () => {
+    expect(listShadowingNames([], [])).toStrictEqual([]);
   });
 });
 

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -809,18 +809,27 @@ export const projectClientReservedValues = (
   );
 
 /**
- * **The grandfather rule, as one expression.** Reserved values go in FIRST so `responseData` spreads
- * over them and wins on every colliding key.
+ * **The grandfather rule, second half.** Reserved values go in FIRST so `responseData` spreads over
+ * them and wins on every colliding key.
  *
  * `FORBIDDEN_IDS` never guarded the reserved names, so surveys stored today legitimately declare a
  * hidden field called `country` or `url`. Its value lives at `response.data["country"]`, and
  * `#recall:country#` in such a survey must keep resolving from there — unchanged, forever.
  * `RESERVED_FIELD_NAMES` (reserved-field-names.ts) stops only *new* declarations, so the collision
- * set is frozen but non-empty, and this ordering is what keeps those surveys working.
+ * set is frozen but non-empty.
  *
- * Flipping the two spreads is the whole regression: reserved metadata would start overwriting
- * answers respondents actually gave. It lives here, called from every consumer, rather than being
- * open-coded per surface, so there is exactly one line to audit and one line to test.
+ * **This is no longer the whole rule, and on its own it was never enough (ENG-2538).** A spread only
+ * wins for keys that *exist*: an absent declared field overwrites nothing, so the reserved value
+ * survived and a survey declaring an optional `url` rendered the page's own address wherever the
+ * respondent left it blank — respondent-facing, and the normal case for a hidden field. The rule is
+ * "declared **owns the name**", not "declared wins if it has a value", so the reserved entry must be
+ * dropped from the projection before it ever reaches this merge: see
+ * {@link dropShadowedReservedEntries}, which every caller applies first.
+ *
+ * What this expression still carries is the case a filter cannot see from the survey definition
+ * alone — a key present in `responseData` that the declared-name list did not predict — and the
+ * falsy-value guarantee: `""` and `0` are answers, so a `??`-style merge would get them wrong.
+ * Flipping the two spreads remains a regression, which is why it stays one line with one test.
  */
 export const mergeReservedValues = (
   reservedValues: Record<string, string | number>,
@@ -828,29 +837,84 @@ export const mergeReservedValues = (
 ): TResponseData => ({ ...reservedValues, ...responseData });
 
 /**
- * Which reserved entries a **mid-survey** picker may offer for one survey (ENG-1840). Both filters
- * exist for a reason a reviewer should be able to check separately:
+ * **The grandfather rule, first half: a declared name owns itself.** Drops every catalog entry whose
+ * name the survey already declares, so the reserved read of that name never happens for that survey
+ * — not in a picker, and not in a value map.
+ *
+ * This used to live inside {@link listMidSurveyReservedEntries}, which meant only the *pickers*
+ * applied it. The value maps relied on {@link mergeReservedValues}'s spread instead, and a spread
+ * only loses to a key that exists — so a declared field with no value let the reserved value through
+ * to recall, logic, quotas and every display surface (ENG-2538). Pulling the filter out is what lets
+ * both kinds of consumer share one definition of "shadowed".
+ *
+ * `declaredStorageKeys` must count **all three** declaration kinds — ingested fields, variables and
+ * element ids — because all three land in the same read namespace and any of them resolves ahead of
+ * a reserved entry. Element ids matter more than they look: a question whose id is `url` is only in
+ * `response.data` once it has been answered, so without it here `#recall:url#` would render the page
+ * address until the respondent reaches that question and the author's fallback afterwards.
+ *
+ * Matching is exact, not case-insensitive. `RESERVED_FIELD_NAMES` refuses new declarations under any
+ * casing, and for the legacy names that predate it the read namespace is itself case-sensitive:
+ * `response.data["Country"]` and a reserved `country` are two different keys, so dropping the entry
+ * for a survey declaring `Country` would lose a value that resolves today.
+ */
+export const dropShadowedReservedEntries = (
+  entries: readonly TReservedFieldCatalogEntry[],
+  declaredStorageKeys: readonly string[]
+): TReservedFieldCatalogEntry[] => {
+  const declared = new Set(declaredStorageKeys);
+  return entries.filter((entry) => !declared.has(entry.name));
+};
+
+/**
+ * The `declaredStorageKeys` argument {@link dropShadowedReservedEntries} and
+ * {@link listMidSurveyReservedEntries} expect: every name a survey's own definitions already own in
+ * the read namespace.
+ *
+ * Takes resolved fields rather than a survey because the two kinds of caller legitimately read
+ * different definitions of "declared", and hiding that choice inside here would make one of them
+ * silently wrong: the **editor** must derive from the working copy
+ * ({@link getDeclaredEmbeddedFields}), whose rows are stale from the first card edit until the next
+ * save, while every **runtime** reader holds a saved survey and must use the rows
+ * ({@link getSurveyEmbeddedFields}). Passing the fields in keeps that decision at the call site,
+ * where it is visible.
+ *
+ * What is *not* the caller's choice is which kinds count. All three do, and the doc for
+ * {@link dropShadowedReservedEntries} says why element ids are the easy one to forget.
+ */
+export const listShadowingNames = (
+  embeddedFields: readonly TLinkedEmbeddedField[],
+  elementIds: readonly string[]
+): string[] => [...embeddedFields.map(({ link }) => link.storageKey), ...elementIds];
+
+/**
+ * Which reserved entries a **mid-survey** picker may offer for one survey (ENG-1840). Two filters,
+ * and a reviewer should be able to check them separately:
  *
  * 1. `availability !== "server"` — recall and logic evaluate in the browser while the respondent is
  *    answering, so offering `country` or `durationSeconds` would let an author build a condition
  *    that can never be true. Filtering on the catalog's own field (rather than a list here) means
  *    entries added later light up automatically, and none can be offered without declaring when it
  *    is knowable.
- * 2. Not shadowed by a declared field — the picker counterpart of {@link mergeReservedValues}. If a
- *    survey declares its own `country`, that name already resolves to the declared value, so listing
- *    the reserved entry too would show two identically-named rows with no way to tell them apart and
- *    the reserved one would be a lie. The declared field is already offered by its own group.
+ * 2. {@link dropShadowedReservedEntries} — if a survey declares its own `country`, that name already
+ *    resolves to the declared value, so listing the reserved entry too would show two
+ *    identically-named rows with no way to tell them apart and the reserved one would be a lie. The
+ *    declared field is already offered by its own group.
  *
- * Pass the survey's declared storage keys (hidden/ingested fields and variables) as
+ * Only the availability gate is the picker's own; the shadow gate is shared with the value maps,
+ * which is the whole point of it being a separate function.
+ *
+ * Pass the survey's declared storage keys (ingested fields, variables and element ids) as
  * `declaredStorageKeys`.
  */
 export const listMidSurveyReservedEntries = (
   entries: readonly TReservedFieldCatalogEntry[],
   declaredStorageKeys: readonly string[]
-): TReservedFieldCatalogEntry[] => {
-  const declared = new Set(declaredStorageKeys);
-  return entries.filter((entry) => entry.availability !== "server" && !declared.has(entry.name));
-};
+): TReservedFieldCatalogEntry[] =>
+  dropShadowedReservedEntries(
+    entries.filter((entry) => entry.availability !== "server"),
+    declaredStorageKeys
+  );
 
 /** One referenceable field, carrying the key a consumer must use to address it. */
 export interface TReadableField {

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -2119,6 +2119,23 @@ const isInvalidOperatorsForQuestionType = (
   return isInvalidOperator;
 };
 
+/**
+ * Compile-time exhaustiveness guard for a left-operand chain. The parameter is `never`, so passing a
+ * still-possible operand type is a type error, and adding a member to `ZDynamicLogicFieldValue` fails
+ * the build at every chain that has not learned about it.
+ *
+ * This exists because ENG-1840 added `reserved` to that union and two validators here kept treating
+ * it as a hidden field for a whole milestone — a bare `else` commented `leftOperand.type ===
+ * "hiddenField"` accepted the new member silently, and every survey with a logic condition on a
+ * reserved field became unsaveable (ENG-2538). A type error is what that should have been.
+ *
+ * Does nothing at runtime, deliberately: a stored survey that somehow carries an unknown operand
+ * should still validate rather than throw inside a Zod refinement.
+ */
+const assertNoUnhandledLeftOperand = (_leftOperand: never): void => {
+  // Exhaustiveness is enforced entirely by the parameter type.
+};
+
 const isInvalidOperatorsForVariableType = (
   variableType: "text" | "number",
   operator: TSurveyLogicConditionsOperator
@@ -2689,7 +2706,11 @@ const validateConditions = (
           }
         }
       }
-    } else {
+    } else if (leftOperand.type === "reserved") {
+      // Same as the block-path arm below — see the comment there. The legacy validator carried the
+      // identical bare `else`, so a reserved operand on a questions-shaped survey was reported as a
+      // missing hidden field too.
+    } else if (leftOperand.type === "hiddenField") {
       const hiddenFieldId = leftOperand.value;
       const hiddenField = survey.hiddenFields.fieldIds?.find((fieldId) => fieldId === hiddenFieldId);
 
@@ -3573,8 +3594,22 @@ const validateBlockConditions = (
           });
         }
       }
-    } else {
-      // leftOperand.type === "hiddenField"
+    } else if (leftOperand.type === "reserved") {
+      // A reserved operand names a `RESERVED_FIELD_CATALOG` entry, not anything stored on the survey,
+      // so there is nothing to look up and nothing to report — and that is deliberate, not an
+      // omission (ENG-2538). `ZDynamicReservedField` validates the name as non-empty only, precisely
+      // so a survey saved against a newer catalog still parses on an older self-hosted deployment;
+      // checking it against the catalog here would reintroduce exactly the failure that schema
+      // avoids, for the whole survey rather than one condition. An operand naming an entry that does
+      // not exist resolves as unset, the same outcome a stale variable or hidden-field operand
+      // already has.
+      //
+      // The arm exists because the chain below used to end in a bare `else` commented
+      // `leftOperand.type === "hiddenField"`, which was true until ENG-1840 added this fourth type.
+      // A reserved operand fell into it, was looked up in `survey.hiddenFields.fieldIds` and reported
+      // missing — so picking any of the 16 reserved fields the picker offers made the survey
+      // unsaveable, and the "usable in logic" half of ENG-1840 did not work at all.
+    } else if (leftOperand.type === "hiddenField") {
       const fieldId = leftOperand.value;
       const field = survey.hiddenFields.fieldIds?.find((id) => id === fieldId);
 
@@ -3585,6 +3620,11 @@ const validateBlockConditions = (
           path: ["blocks", blockIndex, "logic", logicIndex, "conditions"],
         });
       }
+    } else {
+      // Spelled out rather than left as the `hiddenField` fallthrough so a fifth operand type is a
+      // compile error here instead of being silently validated as a hidden field, which is how the
+      // fourth one got through review.
+      assertNoUnhandledLeftOperand(leftOperand);
     }
   };
 

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -2706,6 +2706,10 @@ const validateConditions = (
           }
         }
       }
+    } else if (leftOperand.type === "element") {
+      // Nothing to check: `element` is the blocks-era operand and this validator resolves against
+      // `survey.questions`. It was already dropping out of this chain unvalidated — spelled out so the
+      // guard at the end can be exhaustive without changing what the validator accepts.
     } else if (leftOperand.type === "reserved") {
       // Same as the block-path arm below — see the comment there. The legacy validator carried the
       // identical bare `else`, so a reserved operand on a questions-shaped survey was reported as a
@@ -2793,6 +2797,11 @@ const validateConditions = (
           });
         }
       }
+    } else {
+      // The block-path chain's guard, on the second of the two chains that carried the ENG-2538 bug.
+      // Without it `assertNoUnhandledLeftOperand`'s own promise — a build failure at *every* chain
+      // that has not learned about a new member — held for only one of them.
+      assertNoUnhandledLeftOperand(leftOperand);
     }
   };
 
@@ -3609,6 +3618,12 @@ const validateBlockConditions = (
       // A reserved operand fell into it, was looked up in `survey.hiddenFields.fieldIds` and reported
       // missing — so picking any of the 16 reserved fields the picker offers made the survey
       // unsaveable, and the "usable in logic" half of ENG-1840 did not work at all.
+      //
+      // No operator validation here, deliberately: the `hiddenField` arm's allowlist is string-only,
+      // so reusing it would reject `isGreaterThan` on `durationSeconds` — a comparison the picker
+      // legitimately offers. Operators for reserved operands stay unchecked until they can be judged
+      // against the entry's own dataType, which must also tolerate an entry an older self-hosted
+      // catalog does not know. An unknown operator evaluates to `false`, so nothing misbehaves.
     } else if (leftOperand.type === "hiddenField") {
       const fieldId = leftOperand.value;
       const field = survey.hiddenFields.fieldIds?.find((id) => id === fieldId);


### PR DESCRIPTION
Fixes ENG-2538

## What & why

[ENG-1840](https://linear.app/formbricks/issue/ENG-1840) added `reserved` as a fourth member of several closed sets — the recall value map, the logic operand union, the reserved value projection — and only *some* consumers learned about it. Three bugs fell out of that during the M1+M2 verification pass. They share one fix shape: **use the filter or the catalog that already exists, instead of a local list or an assumption about what a set contains.**

None of the three needs a product decision; all three are unambiguously wrong. The API-side question that *does* need one is deliberately separate ([ENG-2539](https://linear.app/formbricks/issue/ENG-2539), stacked on this branch).

### Bug 1 — reserved leaked into respondent-facing copy when the declared field was empty

**Worst of the three: silent, respondent-facing, and live on 195 production surveys the day v1 ships.**

A survey declaring `url` rendered the *reserved* value — the page's own address — whenever the respondent did not supply the field. `mergeReservedValues` is `{ ...reservedValues, ...responseData }`, and a spread only wins for keys that **exist**; an absent key overwrites nothing, so the reserved value survived. The grandfather rule was implemented as *"declared wins if it has a value"* rather than *"declared **owns the name**"* — and for an optional hidden field, which is the normal case, reserved leaked in.

`listMidSurveyReservedEntries` already dropped entries a survey declares, and its own doc called itself "the picker counterpart of `mergeReservedValues`". The two were not equivalent: the picker drops a shadowed entry outright, the merge only loses to a *present* value.

- **`dropShadowedReservedEntries`** is that filter, split out of the picker helper so both kinds of consumer share one definition of "shadowed". `listMidSurveyReservedEntries` is now `dropShadowedReservedEntries(entries.filter(availability !== "server"), keys)` — the availability gate is the picker's own, the shadow gate is shared.
- **`listShadowingNames`** builds the key list. It takes resolved fields rather than a survey on purpose: the editor must derive from its working copy (stale rows from the first card edit until save), every runtime reader must use the stored rows. Passing the fields in keeps that choice at the call site. What is *not* the caller's choice is which kinds count — ingested fields, variables **and element ids**, all three.
- **`buildServerEmbeddedValues(response, survey)`** — the server one could not be fixed in place: it took only a response, so it had nothing to filter by, and quotas plus server-side logic inherited the leak.
- The renderer's `reservedValues` memo (`packages/surveys/.../survey.tsx`) passed `RESERVED_FIELD_CATALOG` **unfiltered** into `projectClientReservedValues`; it now passes the filtered entries.

Element ids are the easy half to forget and they matter: a question with id `url` is absent from `response.data` until it is answered, so without them the reserved read would win for exactly as long as the respondent had not reached that question.

`mergeReservedValues` stays, re-documented as the second half rather than the whole rule. It still carries what a filter cannot see from the survey definition alone, and the falsy-value guarantee — `""` and `0` are answers, so a `??`-style merge would get them wrong.

### Bug 2 — a logic condition on any reserved field made the survey unsaveable

`packages/types/surveys/types.ts` ended its block-logic left-operand chain with a bare `} else {` carrying the comment `// leftOperand.type === "hiddenField"`. That comment was true until ENG-1840 added a fourth operand type. `reserved` fell into it, was looked up in `survey.hiddenFields.fieldIds`, and was reported missing:

```
Conditional Logic: Hidden field ID timezone does not exist in logic no: 3 of block 1
```

The legacy questions-path validator had the identical shape. The picker offers 16 reserved fields and picking any of them made the survey unsaveable, so the "usable in **logic**" half of ENG-1840 did not work at all.

- A `reserved` arm on each chain, and the bare `else` is now an explicit `hiddenField` check.
- The reserved arm deliberately does **not** validate the name against the catalog. `ZDynamicReservedField` only checks non-empty so a survey saved against a newer catalog still parses on an older self-hosted deployment; the validator has to match that, and a test pins a name absent from today's catalog saving for the same reason.
- `assertNoUnhandledLeftOperand(operand: never)` makes a **fifth** operand type a compile error at every chain, instead of the silent acceptance that let the fourth one through review.

### Bug 3 — reserved recall resolved only in the live survey

`parseRecallInfo` has two lookup branches — `variables`, then `responseData` — then falls back. No reserved branch, by design: every caller is expected to pass a map that already carries the reserved values. ENG-1840 wired that into the renderer, the server logic evaluator and quotas, and left every display caller passing raw `response.data`. So a reserved recall token rendered its fallback on the response card, in exports, in integrations and in notification emails.

| Site | Change |
| --- | --- |
| `lib/responses.ts` (`getElementResponseMapping`) | feeds exports **and** the response-finished email; `TElementResponseMappingSurvey` widened to carry the declared-field carriers |
| `SingleResponseCardBody.tsx` | already held `survey` + `response` |
| `ElementSkip.tsx` (×2) | `responseData` renamed to `recallValues` — it was used for nothing else — and the parent passes the merged map |
| `email/lib/survey-response-email.ts` | `sanitizeBody` gains `survey` |
| `response-pipeline/lib/handle-integrations.ts` | **Slack branch only**, see below |

<details>
<summary><b>Two deliberate deviations from the ticket's list of call sites</b></summary>

**`handle-integrations.ts` — Slack only, not all four integrations.** The code picks `responseDataForRecall = integrationType === "slack" ? response.data : emptyResponseObject`. The empty object is not an oversight: for Sheets / Airtable / Notion the recalled headline **is the column header**, which must read identically for every response. Interpolating this response's values there would rename the column on every write. Reserved values are per-response too, so they belong on the Slack side only.

**`preview-email-template.tsx` — unchanged.** It passes `undefined` because a preview has **no response at all**. There is nothing to resolve and the author's fallback is the correct render of an unfilled survey. Marked with a comment so the next reader does not "finish the job".

</details>

### Also fixed: the one-sided exhaustiveness the ticket asks to close

Both logic engines coerced a right operand to a number only for `hiddenField`. A reserved value is `string | number` in the projected map, so every number-typed entry (`durationSeconds`, `viewportWidth`, `screenHeight`) reached the comparison unconverted and a number-typed variable measured against one could never match. ENG-1840 already filters reserved right operands by `dataType` in the picker, so the operand shape is reachable from the editor.

### The audit — "then find the fourth"

The three above were found by using the feature, not by reading the diff, so the ticket asks for a sweep of the same shape. Findings:

- **`app/api/v3/surveys/reference-validation.ts`** — `validateDynamicOperand` handles `element`, `variable` and `hiddenField` as three independent `if`s and has no `reserved` arm, so a reserved operand posted through v3 passes unvalidated. That is **correct** (it matches `ZDynamicReservedField`'s deliberate non-catalog check) but accidental. Now commented, and pinned by a test so nobody tidies it into a refusal.
- **No other bare `else` after an operand-type chain exists in the repo.** `packages/surveys/src/lib/logic.ts` and `apps/web/lib/surveyLogic/utils.ts` use `switch` with `default`, and ENG-1840 added the `reserved` case to each.
- **`METADATA_FIELDS` and the response card's own list** are real and tracked as ENG-2540 — a different surface, and a display gap rather than a correctness bug.
- **`buildServerEmbeddedValues` consumers** — quotas was the only one; it is now six.

## Breaking changes

- [ ] This PR contains breaking changes

None. No schema, API, SDK or wire-payload shape changes. `buildServerEmbeddedValues` gained a required parameter and `ElementSkip`'s prop was renamed, but both are internal to `apps/web` and every call site is updated in this diff. The one *behaviour* change is the bug fix itself: a survey declaring a reserved name no longer resolves the reserved value for that name, which is the documented grandfather rule finally being applied at read time.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| A logic condition on a reserved field saves — block path and legacy questions path | unit (red on main) | `apps/web/lib/survey/reserved-logic-operands.test.ts`, new file, 4 tests. Stashing the fix and running it gives **3 failed / 1 passed** with exactly `Conditional Logic: Hidden field ID timezone does not exist in logic no: 1 of block 1` and its `of question 1` twin — the ticket's message verbatim. Command below. |
| A hidden-field operand naming nothing the survey declares is **still** reported | unit (guard) | Same file. A fix that made the chain lenient for every unmatched type would pass the tests above while silently losing this. |
| A reserved name absent from today's catalog still saves | unit (guard) | Same file — pins that the validator does not consult the catalog, matching `ZDynamicReservedField`. |
| A declared-but-**empty** field owns its name in the server value map | unit (mutation) | `apps/web/lib/surveyLogic/utils.test.ts`. Asserts `values` has **no** `url` property — not merely outranked — and that undeclared entries still resolve. Mutate: drop the `dropShadowedReservedEntries` call in `apps/web/lib/surveyLogic/utils.ts:267` and it goes red. |
| An **element id** shadows a reserved name before the question is answered | unit (mutation) | Same file. Mutate: remove `elementIds` from the `listShadowingNames` call at the same site. |
| The shadow filter itself: keeps server entries (unlike the picker), per-name, case-sensitive | unit (mutation) | `packages/types/embedded-data-resolver.test.ts` → `describe("dropShadowedReservedEntries")` + `describe("listShadowingNames")`, 8 new tests. |
| A reserved token renders the author's fallback when the declared field has **no key at all** | unit (guard) | `apps/web/lib/utils/recall.test.ts`. The asymmetry that hid bug 1: every pre-existing test in that block passes a key that *exists*. |
| A number variable vs a reserved right operand coerces — both engines | unit (mutation) | `apps/web/lib/surveyLogic/utils.test.ts` and `packages/surveys/src/lib/logic.test.ts`. Mutate: drop `\|\| ...type === "reserved"` from either coercion arm. |
| A reserved recall token resolves in a notification email body | unit (mutation) | `apps/web/modules/email/lib/survey-response-email.test.ts` — the existing sanitize test now asserts the merged map (superset of `response.data`, plus `responseId`/`surveyId`) and that the respondent's answers still win. |
| A v3 reserved operand is not validated against the catalog, either side | unit (guard) | `apps/web/app/api/v3/surveys/reference-validation.test.ts` — the audit finding, pinned rather than inferred from absent code. |
| **Bug 1 end-to-end**: a survey declaring `url` with nothing supplied renders the fallback in the running survey | e2e | `apps/web/playwright/survey-reserved-fields.spec.ts`, new test. Publishes a link survey with `url=#recall:url/fallback:FALLBACK-HIT#`, writes the `EmbeddedData` + `SurveyEmbeddedData` rows directly (ENG-1839's guard refuses to *create* the name — which is the point: the production surveys that already declare it are the ones this hurt), then opens the link **without** the param (fallback, and asserts no `http` reaches the headline) and **with** it (respondent's value wins). |
| Nothing else regressed | unit (guard) | `pnpm test` — **25/25 tasks, 7737 tests, 595 files, all green.** `pnpm typecheck` 25/25. `pnpm lint` 20/20, 0 errors. |

<details>
<summary>Commands</summary>

```bash
# red on main
git stash && cp <the new test> apps/web/lib/survey/ && \
  pnpm --filter=@formbricks/web test lib/survey/reserved-logic-operands.test.ts
# → 3 failed | 1 passed, with "Conditional Logic: Hidden field ID timezone does not exist"

pnpm test && pnpm typecheck && pnpm lint
pnpm test:e2e -- survey-reserved-fields
```

</details>

**Open gaps**

- **`pnpm format` on this branch rewrites ~40 unrelated files** and there is no `format:check` script here to have caught it (that landed on `main` after the epic branched). I reverted every file the formatter touched that this change does not own, so the diff is 22 files. Worth knowing before the next person runs it.
- Reserved **date** entries (`startedAt`, `finishedAt`) project as ISO strings and `parseRecallInfo` has no `dateFormats` entry for them, so a recall of one renders raw ISO on the display surfaces this PR wires up. Pre-existing shape of the projection, not introduced here; out of scope.
- The `deviceType` / `device` spelling divergence between the catalog and the response table is untouched — ENG-2540 owns it.

**Risks**

- **The shadow filter is now load-bearing in three places.** If `listShadowingNames` ever misses a declaration kind, that name silently resolves to reserved metadata again. The three call sites are identical by construction, which is why the helper exists rather than three inline arrays.
- `buildServerEmbeddedValues` needs the survey's **rows** (`embeddedFields`), so a caller whose select omits `selectSurveyEmbeddedDataLinks` would see the survey as declaring nothing and get the old behaviour. Every caller in this diff goes through `selectSurvey` or `toJsWorkspaceStateSurvey`.
- `TIntegrationPipelineData.response` widened from five keys to the `TEmbeddedValueResponse` set. The caller already hands over a whole `ZResponsePipelineJobResponse`, so the old pick was under-declaring rather than guarding — but it is worth a glance.
- Open PR #8935 (ENG-1845) also touches `packages/surveys/.../survey.tsx`, in the import block and the `responseData` state, not the `reservedValues` memo. Expect an import-block conflict for whichever merges second.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyQuJ5nzCEvWosjZW8M2CM)_