### PR TITLE
fix(contacts): gate contact write paths and attribute-key APIs on the contacts entitlement [ENG-2295]

### DIFF
--- a/apps/web/modules/api/v2/management/contact-attribute-keys/[contactAttributeKeyId]/route.ts
+++ b/apps/web/modules/api/v2/management/contact-attribute-keys/[contactAttributeKeyId]/route.ts
@@ -13,6 +13,7 @@ import {
   ZContactAttributeKeyUpdateSchema,
 } from "@/modules/api/v2/management/contact-attribute-keys/[contactAttributeKeyId]/types/contact-attribute-keys";
 import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
+import { checkContactsEnabledApiV2 } from "@/modules/ee/contacts/lib/contacts-entitlement";
 import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
 
 export const GET = async (
@@ -27,6 +28,11 @@ export const GET = async (
     externalParams: props.params,
     handler: async ({ authentication, parsedInput }) => {
       const { params } = parsedInput;
+
+      const contactsNotEnabledError = await checkContactsEnabledApiV2(authentication.organizationId);
+      if (contactsNotEnabledError) {
+        return handleApiError(request, contactsNotEnabledError);
+      }
 
       const res = await getContactAttributeKey(params.contactAttributeKeyId);
 
@@ -61,6 +67,11 @@ export const PUT = async (
 
       if (auditLog) {
         auditLog.targetId = params.contactAttributeKeyId;
+      }
+
+      const contactsNotEnabledError = await checkContactsEnabledApiV2(authentication.organizationId);
+      if (contactsNotEnabledError) {
+        return handleApiError(request, contactsNotEnabledError, auditLog);
       }
 
       const res = await getContactAttributeKey(params.contactAttributeKeyId);
@@ -133,6 +144,11 @@ export const DELETE = async (
 
       if (auditLog) {
         auditLog.targetId = params.contactAttributeKeyId;
+      }
+
+      const contactsNotEnabledError = await checkContactsEnabledApiV2(authentication.organizationId);
+      if (contactsNotEnabledError) {
+        return handleApiError(request, contactsNotEnabledError, auditLog);
       }
 
       const res = await getContactAttributeKey(params.contactAttributeKeyId);

--- a/apps/web/modules/api/v2/management/contact-attribute-keys/[contactAttributeKeyId]/route.ts
+++ b/apps/web/modules/api/v2/management/contact-attribute-keys/[contactAttributeKeyId]/route.ts
@@ -13,7 +13,7 @@ import {
   ZContactAttributeKeyUpdateSchema,
 } from "@/modules/api/v2/management/contact-attribute-keys/[contactAttributeKeyId]/types/contact-attribute-keys";
 import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
-import { checkContactsEnabledApiV2 } from "@/modules/ee/contacts/lib/contacts-entitlement";
+import { checkContactsEnabledApiV2 } from "@/modules/ee/license-check/lib/contacts-api-guard";
 import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
 
 export const GET = async (

--- a/apps/web/modules/api/v2/management/contact-attribute-keys/route.ts
+++ b/apps/web/modules/api/v2/management/contact-attribute-keys/route.ts
@@ -12,7 +12,7 @@ import {
 } from "@/modules/api/v2/management/contact-attribute-keys/types/contact-attribute-keys";
 import { resolveBodyIdsV2 } from "@/modules/api/v2/management/lib/workspace-resolver";
 import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
-import { checkContactsEnabledApiV2 } from "@/modules/ee/contacts/lib/contacts-entitlement";
+import { checkContactsEnabledApiV2 } from "@/modules/ee/license-check/lib/contacts-api-guard";
 
 export const GET = async (request: NextRequest) =>
   authenticatedApiClient({

--- a/apps/web/modules/api/v2/management/contact-attribute-keys/route.ts
+++ b/apps/web/modules/api/v2/management/contact-attribute-keys/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/modules/api/v2/management/contact-attribute-keys/types/contact-attribute-keys";
 import { resolveBodyIdsV2 } from "@/modules/api/v2/management/lib/workspace-resolver";
 import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
+import { checkContactsEnabledApiV2 } from "@/modules/ee/contacts/lib/contacts-entitlement";
 
 export const GET = async (request: NextRequest) =>
   authenticatedApiClient({
@@ -21,6 +22,11 @@ export const GET = async (request: NextRequest) =>
     },
     handler: async ({ authentication, parsedInput }) => {
       const { query } = parsedInput;
+
+      const contactsNotEnabledError = await checkContactsEnabledApiV2(authentication.organizationId);
+      if (contactsNotEnabledError) {
+        return handleApiError(request, contactsNotEnabledError);
+      }
 
       const workspaceIds = [
         ...new Set(authentication.workspacePermissions.map((permission) => permission.workspaceId)),
@@ -47,8 +53,13 @@ export const POST = async (request: NextRequest) =>
       if (!resolved.ok) throw resolved.error;
       return { ...body, ...resolved.data };
     },
-    handler: async ({ parsedInput, auditLog }) => {
+    handler: async ({ authentication, parsedInput, auditLog }) => {
       const { body } = parsedInput;
+
+      const contactsNotEnabledError = await checkContactsEnabledApiV2(authentication.organizationId);
+      if (contactsNotEnabledError) {
+        return handleApiError(request, contactsNotEnabledError, auditLog);
+      }
 
       const createContactAttributeKeyResult = await createContactAttributeKey(body);
 

--- a/apps/web/modules/ee/contacts/[contactId]/actions.ts
+++ b/apps/web/modules/ee/contacts/[contactId]/actions.ts
@@ -12,6 +12,7 @@ import {
   getWorkspaceIdFromSurveyId,
 } from "@/lib/utils/helper";
 import { getContactSurveyLink } from "@/modules/ee/contacts/lib/contact-survey-link";
+import { ensureContactsEnabled } from "@/modules/ee/contacts/lib/contacts-entitlement";
 import { CONTACT_SURVEY_WORKSPACE_MISMATCH_ERROR_CODE } from "@/modules/ee/contacts/lib/personal-link-errors";
 
 const ZGeneratePersonalSurveyLinkAction = z.object({
@@ -41,6 +42,8 @@ export const generatePersonalSurveyLinkAction = authenticatedActionClient
         },
       ],
     });
+
+    await ensureContactsEnabled(organizationId);
 
     // Cross-tenant guard: the survey must belong to the same workspace as the
     // contact the caller was authorized against. Authorization above is derived

--- a/apps/web/modules/ee/contacts/actions.ts
+++ b/apps/web/modules/ee/contacts/actions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { prisma } from "@formbricks/database";
 import { ZId } from "@formbricks/types/common";
 import { ZContactAttributesInput } from "@formbricks/types/contact-attribute";
-import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
@@ -14,7 +14,7 @@ import {
   getWorkspaceIdFromContactId,
 } from "@/lib/utils/helper";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
-import { getIsContactsEnabled } from "@/modules/ee/license-check/lib/utils";
+import { ensureContactsEnabled } from "@/modules/ee/contacts/lib/contacts-entitlement";
 import { createContactsFromCSV, deleteContact, getContact, getContacts } from "./lib/contacts";
 import { updateContactAttributes } from "./lib/update-contact-attributes";
 import {
@@ -51,10 +51,7 @@ export const getContactsAction = authenticatedActionClient
       ],
     });
 
-    const isContactsEnabled = await getIsContactsEnabled(organizationId);
-    if (!isContactsEnabled) {
-      throw new OperationNotAllowedError("Contacts are not enabled for this organization");
-    }
+    await ensureContactsEnabled(organizationId);
 
     return getContacts(workspaceId, parsedInput.offset, parsedInput.searchValue);
   });
@@ -83,6 +80,8 @@ export const deleteContactAction = authenticatedActionClient.inputSchema(ZContac
         },
       ],
     });
+
+    await ensureContactsEnabled(organizationId);
 
     ctx.auditLoggingCtx.organizationId = organizationId;
     ctx.auditLoggingCtx.contactId = parsedInput.contactId;
@@ -122,6 +121,8 @@ export const createContactsFromCSVAction = authenticatedActionClient
           },
         ],
       });
