### PR TITLE
fix(logger): make survey-API 500s diagnosable [ENG-2578]

### DIFF
--- a/apps/web/app/api/v3/surveys/lib/operations.test.ts
+++ b/apps/web/app/api/v3/surveys/lib/operations.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { DatabaseError, ResourceNotFoundError, ValidationError } from "@formbricks/types/errors";
 import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
 import { problemForbidden } from "@/app/api/v3/lib/response";
 import { capturePostHogEvent } from "@/lib/posthog";
@@ -482,6 +482,32 @@ describe("createV3SurveyResponse", () => {
         })
       ).status
     ).toBe(500);
+  });
+
+  test("reports the reason for a service-layer ValidationError instead of an opaque 500", async () => {
+    vi.mocked(createV3Survey).mockRejectedValueOnce(
+      new ValidationError(
+        "Validation failed: blocks.5.elements.0.choicesElement 1 in block 6 has duplicate choice labels"
+      )
+    );
+
+    const response = await createV3SurveyResponse({
+      body: parsedCreateBody,
+      authentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      detail: "Survey document failed validation",
+      invalid_params: [
+        {
+          name: "body",
+          reason: expect.stringContaining("duplicate choice labels"),
+        },
+      ],
+    });
   });
 });
 

--- a/apps/web/app/api/v3/surveys/lib/operations.ts
+++ b/apps/web/app/api/v3/surveys/lib/operations.ts
@@ -1,7 +1,12 @@
 import "server-only";
 import { z } from "zod";
 import { logger } from "@formbricks/logger";
