### PR TITLE
chore: enable the eslint/typescript-eslint recommended baseline as warnings in apps/web (ENG-2264)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,10 @@ Heuristic:
 
 - Keep code DRY and small; remove dead code and unused imports.
 - Follow React hooks rules, keep effects focused, and avoid unnecessary `useMemo`/`useCallback`.
-- Prefer type inference, avoid `any`, and use shared types from `@formbricks/types`.
+- Prefer type inference, avoid `any`, and use shared types from `@formbricks/types`. This is enforced:
+  `@typescript-eslint/no-explicit-any` is an error in `packages/*` and a warning in `apps/web`, where the
+  typescript-eslint baseline is being ratcheted to error rule by rule (ENG-2264). Never add new `any`s —
+  a warning today becomes an error once its rule's backlog is cleared.
 - Keep components focused, avoid deep nesting, and ensure basic accessibility.
 
 ## Commit & Pull Request Guidelines

--- a/packages/config-eslint/next.mjs
+++ b/packages/config-eslint/next.mjs
@@ -1,16 +1,50 @@
+import js from "@eslint/js";
 import nextConfig from "eslint-config-next";
-import { base, commonIgnores, typescriptParsing } from "./base.mjs";
+import tseslint from "typescript-eslint";
+import { base, commonIgnores, typescriptParsing, unusedVarsConvention } from "./base.mjs";
 
 /*
  * Flat config for the Next.js app — the successor of `legacy-next.js`:
  * eslint-config-next + turbo + prettier + the vitest convention, with the same rule
- * overrides the legacy config carried. Deliberately does not add the
- * eslint/typescript-eslint recommended baselines yet to keep rule parity with the
- * previous setup — tightening is a separate step (ENG-2264).
+ * overrides the legacy config carried.
+ *
+ * The eslint/typescript-eslint recommended baselines are active but downgraded to
+ * warnings (ENG-2264): apps/web was never linted against them, so the backlog is
+ * large and enabling them as errors in one step would block every PR. Rules are
+ * promoted to "error" individually as their violation count reaches zero — the
+ * per-rule counts and ratchet plan live on the ticket. `recommendedTypeChecked`
+ * (used by the library/react tiers) is a separate decision, also tracked there.
  */
+
+// The recommended baselines ship rules at "error"; keep their options but lower the
+// severity so the backlog surfaces without failing CI. "off" entries (e.g. the core
+// rules that eslint-recommended disables for TS files) pass through untouched.
+const isErrorSeverity = (severity) => severity === "error" || severity === 2;
+
+const downgradeToWarn = ({ rules, ...config }) => ({
+  ...config,
+  ...(rules && {
+    rules: Object.fromEntries(
+      Object.entries(rules).map(([id, entry]) => {
+        if (Array.isArray(entry)) {
+          const [severity, ...options] = entry;
+          return [id, isErrorSeverity(severity) ? ["warn", ...options] : entry];
+        }
+        return [id, isErrorSeverity(entry) ? "warn" : entry];
+      })
+    ),
+  }),
+});
+
 export const next = [
   commonIgnores,
   typescriptParsing,
+  downgradeToWarn(js.configs.recommended),
+  ...tseslint.configs.recommended.map(downgradeToWarn),
+  // Same underscore convention as the other tiers, at warning severity like the rest
+  // of the baseline; without the options, default no-unused-vars would flag the
+  // repo-sanctioned `_`-prefixed intentionally-unused bindings.
+  downgradeToWarn(unusedVarsConvention),
   ...nextConfig,
   {
     rules: {


### PR DESCRIPTION
Ref ENG-2264

## What & why

- `packages/config-eslint/next.mjs` deliberately omitted the eslint/typescript-eslint recommended baselines, so rules like `@typescript-eslint/no-explicit-any` never ran in `apps/web` — our largest codebase — while being errors in `packages/*`.
- This PR adds `js.configs.recommended` + `tseslint.configs.recommended` to the `next` tier, with every rule downgraded to `warn` (options preserved). Warnings don't fail CI (`eslint .` has no `--max-warnings`), so no PR is blocked; rules get promoted to `error` one by one as their backlog clears.
- Also adds the repo's `_`-prefix `no-unused-vars` convention (shared `unusedVarsConvention`, at warn) so intentionally-unused bindings aren't flagged, and updates the `AGENTS.md` "avoid `any`" line to state how it's now enforced.
- Deliberately **not** `recommendedTypeChecked` (used by the library/react tiers): apps/web measured 9,204 violations and OOMs at Node's default heap under it — that stays a separate decision on the ticket.

**Measured backlog** (recorded on the ticket with the ratchet plan): 1,892 warnings across 386 of 2,656 files. 1,552 are in test/mock files, only 300 in product code. `no-explicit-any` is 1,583 of the total (1,476 test/mock, 107 source).

## Breaking changes

- [ ] This PR contains breaking changes

None — lint-severity change only (new warnings, zero new errors); no runtime code touched.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Baseline rules now report in `apps/web` | manual | `pnpm exec eslint . --format json` in `apps/web`: 1,892 warnings from the expected rule set (`no-explicit-any`, `prefer-const`, `no-unused-vars`, …) |
| Nothing newly fails — merge behaviour unchanged | manual | Same run exits 0: zero error-level messages, warnings only |
| Other packages unaffected | manual | `next.mjs` has exactly one consumer (`apps/web/eslint.config.mjs`, verified by grep); library/react tiers untouched |

**Open gaps**

- Root `pnpm lint` (turbo, all workspaces) not run locally — only `apps/web` was linted directly; CI covers the rest. The change is scoped to the `next` tier, which no other workspace consumes.
- `_`-prefix handling relies on reusing the shared `unusedVarsConvention` options; I didn't construct a dedicated fixture to confirm an `_arg` goes unflagged in apps/web.

**Risks**

- Editor/PR-annotation noise from the new warnings until the ratchet clears them; if a rule proves too noisy, its severity can be adjusted in one place in `next.mjs`.
- `eslint-disable` comments in apps/web referencing typescript-eslint rules were previously inert; the plugin now being loaded can change whether they count as used or unused directives (unused ones surface as warnings via `reportUnusedDisableDirectives`, already `warn`).

---

> [!NOTE]
> **AI model used** — `claude-fable-5` (Claude Code, version unknown), reasoning effort `unknown`.