+
+      await ensureContactsEnabled(organizationId);
 
       ctx.auditLoggingCtx.organizationId = organizationId;
       const existingContactCount = await prisma.contact.count({
@@ -185,6 +186,8 @@ export const updateContactAttributesAction = authenticatedActionClient
           },
         ],
       });
+
+      await ensureContactsEnabled(organizationId);
 
       ctx.auditLoggingCtx.organizationId = organizationId;
       ctx.auditLoggingCtx.contactId = parsedInput.contactId;

--- a/apps/web/modules/ee/contacts/api/v1/management/contact-attribute-keys/[contactAttributeKeyId]/route.ts
+++ b/apps/web/modules/ee/contacts/api/v1/management/contact-attribute-keys/[contactAttributeKeyId]/route.ts
@@ -4,6 +4,8 @@ import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { TApiKeyAuthentication, THandlerParams, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
+import { CONTACTS_API_V1_NOT_ENABLED_MESSAGE } from "@/modules/ee/contacts/lib/contacts-entitlement";
+import { getIsContactsEnabled } from "@/modules/ee/license-check/lib/utils";
 import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
 import {
   deleteContactAttributeKey,
@@ -14,15 +16,22 @@ import { ZContactAttributeKeyUpdateInput } from "./types/contact-attribute-keys"
 
 async function fetchAndAuthorizeContactAttributeKey(
   attributeKeyId: string,
-  workspacePermissions: NonNullable<TApiKeyAuthentication>["workspacePermissions"],
+  authentication: NonNullable<TApiKeyAuthentication>,
   requiredPermission: "GET" | "PUT" | "DELETE"
 ) {
+  // Entitlement first, matching the plural route: without the contacts feature the caller may
+  // not interact with attribute keys at all, regardless of workspace permissions.
+  const isContactsEnabled = await getIsContactsEnabled(authentication.organizationId);
+  if (!isContactsEnabled) {
+    return { error: responses.forbiddenResponse(CONTACTS_API_V1_NOT_ENABLED_MESSAGE) };
+  }
+
   const attributeKey = await getContactAttributeKey(attributeKeyId);
   if (!attributeKey) {
     return { error: responses.notFoundResponse("Attribute Key", attributeKeyId) };
   }
 
-  if (!hasPermission(workspacePermissions, attributeKey.workspaceId, requiredPermission)) {
+  if (!hasPermission(authentication.workspacePermissions, attributeKey.workspaceId, requiredPermission)) {
     return { error: responses.unauthorizedResponse() };
   }
 
@@ -42,7 +51,7 @@ export const GET = withV1ApiWrapper({
 
       const result = await fetchAndAuthorizeContactAttributeKey(
         params.contactAttributeKeyId,
-        authentication.workspacePermissions,
+        authentication,
         "GET"
       );
       if (result.error) {
@@ -55,14 +64,6 @@ export const GET = withV1ApiWrapper({
         response: responses.successResponse(result.attributeKey),
       };
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message === "Contacts are only enabled for Enterprise Edition, please upgrade."
-      ) {
-        return {
-          response: responses.forbiddenResponse(error.message),
-        };
-      }
       return handleErrorResponse(error);
     }
   },
@@ -85,7 +86,7 @@ export const DELETE = withV1ApiWrapper({
     try {
       const result = await fetchAndAuthorizeContactAttributeKey(
         params.contactAttributeKeyId,
-        authentication.workspacePermissions,
+        authentication,
         "DELETE"
       );
 
@@ -132,7 +133,7 @@ export const PUT = withV1ApiWrapper({
     try {
       const result = await fetchAndAuthorizeContactAttributeKey(
         params.contactAttributeKeyId,
-        authentication.workspacePermissions,
+        authentication,
         "PUT"
       );
       if (result.error) {

--- a/apps/web/modules/ee/contacts/api/v1/management/contact-attribute-keys/route.ts
+++ b/apps/web/modules/ee/contacts/api/v1/management/contact-attribute-keys/route.ts
@@ -5,6 +5,7 @@ import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { THandlerParams, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
+import { CONTACTS_API_V1_NOT_ENABLED_MESSAGE } from "@/modules/ee/contacts/lib/contacts-entitlement";
 import { getIsContactsEnabled } from "@/modules/ee/license-check/lib/utils";
 import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
 import { ZContactAttributeKeyCreateInput } from "./[contactAttributeKeyId]/types/contact-attribute-keys";
@@ -20,9 +21,7 @@ export const GET = withV1ApiWrapper({
       const isContactsEnabled = await getIsContactsEnabled(authentication.organizationId);
       if (!isContactsEnabled) {
         return {
-          response: responses.forbiddenResponse(
-            "Contacts are only enabled for Enterprise Edition, please upgrade."
-          ),
+          response: responses.forbiddenResponse(CONTACTS_API_V1_NOT_ENABLED_MESSAGE),
         };
       }
 
@@ -56,9 +55,7 @@ export const POST = withV1ApiWrapper({
       const isContactsEnabled = await getIsContactsEnabled(authentication.organizationId);
       if (!isContactsEnabled) {
         return {
-          response: responses.forbiddenResponse(
-            "Contacts are only enabled for Enterprise Edition, please upgrade."
-          ),
+          response: responses.forbiddenResponse(CONTACTS_API_V1_NOT_ENABLED_MESSAGE),
         };
       }
 

--- a/apps/web/modules/ee/contacts/attributes/actions.ts
+++ b/apps/web/modules/ee/contacts/attributes/actions.ts
@@ -20,6 +20,7 @@ import {
   getContactAttributeKeyById,
   updateContactAttributeKey,
 } from "@/modules/ee/contacts/lib/contact-attribute-keys";
+import { ensureContactsEnabled } from "@/modules/ee/contacts/lib/contacts-entitlement";
 
 const ZCreateContactAttributeKeyAction = z.object({
   workspaceId: ZId,
@@ -59,6 +60,8 @@ export const createContactAttributeKeyAction = authenticatedActionClient
           },
         ],
       });
+
+      await ensureContactsEnabled(organizationId);
 
       ctx.auditLoggingCtx.organizationId = organizationId;
 
@@ -122,6 +125,8 @@ export const updateContactAttributeKeyAction = authenticatedActionClient
         ],
       });
 
+      await ensureContactsEnabled(organizationId);
+
       ctx.auditLoggingCtx.organizationId = organizationId;
       ctx.auditLoggingCtx.oldObject = existingKey;
 
@@ -168,6 +173,8 @@ export const deleteContactAttributeKeyAction = authenticatedActionClient
           },
         ],
       });
+
+      await ensureContactsEnabled(organizationId);
 
       ctx.auditLoggingCtx.organizationId = organizationId;
       ctx.auditLoggingCtx.oldObject = existingKey;

--- a/apps/web/modules/ee/contacts/lib/contacts-entitlement.test.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts-entitlement.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { OperationNotAllowedError } from "@formbricks/types/errors";
+
+const mocks = vi.hoisted(() => ({
+  getIsContactsEnabled: vi.fn(),
+}));
+
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({
+  getIsContactsEnabled: mocks.getIsContactsEnabled,
+}));
+
+const { CONTACTS_NOT_ENABLED_MESSAGE, checkContactsEnabledApiV2, ensureContactsEnabled } =
+  await import("./contacts-entitlement");
+
+describe("ensureContactsEnabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("throws OperationNotAllowedError when the entitlement is missing", async () => {
+    mocks.getIsContactsEnabled.mockResolvedValue(false);
+
+    await expect(ensureContactsEnabled("org1")).rejects.toThrow(OperationNotAllowedError);
+    await expect(ensureContactsEnabled("org1")).rejects.toThrow(CONTACTS_NOT_ENABLED_MESSAGE);
+    expect(mocks.getIsContactsEnabled).toHaveBeenCalledWith("org1");
+  });
+
+  test("resolves when the entitlement is present", async () => {
+    mocks.getIsContactsEnabled.mockResolvedValue(true);
+
+    await expect(ensureContactsEnabled("org1")).resolves.toBeUndefined();
+  });
+});
+
+describe("checkContactsEnabledApiV2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns a forbidden error object when the entitlement is missing", async () => {
+    mocks.getIsContactsEnabled.mockResolvedValue(false);
+
+    const error = await checkContactsEnabledApiV2("org1");
+
+    expect(error).toEqual({
+      type: "forbidden",
+      details: [{ field: "contacts", issue: "Contacts feature is not enabled for this organization" }],
+    });
+  });
+
+  test("returns null when the entitlement is present", async () => {
+    mocks.getIsContactsEnabled.mockResolvedValue(true);
+
+    await expect(checkContactsEnabledApiV2("org1")).resolves.toBeNull();
+  });
+});

--- a/apps/web/modules/ee/contacts/lib/contacts-entitlement.test.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts-entitlement.test.ts
@@ -9,8 +9,7 @@ vi.mock("@/modules/ee/license-check/lib/utils", () => ({
   getIsContactsEnabled: mocks.getIsContactsEnabled,
 }));
 
-const { CONTACTS_NOT_ENABLED_MESSAGE, checkContactsEnabledApiV2, ensureContactsEnabled } =
-  await import("./contacts-entitlement");
+const { CONTACTS_NOT_ENABLED_MESSAGE, ensureContactsEnabled } = await import("./contacts-entitlement");
 
 describe("ensureContactsEnabled", () => {
   beforeEach(() => {
@@ -29,28 +28,5 @@ describe("ensureContactsEnabled", () => {
     mocks.getIsContactsEnabled.mockResolvedValue(true);
 
     await expect(ensureContactsEnabled("org1")).resolves.toBeUndefined();
-  });
-});
-
-describe("checkContactsEnabledApiV2", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  test("returns a forbidden error object when the entitlement is missing", async () => {
-    mocks.getIsContactsEnabled.mockResolvedValue(false);
-
-    const error = await checkContactsEnabledApiV2("org1");
-
-    expect(error).toEqual({
-      type: "forbidden",
-      details: [{ field: "contacts", issue: "Contacts feature is not enabled for this organization" }],
-    });
-  });
-
-  test("returns null when the entitlement is present", async () => {
-    mocks.getIsContactsEnabled.mockResolvedValue(true);
-
-    await expect(checkContactsEnabledApiV2("org1")).resolves.toBeNull();
   });
 });

--- a/apps/web/modules/ee/contacts/lib/contacts-entitlement.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts-entitlement.ts
@@ -1,0 +1,45 @@
+import "server-only";
+import { OperationNotAllowedError } from "@formbricks/types/errors";
+import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
+import { getIsContactsEnabled } from "@/modules/ee/license-check/lib/utils";
+
+export const CONTACTS_NOT_ENABLED_MESSAGE = "Contacts are not enabled for this organization";
+
+/**
+ * The exact string the v1 management routes have always returned for a missing contacts
+ * entitlement — kept verbatim for API consumers that match on it.
+ */
+export const CONTACTS_API_V1_NOT_ENABLED_MESSAGE =
+  "Contacts are only enabled for Enterprise Edition, please upgrade.";
+
+/**
+ * Module-boundary guard for the contacts (EE) entitlement, for server actions.
+ *
+ * Every server action in `modules/ee/contacts` that reads or writes contact data must call this
+ * right after authorization. The entitlement check used to be inlined per call site and rotted
+ * out of several write paths over time (it survived only in some siblings), so new call sites
+ * must go through this helper instead of re-inlining `getIsContactsEnabled`.
+ */
+export const ensureContactsEnabled = async (organizationId: string): Promise<void> => {
+  const isContactsEnabled = await getIsContactsEnabled(organizationId);
+  if (!isContactsEnabled) {
+    throw new OperationNotAllowedError(CONTACTS_NOT_ENABLED_MESSAGE);
+  }
+};
+
+/**
+ * The v2/v3-flavored variant of the same guard: returns the `forbidden` error object for
+ * `handleApiError` when the entitlement is missing, `null` when the caller may proceed.
+ */
+export const checkContactsEnabledApiV2 = async (
+  organizationId: string
+): Promise<ApiErrorResponseV2 | null> => {
+  const isContactsEnabled = await getIsContactsEnabled(organizationId);
+  if (isContactsEnabled) {
+    return null;
+  }
+  return {
+    type: "forbidden",
+    details: [{ field: "contacts", issue: "Contacts feature is not enabled for this organization" }],
+  };
+};

--- a/apps/web/modules/ee/contacts/lib/contacts-entitlement.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts-entitlement.ts
@@ -1,6 +1,5 @@
 import "server-only";
 import { OperationNotAllowedError } from "@formbricks/types/errors";
-import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
 import { getIsContactsEnabled } from "@/modules/ee/license-check/lib/utils";
 
 export const CONTACTS_NOT_ENABLED_MESSAGE = "Contacts are not enabled for this organization";
@@ -25,21 +24,4 @@ export const ensureContactsEnabled = async (organizationId: string): Promise<voi
   if (!isContactsEnabled) {
     throw new OperationNotAllowedError(CONTACTS_NOT_ENABLED_MESSAGE);
   }
-};
-
-/**
- * The v2/v3-flavored variant of the same guard: returns the `forbidden` error object for
- * `handleApiError` when the entitlement is missing, `null` when the caller may proceed.
- */
-export const checkContactsEnabledApiV2 = async (
-  organizationId: string
-): Promise<ApiErrorResponseV2 | null> => {
-  const isContactsEnabled = await getIsContactsEnabled(organizationId);
-  if (isContactsEnabled) {
-    return null;
-  }
-  return {
-    type: "forbidden",
-    details: [{ field: "contacts", issue: "Contacts feature is not enabled for this organization" }],
-  };
 };

--- a/apps/web/modules/ee/contacts/segments/actions.ts
+++ b/apps/web/modules/ee/contacts/segments/actions.ts
@@ -344,9 +344,11 @@ const ZGetDistinctAttributeValuesAction = z.object({
 export const getDistinctAttributeValuesAction = authenticatedActionClient
   .inputSchema(ZGetDistinctAttributeValuesAction)
   .action(async ({ ctx, parsedInput }) => {
+    const organizationId = await getOrganizationIdFromContactAttributeKeyId(parsedInput.attributeKeyId);
+
     await checkAuthorizationUpdated({
       userId: ctx.user.id,
-      organizationId: await getOrganizationIdFromContactAttributeKeyId(parsedInput.attributeKeyId),
+      organizationId,
       access: [
         {
           type: "organization",
@@ -359,6 +361,8 @@ export const getDistinctAttributeValuesAction = authenticatedActionClient
         },
       ],
     });
+
+    await checkAdvancedTargetingPermission(organizationId);
 
     return await getDistinctAttributeValues(parsedInput.attributeKeyId);
   });

--- a/apps/web/modules/ee/license-check/lib/contacts-api-guard.test.ts
+++ b/apps/web/modules/ee/license-check/lib/contacts-api-guard.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getIsContactsEnabled: vi.fn(),
+}));
+
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({
+  getIsContactsEnabled: mocks.getIsContactsEnabled,
+}));
+
+const { checkContactsEnabledApiV2 } = await import("./contacts-api-guard");
+
+describe("checkContactsEnabledApiV2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns a forbidden error object when the entitlement is missing", async () => {
+    mocks.getIsContactsEnabled.mockResolvedValue(false);
+
+    const error = await checkContactsEnabledApiV2("org1");
+
+    expect(error).toEqual({
+      type: "forbidden",
+      details: [{ field: "contacts", issue: "Contacts feature is not enabled for this organization" }],
+    });
+    expect(mocks.getIsContactsEnabled).toHaveBeenCalledWith("org1");
+  });
+
+  test("returns null when the entitlement is present", async () => {
+    mocks.getIsContactsEnabled.mockResolvedValue(true);
+
+    await expect(checkContactsEnabledApiV2("org1")).resolves.toBeNull();
+  });
+});

