### PR TITLE
fix: default question headlines to normal weight instead of bold

### DIFF
--- a/apps/web/lib/styling/constants.ts
+++ b/apps/web/lib/styling/constants.ts
@@ -115,7 +115,7 @@ export const STYLE_DEFAULTS: TWorkspaceStyling = {
   // Headlines & Descriptions
   elementHeadlineColor: { light: _colors["elementHeadlineColor.light"] },
   elementHeadlineFontSize: 16,
-  elementHeadlineFontWeight: 500,
+  elementHeadlineFontWeight: 400,
   elementDescriptionColor: { light: _colors["elementDescriptionColor.light"] },
   elementDescriptionFontSize: 14,
   elementDescriptionFontWeight: 400,

--- a/packages/survey-ui/src/styles/globals.css
+++ b/packages/survey-ui/src/styles/globals.css
@@ -81,7 +81,7 @@
 
   /* ── Headlines ─────────────────────────────────────────────────────── */
   --fb-element-headline-font-family: inherit;
-  --fb-element-headline-font-weight: 500;
+  --fb-element-headline-font-weight: 400;
   --fb-element-headline-font-size: 16px;
   --fb-element-headline-color: #142a72;
   --fb-element-headline-opacity: 1;

--- a/packages/surveys/src/components/general/headline.tsx
+++ b/packages/surveys/src/components/general/headline.tsx
@@ -47,9 +47,7 @@ export function Headline({
             dangerouslySetInnerHTML={{ __html: safeHtml }}
           />
         ) : (
-          <HeadingTag
-            data-testid="fb__surveys__headline-text-test"
-            className="label-headline text-base font-semibold">
+          <HeadingTag data-testid="fb__surveys__headline-text-test" className="label-headline text-base">
             {headline}
           </HeadingTag>
         )}


### PR DESCRIPTION
No ticket — small default-value change requested directly.

## What & why

Survey question headlines render bold by default (`font-semibold` / CSS weight `500`), but recall/fallback substitution inside a headline can't currently be rendered in bold, so a headline mixing literal text and a recall/fallback value looks visibly inconsistent (part bold, part not).

Changes the default headline font-weight to normal (`400`) for every question type, matching the existing description (`400`) and upper-label (`400`) defaults:

- `apps/web/lib/styling/constants.ts` — `STYLE_DEFAULTS.elementHeadlineFontWeight`: `500` → `400`. This is the single source of truth used by the editor's styling form, the "Restore defaults" action, the survey renderer, and the email preview template.
- `packages/survey-ui/src/styles/globals.css` — `--fb-element-headline-font-weight` static CSS fallback: `500` → `400`. Governs every question type except the three below (openText, single/multi-select, rating, NPS, matrix, consent, contactInfo, address, fileUpload, ranking, pictureSelection, CTA, date).
- `packages/surveys/src/components/general/headline.tsx` — removed a hardcoded `font-semibold` class that always forced bold regardless of the styling settings above. This is the `Headline` component used by the welcome card, ending/thank-you card, and the Cal.com booking question — it was also internally inconsistent, since the HTML-headline branch right next to it never had this class.

Workspaces/surveys that already set an explicit `elementHeadlineFontWeight` (via Advanced Styling → Headlines & Descriptions → Headline Font Weight) are unaffected — this only changes what renders when no explicit value is set.

## Breaking changes

- [ ] This PR contains breaking changes

None — this only changes a visual default (headline font-weight). No API/SDK shape, env var, route, or config key changes, and nothing requires self-hoster migration action. Surveys/workspaces without an explicit headline-weight override will simply render headlines slightly lighter after deploy.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Question headlines render at normal (400) weight by default | manual | Storybook `Elements/Rating/Default` story: `getComputedStyle` on `.label-headline` returns `font-weight: 400` (was `500`) |
| Hardcoded bold removed from welcome/ending-card/Cal.com headline | manual (built-bundle inspection) | Rebuilt `@formbricks/surveys` and grepped the compiled `apps/web/public/js/surveys.umd.cjs`: the plain-text headline branch's className is now `label-headline text-base` (no `font-semibold`), and `--fb-element-headline-font-weight:400` is the compiled default |
| Existing behaviour (custom headline weight, recall/fallback substitution, HTML headlines) unaffected | unit (guard) | `pnpm test --filter=@formbricks/surveys --filter=@formbricks/survey-ui` — 721 + existing survey-ui tests pass unchanged, including `styles.test.ts` cases that set an explicit `elementHeadlineFontWeight` |

**Open gaps**

- Didn't visually screenshot the welcome card / ending card / Cal.com booking question specifically (no Storybook stories exist for them) — verified via compiled-bundle inspection instead, since they share the exact same `Headline` component and CSS variable as the Storybook-verified path.
- No full end-to-end run against a live DB-backed app in this environment (worktree lacks `DATABASE_URL`/`ENCRYPTION_KEY`/etc.), so the change wasn't clicked through in the actual survey editor/link-survey UI.

**Risks**

- This changes a global rendering default: any live survey/workspace that hasn't explicitly set a headline font weight will visibly render lighter headlines immediately after deploy. This is the intended, requested behavior change, not a regression, but worth calling out since it's a visible change with no opt-in.

---

> [!NOTE]
> **AI model used** — `claude-sonnet-5`, reasoning effort `medium`.