### PR TITLE
feat: add Formbricks logo to MCP OAuth consent page

### DIFF
--- a/apps/web/app/(app)/account/authorize/page.tsx
+++ b/apps/web/app/(app)/account/authorize/page.tsx
@@ -59,13 +59,14 @@ const getPublicOAuthClient = async (clientId: string): Promise<TOAuthPublicClien
   }
 };
 
-const OAuthConsentLogo = () => (
+const OAuthConsentLogo = ({ label }: Readonly<{ label: string }>) => (
   <div className="mb-6 flex justify-center">
     <Link
       target="_blank"
       href="https://formbricks.com?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=oauth_consent_logo"
-      rel="noopener noreferrer">
-      <Logo className="h-8 w-auto" />
+      rel="noopener noreferrer"
+      aria-label={label}>
+      <Logo aria-hidden="true" className="h-8 w-auto" />
     </Link>
   </div>
 );
@@ -89,7 +90,7 @@ const Page = async ({ searchParams }: Readonly<{ searchParams: Promise<TSearchPa
     return (
       <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-10">
         <div className="w-full max-w-xl rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-          <OAuthConsentLogo />
+          <OAuthConsentLogo label={t("auth.oauth.formbricks_website")} />
           <Alert variant="error" role="status">
             <AlertTitle>{t("auth.oauth.invalid_oauth_request")}</AlertTitle>
             <AlertDescription>{t("auth.oauth.invalid_oauth_request_description")}</AlertDescription>
@@ -105,7 +106,7 @@ const Page = async ({ searchParams }: Readonly<{ searchParams: Promise<TSearchPa
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-10">
       <div className="w-full max-w-xl rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-        <OAuthConsentLogo />
+        <OAuthConsentLogo label={t("auth.oauth.formbricks_website")} />
         <div className="space-y-1">
           <p className="text-sm font-medium text-slate-500">{t("auth.oauth.authorization_request")}</p>
           <h1 className="text-2xl font-semibold text-slate-900">

--- a/apps/web/app/(app)/account/authorize/page.tsx
+++ b/apps/web/app/(app)/account/authorize/page.tsx
@@ -1,4 +1,5 @@
 import { headers } from "next/headers";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getTranslate } from "@/lingodotdev/server";
 import { auth } from "@/modules/auth/lib/auth";
@@ -10,6 +11,7 @@ import {
 } from "@/modules/auth/lib/oauth-client-metadata";
 import { getSession } from "@/modules/auth/lib/session";
 import { Alert, AlertDescription, AlertTitle } from "@/modules/ui/components/alert";
+import { Logo } from "@/modules/ui/components/logo";
 import { OAuthConsentActions } from "./components/OAuthConsentActions";
 
 type TSearchParams = Record<string, string | string[] | undefined>;
@@ -57,6 +59,17 @@ const getPublicOAuthClient = async (clientId: string): Promise<TOAuthPublicClien
   }
 };
 
+const OAuthConsentLogo = () => (
+  <div className="mb-6 flex justify-center">
+    <Link
+      target="_blank"
+      href="https://formbricks.com?utm_source=formbricks-app&utm_medium=webapp&utm_campaign=oauth_consent_logo"
+      rel="noopener noreferrer">
+      <Logo className="h-8 w-auto" />
+    </Link>
+  </div>
+);
+
 const Page = async ({ searchParams }: Readonly<{ searchParams: Promise<TSearchParams> }>) => {
   const resolvedSearchParams = await searchParams;
   const session = await getSession();
@@ -76,6 +89,7 @@ const Page = async ({ searchParams }: Readonly<{ searchParams: Promise<TSearchPa
     return (
       <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-10">
         <div className="w-full max-w-xl rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <OAuthConsentLogo />
           <Alert variant="error" role="status">
             <AlertTitle>{t("auth.oauth.invalid_oauth_request")}</AlertTitle>
             <AlertDescription>{t("auth.oauth.invalid_oauth_request_description")}</AlertDescription>
@@ -91,6 +105,7 @@ const Page = async ({ searchParams }: Readonly<{ searchParams: Promise<TSearchPa
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-10">
       <div className="w-full max-w-xl rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <OAuthConsentLogo />
         <div className="space-y-1">
           <p className="text-sm font-medium text-slate-500">{t("auth.oauth.authorization_request")}</p>
           <h1 className="text-2xl font-semibold text-slate-900">

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -66,6 +66,7 @@ checksums:
     auth/oauth/consent_failed: d6c92762fac20817ff0ec8d9cbc0412c
     auth/oauth/consent_revoked: f1c243aaacd7c466b9986e484b93247b
     auth/oauth/deny_access: ba3ac7dc12f362da277df5c9ba21e752
+    auth/oauth/formbricks_website: 95c2f69c6b6428e1aa6c26f4dd427e22
     auth/oauth/invalid_oauth_request: 02936ced8cd4df963282fe5d413f6900
     auth/oauth/invalid_oauth_request_description: 39322e962c0c20c766ae82d0b8917ebb
     auth/oauth/localhost_redirect_warning: e0368262d25dc98ea02158eebd0066c1

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -80,6 +80,7 @@
       "consent_failed": "OAuth consent failed. Please try again.",
       "consent_revoked": "OAuth app access revoked.",
       "deny_access": "Deny access",
+      "formbricks_website": "Formbricks",
       "invalid_oauth_request": "Invalid OAuth request",
       "invalid_oauth_request_description": "The OAuth client could not be found or the authorization request is missing required details.",
       "localhost_redirect_warning": "Local redirect URI",


### PR DESCRIPTION
No Linear ticket — small UI polish requested directly by the team.

## What & why

The `/account/authorize` page (shown when an MCP client like Claude requests access to a user's Formbricks account) rendered as a plain, unbranded card — no logo, nothing to indicate it's actually Formbricks. That makes it look untrustworthy/phishy right at the moment a user is asked to grant account access.

Add the same `Logo` component used on login/signup (`@/modules/ui/components/logo`), linked to formbricks.com, above both the consent card and the invalid-request error card, matching the branding pattern already established by `FormWrapper` on the auth pages.

## Breaking changes

- [ ] This PR contains breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Logo renders above the consent card (client name, scopes, allow/deny) | manual (static reproduction of the JSX/Tailwind markup rendered in-browser) | Logo displays centered above the card, linked out, matches auth-page branding |
| Logo renders above the invalid-request error card | manual (code inspection — same `OAuthConsentLogo` component used in both branches) | Present in both render paths |

**Open gaps**

- Not exercised against the actual running `/account/authorize` route end-to-end (no Postgres/Docker available in this environment to boot the full app + a real MCP OAuth handshake). Verified the exact markup/classes visually via a standalone reproduction instead. Worth a quick manual check on a preview deploy before merge.

**Risks**

- Low risk: purely additive JSX (a linked logo) in a Server Component; no logic, props, or existing markup changed.

---

Written by claude-sonnet-5 (Claude Code) at effort level: medium.