-import { DatabaseError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
+import {
+  DatabaseError,
+  InvalidInputError,
+  ResourceNotFoundError,
+  ValidationError,
+} from "@formbricks/types/errors";
 import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
 import {
   createdResponse,
@@ -234,6 +239,18 @@ function mapV3SurveyCreateError(
     log.warn({ statusCode: 422, invalidParams: err.invalidParams }, "Survey document validation failed");
     return problemUnprocessableContent(requestId, "Survey document failed validation", {
       invalid_params: err.invalidParams,
+      instance,
+    });
+  }
+  if (err instanceof ValidationError) {
+    // `createSurvey` re-validates its input against ZSurveyCreateInput via `validateInputs`, which
+    // throws a bare ValidationError. That is the same class of failure as above — a well-formed
+    // document that breaks a semantic rule (duplicate choice labels, dangling logic targets) — so it
+    // must report the reason as a 422. Left unmapped it fell through to the catch-all 500 "An
+    // unexpected error occurred.", which told the caller nothing about what to fix (ENG-2578).
+    log.warn({ statusCode: 422, errorCode: err.name }, "Survey document validation failed");
+    return problemUnprocessableContent(requestId, "Survey document failed validation", {
+      invalid_params: [{ name: "body", reason: err.message }],
       instance,
     });
   }
@@ -588,6 +605,16 @@ function mapV3SurveyPatchError(
     );
     return problemUnprocessableContent(requestId, "Survey document failed validation", {
       invalid_params: err.invalidParams,
+      instance,
+    });
+  }
+
+  if (err instanceof ValidationError) {
+    // Same as the create path: `updateSurvey`'s own `validateInputs` throws a bare ValidationError for
+    // a semantic rule break, which would otherwise be reported as an opaque 500.
+    log.warn({ statusCode: 422, workspaceId, errorCode: err.name }, "Survey document validation failed");
+    return problemUnprocessableContent(requestId, "Survey document failed validation", {
+      invalid_params: [{ name: "body", reason: err.message }],
       instance,
     });
   }

--- a/apps/web/app/api/v3/surveys/templates/lib/template-catalog-create.test.ts
+++ b/apps/web/app/api/v3/surveys/templates/lib/template-catalog-create.test.ts
@@ -1,0 +1,107 @@
+import { createInstance } from "i18next";
+import type { TFunction } from "i18next";
+import ICU from "i18next-icu";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { ZSurveyCreateInput } from "@formbricks/types/surveys/types";
+import { prepareV3SurveyCreate } from "@/app/api/v3/surveys/prepare";
+import { ZV3CreateSurveyBody } from "@/app/api/v3/surveys/schemas";
+import { templates } from "@/app/lib/templates";
+import { replacePresetPlaceholders } from "@/lib/utils/templates";
+import enUS from "@/locales/en-US.json";
+import { buildV3SurveyCreatePayloadFromTemplate } from "./template-to-v3";
+
+vi.mock("server-only", () => ({}));
+
+/**
+ * The trusted template route rebuilds a template server-side and pushes it through the same three
+ * gates a hand-written create body goes through. Only the first one reports a usable error: the
+ * request schema fails with a 400 naming the field, reference validation with a 422, but
+ * `createSurvey`'s own `validateInputs(ZSurveyCreateInput)` throws a bare ValidationError from deep
+ * inside the service layer. So a template that trips the last gate only ever surfaced as "An
+ * unexpected error occurred." with no indication of which template or which rule (ENG-2578).
+ *
+ * Walking the whole catalog through all three gates is what catches that before a release: the
+ * template bodies are generated from translations, so a rule like "no two choices may share a label"
+ * can break for a single template without any code change.
+ */
+const t = (): TFunction => {
+  const instance = createInstance();
+  // ICU matches the server's `getTranslate`, so a template string that ICU cannot parse fails here
+  // rather than at request time.
+  instance.use(ICU).init({
+    lng: "en-US",
+    fallbackLng: "en-US",
+    resources: { "en-US": { translation: enUS } },
+    interpolation: { escapeValue: false },
+  });
+  return instance.getFixedT("en-US");
+};
+
+const workspace = { id: "cmnh38nzx00003b6r3svd9pv2", name: "Acme" };
+
+let catalogIds: string[];
+let translate: TFunction;
+
+beforeAll(() => {
+  translate = t();
+  catalogIds = templates(translate).map((template) => template.id);
+});
+
+describe("catalog templates are creatable", () => {
+  test("the catalog is non-empty", () => {
+    expect(catalogIds.length).toBeGreaterThan(0);
+  });
+
+  test.each(["link", "app"] as const)("every template passes every create gate as %s", (surveyType) => {
+    const rejected: string[] = [];
+
+    for (const template of templates(translate).map((raw) => replacePresetPlaceholders(raw, workspace))) {
+      const body = ZV3CreateSurveyBody.safeParse(
+        buildV3SurveyCreatePayloadFromTemplate({
+          template,
+          workspaceId: workspace.id,
+          surveyType,
+          defaultLanguage: "en-US",
+        })
+      );
+
+      if (!body.success) {
+        rejected.push(`${template.id}: request schema — ${body.error.issues[0]?.message}`);
+        continue;
+      }
+
+      const prepared = prepareV3SurveyCreate(body.data);
+      if (!prepared.ok) {
+        rejected.push(`${template.id}: references — ${prepared.validation.invalidParams[0]?.reason}`);
+        continue;
+      }
+
+      // The shape `executeV3SurveyCreate` hands to `createSurvey`: a template declares no languages,
+      // triggers or targeting, so the document fields are the only ones that vary per template.
+      const createInput = ZSurveyCreateInput.safeParse({
+        name: prepared.document.name,
+        type: prepared.document.type,
+        status: prepared.document.status,
+        metadata: prepared.document.metadata,
+        welcomeCard: prepared.document.welcomeCard,
+        blocks: prepared.document.blocks,
+        endings: prepared.document.endings,
+        hiddenFields: prepared.document.hiddenFields,
+        variables: prepared.document.variables,
+        languages: [],
+        questions: [],
+        createdBy: "cltwumfbz0000echxysz6ptvq",
+      });
+
+      if (!createInput.success) {
+        rejected.push(
+          `${template.id}: survey document — ${createInput.error.issues
+            .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+            .join("; ")}`
+        );
+      }
+    }
+
+    expect(rejected).toEqual([]);
+  });
+});

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1,5 +1,5 @@
 // Import pino after the mock is defined
-import Pino from "pino";
+import Pino, { stdSerializers } from "pino";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { LOG_LEVELS } from "./types/logger";
 
@@ -151,6 +151,17 @@ describe("Logger", () => {
     );
 
     expect(logger).toBeDefined();
+  });
+
+  test("serializes the `error` key the same way as `err`", async () => {
+    // Nearly every call site logs a caught exception as `{ error }`. Without this the key gets no
+    // serializer, so an Error reaches the output with its prototype fields (name, message, stack)
+    // stripped and only its own enumerable properties left — the failure mode behind ENG-2578.
+    await import("./logger");
+
+    const { serializers } = vi.mocked(Pino).mock.calls[0][0] as Pino.LoggerOptions;
+
+    expect(serializers?.error).toBe(stdSerializers.err);
   });
 
   test("production OTEL endpoint does not enable OTEL log transport without OTEL_LOGS_ENABLED", async () => {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -38,6 +38,14 @@ const baseLoggerConfig: LoggerOptions = {
   level: getLogLevel(),
   serializers: {
     err: stdSerializers.err,
+    // Almost every call site in the app logs a caught exception as `{ error }`, not `{ err }`, and
+    // without a serializer for that key Pino writes the object as-is. An Error's `name`, `message`
+    // and `stack` live on the prototype and are non-enumerable, so all that survives is whatever own
+    // enumerable fields the subclass happens to add — a Prisma failure logged as
+    // `{"error":{"clientVersion":"7.8.0"}}`, with no type, message or code to act on (ENG-2578).
+    // `stdSerializers.err` returns non-error values untouched, so keys that carry something other
+    // than an Error are unaffected.
+    error: stdSerializers.err,
     req: stdSerializers.req,
     res: stdSerializers.res,
   },


### PR DESCRIPTION
Ref ENG-2578

## What & why

ENG-2578 reports "An unexpected error occurred" when creating a survey from a template. The template is a red herring — the reporter later confirmed it hits **every** template, "start from scratch" too, and that retrying sometimes succeeds. Production logs show the same 500 on `GET /api/v3/surveys`:

```
{"requestId":"…","method":"POST","path":"/api/v3/surveys/templates",
 "error":{"clientVersion":"7.8.0"},"statusCode":500,"msg":"V3 API unexpected error"}
```

`clientVersion: "7.8.0"` is a Prisma error — and it is the *only* field that survived. That is the actual bug this PR fixes: **the logs cannot tell you what went wrong.**

- **`packages/logger`** — Pino applies a serializer only to keys that have one registered. The logger registered `err`; essentially every call site in the app logs a caught exception as `{ error }`. `name`, `message` and `stack` live on `Error.prototype` and are non-enumerable, so those call sites emitted only the subclass's own enumerable fields — for a Prisma failure, `clientVersion` alone. No type, no message, no `code`, no stack, so a connection-pool timeout is indistinguishable from a bad query. Registering the same serializer for `error` fixes it for every existing call site at once; it returns non-error values unchanged, so keys carrying something else are unaffected.

- **`apps/web/app/api/v3/surveys`** — the create and patch handlers mapped only errors they knew by type. A bare `ValidationError` — what `validateInputs` throws when `createSurvey`/`updateSurvey` re-check their input against `ZSurveyCreateInput` — fell through to the catch-all and came back as a 500 with no field and no reason, so a survey that broke a document rule looked identical to a server fault. Mapped to 422 with the reason, the way `V3SurveyReferenceValidationError` already is.

That second gap is reachable today from the template catalog: **`employee-satisfaction` cannot be created in `nl-NL`, `pt-BR`, `ro-RO` or `zh-Hant-TW`** (and `career-development-survey` in `tr-TR`), because "Extremely likely" and "Very likely" translate to the same string and trip the "no two choices may share a label" rule. That needs a translation change, not a code change — see Open gaps. The new catalog sweep is what surfaces this class of breakage as a failing test instead of a user's failing request.

<details>
<summary>What the 500 in ENG-2578 is <em>not</em></summary>

Ruled out by reproducing the real route handler against a real Postgres (`createTrustedTemplateSurveyResponse`, auth stubbed, everything else live):

- **Template data** — all 52 catalog templates create successfully in `en-US`, including `churn-survey` and `site-abandonment`, across `link` and `app`. Across all 15 locales, only the 5 duplicate-label combinations above fail.
- **The post-commit path** — `subscribeOrganizationMembersToSurveyResponses` read-modify-writes `user.notificationSettings` after the survey row is committed and looked like a plausible flake. 780 consecutive creates for one user ran it 780 times without a failure.
- **Audit logging / rate limiting** — `queueV3AuditLog` swallows its own errors; a rate-limit failure returns 429, not 500.

Combined with the intermittency, both pods affected, and the same error on the read path, the remaining cause is database connectivity in that environment — pool exhaustion or a flapping connection. Which of those it is should be readable straight off the log line once this PR is deployed.
</details>

## Breaking changes

- [ ] This PR contains breaking changes

None. The logger change adds a serializer for a key that previously had none, so `error` fields in log output gain `type`/`message`/`stack` — a shape change in logs, not in any API, env var or config key. The 422 replaces a 500 on a path that was already failing.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| An exception logged as `{ error }` keeps its type, message and stack | unit (red on main) | `packages/logger/src/logger.test.ts` → "serializes the `error` key the same way as `err`". Deleting the `error: stdSerializers.err` line at `packages/logger/src/logger.ts:41` fails it; `pnpm --filter @formbricks/logger test` |
| A service-layer `ValidationError` returns 422 with the reason, not an opaque 500 | unit (red on main) | `apps/web/app/api/v3/surveys/lib/operations.test.ts` → "reports the reason for a service-layer ValidationError instead of an opaque 500". Asserts status 422 and that `invalid_params[0].reason` carries the rule that was broken |
| Every catalog template survives all three create gates | unit (mutation) | `apps/web/app/api/v3/surveys/templates/lib/template-catalog-create.test.ts`. Passes on `main`; pointing `churn_survey_question_1_choice_2` at `..._choice_1` in `apps/web/app/lib/templates.ts:520` fails it with `churn-survey: survey document — blocks.0.elements.0.choices: Element 1 in block 1 has duplicate choice labels` |
| Templates still create end to end after the 422 mapping | manual | Real Postgres 16 + pgvector, migrations applied, `createTrustedTemplateSurveyResponse` with auth stubbed: `churn-survey` and `site-abandonment` → 201; `employee-satisfaction`/`nl-NL` → 422 containing "duplicate choice labels" (was 500 "An unexpected error occurred.") |

**Open gaps**

- **ENG-2578's own intermittent 500 is not fixed here** — the evidence points at database connectivity in that environment, not at code on this path. This PR makes the next occurrence say which Prisma error it is. Hence `Ref`, not `Fixes`.
- **`employee-satisfaction` in `nl-NL`/`pt-BR`/`ro-RO`/`zh-Hant-TW` and `career-development-survey` in `tr-TR` are still uncreatable.** The collision is in the machine translations, and `AGENTS.md` allows edits only to `en-US.json` with `pnpm i18n` to regenerate — which needs a `LINGO_API_KEY` I do not have. Needs either re-translation of those keys or en-US labels that stay distinct once translated. The catalog sweep therefore asserts `en-US` only; widening it to all 15 locales is the follow-up once the translations are fixed.
- Not exercised against a live Redis (the harness ran with caching disabled), so the Redis-backed cache and rate-limit paths are unchanged but unverified here.

**Risks**

- The logger change alters the shape of every `{ error }` field in log output — anything parsing those lines (SigNoz dashboards, alert rules) now sees `error.type`/`error.message` instead of a bare object. Worth a glance at any saved query that reads `error` as a scalar.
- The 422 is a new status on `POST /api/v3/surveys` and `PATCH /api/v3/surveys/:id` for inputs that previously 500'd. Clients treating only 5xx as retryable will now stop retrying — which is the intent, since these are not transient.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SkkcSQy3Z8hcpnAnh9CuT4)_