### PR TITLE
fix(segments): bound the survey-interaction filter IN queries (ENG-2305)

### DIFF
--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/__mocks__/database";
+import { createId } from "@paralleldrive/cuid2";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { testInputValidation } from "vitestSetup";
 import { ActionClass, Prisma, Survey } from "@formbricks/database/prisma";
@@ -11,7 +12,12 @@ import {
   ResourceNotFoundError,
   ValidationError,
 } from "@formbricks/types/errors";
-import { MAX_SEGMENT_FILTERS_PER_TREE, TBaseFilters, TSegment } from "@formbricks/types/segment";
+import {
+  MAX_SEGMENT_FILTERS_PER_TREE,
+  MAX_SEGMENT_SURVEYS,
+  TBaseFilters,
+  TSegment,
+} from "@formbricks/types/segment";
 import { TSurveyFollowUp } from "@formbricks/types/surveys/follow-up";
 import { TSurvey, TSurveyCreateInput, TSurveyQuestionTypeEnum } from "@formbricks/types/surveys/types";
 import { getActionClasses } from "@/lib/actionClass/service";
@@ -604,6 +610,126 @@ describe("Tests for updateSurvey", () => {
         expect.objectContaining({
           where: { id: "clownsegment000000000001" },
           data: expect.objectContaining({ filters: halfBuiltFilters }),
+        })
+      );
+    });
+
+    // ENG-2305 sibling of the filter-tree gate: on the draft path segment.surveys is just as
+    // unvalidated as the filter tree (ZSurveyDraft.segment is an untyped record), so the id-format
+    // rule and MAX_SEGMENT_SURVEYS cap must hold unconditionally — BEFORE the ids drive the batched
+    // workspace lookup. An over-limit or junk draft must perform no survey queries at all.
+    test("rejects an over-cap segment.surveys list on the draft path without any survey lookup", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce({ ...mockSurveyOutput, status: "draft" });
+      prisma.segment.findUnique.mockResolvedValueOnce({
+        workspaceId: updateSurveyInput.workspaceId,
+      } as any);
+
+      // Every id is a valid cuid2 — only the cap can reject this list.
+      const overCapSurveys = Array.from({ length: MAX_SEGMENT_SURVEYS + 1 }, () => createId());
+
+      await expect(
+        updateSurveyInternal(
+          {
+            ...updateSurveyInput,
+            status: "draft",
+            type: "app",
+            segment: {
+              id: "clownsegment000000000001",
+              title: "seg",
+              description: null,
+              isPrivate: false,
+              filters: [],
+              workspaceId: updateSurveyInput.workspaceId,
+              surveys: overCapSurveys,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          } as any,
+          true
+        )
+      ).rejects.toThrow(InvalidInputError);
+
+      expect(prisma.survey.findMany).not.toHaveBeenCalled();
+      expect(prisma.segment.update).not.toHaveBeenCalled();
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    test("rejects a non-id junk string in segment.surveys on the draft path without any survey lookup", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce({ ...mockSurveyOutput, status: "draft" });
+      prisma.segment.findUnique.mockResolvedValueOnce({
+        workspaceId: updateSurveyInput.workspaceId,
+      } as any);
+
+      await expect(
+        updateSurveyInternal(
+          {
+            ...updateSurveyInput,
+            status: "draft",
+            type: "app",
+            segment: {
+              id: "clownsegment000000000001",
+              title: "seg",
+              description: null,
+              isPrivate: false,
+              filters: [],
+              workspaceId: updateSurveyInput.workspaceId,
+              surveys: ["not-a-survey-id"],
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          } as any,
+          true
+        )
+      ).rejects.toThrow(InvalidInputError);
+
+      expect(prisma.survey.findMany).not.toHaveBeenCalled();
+      expect(prisma.segment.update).not.toHaveBeenCalled();
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    // Guard test locking the happy path: a within-cap, well-formed surveys list still flows into
+    // the ownership lookup and connects exactly as before.
+    test("still runs the ownership lookup for a within-cap segment.surveys list on the draft path", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce({ ...mockSurveyOutput, status: "draft" });
+      prisma.segment.findUnique.mockResolvedValueOnce({
+        workspaceId: updateSurveyInput.workspaceId,
+      } as any);
+      const connectedSurveyId = createId();
+      prisma.survey.findMany.mockResolvedValueOnce([
+        { id: connectedSurveyId, workspaceId: updateSurveyInput.workspaceId },
+      ] as any);
+      prisma.survey.update.mockResolvedValueOnce({ ...mockSurveyOutput, status: "draft" } as any);
+
+      await updateSurveyInternal(
+        {
+          ...updateSurveyInput,
+          status: "draft",
+          type: "app",
+          segment: {
+            id: "clownsegment000000000001",
+            title: "seg",
+            description: null,
+            isPrivate: false,
+            filters: [],
+            workspaceId: updateSurveyInput.workspaceId,
+            surveys: [connectedSurveyId],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        } as any,
+        true
+      );
+
+      expect(prisma.survey.findMany).toHaveBeenCalledWith({
+        where: { id: { in: [connectedSurveyId] } },
+        select: { id: true, workspaceId: true },
+      });
+      expect(prisma.segment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "clownsegment000000000001" },
+          data: expect.objectContaining({
+            surveys: { connect: [{ id: connectedSurveyId }] },
+          }),
         })
       );
     });

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -11,7 +11,7 @@ import {
   ResourceNotFoundError,
   ValidationError,
 } from "@formbricks/types/errors";
-import { TBaseFilters, TSegment } from "@formbricks/types/segment";
+import { MAX_SEGMENT_FILTERS_PER_TREE, TBaseFilters, TSegment } from "@formbricks/types/segment";
 import { TSurveyFollowUp } from "@formbricks/types/surveys/follow-up";
 import { TSurvey, TSurveyCreateInput, TSurveyQuestionTypeEnum } from "@formbricks/types/surveys/types";
 import { getActionClasses } from "@/lib/actionClass/service";
@@ -522,6 +522,90 @@ describe("Tests for updateSurvey", () => {
       ).rejects.toThrow(InvalidInputError);
 
       expect(prisma.segment.update).not.toHaveBeenCalled();
+    });
+
+    // ENG-2305: the draft save (skipValidation=true) deliberately skips full semantic validation,
+    // but the filter tree BOUNDS must hold unconditionally — an over-bounds tree persisted through
+    // a draft would break every consumer that parses the row back (publish validation, clone,
+    // evaluation).
+    test("rejects an over-bounds segment filter tree even when validation is skipped (draft save)", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce({ ...mockSurveyOutput, status: "draft" });
+      prisma.segment.findUnique.mockResolvedValueOnce({
+        workspaceId: updateSurveyInput.workspaceId,
+      } as any); // segment belongs to the survey's workspace (passes the segment guard)
+
+      // One node over the tree-wide cap. Junk-shaped on purpose: the bounds walk counts raw nodes
+      // without requiring valid filter shapes, exactly what an unvalidated draft can carry.
+      const overBoundsFilters = Array.from({ length: MAX_SEGMENT_FILTERS_PER_TREE + 1 }, (_, index) => ({
+        id: `f_${index}`,
+        connector: index === 0 ? null : "and",
+        resource: {},
+      }));
+
+      await expect(
+        updateSurveyInternal(
+          {
+            ...updateSurveyInput,
+            status: "draft",
+            type: "app",
+            segment: {
+              id: "clownsegment000000000001",
+              title: "seg",
+              description: null,
+              isPrivate: false,
+              filters: overBoundsFilters,
+              workspaceId: updateSurveyInput.workspaceId,
+              surveys: [],
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          } as any,
+          true
+        )
+      ).rejects.toThrow(InvalidInputError);
+
+      expect(prisma.segment.update).not.toHaveBeenCalled();
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    // Locks the draft UX the bounds check must not regress: a half-built (semantically invalid,
+    // within-bounds) filter tree still saves when validation is skipped.
+    test("still saves a draft whose segment filters are within bounds but semantically invalid", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce({ ...mockSurveyOutput, status: "draft" });
+      prisma.segment.findUnique.mockResolvedValueOnce({
+        workspaceId: updateSurveyInput.workspaceId,
+      } as any);
+      prisma.survey.update.mockResolvedValueOnce({ ...mockSurveyOutput, status: "draft" } as any);
+
+      // Fails ZSegmentFilters (junk leaf shape, non-cuid id) but is far inside every tree bound.
+      const halfBuiltFilters = [{ id: "f1", connector: null, resource: { root: { type: "attribute" } } }];
+
+      await updateSurveyInternal(
+        {
+          ...updateSurveyInput,
+          status: "draft",
+          type: "app",
+          segment: {
+            id: "clownsegment000000000001",
+            title: "seg",
+            description: null,
+            isPrivate: false,
+            filters: halfBuiltFilters,
+            workspaceId: updateSurveyInput.workspaceId,
+            surveys: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        } as any,
+        true
+      );
+
+      expect(prisma.segment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "clownsegment000000000001" },
+          data: expect.objectContaining({ filters: halfBuiltFilters }),
+        })
+      );
     });
 
     // Archived surveys are read-only on every write path that flows through updateSurveyInternal

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -10,7 +10,11 @@ import {
   OperationNotAllowedError,
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
-import { TBaseFilters, ZSegmentFilters } from "@formbricks/types/segment";
+import {
+  TBaseFilters,
+  ZSegmentFilters,
+  getSegmentFilterTreeBoundsViolation,
+} from "@formbricks/types/segment";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import { TSurvey, TSurveyCreateInput, ZSurvey, ZSurveyCreateInput } from "@formbricks/types/surveys/types";
 import { scheduleFeedbackSourceReconciliation } from "@/lib/feedback-source/mapping-reconciliation";
@@ -429,6 +433,15 @@ export const updateSurveyInternal = async (
     // if the survey body has type other than "app" but has a private segment, we delete that segment, and if it has a public segment, we disconnect from to the survey
     if (segment) {
       if (type === "app") {
+        // ENG-2305: tree bounds are enforced UNCONDITIONALLY — the draft save (skipValidation)
+        // deliberately skips full semantic validation so half-built filters can be saved, but an
+        // over-bounds tree persisted through it would break every consumer that parses the row
+        // back (publish validation, clone, evaluation).
+        const boundsViolation = getSegmentFilterTreeBoundsViolation(segment.filters);
+        if (boundsViolation) {
+          throw new InvalidInputError(boundsViolation);
+        }
+
         // parse the segment filters:
         const parsedFilters = ZSegmentFilters.safeParse(segment.filters);
         if (!skipValidation && !parsedFilters.success) {

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -11,8 +11,10 @@ import {
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
 import {
+  MAX_SEGMENT_SURVEYS,
   TBaseFilters,
   ZSegmentFilters,
+  ZSegmentSurveyIds,
   getSegmentFilterTreeBoundsViolation,
 } from "@formbricks/types/segment";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
@@ -446,6 +448,17 @@ export const updateSurveyInternal = async (
         const parsedFilters = ZSegmentFilters.safeParse(segment.filters);
         if (!skipValidation && !parsedFilters.success) {
           throw new InvalidInputError("Invalid user segment filters");
+        }
+
+        // ENG-2305 sibling of the filter-tree gate above: on the draft path (skipValidation)
+        // segment.surveys reaches this point unvalidated — ZSurveyDraft.segment is an untyped
+        // record, so neither the ZId format rule nor the MAX_SEGMENT_SURVEYS cap has applied. Both
+        // must hold unconditionally BEFORE the ids drive the batched workspace lookup below; the
+        // validated (non-draft) path re-checks the same schema it already passed, a no-op.
+        if (segment.surveys && !ZSegmentSurveyIds.safeParse(segment.surveys).success) {
+          throw new InvalidInputError(
+            `Invalid segment surveys: at most ${MAX_SEGMENT_SURVEYS} valid survey ids are allowed`
+          );
         }
 
         // ENG-1749/ENG-1920: the connected survey ids are client-supplied; ensure each belongs to

--- a/apps/web/modules/ee/contacts/segments/lib/helper.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/helper.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { InvalidInputError } from "@formbricks/types/errors";
-import { TBaseFilters, TSegmentWithSurveyRefs } from "@formbricks/types/segment";
+import {
+  MAX_SEGMENT_FILTERS_PER_TREE,
+  TBaseFilters,
+  TSegmentWithSurveyRefs,
+} from "@formbricks/types/segment";
 import {
   assertSurveyInteractionSurveyIds,
   checkForRecursiveSegmentFilter,
@@ -335,5 +339,82 @@ describe("assertSurveyInteractionSurveyIds", () => {
     await expect(
       assertSurveyInteractionSurveyIds(buildSpecificFilter(["s1", "s2"]), "workspace-1")
     ).rejects.toThrow(new InvalidInputError("Survey not found in workspace: s2"));
+  });
+
+  test("deduplicates ids collected across filters before querying", async () => {
+    const filters = [
+      ...buildSpecificFilter(["s1", "s2"]),
+      ...buildSpecificFilter(["s2", "s1"]),
+    ] as unknown as TBaseFilters;
+    mockSurveyFindMany.mockResolvedValue([{ id: "s1" }, { id: "s2" }]);
+
+    await expect(assertSurveyInteractionSurveyIds(filters, "workspace-1")).resolves.toBeUndefined();
+
+    expect(mockSurveyFindMany).toHaveBeenCalledTimes(1);
+    expect(mockSurveyFindMany).toHaveBeenCalledWith({
+      where: { id: { in: ["s1", "s2"] }, workspaceId: "workspace-1" },
+      select: { id: true },
+    });
+  });
+
+  test("splits an oversized id list into bounded sequential batches, all workspace-scoped", async () => {
+    const surveyIds = Array.from({ length: 450 }, (_, index) => `s_${index}`);
+    mockSurveyFindMany.mockImplementation(async ({ where }: any) =>
+      where.id.in.map((id: string) => ({ id }))
+    );
+
+    await expect(
+      assertSurveyInteractionSurveyIds(buildSpecificFilter(surveyIds), "workspace-1")
+    ).resolves.toBeUndefined();
+
+    // 450 ids at a batch size of 200 -> 200 / 200 / 50, each query scoped to the workspace.
+    const batchSizes = mockSurveyFindMany.mock.calls.map(([args]: any) => args.where.id.in.length);
+    expect(batchSizes).toEqual([200, 200, 50]);
+    for (const [args] of mockSurveyFindMany.mock.calls) {
+      expect((args as any).where.workspaceId).toBe("workspace-1");
+    }
+  });
+
+  test("throws on the first missing id in collection order and stops querying further batches", async () => {
+    const surveyIds = Array.from({ length: 450 }, (_, index) => `s_${index}`);
+    // Two ids in the second batch are foreign/unknown; the earlier one must win, and the third
+    // batch must never be queried.
+    mockSurveyFindMany.mockImplementation(async ({ where }: any) =>
+      where.id.in.filter((id: string) => id !== "s_205" && id !== "s_210").map((id: string) => ({ id }))
+    );
+
+    await expect(
+      assertSurveyInteractionSurveyIds(buildSpecificFilter(surveyIds), "workspace-1")
+    ).rejects.toThrow(new InvalidInputError("Survey not found in workspace: s_205"));
+
+    expect(mockSurveyFindMany).toHaveBeenCalledTimes(2);
+  });
+
+  test("a pre-existing tree over the Zod tree cap still flows through without throwing on size", async () => {
+    // Trees persisted before MAX_SEGMENT_FILTERS_PER_TREE existed can exceed it; the write-time
+    // guard must still process their ids (batched), not reject them for size.
+    const filterCount = MAX_SEGMENT_FILTERS_PER_TREE + 100;
+    const filters = Array.from({ length: filterCount }, (_, index) => ({
+      id: `f_${index}`,
+      connector: index === 0 ? null : "and",
+      resource: {
+        id: `si_${index}`,
+        root: { type: "surveyInteraction" },
+        qualifier: { operator: "haveSeen" },
+        value: {
+          surveyScope: "specific",
+          surveyIds: [`s_${index}`],
+          within: { amount: 1, unit: "months" },
+        },
+      },
+    })) as unknown as TBaseFilters;
+    mockSurveyFindMany.mockImplementation(async ({ where }: any) =>
+      where.id.in.map((id: string) => ({ id }))
+    );
+
+    await expect(assertSurveyInteractionSurveyIds(filters, "workspace-1")).resolves.toBeUndefined();
+
+    const batchSizes = mockSurveyFindMany.mock.calls.map(([args]: any) => args.where.id.in.length);
+    expect(batchSizes).toEqual([200, 200, 200, 200, 200, 100]);
   });
 });

--- a/apps/web/modules/ee/contacts/segments/lib/helper.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/helper.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { InvalidInputError } from "@formbricks/types/errors";
 import {
-  MAX_SEGMENT_FILTERS_PER_TREE,
+  MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE,
   TBaseFilters,
   TSegmentWithSurveyRefs,
 } from "@formbricks/types/segment";
@@ -390,20 +390,21 @@ describe("assertSurveyInteractionSurveyIds", () => {
     expect(mockSurveyFindMany).toHaveBeenCalledTimes(2);
   });
 
-  test("a pre-existing tree over the Zod tree cap still flows through without throwing on size", async () => {
-    // Trees persisted before MAX_SEGMENT_FILTERS_PER_TREE existed can exceed it; the write-time
-    // guard must still process their ids (batched), not reject them for size.
-    const filterCount = MAX_SEGMENT_FILTERS_PER_TREE + 100;
-    const filters = Array.from({ length: filterCount }, (_, index) => ({
-      id: `f_${index}`,
-      connector: index === 0 ? null : "and",
+  test("a parsed-tree-max payload (the tree-wide id cap) resolves in exactly five batches", async () => {
+    // Callers pass ZSegmentFilters-parsed trees, so the largest total this guard can receive is
+    // MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE ids — pin that worst case: ceil(1000/200) = 5
+    // sequential batches, no more.
+    const filterCount = MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE / 100;
+    const filters = Array.from({ length: filterCount }, (_, filterIndex) => ({
+      id: `f_${filterIndex}`,
+      connector: filterIndex === 0 ? null : "and",
       resource: {
-        id: `si_${index}`,
+        id: `si_${filterIndex}`,
         root: { type: "surveyInteraction" },
         qualifier: { operator: "haveSeen" },
         value: {
           surveyScope: "specific",
-          surveyIds: [`s_${index}`],
+          surveyIds: Array.from({ length: 100 }, (_, idIndex) => `s_${filterIndex * 100 + idIndex}`),
           within: { amount: 1, unit: "months" },
         },
       },
@@ -415,6 +416,6 @@ describe("assertSurveyInteractionSurveyIds", () => {
     await expect(assertSurveyInteractionSurveyIds(filters, "workspace-1")).resolves.toBeUndefined();
 
     const batchSizes = mockSurveyFindMany.mock.calls.map(([args]: any) => args.where.id.in.length);
-    expect(batchSizes).toEqual([200, 200, 200, 200, 200, 100]);
+    expect(batchSizes).toEqual([200, 200, 200, 200, 200]);
   });
 });

--- a/apps/web/modules/ee/contacts/segments/lib/helper.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/helper.ts
@@ -2,7 +2,10 @@ import { prisma } from "@formbricks/database";
 import { InvalidInputError } from "@formbricks/types/errors";
 import { TBaseFilters, TSegmentSurveyInteractionFilter } from "@formbricks/types/segment";
 import { getSegment } from "@/modules/ee/contacts/segments/lib/segments";
-import { isResourceFilter } from "@/modules/ee/contacts/segments/lib/utils";
+import {
+  SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE,
+  isResourceFilter,
+} from "@/modules/ee/contacts/segments/lib/utils";
 
 /**
  * Checks if a segment filter contains a recursive reference to itself
@@ -62,19 +65,16 @@ export const collectSurveyIdsFromSegmentFilters = (filters: TBaseFilters): strin
   return surveyIds;
 };
 
-// Upper bound on ids per `IN (...)` lookup below, mirroring SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE in
-// segments.ts (ENG-2004/ENG-2305). MAX_SEGMENT_FILTERS_PER_TREE caps what a client can submit, but
-// this guard also runs over trees persisted before that cap existed, so the query itself is bounded
-// instead of trusting the collected array's length.
-const SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE = 200;
-
 /**
  * Ensures every survey referenced by a "specific" survey-interaction filter belongs to the given
  * workspace. This is the tenancy guard for interaction filters — the runtime evaluation query is
  * already workspace-scoped, but we reject unknown/foreign ids at write time to avoid persisting
  * dead references. The deduplicated ids are looked up in bounded batches, sequentially: each batch
  * is checked before the next query runs, so the first missing id (in collection order) still
- * rejects, and no further queries are issued after a rejection.
+ * rejects, and no further queries are issued after a rejection. Callers pass ZSegmentFilters-parsed
+ * trees, so the total is already capped (MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE — a handful of
+ * batches at most); the chunking is defense in depth for each query's parameter payload and for any
+ * future caller that skips the parse.
  * @throws {InvalidInputError} When a referenced survey is not found in the workspace
  */
 export const assertSurveyInteractionSurveyIds = async (filters: TBaseFilters, workspaceId: string) => {

--- a/apps/web/modules/ee/contacts/segments/lib/helper.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/helper.ts
@@ -62,29 +62,36 @@ export const collectSurveyIdsFromSegmentFilters = (filters: TBaseFilters): strin
   return surveyIds;
 };
 
+// Upper bound on ids per `IN (...)` lookup below, mirroring SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE in
+// segments.ts (ENG-2004/ENG-2305). MAX_SEGMENT_FILTERS_PER_TREE caps what a client can submit, but
+// this guard also runs over trees persisted before that cap existed, so the query itself is bounded
+// instead of trusting the collected array's length.
+const SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE = 200;
+
 /**
  * Ensures every survey referenced by a "specific" survey-interaction filter belongs to the given
  * workspace. This is the tenancy guard for interaction filters — the runtime evaluation query is
  * already workspace-scoped, but we reject unknown/foreign ids at write time to avoid persisting
- * dead references.
+ * dead references. The deduplicated ids are looked up in bounded batches, sequentially: each batch
+ * is checked before the next query runs, so the first missing id (in collection order) still
+ * rejects, and no further queries are issued after a rejection.
  * @throws {InvalidInputError} When a referenced survey is not found in the workspace
  */
 export const assertSurveyInteractionSurveyIds = async (filters: TBaseFilters, workspaceId: string) => {
   const surveyIds = Array.from(new Set(collectSurveyIdsFromSegmentFilters(filters)));
 
-  if (surveyIds.length === 0) {
-    return;
-  }
+  for (let i = 0; i < surveyIds.length; i += SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE) {
+    const batch = surveyIds.slice(i, i + SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE);
+    const foundSurveys = await prisma.survey.findMany({
+      where: { id: { in: batch }, workspaceId },
+      select: { id: true },
+    });
 
-  const foundSurveys = await prisma.survey.findMany({
-    where: { id: { in: surveyIds }, workspaceId },
-    select: { id: true },
-  });
+    const foundIds = new Set(foundSurveys.map((survey) => survey.id));
+    const missingId = batch.find((id) => !foundIds.has(id));
 
-  const foundIds = new Set(foundSurveys.map((survey) => survey.id));
-  const missingId = surveyIds.find((id) => !foundIds.has(id));
-
-  if (missingId) {
-    throw new InvalidInputError(`Survey not found in workspace: ${missingId}`);
+    if (missingId) {
+      throw new InvalidInputError(`Survey not found in workspace: ${missingId}`);
+    }
   }
 };

--- a/apps/web/modules/ee/contacts/segments/lib/segment-schema.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segment-schema.test.ts
@@ -1,6 +1,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import { describe, expect, test } from "vitest";
 import {
+  MAX_SEGMENT_FILTERS_PER_TREE,
   MAX_SEGMENT_SURVEYS,
   type TBaseFilters,
   type TSurveyInteractionOperator,
@@ -123,6 +124,68 @@ describe("segment schema validation", () => {
     });
 
     expect(result.success).toBe(true);
+  });
+});
+
+describe("segment filter tree size cap", () => {
+  const attributeLeaf = (connector: "and" | null) => ({
+    id: createId(),
+    connector,
+    resource: {
+      id: createId(),
+      root: { type: "attribute" as const, contactAttributeKey: "email" },
+      value: "user@example.com",
+      qualifier: { operator: "equals" as const },
+    },
+  });
+
+  const flatTree = (length: number) =>
+    Array.from({ length }, (_, index) => attributeLeaf(index === 0 ? null : "and"));
+
+  test("accepts a flat tree with exactly the maximum number of filters", () => {
+    const result = ZSegmentFilters.safeParse(flatTree(MAX_SEGMENT_FILTERS_PER_TREE));
+
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a flat tree one filter over the cap", () => {
+    const result = ZSegmentFilters.safeParse(flatTree(MAX_SEGMENT_FILTERS_PER_TREE + 1));
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      `Too many filters: a segment supports at most ${MAX_SEGMENT_FILTERS_PER_TREE} filters in total`
+    );
+  });
+
+  test("rejects an over-cap tree hidden behind nesting (small arrays at every level)", () => {
+    // Each wrap keeps the per-level array at 10 entries (9 leaves + 1 nested group), so any
+    // per-level `.max()` would pass — only a whole-tree bound catches the total.
+    let filters: unknown[] = flatTree(10);
+    let nodeCount = 10;
+    while (nodeCount <= MAX_SEGMENT_FILTERS_PER_TREE) {
+      filters = [...flatTree(9), { id: createId(), connector: "and" as const, resource: filters }];
+      nodeCount += 10;
+    }
+
+    const result = ZSegmentFilters.safeParse(filters);
+
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts a nested tree under the cap", () => {
+    const filters = [...flatTree(3), { id: createId(), connector: "and" as const, resource: flatTree(5) }];
+
+    const result = ZSegmentFilters.safeParse(filters);
+
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects an over-cap tree submitted through a segment update", () => {
+    const result = ZSegmentUpdateInput.safeParse({
+      filters: flatTree(MAX_SEGMENT_FILTERS_PER_TREE + 1),
+    });
+
+    expect(result.success).toBe(false);
   });
 });
 

--- a/apps/web/modules/ee/contacts/segments/lib/segment-schema.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segment-schema.test.ts
@@ -2,7 +2,9 @@ import { createId } from "@paralleldrive/cuid2";
 import { describe, expect, test } from "vitest";
 import {
   MAX_SEGMENT_FILTERS_PER_TREE,
+  MAX_SEGMENT_FILTER_DEPTH,
   MAX_SEGMENT_SURVEYS,
+  MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE,
   type TBaseFilters,
   type TSurveyInteractionOperator,
   ZSegmentCreateInput,
@@ -127,7 +129,7 @@ describe("segment schema validation", () => {
   });
 });
 
-describe("segment filter tree size cap", () => {
+describe("segment filter tree bounds", () => {
   const attributeLeaf = (connector: "and" | null) => ({
     id: createId(),
     connector,
@@ -141,6 +143,36 @@ describe("segment filter tree size cap", () => {
 
   const flatTree = (length: number) =>
     Array.from({ length }, (_, index) => attributeLeaf(index === 0 ? null : "and"));
+
+  // One group node per level around a single innermost leaf: depth === node count. Built with a
+  // loop on purpose — a recursive builder would blow the stack on the deep trees this exercises.
+  const leftSpine = (depth: number): unknown[] => {
+    let filters: unknown[] = [attributeLeaf(null)];
+    for (let level = 1; level < depth; level++) {
+      filters = [{ id: createId(), connector: null, resource: filters }];
+    }
+    return filters;
+  };
+
+  const interactionLeaf = (connector: "and" | null, surveyIdCount: number) => ({
+    id: createId(),
+    connector,
+    resource: {
+      id: createId(),
+      root: { type: "surveyInteraction" as const },
+      qualifier: { operator: "haveSeen" as const },
+      value: {
+        surveyScope: "specific" as const,
+        surveyIds: Array.from({ length: surveyIdCount }, () => createId()),
+        within: { amount: 1, unit: "months" as const },
+      },
+    },
+  });
+
+  const interactionTree = (filterCount: number, surveyIdsPerFilter: number) =>
+    Array.from({ length: filterCount }, (_, index) =>
+      interactionLeaf(index === 0 ? null : "and", surveyIdsPerFilter)
+    );
 
   test("accepts a flat tree with exactly the maximum number of filters", () => {
     const result = ZSegmentFilters.safeParse(flatTree(MAX_SEGMENT_FILTERS_PER_TREE));
@@ -158,18 +190,22 @@ describe("segment filter tree size cap", () => {
   });
 
   test("rejects an over-cap tree hidden behind nesting (small arrays at every level)", () => {
-    // Each wrap keeps the per-level array at 10 entries (9 leaves + 1 nested group), so any
-    // per-level `.max()` would pass — only a whole-tree bound catches the total.
-    let filters: unknown[] = flatTree(10);
-    let nodeCount = 10;
+    // Each wrap keeps the per-level array at 25 entries (24 leaves + 1 nested group) and the depth
+    // within MAX_SEGMENT_FILTER_DEPTH, so any per-level `.max()` (and the depth bound) would pass —
+    // only the whole-tree node bound catches the total.
+    let filters: unknown[] = flatTree(25);
+    let nodeCount = 25;
     while (nodeCount <= MAX_SEGMENT_FILTERS_PER_TREE) {
-      filters = [...flatTree(9), { id: createId(), connector: "and" as const, resource: filters }];
-      nodeCount += 10;
+      filters = [...flatTree(24), { id: createId(), connector: "and" as const, resource: filters }];
+      nodeCount += 25;
     }
 
     const result = ZSegmentFilters.safeParse(filters);
 
     expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      `Too many filters: a segment supports at most ${MAX_SEGMENT_FILTERS_PER_TREE} filters in total`
+    );
   });
 
   test("accepts a nested tree under the cap", () => {
@@ -186,6 +222,53 @@ describe("segment filter tree size cap", () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  test("a deep left-spine tree within the node cap fails with a clean depth issue, not a RangeError", () => {
+    // Regression: depth === MAX_SEGMENT_FILTERS_PER_TREE nodes is within the node cap, but deep
+    // enough that the recursive parse alone would overflow the call stack (safeParse does not catch
+    // RangeError). The bounds gate must reject it BEFORE the recursive parse ever runs.
+    const result = ZSegmentFilters.safeParse(leftSpine(MAX_SEGMENT_FILTERS_PER_TREE));
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      `Segment filters are nested too deeply: at most ${MAX_SEGMENT_FILTER_DEPTH} levels are supported`
+    );
+  });
+
+  test("accepts a tree nested exactly at the depth limit", () => {
+    const result = ZSegmentFilters.safeParse(leftSpine(MAX_SEGMENT_FILTER_DEPTH));
+
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a tree nested one level over the depth limit", () => {
+    const result = ZSegmentFilters.safeParse(leftSpine(MAX_SEGMENT_FILTER_DEPTH + 1));
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      `Segment filters are nested too deeply: at most ${MAX_SEGMENT_FILTER_DEPTH} levels are supported`
+    );
+  });
+
+  test("accepts survey-interaction filters totalling exactly the tree-wide id cap", () => {
+    // 10 filters x 100 ids: each filter at its own per-filter cap, tree total exactly at the bound.
+    const result = ZSegmentFilters.safeParse(
+      interactionTree(10, MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE / 10)
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects survey-interaction filters totalling one id over the tree-wide cap", () => {
+    // 11 filters x 91 ids = 1001: every filter is under the per-filter cap (100), so only the
+    // tree-wide total can catch it.
+    const result = ZSegmentFilters.safeParse(interactionTree(11, 91));
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      `Too many surveys referenced: survey-interaction filters may reference at most ${MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE} surveys in total`
+    );
   });
 });
 

--- a/apps/web/modules/ee/contacts/segments/lib/segments.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segments.test.ts
@@ -256,6 +256,40 @@ describe("Segment Service Tests", () => {
       expect(result.size).toBe(0);
       expect(prisma.survey.findMany).not.toHaveBeenCalled();
     });
+
+    test("deduplicates ids before querying", async () => {
+      vi.mocked(prisma.survey.findMany).mockResolvedValue([{ id: "survey1" }] as any);
+
+      const result = await getExistingWorkspaceSurveyIds("ws_1", ["survey1", "survey1", "survey1"]);
+
+      expect(result).toEqual(new Set(["survey1"]));
+      expect(prisma.survey.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.survey.findMany).toHaveBeenCalledWith({
+        where: { workspaceId: "ws_1", id: { in: ["survey1"] } },
+        select: { id: true },
+      });
+    });
+
+    test("splits an oversized id list into bounded batches and still returns only the found subset", async () => {
+      const surveyIds = Array.from({ length: 450 }, (_, index) => `survey_${index}`);
+      // survey_449 (last batch) is foreign/unknown — everything else belongs to the workspace.
+      vi.mocked(prisma.survey.findMany).mockImplementation((async ({ where }: any) =>
+        where.id.in.filter((id: string) => id !== "survey_449").map((id: string) => ({ id }))) as any);
+
+      const result = await getExistingWorkspaceSurveyIds("ws_1", surveyIds);
+
+      // 450 ids at a batch size of 200 -> 200 / 200 / 50, each query scoped to the workspace.
+      const batchSizes = vi
+        .mocked(prisma.survey.findMany)
+        .mock.calls.map(([args]: any) => args.where.id.in.length);
+      expect(batchSizes).toEqual([200, 200, 50]);
+      for (const [args] of vi.mocked(prisma.survey.findMany).mock.calls) {
+        expect((args as any).where.workspaceId).toBe("ws_1");
+      }
+      expect(result.size).toBe(449);
+      expect(result.has("survey_0")).toBe(true);
+      expect(result.has("survey_449")).toBe(false);
+    });
   });
 
   describe("createSegment", () => {

--- a/apps/web/modules/ee/contacts/segments/lib/segments.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segments.ts
@@ -172,23 +172,40 @@ export const getSurveyRefsForWorkspace = reactCache(
   }
 );
 
+// Upper bound on ids per `IN (...)` survey lookup in this module. ZSegment/ZSegmentUpdateInput
+// already cap what a client can submit (MAX_SEGMENT_SURVEYS, MAX_SEGMENT_FILTERS_PER_TREE), but
+// these helpers are also reached with ids read back from the database (updateSurveyInternal's
+// skipValidation path, rows persisted before the caps existed), so they bound the query itself
+// instead of trusting the caller's array length.
+const SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE = 200;
+
 /**
  * Returns the subset of `surveyIds` that actually belong to `workspaceId`. Unlike
  * {@link getSurveyRefsForWorkspace} (which caps at {@link SURVEY_FILTER_REF_LIMIT} for the picker),
  * this queries by the exact ids being validated, so it stays correct for workspaces with more than
  * that many surveys — a referenced-but-valid survey outside the picker's recent window is no longer
- * wrongly rejected. Returns an empty set for an empty input without hitting the DB.
+ * wrongly rejected. Ids are deduplicated and looked up in bounded sequential batches (ENG-2305),
+ * mirroring {@link getSurveyWorkspaceIdMap}. Returns an empty set for an empty input without
+ * hitting the DB.
  */
 export const getExistingWorkspaceSurveyIds = reactCache(
   async (workspaceId: string, surveyIds: string[]): Promise<Set<string>> => {
     validateInputs([workspaceId, ZId], [surveyIds, z.array(ZId)]);
-    if (surveyIds.length === 0) return new Set();
+    const uniqueSurveyIds = Array.from(new Set(surveyIds));
+    const existingSurveyIds = new Set<string>();
+    if (uniqueSurveyIds.length === 0) return existingSurveyIds;
     try {
-      const surveys = await prisma.survey.findMany({
-        where: { workspaceId, id: { in: surveyIds } },
-        select: { id: true },
-      });
-      return new Set(surveys.map((survey) => survey.id));
+      for (let i = 0; i < uniqueSurveyIds.length; i += SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE) {
+        const batch = uniqueSurveyIds.slice(i, i + SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE);
+        const surveys = await prisma.survey.findMany({
+          where: { workspaceId, id: { in: batch } },
+          select: { id: true },
+        });
+        for (const survey of surveys) {
+          existingSurveyIds.add(survey.id);
+        }
+      }
+      return existingSurveyIds;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         throw new DatabaseError(error.message);
@@ -414,12 +431,6 @@ export const resetSegmentInSurvey = async (surveyId: string): Promise<TSegment> 
     throw error;
   }
 };
-
-// Upper bound on ids per `IN (...)` lookup below. ZSegment/ZSegmentUpdateInput already cap what a
-// client can submit (MAX_SEGMENT_SURVEYS), but this helper is also reached with ids read back from
-// the database (updateSurveyInternal's skipValidation path, rows persisted before the cap existed),
-// so it bounds the query itself instead of trusting the caller's array length.
-const SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE = 200;
 
 /**
  * Batched lookup of the owning workspace for a set of surveys, used to keep segment↔survey links

--- a/apps/web/modules/ee/contacts/segments/lib/segments.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segments.ts
@@ -35,7 +35,11 @@ import {
 } from "@formbricks/types/segment";
 import { getSurvey } from "@/lib/survey/service";
 import { validateInputs } from "@/lib/utils/validate";
-import { isResourceFilter, searchForAttributeKeyInSegment } from "@/modules/ee/contacts/segments/lib/utils";
+import {
+  SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE,
+  isResourceFilter,
+  searchForAttributeKeyInSegment,
+} from "@/modules/ee/contacts/segments/lib/utils";
 import { isSameDay, subtractTimeUnit } from "./date-utils";
 import { combineFilterResults, evaluateSurveyInteractionFilterInMemory } from "./filter/survey-interaction";
 
@@ -171,13 +175,6 @@ export const getSurveyRefsForWorkspace = reactCache(
     }
   }
 );
-
-// Upper bound on ids per `IN (...)` survey lookup in this module. ZSegment/ZSegmentUpdateInput
-// already cap what a client can submit (MAX_SEGMENT_SURVEYS, MAX_SEGMENT_FILTERS_PER_TREE), but
-// these helpers are also reached with ids read back from the database (updateSurveyInternal's
-// skipValidation path, rows persisted before the caps existed), so they bound the query itself
-// instead of trusting the caller's array length.
-const SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE = 200;
 
 /**
  * Returns the subset of `surveyIds` that actually belong to `workspaceId`. Unlike

--- a/apps/web/modules/ee/contacts/segments/lib/utils.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/utils.ts
@@ -24,6 +24,17 @@ export const isResourceFilter = (resource: TSegmentFilter | TBaseFilters): resou
   return (resource as TSegmentFilter).root !== undefined;
 };
 
+/**
+ * Upper bound on ids per `IN (...)` survey lookup in the segment write path (segments.ts and
+ * helper.ts). The Zod boundary already bounds what a client can submit (MAX_SEGMENT_SURVEYS,
+ * MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE), so batching is defense in depth: it keeps each
+ * query's SQL parameter payload flat for within-cap totals (a handful of batches at most) and
+ * holds for callers whose arrays never went through those schemas (the survey editor's draft-save
+ * path). Batches run sequentially — the point is to cap per-query and concurrent database work,
+ * not to fan it out.
+ */
+export const SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE = 200;
+
 export const convertOperatorToText = (operator: TAllOperators, t: TFunction) => {
   switch (operator) {
     case "equals":

--- a/packages/types/segment.ts
+++ b/packages/types/segment.ts
@@ -526,7 +526,9 @@ export const MAX_SEGMENT_SURVEYS = 500;
 
 // `ZId` (cuid2) also keeps non-id junk from reaching the database. Ownership is still enforced at
 // write time — every id must resolve to a survey in the segment's workspace (ENG-1749/ENG-1920).
-const ZSegmentSurveyIds = z.array(ZId).max(MAX_SEGMENT_SURVEYS);
+// Exported so the survey draft-save path (which skips the segment schemas) can enforce the exact
+// same rule before the ids drive its batched workspace lookup (ENG-2305).
+export const ZSegmentSurveyIds = z.array(ZId).max(MAX_SEGMENT_SURVEYS);
 
 export const ZSegment = z.object({
   id: z.string(),

--- a/packages/types/segment.ts
+++ b/packages/types/segment.ts
@@ -367,16 +367,6 @@ export interface TBaseFilter {
 
 export type TBaseFilters = TBaseFilter[];
 
-export const ZBaseFilter: z.ZodType<TBaseFilter> = z.lazy(() =>
-  z.object({
-    id: ZId,
-    connector: ZSegmentConnector,
-    resource: z.union([ZSegmentFilter, ZBaseFilters]),
-  })
-);
-
-export const ZBaseFilters: z.ZodType<TBaseFilters> = z.lazy(() => z.array(ZBaseFilter));
-
 // here again, we refine the filters to make sure that the filters are valid
 const refineFilters = (filters: TBaseFilters): boolean => {
   let result = true;
@@ -396,6 +386,28 @@ const refineFilters = (filters: TBaseFilters): boolean => {
   return result;
 };
 
+/**
+ * Maximum number of filter nodes — leaf filters plus nested groups — across the WHOLE recursive
+ * filter tree. The tree schema has no per-level length cap, so a per-level `.max()` alone would be
+ * bypassable by nesting; only a total bound keeps N filters × the per-filter surveyIds cap (100)
+ * from becoming an unbounded id payload (ENG-2305, sibling of ENG-2004). The same schema also
+ * parses trees read back from the database (clone, publish validation, segment editor), so the cap
+ * is deliberately generous — orders of magnitude above anything the segment editor produces — to
+ * never brick a pre-existing segment on read.
+ */
+export const MAX_SEGMENT_FILTERS_PER_TREE = 1000;
+
+const countSegmentFilterNodes = (filters: TBaseFilters): number => {
+  let count = 0;
+  for (const filter of filters) {
+    count += 1;
+    if (Array.isArray(filter.resource)) {
+      count += countSegmentFilterNodes(filter.resource);
+    }
+  }
+  return count;
+};
+
 // The filters can be nested, so we need to use z.lazy to define the type
 // more on recusrsive types -> https://zod.dev/?id=recursive-types
 export const ZSegmentFilters: z.ZodType<TBaseFilters> = z
@@ -408,6 +420,9 @@ export const ZSegmentFilters: z.ZodType<TBaseFilters> = z
   )
   .refine(refineFilters, {
     error: "Invalid filters applied",
+  })
+  .refine((filters) => countSegmentFilterNodes(filters) <= MAX_SEGMENT_FILTERS_PER_TREE, {
+    error: `Too many filters: a segment supports at most ${MAX_SEGMENT_FILTERS_PER_TREE} filters in total`,
   });
 
 const ZRequiredSegmentFilters = ZSegmentFilters.refine((filters) => filters.length > 0, {

--- a/packages/types/segment.ts
+++ b/packages/types/segment.ts
@@ -389,41 +389,127 @@ const refineFilters = (filters: TBaseFilters): boolean => {
 /**
  * Maximum number of filter nodes — leaf filters plus nested groups — across the WHOLE recursive
  * filter tree. The tree schema has no per-level length cap, so a per-level `.max()` alone would be
- * bypassable by nesting; only a total bound keeps N filters × the per-filter surveyIds cap (100)
- * from becoming an unbounded id payload (ENG-2305, sibling of ENG-2004). The same schema also
- * parses trees read back from the database (clone, publish validation, segment editor), so the cap
- * is deliberately generous — orders of magnitude above anything the segment editor produces — to
- * never brick a pre-existing segment on read.
+ * bypassable by nesting; only a total bound keeps the tree size itself from being an unbounded
+ * payload (ENG-2305, sibling of ENG-2004). The same schema also parses trees read back from the
+ * database (clone, publish validation, segment editor), so the cap is deliberately generous —
+ * orders of magnitude above anything the segment editor produces — to never brick a pre-existing
+ * segment on read.
  */
 export const MAX_SEGMENT_FILTERS_PER_TREE = 1000;
 
-const countSegmentFilterNodes = (filters: TBaseFilters): number => {
-  let count = 0;
-  for (const filter of filters) {
-    count += 1;
-    if (Array.isArray(filter.resource)) {
-      count += countSegmentFilterNodes(filter.resource);
-    }
+/**
+ * Maximum nesting depth of the filter tree. The recursive Zod parse (and every recursive consumer
+ * of a parsed tree) grows the JS call stack with nesting depth and overflows around depth ~1000 in
+ * practice — a RangeError that `safeParse` does NOT catch, so no post-parse `.refine` can guard
+ * against it; only a pre-parse check can (see ZSegmentFilters). The editor produces single-digit
+ * depth; 50 leaves ~20x headroom below the measured stack limit.
+ */
+export const MAX_SEGMENT_FILTER_DEPTH = 50;
+
+/**
+ * Maximum total surveyIds across every survey-interaction filter in the tree. The per-filter cap
+ * (100) times the node cap would still admit 100k ids in one request — hundreds of sequential
+ * batched lookups, each holding a pooled DB connection. 1000 total ids means at most a handful of
+ * batches at write time, and is far beyond any tree the editor produces.
+ */
+export const MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE = 1000;
+
+const countLeafSurveyInteractionIds = (resource: unknown): number => {
+  if (typeof resource !== "object" || resource === null) return 0;
+  const { root, value } = resource as { root?: unknown; value?: unknown };
+  if (typeof root !== "object" || root === null) return 0;
+  if ((root as { type?: unknown }).type !== "surveyInteraction") return 0;
+  if (typeof value !== "object" || value === null) return 0;
+  const surveyIds = (value as { surveyIds?: unknown }).surveyIds;
+  return Array.isArray(surveyIds) ? surveyIds.length : 0;
+};
+
+/**
+ * Measures the raw (untrusted, unparsed) filter tree in one linear pass: total nodes, max nesting
+ * depth, and total survey-interaction surveyIds. Iterative (explicit stack) on purpose — this walk
+ * is what protects the recursive parse from stack overflow, so it must not recurse itself. Junk
+ * shapes are simply not counted; shape errors are the schema's job.
+ */
+const measureSegmentFilterTree = (
+  raw: unknown
+): { nodes: number; depth: number; surveyInteractionIds: number } => {
+  let nodes = 0;
+  let depth = 0;
+  let surveyInteractionIds = 0;
+
+  const pending: { group: unknown[]; level: number }[] = [];
+  if (Array.isArray(raw)) {
+    pending.push({ group: raw, level: 1 });
   }
-  return count;
+
+  let entry = pending.pop();
+  while (entry) {
+    const { group, level } = entry;
+    depth = Math.max(depth, level);
+    for (const node of group) {
+      nodes += 1;
+      const resource =
+        typeof node === "object" && node !== null ? (node as { resource?: unknown }).resource : undefined;
+      if (Array.isArray(resource)) {
+        pending.push({ group: resource, level: level + 1 });
+      } else {
+        surveyInteractionIds += countLeafSurveyInteractionIds(resource);
+      }
+    }
+    entry = pending.pop();
+  }
+
+  return { nodes, depth, surveyInteractionIds };
+};
+
+/**
+ * Returns a human-readable message when the raw tree exceeds any bound, or null when it is within
+ * all of them. Shared by ZSegmentFilters (rejects at the schema boundary, before the recursive
+ * parse) and the survey draft-save path, which skips full semantic validation but must never
+ * persist an over-bounds tree.
+ */
+export const getSegmentFilterTreeBoundsViolation = (raw: unknown): string | null => {
+  const { nodes, depth, surveyInteractionIds } = measureSegmentFilterTree(raw);
+
+  if (depth > MAX_SEGMENT_FILTER_DEPTH) {
+    return `Segment filters are nested too deeply: at most ${MAX_SEGMENT_FILTER_DEPTH} levels are supported`;
+  }
+  if (nodes > MAX_SEGMENT_FILTERS_PER_TREE) {
+    return `Too many filters: a segment supports at most ${MAX_SEGMENT_FILTERS_PER_TREE} filters in total`;
+  }
+  if (surveyInteractionIds > MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE) {
+    return `Too many surveys referenced: survey-interaction filters may reference at most ${MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE} surveys in total`;
+  }
+  return null;
 };
 
 // The filters can be nested, so we need to use z.lazy to define the type
 // more on recusrsive types -> https://zod.dev/?id=recursive-types
-export const ZSegmentFilters: z.ZodType<TBaseFilters> = z
+const ZSegmentFiltersInner: z.ZodType<TBaseFilters> = z
   .array(
     z.object({
       id: ZId,
       connector: ZSegmentConnector,
-      resource: z.union([ZSegmentFilter, z.lazy(() => ZSegmentFilters)]),
+      resource: z.union([ZSegmentFilter, z.lazy(() => ZSegmentFiltersInner)]),
     })
   )
   .refine(refineFilters, {
     error: "Invalid filters applied",
-  })
-  .refine((filters) => countSegmentFilterNodes(filters) <= MAX_SEGMENT_FILTERS_PER_TREE, {
-    error: `Too many filters: a segment supports at most ${MAX_SEGMENT_FILTERS_PER_TREE} filters in total`,
   });
+
+// Bounds gate + recursive parse. The bounds MUST run on the raw value before the recursive parse:
+// a deep enough tree overflows the call stack inside the parse itself, throwing a RangeError that
+// even safeParse does not catch — so a post-parse refine could never see it. `.pipe` short-circuits
+// on failure, so the recursive inner schema never sees a tree that failed the bounds check.
+export const ZSegmentFilters: z.ZodType<TBaseFilters> = z
+  .unknown()
+  .superRefine((raw, ctx) => {
+    const violation = getSegmentFilterTreeBoundsViolation(raw);
+    if (violation) {
+      ctx.addIssue({ code: "custom", message: violation });
+    }
+  })
+  .pipe(ZSegmentFiltersInner);
 
 const ZRequiredSegmentFilters = ZSegmentFilters.refine((filters) => filters.length > 0, {
   error: "At least one filter is required",


### PR DESCRIPTION
Fixes ENG-2305

## What & why

Follow-up to #8772 (ENG-2004): that PR bounded `getSurveyWorkspaceIdMap`, but two sibling helpers reachable from the same actions kept the unbounded Prisma `IN (...)` shape. `ZSegmentSurveyInteractionFilterValue.surveyIds` caps a single filter at 100 ids, but `ZSegmentFilters` is a recursive array with no length or depth cap — so N filters × 100 ids made the total unbounded: a cheap authenticated DoS lever through `createSegmentAction`, `updateSegmentAction`, and the v3 targeting route.

Same two layers as #8772, hardened further after review:

- **Pre-parse bounds gate** (`packages/types/segment.ts`): an iterative (explicit-stack, non-recursive) walker measures the **raw** tree — total nodes, nesting depth, total survey-interaction ids — and rejects before the recursive Zod parse runs, wired as `z.unknown().superRefine(bounds).pipe(recursive schema)`. Pre-parse is load-bearing, not style: a deep enough tree overflows the call stack *inside* the recursive parse with a `RangeError` that even `safeParse` doesn't catch (escapes as a 500), so a post-parse `.refine` can never guard it. Three exported caps: `MAX_SEGMENT_FILTERS_PER_TREE = 1000` (total nodes; nesting can't dodge it since every level costs nodes), `MAX_SEGMENT_FILTER_DEPTH = 50` (~20x below the measured stack limit; the editor produces single-digit depth), `MAX_SEGMENT_SURVEY_INTERACTION_IDS_PER_TREE = 1000` (bounds write-time lookups to ≤5 batches per request instead of ~500).
- **Draft-save gate** (`apps/web/lib/survey/service.ts`): the survey-editor draft save (`updateSurveyDraftAction` → `updateSurveyInternal` with `skipValidation`) used to persist the segment without ever parsing its schemas — an open bypass around every cap. Two unconditional checks now run before the segment persist: the filter-tree bounds check, and `ZSegmentSurveyIds` (the ENG-2004 `ZId` + 500-link cap, now exported instead of duplicated) on `segment.surveys` before the ids drive the batched workspace lookup. Full semantic validation stays skippable, so drafts with half-built filter values save exactly as before.
- **Defensive batching in the helpers**: `assertSurveyInteractionSurveyIds` (`helper.ts`) and `getExistingWorkspaceSurveyIds` (`segments.ts`) look ids up in sequential 200-size batches via the now-shared `SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE` (moved to `segments/lib/utils.ts`, single definition). Semantics unchanged: the assert helper throws the same `InvalidInputError` on the first missing/foreign id (and stops querying), `getExistingWorkspaceSurveyIds` still returns only the found subset. With the id cap this layer is defense in depth for within-cap totals and any future unparsed caller.

On the cap values: hand-built segment trees are tens of nodes at single-digit depth, so 1000/50/1000 are orders of magnitude above real usage. `ZSegmentFilters` also parses trees read back from the DB (clone, publish validation, editor), so the caps must never brick a legacy row — hence generous, and with the draft bypass closed there is no writer left that can persist an over-bounds tree.

Also removed `ZBaseFilter`/`ZBaseFilters`: a dead, unrefined duplicate of the same tree schema (no consumers anywhere, verified by grep and typecheck). Keeping an uncapped copy around would let a future consumer silently bypass this fix; the widely-used `TBaseFilter`/`TBaseFilters` TS types are defined independently and stay.

## Breaking changes

- [ ] This PR contains breaking changes

None — the new validation only rejects segment filter trees beyond 1000 total nodes, 50 nesting levels, or 1000 survey-interaction ids, all far beyond anything the product can produce; no API shape, endpoint, env var, default or payload change.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Filter tree over the node cap is rejected at the Zod boundary, including the nesting-bypass shape (small arrays at every level) | unit (red on main) | `segment-schema.test.ts`: accepts exactly 1000 nodes, rejects 1001 with the cap message, rejects the nested-bypass tree and over-cap input through `ZSegmentUpdateInput`. Fails on main, where no cap existed — rerun: `pnpm test --filter=@formbricks/web` (file: `apps/web/modules/ee/contacts/segments/lib/segment-schema.test.ts`) |
| A deep left-spine tree **within** the node cap fails with a clean depth `ZodError` — not a `RangeError` escaping `safeParse` as a 500 | unit (red on main) | `segment-schema.test.ts`: 1000-deep spine → depth message; depth exactly 50 accepted, 51 rejected. On main the same tree throws `RangeError: Maximum call stack size exceeded` out of `safeParse` |
| Survey-interaction ids capped tree-wide, not just per filter | unit (red on main) | `segment-schema.test.ts`: 10×100 ids accepted, 11×91 = 1001 rejected with the id-cap message |
| Draft save can no longer persist an over-bounds tree (`skipValidation` bypass closed), while a within-bounds draft with semantically invalid filters still saves | unit (red on main) + unit (guard) | `apps/web/lib/survey/service.test.ts`: over-bounds tree with `skipValidation: true` → `InvalidInputError`, no `segment.update`; junk-but-small filters still persist (locks draft UX) |
| Draft save rejects an over-cap or non-id `segment.surveys` list **before any survey lookup runs** (500-cap + `ZId` now enforced on the draft path too), while a within-cap valid list still reaches the ownership check | unit (red on main) + unit (guard) | `apps/web/lib/survey/service.test.ts`: 501 valid ids and a junk string each → `InvalidInputError` with zero `survey.findMany` / `segment.update` calls (both red on the previous head); within-cap list proceeds unchanged |
| `assertSurveyInteractionSurveyIds` batches: 450 ids → queries of [200, 200, 50] with `workspaceId` on every query; first missing id throws the same error and later batches are never queried; a parsed-tree-max payload (1000 ids) resolves in exactly 5 batches | unit (mutation) | `helper.test.ts` — asserts exact batch contents and call counts |
| `getExistingWorkspaceSurveyIds` dedupes + batches, still returns only the found subset | unit (mutation) | `segments.test.ts` |
| Tenancy write-time guard unchanged — foreign/unknown survey ids still rejected (the ENG-1749 / ENG-1920 behavior) | unit (guard) | zero pre-existing tests modified; foreign-id rejection re-asserted on the batched path |

Full root gate after the review-fix round: typecheck 27/27, lint 21/21 (0 errors), test 26/26 tasks (`@formbricks/web`: 640 files / 8508 tests).

**Open gaps**

- The caps weren't checked against real production segment sizes (no data access from here). They're orders of magnitude above what the editor can build, and the draft-save path — until this PR the only writer that could persist an unvalidated tree — is now gated. But a segment created programmatically before this PR beyond 1000 nodes / depth 50 would become unsavable on paths that parse `ZSegmentFilters` (clone, publish validation, editor). Worth a one-off prod query if we want certainty.
- No manual UI pass — unit-only change through the same schemas the editor already exercises.

**Risks**

- Read-time cost within the cap is unchanged: one saved segment with ~1000 attribute filters still drives ~1000 sequential evaluation queries per request on the SDK-facing user endpoint. Pre-existing (there was no cap at all before), out of this PR's scope — candidate follow-up ticket.
- Draft saves now reject over-bounds filter trees and over-cap/malformed `segment.surveys` lists with `InvalidInputError` where they previously persisted (or looked up) anything; no known client builds such drafts.

---

> [!NOTE]
> **AI model used** — `claude-fable-5`, reasoning effort `unknown`.
