### PR TITLE
fix(sso): write the canonical Account.issuer so Google sign-in stops looping

### DIFF
--- a/apps/web/integration/credential-backfill.integration.test.ts
+++ b/apps/web/integration/credential-backfill.integration.test.ts
@@ -1,9 +1,9 @@
-import { createLocalAccountIssuer } from "@better-auth/core/db";
 import { beforeEach, describe, expect, test } from "vitest";
 import { prisma } from "@formbricks/database";
 import { resetDb } from "@/integration/reset-db";
 import { hashSecret } from "@/lib/crypto";
 import { auth } from "@/modules/auth/lib/auth";
+import { canonicalAccountIssuer } from "@/modules/ee/sso/lib/constants";
 // The cutover data migration under test (auto-discovered by the migration runner at the flip).
 import { backfillCredentialAccounts } from "../../../packages/database/migration/20260619120000_eng_1054_credential_account_backfill/migration";
 
@@ -12,14 +12,28 @@ import { backfillCredentialAccounts } from "../../../packages/database/migration
  * (data and schema migrations run in strict timestamp order), always runs BEFORE the schema migration
  * that adds that column — so it genuinely cannot set it, and its rows are inserted with issuer=NULL.
  * In real deployments that's fine: ENG-2343's schema migration runs immediately after this one and
- * backfills every NULL-issuer credential row. A test calling this function standalone has to simulate
- * that follow-up step itself before asserting a real Better Auth sign-in succeeds.
+ * backfills every NULL-issuer row. A test calling this function standalone has to simulate that
+ * follow-up step itself before asserting a real Better Auth sign-in succeeds — using the same canonical
+ * mapping production uses, so the fixture cannot drift from it (ENG-2555).
  */