--- a/apps/web/modules/ee/license-check/lib/contacts-api-guard.ts
+++ b/apps/web/modules/ee/license-check/lib/contacts-api-guard.ts
@@ -1,0 +1,26 @@
+import "server-only";
+import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
+import { getIsContactsEnabled } from "@/modules/ee/license-check/lib/utils";
+
+/**
+ * Contacts entitlement guard for the v2/v3-flavored management APIs: returns the `forbidden`
+ * error object for `handleApiError` when the entitlement is missing, `null` when the caller may
+ * proceed.
+ *
+ * Lives in license-check (not `modules/ee/contacts`) because the v2 attribute-key routes under
+ * the OSS `modules/api/v2` path consume it, and license-check is the sanctioned import boundary
+ * for OSS code. The server-action flavour (`ensureContactsEnabled`) stays in
+ * `modules/ee/contacts/lib/contacts-entitlement.ts`, which only EE code imports.
+ */
+export const checkContactsEnabledApiV2 = async (
+  organizationId: string
+): Promise<ApiErrorResponseV2 | null> => {
+  const isContactsEnabled = await getIsContactsEnabled(organizationId);
+  if (isContactsEnabled) {
+    return null;
+  }
+  return {
+    type: "forbidden",
+    details: [{ field: "contacts", issue: "Contacts feature is not enabled for this organization" }],
+  };
+};


