### PR TITLE
fix: correct vertical misalignment of type select in survey variables row

### DIFF
--- a/apps/web/modules/survey/editor/components/survey-variables-card-item.tsx
+++ b/apps/web/modules/survey/editor/components/survey-variables-card-item.tsx
@@ -202,6 +202,7 @@ export const SurveyVariablesCardItem = ({
               name="type"
               render={({ field }) => (
                 <FormItem
+                  className="space-y-0"
                   onBlur={mode === "edit" ? () => form.handleSubmit(editSurveyVariable)() : undefined}>
                   <Select
                     {...field}


### PR DESCRIPTION
<!-- No ticket: this was reported directly via a screenshot in chat, not a Linear ticket. -->

## What & why

The "Add variable" row in the survey editor's Variables card (`survey-variables-card-item.tsx`) rendered the "Number"/"Text" type dropdown visibly offset upward relative to the surrounding `Field name` and `Initial value` inputs, even though all three controls share the same `h-10` height.

Root cause: Radix's `<Select>` renders a visually-hidden native `<select>` as a second child of its wrapper `<div>` (used for native form/accessibility bubbling). That wrapper is a `FormItem`, which applies Tailwind's `space-y-2` (`margin-bottom` on every child except the last). Because the hidden native select becomes the *last* child, the margin lands on the visible `SelectTrigger` button instead of being absorbed — shifting it up by half the margin relative to its siblings, which have no such hidden sibling.

Fix: set `space-y-0` on that specific `FormItem` (it only ever has one visible child, so the spacing utility was never doing anything useful there anyway).

**Before / after** (isolated repro using the real `Input`/`Select`/`Button`/`FormItem` components and the app's actual Tailwind build — see "How this was tested"):

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/formbricks/formbricks/3ad20fe629b6a4d9a04242bef7b44c85d38f213e/before.png" width="380" /> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/3ad20fe629b6a4d9a04242bef7b44c85d38f213e/after.png" width="380" /> |

## Breaking changes

- [ ] This PR contains breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Type `Select` trigger vertically aligned with the `Field name`/`Initial value` inputs in the "Add variable" row | manual | Built an isolated Vite+React repro importing the actual production `Input`, `Select`, `Button`, `FormItem`/`FormField`/`FormControl` components (`apps/web/modules/ui/components/*`) plus `react-hook-form`, compiled through the app's real `globals.css` (Tailwind v4 + `@tailwindcss/forms`). Confirmed via `getBoundingClientRect()` that before the fix the trigger's `top`/`bottom` were offset by 4px from the inputs (traced to the `space-y-2` margin landing on the trigger, per the root cause above); after adding `space-y-0` all four controls report identical `top`/`bottom`. Screenshots above captured from this repro with Playwright. |

**Open gaps**

- Not verified against a live survey editor page (no local DB/auth environment available in this session) — only the isolated component repro above. The change is a single Tailwind class on an existing `FormItem`, so risk is low, but worth a quick visual sanity check on staging.

**Risks**

- None expected — `space-y-0` only removes now-unnecessary spacing on a `FormItem` with a single visible child; no effect on the `name`/`value` fields or other `FormItem` usages.

---

> [!NOTE]
> **AI model used** — `claude-sonnet-5` (Claude Code), reasoning effort `unknown`.