-const applyEng2343IssuerBackfill = (): Promise<{ count: number }> =>
-  prisma.account.updateMany({
-    where: { provider: "credential", issuer: null },
-    data: { issuer: createLocalAccountIssuer("credential") },
+const applyEng2343IssuerBackfill = async (): Promise<void> => {
+  const rows = await prisma.account.findMany({
+    where: { issuer: null },
+    select: { id: true, provider: true },
   });
+
+  // Per row, because the real backfill is a CASE over `provider` — a single `updateMany` could only
+  // reproduce one arm of it. An earlier version of this helper did exactly that (credential only), which
+  // left the google row below at issuer=NULL and quietly diverged from what production data looks like.
+  await Promise.all(
+    rows.map((row) =>
+      prisma.account.update({
+        where: { id: row.id },
+        data: { issuer: canonicalAccountIssuer(row.provider) },
+      })
+    )
+  );
+};
 
 /**
  * Integration coverage for the cutover credential-account backfill (ENG-1054) against real Postgres.

--- a/apps/web/integration/repair-account-issuer.integration.test.ts
+++ b/apps/web/integration/repair-account-issuer.integration.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { resetDb } from "@/integration/reset-db";
+// The repair data migration under test (auto-discovered by the migration runner at deploy).
+import { repairAccountIssuer } from "../../../packages/database/migration/20260821165535_repair_account_issuer/migration";
+
+/**
+ * Integration coverage for the ENG-2555 `Account.issuer` repair against real Postgres — the one piece
+ * of that PR that was otherwise verified only by hand. The stakes are the same as the bug it repairs:
+ * this migration is an independent transcription of the canonical provider→issuer mapping, so a drift
+ * here (swap `IS DISTINCT FROM` for `<>`, drop the google arm) silently stops repairing rows while the
+ * unit suite stays green. `constants.test.ts` pins the SQL text; this proves the SQL's behaviour.
+ *
+ * The runner supplies `run` with its interactive transaction; here `prisma` stands in, which is the
+ * same shape the credential-backfill test uses for its migration.
+ */
+const runRepair = () => repairAccountIssuer.run!({ prisma, tx: prisma as never });
+
+/** The seed matrix from the manual verification run — one row per repair class. */
+const seedMatrix = async (): Promise<string> => {
+  const user = await prisma.user.create({
+    data: { email: "issuer-matrix@example.com", name: "Matrix", emailVerified: true },
+  });
+  await prisma.account.createMany({
+    data: [
+      // the ENG-2555 shape: google stomped with the synthetic form
+      {
+        userId: user.id,
+        type: "oauth",
+        provider: "google",
+        providerAccountId: "g-sub",
+        issuer: "local:oauth:google",
+      },
+      // already canonical — must stay byte-identical
+      {
+        userId: user.id,
+        type: "oauth",
+        provider: "github",
+        providerAccountId: "gh-sub",
+        issuer: "local:oauth:github",
+      },
+      {
+        userId: user.id,
+        type: "credential",
+        provider: "credential",
+        providerAccountId: user.id,
+        issuer: "local:credential",
+      },
+      // pre-backfill leftover: NULL issuer (IS DISTINCT FROM must catch it, `<>` would not)
+      { userId: user.id, type: "oauth", provider: "openid", providerAccountId: "oid-sub", issuer: null },
+    ],
+  });
+  return user.id;
+};
+
+const issuersByProvider = async (userId: string): Promise<Record<string, string | null>> => {
+  const rows = await prisma.account.findMany({
+    where: { userId },
+    select: { provider: true, issuer: true },
+  });
+  return Object.fromEntries(rows.map((r) => [r.provider, r.issuer]));
+};
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("repairAccountIssuer data migration (real Postgres)", () => {
+  test("repairs the stomped google row and the NULL row, leaves canonical rows untouched", async () => {
+    const userId = await seedMatrix();
+
+    await runRepair();
+
+    expect(await issuersByProvider(userId)).toEqual({
+      google: "https://accounts.google.com",
+      github: "local:oauth:github",
+      credential: "local:credential",
+      openid: "local:oauth:openid",
+    });
+  });
+
+  test("is idempotent: a second run changes nothing", async () => {
+    const userId = await seedMatrix();
+    await runRepair();
+    const first = await issuersByProvider(userId);
+
+    await runRepair();
+
+    expect(await issuersByProvider(userId)).toEqual(first);
+  });
+
+  test("is a no-op on a database with no Account rows", async () => {
+    await expect(runRepair()).resolves.toBeUndefined();
+    expect(await prisma.account.count()).toBe(0);
+  });
+
+  /**
+   * The repaired row must be findable under Better Auth's own key — the property the whole ticket is
+   * about, asserted through the `@@unique([issuer, providerAccountId])` lookup 1.7 filters on.
+   */
+  test("a repaired google row resolves by Better Auth's (issuer, accountId) key", async () => {
+    const userId = await seedMatrix();
+
+    await runRepair();
+
+    const found = await prisma.account.findUnique({
+      where: {
+        issuer_providerAccountId: { issuer: "https://accounts.google.com", providerAccountId: "g-sub" },
+      },
+      select: { userId: true },
+    });
+    expect(found?.userId).toBe(userId);
+  });
+});

--- a/apps/web/modules/ee/sso/lib/account-linking.test.ts
+++ b/apps/web/modules/ee/sso/lib/account-linking.test.ts
@@ -31,7 +31,7 @@ describe("syncSsoIdentityForUser", () => {
     type: "oauth" as const,
     provider: "google",
     providerAccountId: "provider-account-1",
-    issuer: "local:oauth:google",
+    issuer: "https://accounts.google.com",
     access_token: "access-token",
     refresh_token: "refresh-token",
     scope: "openid email profile",
@@ -101,10 +101,11 @@ describe("syncSsoIdentityForUser", () => {
         id: "account_1",
       },
       data: {
-        // `issuer` on the token-refresh branch too (ENG-2343): the canonical row may predate the
-        // backfill window, and 1.7's account lookup filters on `(issuer, accountId)` — so leaving it
-        // NULL here would keep a recovered link invisible and re-trigger recovery on the next sign-in.
-        issuer: "local:oauth:google",
+        // `issuer` on the token-refresh branch too (ENG-2343, corrected in ENG-2555): the canonical row
+        // may predate the backfill window OR carry a wrong value written before the fix, and 1.7's
+        // account lookup filters on `(issuer, accountId)` — so leaving it alone here would keep a
+        // recovered link invisible and re-trigger recovery on the next sign-in, forever.
+        issuer: "https://accounts.google.com",
         access_token: "access-token",
         refresh_token: "refresh-token",
         scope: "openid email profile",
@@ -138,7 +139,7 @@ describe("syncSsoIdentityForUser", () => {
         type: "oauth",
         provider: "google",
         providerAccountId: "provider-account-1",
-        issuer: "local:oauth:google",
+        issuer: "https://accounts.google.com",
         access_token: "access-token",
         refresh_token: "refresh-token",
         scope: "openid email profile",
@@ -186,7 +187,10 @@ describe("syncSsoIdentityForUser", () => {
       where: {
         id: "account_1",
       },
+      // `issuer` is written here as of ENG-2555 — this branch used to update tokens only, which is what
+      // stopped a row with a wrong issuer from ever healing.
       data: {
+        issuer: "https://accounts.google.com",
         access_token: "access-token",
         refresh_token: "refresh-token",
         scope: "openid email profile",
@@ -222,7 +226,7 @@ describe("syncSsoIdentityForUser", () => {
         type: "oauth",
         provider: "google",
         providerAccountId: "provider-account-1",
-        issuer: "local:oauth:google",
+        issuer: "https://accounts.google.com",
         access_token: "access-token",
         refresh_token: "refresh-token",
         expires_at: 1234,
@@ -232,5 +236,49 @@ describe("syncSsoIdentityForUser", () => {
       },
     });
     expect(mocks.userUpdate).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * Every other assertion in this file uses google, which is exactly how ENG-2555 shipped: google is the
+   * one provider whose issuer is NOT the synthetic `local:oauth:` form, so a helper that always returned
+   * the synthetic form looked correct against a google-only suite. These two pin both arms.
+   */
+  test("uses the provider's own declared issuer for google, not the synthetic form", async () => {
+    await syncSsoIdentityForUser({ userId: "user_1", provider: "google", account });
+
+    expect(mocks.accountCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ issuer: "https://accounts.google.com" }),
+      })
+    );
+  });
+
+  test("uses the synthetic issuer for a provider that declares none", async () => {
+    await syncSsoIdentityForUser({
+      userId: "user_1",
+      provider: "github",
+      account: { ...account, provider: "github", providerAccountId: "github-account-1" },
+    });
+
+    expect(mocks.accountCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ provider: "github", issuer: "local:oauth:github" }),
+      })
+    );
+  });
+
+  /**
+   * The branch that made the loop unbreakable (ENG-2555): with a canonical row already present and no
+   * legacy row, this used to update tokens only, so a row carrying a wrong issuer could never heal.
+   */
+  test("repairs the issuer on an existing canonical row", async () => {
+    mocks.accountFindUnique.mockResolvedValue({ id: "account_1", userId: "user_1" });
+
+    await syncSsoIdentityForUser({ userId: "user_1", provider: "google", account });
+
+    expect(mocks.accountUpdate).toHaveBeenCalledWith({
+      where: { id: "account_1" },
+      data: expect.objectContaining({ issuer: "https://accounts.google.com" }),
+    });
   });
 });

--- a/apps/web/modules/ee/sso/lib/account-linking.ts
+++ b/apps/web/modules/ee/sso/lib/account-linking.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@formbricks/database";
 import type { IdentityProvider, Prisma } from "@formbricks/database/prisma";
 import type { Account } from "@formbricks/types/auth";
-import { OAUTH_ACCOUNT_NOT_LINKED_ERROR, ssoAccountIssuer } from "@/modules/ee/sso/lib/constants";
+import { OAUTH_ACCOUNT_NOT_LINKED_ERROR, canonicalAccountIssuer } from "@/modules/ee/sso/lib/constants";
 
 export const LINKED_SSO_LOOKUP_SELECT = {
   id: true,
@@ -99,7 +99,7 @@ const syncSsoIdentityForUserWithTx = async ({
         },
         // `issuer` too: the canonical row may predate the ENG-2343 backfill window, and leaving it NULL
         // here would keep the recovered link invisible to 1.7's account lookup.
-        data: { issuer: ssoAccountIssuer(provider), ...getAccountTokenUpdate(account) },
+        data: { issuer: canonicalAccountIssuer(provider), ...getAccountTokenUpdate(account) },
       });
     } else {
       await tx.account.update({
@@ -113,7 +113,7 @@ const syncSsoIdentityForUserWithTx = async ({
           providerAccountId: account.providerAccountId,
           // Same reason as the create branch below: normalising a legacy row without setting `issuer`
           // leaves it unmatched by 1.7's account lookup (ENG-2343).
-          issuer: ssoAccountIssuer(provider),
+          issuer: canonicalAccountIssuer(provider),
           ...getAccountTokenUpdate(account),
         },
       });
@@ -123,7 +123,13 @@ const syncSsoIdentityForUserWithTx = async ({
       where: {
         id: existingCanonicalAccount.id,
       },
-      data: getAccountTokenUpdate(account),
+      // `issuer` here too, and this branch is the one that matters most (ENG-2555). It is the branch
+      // every attempt after the first takes, so while it wrote only tokens a row created with a wrong
+      // or NULL issuer could never heal: sign-in could not see it, recovery ran again, and this update
+      // left the bad value untouched. Writing the canonical value makes the next sign-in repair it.
+      // The row's ownership is already asserted above, and the value derives from `provider`, so this
+      // cannot rebind the row to another identity.
+      data: { issuer: canonicalAccountIssuer(provider), ...getAccountTokenUpdate(account) },
     });
   } else {
     await tx.account.create({
@@ -138,7 +144,7 @@ const syncSsoIdentityForUserWithTx = async ({
         // sign-in because `NULL !== 'local:oauth:<provider>'`. The migration cannot save them either —
         // it runs once, before this row exists. Same value as the provider config and the backfill
         // (ENG-2343); imported rather than re-spelled so the three cannot drift.
-        issuer: ssoAccountIssuer(provider),
+        issuer: canonicalAccountIssuer(provider),
         ...getAccountTokenUpdate(account),
       },
     });

--- a/apps/web/modules/ee/sso/lib/account-linking.ts
+++ b/apps/web/modules/ee/sso/lib/account-linking.ts
@@ -97,8 +97,9 @@ const syncSsoIdentityForUserWithTx = async ({
         where: {
           id: existingCanonicalAccount.id,
         },
-        // `issuer` too: the canonical row may predate the ENG-2343 backfill window, and leaving it NULL
-        // here would keep the recovered link invisible to 1.7's account lookup.
+        // `issuer` too, and the CANONICAL value (ENG-2555): the row may predate the ENG-2343 backfill
+        // window (NULL) or carry the synthetic form where the provider declares its own — either way
+        // 1.7's account lookup cannot see it until this write corrects it.
         data: { issuer: canonicalAccountIssuer(provider), ...getAccountTokenUpdate(account) },
       });
     } else {
@@ -139,11 +140,13 @@ const syncSsoIdentityForUserWithTx = async ({
         provider,
         providerAccountId: account.providerAccountId,
         // 1.7 keys the account on `(issuer, accountId)` and `findAccountByKey` filters on `issuer`, so a
-        // row written without one is invisible to every later sign-in: the user completes
-        // verify-before-link, gets a session, and is then pushed back through recovery on the NEXT
-        // sign-in because `NULL !== 'local:oauth:<provider>'`. The migration cannot save them either —
-        // it runs once, before this row exists. Same value as the provider config and the backfill
-        // (ENG-2343); imported rather than re-spelled so the three cannot drift.
+        // row written with a missing OR non-canonical issuer is invisible to every later sign-in: the
+        // user completes verify-before-link, gets a session, and is pushed back through recovery on the
+        // NEXT sign-in, forever. The migration cannot save them either — it runs once, before this row
+        // exists. NOT the same helper the provider config pins (`ssoAccountIssuer`): google's canonical
+        // issuer is the one upstream declares, not the synthetic form, which is exactly the bug that
+        // shipped here (ENG-2555). `canonicalAccountIssuer` mirrors the backfill's CASE and is pinned
+        // against both the SQL and upstream in constants.test.ts, so the sites cannot drift.
         issuer: canonicalAccountIssuer(provider),
         ...getAccountTokenUpdate(account),
       },

--- a/apps/web/modules/ee/sso/lib/better-auth-recovery-signin.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-recovery-signin.integration.test.ts
@@ -4,6 +4,7 @@ import { resetDb } from "@/integration/reset-db";
 import { WEBAPP_URL } from "@/lib/constants";
 import { createToken } from "@/lib/jwt";
 import { auth } from "@/modules/auth/lib/auth";
+import { syncSsoIdentityForUser } from "@/modules/ee/sso/lib/account-linking";
 
 /**
  * Integration coverage for the SSO-recovery magic-link sign-in (ENG-1054, Phase 7) against real
@@ -70,5 +71,80 @@ describe("SSO recovery sign-in (real Postgres)", () => {
 
     // not single-use: the same token signs in twice (documents the known replay-until-expiry parity)
     expect(await prisma.session.count({ where: { userId: user.id } })).toBe(2);
+  });
+});
+
+/**
+ * ENG-2555. The unit tests for `syncSsoIdentityForUser` mock Prisma and assert the issuer *we* pass, so
+ * they can only ever confirm the value we chose — which is exactly how a wrong one shipped. These assert
+ * the property that actually matters: after recovery links an account, Better Auth can find it again.
+ *
+ * The lookup key is reproduced the way upstream builds it (a declared `accountIssuer` wins, else the
+ * synthetic form), so this fails if our write and upstream's read ever disagree — regardless of which
+ * side moved.
+ */
+describe("SSO recovery writes an issuer Better Auth can find (real Postgres)", () => {
+  const findByBetterAuthKey = (issuer: string, accountId: string) =>
+    prisma.account.findUnique({
+      where: { issuer_providerAccountId: { issuer, providerAccountId: accountId } },
+      select: { userId: true, provider: true },
+    });
+
+  test.each([
+    // google declares its own issuer upstream — the case that broke
+    ["google", "google-sub-1", "https://accounts.google.com"],
+    // github declares none, so the synthetic form is correct for it
+    ["github", "github-id-1", "local:oauth:github"],
+  ] as const)("links %s under the key Better Auth looks it up by", async (provider, sub, expectedIssuer) => {
+    const user = await prisma.user.create({
+      data: { email: `${provider}-link@example.com`, name: "Linked", emailVerified: true },
+    });
+
+    await prisma.$transaction((tx) =>
+      syncSsoIdentityForUser({
+        userId: user.id,
+        provider,
+        account: { type: "oauth", provider, providerAccountId: sub },
+        tx,
+      })
+    );
+
+    const found = await findByBetterAuthKey(expectedIssuer, sub);
+
+    expect(found).not.toBeNull();
+    expect(found?.userId).toBe(user.id);
+    expect(found?.provider).toBe(provider);
+  });
+
+  /**
+   * The branch that made the bug unbreakable: a row already carrying a wrong issuer must be repaired by
+   * the next recovery, not left alone. Before the fix this update wrote tokens only.
+   */
+  test("repairs a row that already carries a wrong issuer", async () => {
+    const user = await prisma.user.create({
+      data: { email: "stomped@example.com", name: "Stomped", emailVerified: true },
+    });
+    await prisma.account.create({
+      data: {
+        userId: user.id,
+        type: "oauth",
+        provider: "google",
+        providerAccountId: "google-sub-2",
+        issuer: "local:oauth:google",
+      },
+    });
+
+    await prisma.$transaction((tx) =>
+      syncSsoIdentityForUser({
+        userId: user.id,
+        provider: "google",
+        account: { type: "oauth", provider: "google", providerAccountId: "google-sub-2" },
+        tx,
+      })
+    );
+
+    expect(await findByBetterAuthKey("https://accounts.google.com", "google-sub-2")).not.toBeNull();
+    // and no duplicate was created in the process
+    expect(await prisma.account.count({ where: { userId: user.id } })).toBe(1);
   });
 });

--- a/apps/web/modules/ee/sso/lib/constants.test.ts
+++ b/apps/web/modules/ee/sso/lib/constants.test.ts
@@ -1,0 +1,115 @@
+import { createLocalAccountIssuer, createOAuthAccountIssuer } from "@better-auth/core/db";
+import { github, google } from "@better-auth/core/social-providers";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { canonicalAccountIssuer, ssoAccountIssuer } from "./constants";
+
+/**
+ * `Account.issuer` is spelled in four places that cannot import each other, and ENG-2555 happened
+ * because two of them disagreed about google: the SQL backfill had a `CASE` arm for it, the TypeScript
+ * helper did not, and every Google sign-in broke while the whole suite stayed green.
+ *
+ * So this pins `canonicalAccountIssuer` against the two sources it has to agree with:
+ *
+ * - the SQL literal, parsed out of the migration rather than restated here — restating it would just
+ *   move the drift into this file;
+ * - Better Auth's own exports, which are what actually key the row at sign-in.
+ *
+ * The upstream leg is the one with a future in it: if a Better Auth release changes google's issuer, or
+ * gives github one it does not have today, this fails at `pnpm test` instead of at somebody's login.
+ */
+const ISSUER_BACKFILL_MIGRATION = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../../../packages/database/migration/20260812110000_eng_2343_better_auth_17_resource_model/migration.sql"
+);
+
+/**
+ * The `CASE` arms of the `UPDATE "Account" SET "issuer" = …` backfill, as `{ provider: issuer }`, plus
+ * the `ELSE` template. Parsed, not transcribed.
+ */
+const parseIssuerCase = (): { arms: Record<string, string>; elseTemplate: string } => {
+  const sql = readFileSync(ISSUER_BACKFILL_MIGRATION, "utf8");
+  const block = /UPDATE "Account"\s+SET "issuer" = CASE([\s\S]*?)END/.exec(sql);
+  if (!block) throw new Error("issuer backfill CASE not found — did the migration move or get renamed?");
+
+  const arms: Record<string, string> = {};
+  const armPattern = /WHEN "provider" = '([^']+)' THEN '([^']+)'/g;
+  let match = armPattern.exec(block[1]);
+  while (match) {
+    arms[match[1]] = match[2];
+    match = armPattern.exec(block[1]);
+  }
+
+  const elseArm = /ELSE '([^']+)' \|\| "provider"/.exec(block[1]);
+  if (!elseArm) throw new Error("issuer backfill ELSE arm not found");
+
+  return { arms, elseTemplate: elseArm[1] };
+};
+
+describe("canonicalAccountIssuer ↔ the ENG-2343 SQL backfill", () => {
+  const { arms, elseTemplate } = parseIssuerCase();
+
+  // Guard the guard: if the regex silently matched nothing, every assertion below would pass against an
+  // empty object and prove precisely nothing.
+  test("the migration's CASE parsed, and still special-cases exactly credential and google", () => {
+    expect(Object.keys(arms).sort()).toEqual(["credential", "google"]);
+    expect(elseTemplate).toBe("local:oauth:");
+  });
+
+  test.each(Object.entries(parseIssuerCase().arms))("agrees with the SQL for %s", (provider, expected) => {
+    expect(canonicalAccountIssuer(provider)).toBe(expected);
+  });
+
+  test.each(["github", "azuread", "openid", "saml"])("agrees with the SQL ELSE arm for %s", (provider) => {
+    expect(canonicalAccountIssuer(provider)).toBe(`${elseTemplate}${provider}`);
+  });
+});
+
+describe("canonicalAccountIssuer ↔ Better Auth's own account key", () => {
+  const providerOptions = { clientId: "pin-test", clientSecret: "pin-test" };
+
+  /**
+   * How upstream resolves the issuer (`better-auth/dist/oauth2/account-key.mjs`): a provider's declared
+   * `accountIssuer` wins, and only its absence falls back to the synthetic form.
+   */
+  test("google declares its own issuer, and we use that rather than the synthetic form", () => {
+    const declared = google(providerOptions).accountIssuer;
+
+    expect(declared).toBe("https://accounts.google.com");
+    expect(canonicalAccountIssuer("google")).toBe(declared);
+    // The regression itself: this is the value that was written, and it is not the one BA looks under.
+    expect(canonicalAccountIssuer("google")).not.toBe(ssoAccountIssuer("google"));
+  });
+
+  /**
+   * Pins the *assumption* behind the fallback, not just the fallback. If a future release gives github a
+   * declared issuer, `local:oauth:github` silently becomes wrong for it in exactly the way it was wrong
+   * for google — and this is what notices.
+   */
+  test("github declares none, so the synthetic fallback is the right answer for it", () => {
+    // `in` rather than reading the property: upstream's type for github has no `accountIssuer` at all,
+    // so this is checked at compile time as well as here. If a release adds one, the property appears
+    // and this fails — which is the notification we want.
+    expect("accountIssuer" in github(providerOptions)).toBe(false);
+    expect(canonicalAccountIssuer("github")).toBe(createOAuthAccountIssuer("github"));
+  });
+
+  test("credential matches Better Auth's local account issuer", () => {
+    expect(canonicalAccountIssuer("credential")).toBe(createLocalAccountIssuer("credential"));
+  });
+});
+
+describe("ssoAccountIssuer stays the pinning helper", () => {
+  // It is still correct for the generic providers we pin `accountIssuer` on, and this records that the
+  // two helpers are deliberately different rather than one being a leftover.
+  test.each(["azuread", "openid", "saml"])("%s keeps the synthetic form", (provider) => {
+    expect(ssoAccountIssuer(provider)).toBe(`local:oauth:${provider}`);
+    expect(canonicalAccountIssuer(provider)).toBe(ssoAccountIssuer(provider));
+  });
+
+  test("percent-encodes a provider id that needs it", () => {
+    expect(ssoAccountIssuer("team/github")).toBe("local:oauth:team%2Fgithub");
+  });
+});

--- a/apps/web/modules/ee/sso/lib/constants.test.ts
+++ b/apps/web/modules/ee/sso/lib/constants.test.ts
@@ -20,50 +20,100 @@ import { canonicalAccountIssuer, ssoAccountIssuer } from "./constants";
  * The upstream leg is the one with a future in it: if a Better Auth release changes google's issuer, or
  * gives github one it does not have today, this fails at `pnpm test` instead of at somebody's login.
  */
-const ISSUER_BACKFILL_MIGRATION = join(
+const MIGRATION_DIR = join(
   dirname(fileURLToPath(import.meta.url)),
-  "../../../../../../packages/database/migration/20260812110000_eng_2343_better_auth_17_resource_model/migration.sql"
+  "../../../../../../packages/database/migration"
 );
 
 /**
- * The `CASE` arms of the `UPDATE "Account" SET "issuer" = …` backfill, as `{ provider: issuer }`, plus
- * the `ELSE` template. Parsed, not transcribed.
+ * The two SQL spellings of the canonical mapping. The ENG-2343 backfill has one `CASE`; the ENG-2555
+ * repair restates it twice (`SET` and the self-excluding `WHERE`). All copies in all files must agree
+ * with each other and with `canonicalAccountIssuer` — a repair that drifts would *un-fix* rows through
+ * the migration meant to cure them.
  */
-const parseIssuerCase = (): { arms: Record<string, string>; elseTemplate: string } => {
-  const sql = readFileSync(ISSUER_BACKFILL_MIGRATION, "utf8");
-  const block = /UPDATE "Account"\s+SET "issuer" = CASE([\s\S]*?)END/.exec(sql);
-  if (!block) throw new Error("issuer backfill CASE not found — did the migration move or get renamed?");
+const ISSUER_MIGRATION_SOURCES = {
+  "eng-2343 backfill": "20260812110000_eng_2343_better_auth_17_resource_model/migration.sql",
+  "eng-2555 repair": "20260821165535_repair_account_issuer/migration.ts",
+} as const;
 
-  const arms: Record<string, string> = {};
-  const armPattern = /WHEN "provider" = '([^']+)' THEN '([^']+)'/g;
-  let match = armPattern.exec(block[1]);
-  while (match) {
-    arms[match[1]] = match[2];
-    match = armPattern.exec(block[1]);
-  }
+interface TParsedIssuerCase {
+  arms: Record<string, string>;
+  elseTemplate: string;
+}
 
-  const elseArm = /ELSE '([^']+)' \|\| "provider"/.exec(block[1]);
-  if (!elseArm) throw new Error("issuer backfill ELSE arm not found");
+/**
+ * Every `"issuer" = CASE … END` block in a migration file, as `{ provider: issuer }` arms plus the
+ * `ELSE` template. Parsed, not transcribed — restating the values here would just move the drift into
+ * this file.
+ */
+const parseIssuerCases = (relativePath: string): TParsedIssuerCase[] => {
+  const source = readFileSync(join(MIGRATION_DIR, relativePath), "utf8");
+  const blocks = [...source.matchAll(/"issuer" (?:= CASE|IS DISTINCT FROM \(\s*CASE)([\s\S]*?)END/g)];
+  if (blocks.length === 0) throw new Error(`no issuer CASE found in ${relativePath} — moved or renamed?`);
 
-  return { arms, elseTemplate: elseArm[1] };
+  return blocks.map(([, body]) => {
+    const arms: Record<string, string> = {};
+    for (const [, provider, issuer] of body.matchAll(/WHEN "provider" = '([^']+)' THEN '([^']+)'/g)) {
+      arms[provider] = issuer;
+    }
+    const elseArm = /ELSE '([^']+)' \|\| "provider"/.exec(body);
+    if (!elseArm) throw new Error(`issuer CASE in ${relativePath} has no ELSE arm`);
+    return { arms, elseTemplate: elseArm[1] };
+  });
 };
 
-describe("canonicalAccountIssuer ↔ the ENG-2343 SQL backfill", () => {
-  const { arms, elseTemplate } = parseIssuerCase();
+const parsedSources = Object.entries(ISSUER_MIGRATION_SOURCES).map(([label, path]) => ({
+  label,
+  cases: parseIssuerCases(path),
+}));
 
+// One canonical parse for the per-arm assertions below; the cross-copy equality tests prove every
+// other copy is identical to it, so asserting against one is asserting against all.
+const { arms, elseTemplate } = parsedSources[0].cases[0];
+
+describe("canonicalAccountIssuer ↔ every SQL spelling of the mapping", () => {
   // Guard the guard: if the regex silently matched nothing, every assertion below would pass against an
-  // empty object and prove precisely nothing.
-  test("the migration's CASE parsed, and still special-cases exactly credential and google", () => {
+  // empty object and prove precisely nothing. The repair file must contain exactly two copies (SET and
+  // the self-excluding WHERE) — a refactor that drops one would weaken its idempotency, and this is
+  // what notices.
+  test("both migrations parsed, with the expected number of CASE copies", () => {
+    expect(parsedSources.map(({ label, cases }) => [label, cases.length])).toEqual([
+      ["eng-2343 backfill", 1],
+      ["eng-2555 repair", 2],
+    ]);
     expect(Object.keys(arms).sort()).toEqual(["credential", "google"]);
     expect(elseTemplate).toBe("local:oauth:");
   });
 
-  test.each(Object.entries(parseIssuerCase().arms))("agrees with the SQL for %s", (provider, expected) => {
+  // The drift that shipped ENG-2555 was two spellings of this mapping disagreeing. Every copy in every
+  // migration must therefore be byte-equal to every other — including the repair's SET and WHERE pair,
+  // which could otherwise drift apart and make the repair non-idempotent.
+  test.each(
+    parsedSources.flatMap(({ label, cases }) => cases.map((c, i) => [`${label} copy ${i + 1}`, c] as const))
+  )("%s is identical to the canonical parse", (_label, parsed) => {
+    expect(parsed.arms).toEqual(arms);
+    expect(parsed.elseTemplate).toBe(elseTemplate);
+  });
+
+  test.each(Object.entries(arms))("agrees with the SQL for %s", (provider, expected) => {
     expect(canonicalAccountIssuer(provider)).toBe(expected);
   });
 
   test.each(["github", "azuread", "openid", "saml"])("agrees with the SQL ELSE arm for %s", (provider) => {
     expect(canonicalAccountIssuer(provider)).toBe(`${elseTemplate}${provider}`);
+  });
+
+  /**
+   * Documents the one input class where the TS and SQL sides deliberately disagree: the SQL ELSE arm
+   * concatenates the raw provider id, while the helper percent-encodes. Identity for every provider id
+   * in use (all encoding-neutral) — but a future provider id carrying a reserved character would make
+   * the migration write a value the app never looks up. This pins the divergence as known and
+   * deliberate rather than letting it look like an oversight; enabling such a provider means adding an
+   * explicit arm to the SQL, per the ENG-2343 migration's own comment.
+   */
+  test("the SQL ELSE arm cannot express an encoded provider id", () => {
+    expect(canonicalAccountIssuer("team/github")).toBe("local:oauth:team%2Fgithub");
+    expect(canonicalAccountIssuer("team/github")).not.toBe(`${elseTemplate}team/github`);
   });
 });
 

--- a/apps/web/modules/ee/sso/lib/constants.ts
+++ b/apps/web/modules/ee/sso/lib/constants.ts
@@ -2,20 +2,53 @@ export const OAUTH_ACCOUNT_NOT_LINKED_ERROR = "OAuthAccountNotLinked";
 export const SSO_RECOVERY_COMPLETION_PATH = "/api/auth/sso/recovery/complete";
 
 /**
- * The synthetic `Account.issuer` for our generic-OAuth providers (ENG-2343).
+ * The synthetic `Account.issuer` for the providers we configure ourselves (ENG-2343).
  *
- * Lives here, in a dependency-free module, because THREE places must produce byte-identical values and
- * a literal repeated three times is a silent-divergence bug waiting to happen:
+ * This is the value we PIN via `accountIssuer` on the generic-OAuth providers in
+ * `better-auth-providers.ts` (azuread / openid / saml). Because it is pinned, Better Auth stores and
+ * looks up exactly what we hand it, so upstream's own format never enters the picture — which is why
+ * this is deliberately NOT `createOAuthAccountIssuer` from `@better-auth/core/db` even though the two
+ * are currently identical. Tracking upstream here would drift us away from rows already written, and
+ * the SQL backfill could not follow.
  *
- * 1. `better-auth-providers.ts` — `accountIssuer`, what Better Auth writes and looks up.
- * 2. `account-linking.ts` — the rows SSO recovery writes itself.
- * 3. `migration/20260812110000_…` — the backfill, as a SQL literal (`'local:oauth:' || "provider"`),
- *    which cannot call TypeScript and is therefore the copy this one has to match.
- *
- * Deliberately NOT `createOAuthAccountIssuer` from `@better-auth/core/db`, even though it is public and
- * currently identical: because `accountIssuer` is set explicitly, Better Auth stores and looks up
- * whatever we hand it, so upstream's format never enters the picture — while the SQL literal in (3)
- * cannot follow an upstream change. Tracking upstream would drift us away from rows already written.
+ * It is NOT the answer to "what issuer does an existing row for provider X have" — a built-in social
+ * provider can declare its own. Use `canonicalAccountIssuer` for that (ENG-2555).
  */
 export const ssoAccountIssuer = (providerId: string): string =>
   `local:oauth:${encodeURIComponent(providerId)}`;
+
+/**
+ * The canonical `Account.issuer` for a given `Account.provider` — the value Better Auth 1.7 actually
+ * keys the row on, and therefore the only value a write may use (ENG-2555).
+ *
+ * 1.7 keys accounts on `(issuer, accountId)` and filters every lookup on it, so a row written with the
+ * wrong issuer is invisible to sign-in. Google is the trap: it is a BUILT-IN social provider that
+ * declares its own `accountIssuer` upstream, so the synthetic `local:oauth:` form is wrong for it.
+ * Writing `local:oauth:google` is what broke Google sign-in on 5.4-rc — the link was created, the user
+ * got a session, and every subsequent sign-in bounced back through verify-before-link forever.
+ *
+ * This mirrors, byte for byte, the `CASE` in `migration/20260812110000_…/migration.sql` — which got
+ * google right, and whose comment already warned that "getting google wrong would leave every existing
+ * Google user unmatched at sign-in". Four sites must agree and cannot import each other:
+ *
+ * 1. Better Auth itself — `provider.accountIssuer`, else `createOAuthAccountIssuer(provider.id)`.
+ * 2. `account-linking.ts` — the rows SSO recovery writes.
+ * 3. `migration/20260812110000_…` — the backfill, as a SQL literal.
+ * 4. `migration/20260821…_repair_account_issuer` — the repair for rows (2) got wrong.
+ *
+ * `constants.test.ts` pins this function against BOTH the SQL literal and upstream's own exports, so a
+ * future Better Auth release that changes google's issuer — or gives github one — fails `pnpm test`
+ * rather than production sign-in.
+ *
+ * Keyed on `Account.provider`, NOT `IdentityProvider`: the credential row's provider is `"credential"`,
+ * a value that enum does not contain.
+ */
+export const canonicalAccountIssuer = (provider: string): string => {
+  // Better Auth's own `createLocalAccountIssuer("credential")`. Unreachable from the SSO recovery
+  // caller (its provider is an `IdentityProvider`, which has no `credential` member) but kept so this
+  // stays a faithful mirror of the SQL, and so a future non-SSO caller cannot get it wrong.
+  if (provider === "credential") return "local:credential";
+  // Declared upstream in `@better-auth/core/dist/social-providers/google.mjs`.
+  if (provider === "google") return "https://accounts.google.com";
+  return ssoAccountIssuer(provider);
+};

--- a/apps/web/modules/ee/sso/lib/constants.ts
+++ b/apps/web/modules/ee/sso/lib/constants.ts
@@ -27,18 +27,23 @@ export const ssoAccountIssuer = (providerId: string): string =>
  * Writing `local:oauth:google` is what broke Google sign-in on 5.4-rc — the link was created, the user
  * got a session, and every subsequent sign-in bounced back through verify-before-link forever.
  *
- * This mirrors, byte for byte, the `CASE` in `migration/20260812110000_…/migration.sql` — which got
- * google right, and whose comment already warned that "getting google wrong would leave every existing
- * Google user unmatched at sign-in". Four sites must agree and cannot import each other:
+ * This mirrors the `CASE` in `migration/20260812110000_…/migration.sql` — which got google right, and
+ * whose comment already warned that "getting google wrong would leave every existing Google user
+ * unmatched at sign-in". One deliberate asymmetry: the SQL `ELSE` concatenates the raw provider id
+ * while this helper percent-encodes it. Identity for every provider id in use (all encoding-neutral,
+ * per that migration's own comment); a provider id ever needing escaping must get an explicit `CASE`
+ * arm in SQL, and `constants.test.ts` documents the divergence so it reads as known, not an
+ * oversight. Four sites must agree and cannot import each other:
  *
  * 1. Better Auth itself — `provider.accountIssuer`, else `createOAuthAccountIssuer(provider.id)`.
  * 2. `account-linking.ts` — the rows SSO recovery writes.
  * 3. `migration/20260812110000_…` — the backfill, as a SQL literal.
  * 4. `migration/20260821…_repair_account_issuer` — the repair for rows (2) got wrong.
  *
- * `constants.test.ts` pins this function against BOTH the SQL literal and upstream's own exports, so a
- * future Better Auth release that changes google's issuer — or gives github one — fails `pnpm test`
- * rather than production sign-in.
+ * `constants.test.ts` pins this function against upstream's own exports AND every SQL copy in both
+ * migrations (the backfill's one, the repair's two), so a future Better Auth release that changes
+ * google's issuer — or gives github one — or any one SQL copy drifting fails `pnpm test` rather than
+ * production sign-in.
  *
  * Keyed on `Account.provider`, NOT `IdentityProvider`: the credential row's provider is `"credential"`,
  * a value that enum does not contain.

--- a/packages/database/migration/20260821165535_repair_account_issuer/migration.ts
+++ b/packages/database/migration/20260821165535_repair_account_issuer/migration.ts
@@ -1,0 +1,60 @@
+import { logger } from "@formbricks/logger";
+import type { MigrationScript } from "../../src/scripts/migration-runner";
+
+/**
+ * Repair `Account.issuer` rows that disagree with the canonical value for their provider (ENG-2555).
+ *
+ * The ENG-2343 backfill (20260812110000) set this correctly for every row that existed when it ran. What
+ * it could not cover is rows written AFTERWARDS by SSO recovery, which used a helper that returned the
+ * synthetic `local:oauth:<provider>` form for every provider — wrong for `google`, which declares its own
+ * `accountIssuer` upstream (`https://accounts.google.com`).
+ *
+ * Better Auth 1.7 keys accounts on `(issuer, accountId)`, so such a row is invisible at sign-in: the user
+ * is pushed back through verify-before-link on every attempt and never converges. This rewrites them.
+ *
+ * The `CASE` is byte-identical to the one in 20260812110000's `migration.sql`, and
+ * `apps/web/modules/ee/sso/lib/constants.test.ts` pins the TypeScript helper against both that SQL and
+ * Better Auth's own exports, so the three cannot drift apart again.
+ *
+ * Safe by construction:
+ * - **No-op on an empty or already-correct database.** `IS DISTINCT FROM` matches only rows that are
+ *   actually wrong (and, unlike `<>`, also catches `issuer IS NULL`). Re-running changes nothing.
+ * - **Cannot merge two identities.** A collision on `@@unique([issuer, providerAccountId])` would need
+ *   two rows sharing a subject and mapping to one issuer. The provider→issuer map is injective and
+ *   `@@unique([provider, providerAccountId])` already forbids two rows per provider+subject, so that is
+ *   unreachable. If the reasoning is ever wrong the unique index aborts the migration, which is the
+ *   outcome we want — no silent merge.
+ * - Only the `issuer` column is touched; `userId`, `provider` and `providerAccountId` are untouched, so
+ *   no row can move between users or organizations.
+ */
+export const repairAccountIssuer: MigrationScript = {
+  type: "data",
+  id: "ghqt118bfqdjs8tpzv1dvbqi",
+  name: "20260821165535_repair_account_issuer",
+  run: async ({ tx }) => {
+    const repaired = await tx.$executeRaw`
+      UPDATE "Account"
+      SET "issuer" = CASE
+        WHEN "provider" = 'credential' THEN 'local:credential'
+        WHEN "provider" = 'google' THEN 'https://accounts.google.com'
+        ELSE 'local:oauth:' || "provider"
+      END
+      WHERE "issuer" IS DISTINCT FROM (
+        CASE
+          WHEN "provider" = 'credential' THEN 'local:credential'
+          WHEN "provider" = 'google' THEN 'https://accounts.google.com'
+          ELSE 'local:oauth:' || "provider"
+        END
+      )
+    `;
+
+    if (repaired === 0) {
+      logger.info("Account.issuer: no rows disagreed with the canonical value; nothing to repair");
+      return;
+    }
+
+    // Worth logging loudly rather than silently: a non-zero count here means those users were stuck in
+    // the SSO verify-before-link loop until this ran.
+    logger.info({ repaired }, "Account.issuer: repaired rows that disagreed with the canonical value");
+  },
+};

--- a/packages/database/migration/20260821165535_repair_account_issuer/migration.ts
+++ b/packages/database/migration/20260821165535_repair_account_issuer/migration.ts
@@ -12,9 +12,13 @@ import type { MigrationScript } from "../../src/scripts/migration-runner";
  * Better Auth 1.7 keys accounts on `(issuer, accountId)`, so such a row is invisible at sign-in: the user
  * is pushed back through verify-before-link on every attempt and never converges. This rewrites them.
  *
- * The `CASE` is byte-identical to the one in 20260812110000's `migration.sql`, and
- * `apps/web/modules/ee/sso/lib/constants.test.ts` pins the TypeScript helper against both that SQL and
- * Better Auth's own exports, so the three cannot drift apart again.
+ * The `CASE` is byte-identical to the one in 20260812110000's `migration.sql` — including,
+ * deliberately, its missing percent-encoding on the `ELSE` arm: the TS helper encodes, the SQL cannot,
+ * and every provider id in use is encoding-neutral so the two coincide. Mirroring the flaw is the
+ * point; "fixing" one side is how ENG-2555 happened. `apps/web/modules/ee/sso/lib/constants.test.ts`
+ * parses every `CASE` copy in BOTH migrations (this file has two — `SET` and the self-excluding
+ * `WHERE`) and pins them against each other, the helper, and Better Auth's own exports, so no copy can
+ * drift silently.
  *
  * Safe by construction:
  * - **No-op on an empty or already-correct database.** `IS DISTINCT FROM` matches only rows that are


### PR DESCRIPTION
Fixes ENG-2555

## What & why

Google SSO has been broken since the Better Auth 1.7 upgrade (#8835): the callback 500s, a refresh lands on `?error=OAuthAccountNotLinked`, and every retry repeats it. Caught on staging; #8835 is in no release tag, so no production data is affected and this lands before 5.4.

1.7 keys accounts on `(issuer, accountId)` and filters every lookup on it. The canonical issuer is **provider-dependent**, and google is the odd one out — it is a built-in social provider that declares its own `accountIssuer` upstream:

| provider | canonical issuer | source |
| --- | --- | --- |
| `credential` | `local:credential` | `createLocalAccountIssuer` |
| `google` | `https://accounts.google.com` | declared by the provider itself |
| github / azuread / openid / saml | `local:oauth:<provider>` | upstream fallback, and what we pin |

The ENG-2343 SQL backfill encoded that correctly — its comment even warns that *"getting google wrong would leave every existing Google user unmatched at sign-in"*. But `ssoAccountIssuer`, which SSO recovery used for every write, returns the synthetic form unconditionally. So linking Google for an existing user wrote `local:oauth:google`, a key Better Auth never looks under: the link was invisible, recovery fired again on the next sign-in, and it never converged.

Two changes:

- **`canonicalAccountIssuer`** mirrors the SQL `CASE`. `ssoAccountIssuer` keeps its one real job — pinning `accountIssuer` on the generic providers, where the synthetic form is correct and deliberate. Two helpers because they answer different questions: *what we pin* vs *what an existing row's issuer must be*. The [1.7 upgrade guide](https://www.better-auth.com/docs/guides/1-7-upgrade-guide) prescribes exactly this ("build an explicit `providerId`-to-issuer map for your deployment").
- **The branch that made it unbreakable.** With a canonical row present and no legacy row, `syncSsoIdentityForUser` updated tokens only and never touched `issuer` — so a row written with a wrong value could not heal: sign-in could not see it, recovery ran again, and the update left it alone. It now writes the canonical issuer, so the next sign-in repairs the row.

**Why the suite stayed green.** Every assertion in `account-linking.test.ts` used google — the one provider the helper got wrong — and asserted the value *our own code passed*, not the one Better Auth looks up. A mocked test cannot notice that upstream reads a different key.

## Breaking changes

- [ ] This PR contains breaking changes

None. It repairs data written by an unreleased version and restores the intended lookup; no API, schema, env or config surface changes.

## Migrations & env

- `20260821165535_repair_account_issuer` (data): rewrites `Account.issuer` rows that disagree with the canonical value for their provider. Idempotent, no-op on an already-correct database, and baselined without running on a fresh one. `IS DISTINCT FROM` means it also repairs any `NULL` issuer left behind.
- Cannot merge identities: that would need two rows sharing a subject *and* mapping to one issuer, which `@@unique([provider, providerAccountId])` plus the injective provider→issuer map forbids. If that reasoning were ever wrong, `@@unique([issuer, providerAccountId])` aborts the migration rather than merging silently.
- No env changes.

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Recovery links google under the key Better Auth actually reads | integration, real Postgres (mutation) | `better-auth-recovery-signin.integration.test.ts` links via `syncSsoIdentityForUser`, then looks the row up by `(issuer, providerAccountId)` built the way upstream builds it. Mutation: deleting the google arm in `constants.ts` fails this **and** the repair case, leaving github passing — the exact signature the bug had |
| github still uses the synthetic form | integration, real Postgres (guard) | Same test, second case. Pins that the fallback stays right for providers that declare no issuer |
| A row already carrying a wrong issuer heals | integration, real Postgres (mutation) | Third case: pre-seed `local:oauth:google`, run recovery, assert it is findable under `https://accounts.google.com` and that no duplicate row appeared |
| No SQL copy of the mapping can drift — in either migration | unit (mutation) | `constants.test.ts` **parses** every `CASE` block in BOTH migrations — the backfill's one and the repair's two (`SET` + the self-excluding `WHERE`) — and asserts each identical to the canonical parse, with a copy-count guard so dropping the repair's `WHERE` copy also fails. Mutations: a trailing slash on google in the repair's `SET` fails 1; dropping an arm from only the `WHERE` copy (the pair diverging, which would break idempotency) fails 1; a trailing slash in the backfill fails 2 |
| …or from upstream | unit (guard) | Same file asserts against Better Auth's own exports — `google({…}).accountIssuer`, `createOAuthAccountIssuer`, `createLocalAccountIssuer` — and that github has **no** `accountIssuer` property at all. A release that changes google's issuer, or gives github one, fails `pnpm test` instead of production sign-in |
| The fourth branch writes the issuer | unit (mutation) | `account-linking.test.ts`; dropping the write fails 2. A pre-existing test also caught it, which is how I knew the change was real |
| Both arms exercised through account-linking | unit (guard) | Added a non-google (github) case — previously every assertion used google, which is why the wrong branch looked right |
| The repair migration, end to end | manual + **integration (mutation)** | Manual: seeded the four-row matrix and ran the real migration runner — google fixed, github/credential untouched, NULL repaired, second run a no-op, fresh DB baselined without running. Now also automated: `repair-account-issuer.integration.test.ts` reproduces that matrix against real Postgres — repair, idempotency, empty-table no-op, and the repaired row resolving by Better Auth's own `(issuer, providerAccountId)` key. DB-level mutations: neutralising the google arms fails 2 tests; `IS DISTINCT FROM` → `<>` fails the NULL-row case |
| The deliberate TS/SQL encoding asymmetry is documented, not latent | unit (guard) | The SQL `ELSE` concatenates the raw provider id; the helper percent-encodes. Identity for every provider id in use. A test pins `team/github` as the divergence case, and both docblocks state the mirror includes the missing encoding on purpose |

| Live SSO smoke: registration → login → recovery loop → logout → deletion | manual, live | Full stack (real Postgres + Redis + Mailhog + stub OIDC IdP). **Registration**: JIT-provisioned user lands on `/`, account written `openid / local:oauth:openid`, session created. **Login**: second sign-in from a fresh browser goes straight through, still exactly 1 account row. **Verify-before-link recovery**: seeded an email-only user, SSO sign-in → `verification-requested`, no account minted before the email; clicked the Mailhog link → session + account `local:oauth:openid`, `identityProvider` flipped; **the loop test**: next sign-in lands on `/` directly, 1 account row, 0 recovery emails sent. **Logout**: `sign-out` 200, DB session row gone, `get-session` → null. **Deletion**: credential user deletes with password confirmation — user, account and session rows all cascade to 0 |
| Deletion & registration guards hold | manual, live | Bare `delete-user` for an SSO (password-less) user is refused with "Password confirmation is required" — the ENG-1054 confirmation-bypass guard, since SSO deletion goes through the email-token action. Native `sign-up/email` on an instance with existing users is refused `signup_disabled` — the ENG-2293 closed-instance gate |
| Credential sign-in resolves through `issuer = local:credential` | manual, live | Seeded a credential account the post-cutover way (bcrypt on `Account.password`) and signed in over HTTP → 200. Exercises `findCredentialAccount`'s issuer filter against a real row |
| **Real Google, end to end — the case this PR exists for** | manual, live | Against a real Google Workspace identity on a throwaway DB, using the dev OAuth client (registered for `localhost:3000`). Existing user, no Google link — the exact staging state. Sign-in → `account_not_linked` → recovery email, and **no account row or session created before the inbox was proven**. Completing the emailed link wrote `provider=google, issuer=https://accounts.google.com` — asserted equal to `google({…}).accountIssuer` read from upstream in the same run. **Pre-fix this write produced `local:oauth:google`.** Then the loop test: a further Google sign-in landed past login (not the "confirm your email" page), still exactly 1 account row, and **0** new recovery emails — the reported symptom, gone |

**Open gaps**

- ~~Not yet verified against real Google.~~ **Done** — see the real-Google row above. Verified locally against a real Google identity rather than a stub, including the loop test. What remains is confirming it on **staging** after deploy, which is a deployment check rather than a gap in the change: staging uses a different Google OAuth client, so its own registration is the only thing left unproven by this run.
- The live smoke needed a local, uncommitted `sso` entitlement override (the dev license falls back to `default`, and `ssoLicenseGateBeforeHandler` 403s the callback without it). Reverted before committing; verified the tracked tree is clean.
- The migration's `logger.info` produces no visible output through `db:migrate:deploy` locally — the runner emitted nothing at all for a run that demonstrably did work. Pre-existing (every data migration logs the same way) and not worth diverging from house convention over, but it means the repaired count is not currently observable at deploy time.
- 8 unrelated `widget-view.test.ts` failures appear locally on my machine only; they are green in CI and come from my Node being 26.4.0 against the repo's `.nvmrc` 24.14.0.

**Risks**

- Nearby: `linkSocial` also resolves accounts by `(issuer, accountId)`, so it was affected by the same wrong value and is fixed by the same change — worth a click if you are exercising connected accounts.
- The connected-accounts UI lists rows by `userId`, so it showed "Google connected" throughout even while sign-in could not use the row. Don't read that list as proof the link works.
- Rolling deploys: a pod still on the old code could re-stomp a row during the window. The remedy is the branch-3 healing write this PR adds — a re-stomped row is repaired by the next sign-in, with no operator action. **Do not reach for re-running the migration**: `runDataMigration` returns early on `status = 'applied'` (`migration-runner.ts:304`) and there is no force flag, so a second `db:migrate:deploy` logs `already completed. Skipping...` and touches nothing. Re-running would need the `DataMigration` row deleted by hand.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code 2.1.233), reasoning effort `high`.