### PR DESCRIPTION
Fixes ENG-2295

## What & why

[ENG-1768](https://linear.app/formbricks/issue/ENG-1768) gated the **read** side of contacts (EE) on the `contacts` entitlement. The **write** side of the same module never got the gate: an authenticated member of an org *without* the entitlement could still mint personal survey links, bulk-import contacts from CSV, edit contact attributes, manage attribute keys, enumerate distinct attribute values, and drive the v1 by-id / v2 attribute-key management APIs. Tenancy was enforced everywhere — this is a licence bypass only, no cross-tenant angle.

The by-id v1 route even carried a **dead catch** matching the "Contacts are only enabled for Enterprise Edition…" message that nothing throws anymore — the check was evidently lost in a refactor. That is why this PR adds a **shared guard** at the module boundary instead of seven more inline checks ([ENG-2507](https://linear.app/formbricks/issue/ENG-2507)'s "close the class, not the instance"):

- **New:** two guard files, split by who may import them. `modules/ee/contacts/lib/contacts-entitlement.ts` — `ensureContactsEnabled(organizationId)` (throws `OperationNotAllowedError`, for the module's server actions) plus the v1 message as a shared constant; only EE code imports it. `modules/ee/license-check/lib/contacts-api-guard.ts` — `checkContactsEnabledApiV2` (returns the `forbidden` error object, for v2 handlers); it lives in license-check because the v2 attribute-key routes under the OSS `modules/api/v2` path consume it, and license-check is the sanctioned EE import boundary for OSS code (per review — the wider `modules/api/v2` → `modules/ee/contacts` imports that already exist on `main` are left for a separate cleanup).
- **Gated server actions:** `generatePersonalSurveyLinkAction`, `createContactsFromCSVAction`, `updateContactAttributesAction`, `deleteContactAction`, attribute-key create/update/delete, `getDistinctAttributeValuesAction` (this one via the segments file's existing `checkAdvancedTargetingPermission`, like every sibling there). `getContactsAction`'s existing inline check is migrated to the shared guard — same message, one way to do it.
- **Gated API routes:** v1 `contact-attribute-keys/[id]` GET/PUT/DELETE (one check inside `fetchAndAuthorizeContactAttributeKey` covers all three; dead catch removed), v2 `contact-attribute-keys` GET/POST and `[id]` GET/PUT/DELETE.
- `deleteContactAction` is not in the ticket's list, but v1 management contact DELETE already gates — leaving the UI action ungated would have kept it the module's one open write path, so it is gated for consistency.

Error strings are kept verbatim (the v1 EE-upgrade message, the action message `getContactsAction` already used), so no consumer-visible message changes for entitled orgs.

## Breaking changes

- [x] This PR contains breaking changes

Breaking only for organizations **without** the contacts entitlement — this enforces the licence the gated sibling routes already enforce, and entitled orgs see no change in shape, status or message. It is ticked because the emitted value of public management endpoints changes for unlicensed consumers, which is exactly what the label, release notes and self-hoster migration guide exist to announce.

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| `GET/PUT/DELETE /api/v1/management/contact-attribute-keys/{id}` | 2xx with data for orgs without the contacts entitlement | 403 "Contacts are only enabled for Enterprise Edition, please upgrade." | Self-hosters / API consumers without the contacts entitlement | Obtain the contacts entitlement, or stop calling these endpoints |
| `GET/POST /api/v2/management/contact-attribute-keys` and `GET/PUT/DELETE …/{id}` | 2xx with data for orgs without the contacts entitlement | 403 `forbidden` error (`Contacts feature is not enabled for this organization`) | Same | Same |

The gated web-app actions (CSV import, attribute editing, personal links, contact delete) are not listed: server actions are not a public API surface, and the contacts UI is already entitlement-gated since ENG-1768.

## Migrations & env

- none

## How this was tested

**Coverage**

Up front: **this bug class has no red-on-main seam under the repo's test conventions.** The missing checks lived in server actions and route handlers, and neither `actions.ts` nor `route.ts` files are unit-tested here (both are in the Sonar coverage exclusions; the convention is to test what they call). The guard itself is new code, so its rows are mutation-proven instead; the wiring — "each action/route calls the guard first" — is the review's job, plus the diff is mechanically uniform (same one-liner after the authz block in every action, same two patterns in the routes as their gated siblings).

| Behaviour | How | Outcome |
| --- | --- | --- |
| `ensureContactsEnabled` throws `OperationNotAllowedError` with the exact message when the entitlement is missing, resolves when present | unit (mutation) | `modules/ee/contacts/lib/contacts-entitlement.test.ts`. Inverting the check at `contacts-entitlement.ts:24` → 2/2 tests fail. |
| `checkContactsEnabledApiV2` returns the `forbidden` error object when missing, `null` when present | unit (mutation) | `modules/ee/license-check/lib/contacts-api-guard.test.ts`. Inverting the check at `contacts-api-guard.ts:19` → 2/2 tests fail. |
| `getContactsAction`'s existing read gate (ENG-1768) is behaviour-identical after migrating to the shared guard | unit (guard) | The guard test asserts the exact error type and message the action previously threw inline (`OperationNotAllowedError`, "Contacts are not enabled for this organization"), so callers see byte-identical failures. The untouched ENG-1920 suite (`segments/actions.test.ts`) still passes against the modified `segments/actions.ts`. |
| Nothing else regressed | unit (guard) | `pnpm test --filter=@formbricks/web`: 641/641 files green. `pnpm typecheck --filter=@formbricks/web` 12/12. ESLint on all touched files: clean. |

**Open gaps**

- **The wiring of the guard into the 8 actions and 8 route handlers has no automated test** — that is the repo convention for actions/routes, not an oversight, but it is exactly how the original check got lost (the dead catch is the fossil). The shared guard reduces the surface to "is the one-liner present", which a reviewer can check per call site from the diff alone.
- **No e2e row.** The Playwright environment runs with `ENTERPRISE_LICENSE_KEY` set (`e2e.yml`), so the entitlement-off behaviour cannot be exercised there at all.
- The dead catch's removal rests on a repo grep: the EE-upgrade message is still *returned* by other v1 routes as an explicit `forbiddenResponse`, but no code path **throws** it as an `Error`, which is all the catch matched.

**Risks**

- An org that loses the entitlement can no longer delete contacts or attribute keys from the app (the v1 management API already refused contact DELETE this way; the module is now uniform). If a downgraded org needs PII removed, that goes through the existing support path — unchanged for the API, new for the UI action.
- v2 attribute-key endpoints now return 403 for unlicensed orgs where they previously returned data; any such consumer was relying on the licence gap this PR closes.

---

> [!NOTE]
> **AI model used** — `claude-fable-5`, reasoning effort `unknown`.
