### PR TITLE
fix(email): show the organization's custom logo in response notification emails

### DIFF
--- a/apps/web/modules/email/index.tsx
+++ b/apps/web/modules/email/index.tsx
@@ -332,6 +332,13 @@ export const sendResponseFinishedEmail = async (
     return element;
   });
 
+  // The whitelabel logo is stored as a relative `/storage/...` path, which an email client cannot
+  // resolve — it has no origin to resolve against, so the `<img>` renders broken. Resolve it to an
+  // absolute URL here, exactly like every other email sender does.
+  const logoUrl = organization.whitelabel?.logoUrl
+    ? resolveStorageUrl(organization.whitelabel.logoUrl)
+    : undefined;
+
   const html = await renderResponseFinishedEmail({
     survey,
     responseCount,
@@ -340,6 +347,7 @@ export const sendResponseFinishedEmail = async (
     workspaceId,
     organization,
     elements: elementsWithResolvedUrls,
+    logoUrl,
     t,
     ...legalProps,
   });

--- a/apps/web/modules/email/response-finished-email.test.ts
+++ b/apps/web/modules/email/response-finished-email.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TResponse } from "@formbricks/types/responses";
+import type { TSurvey } from "@formbricks/types/surveys/types";
+import { sendResponseFinishedEmail } from "./index";
+
+const {
+  mockRenderResponseFinishedEmail,
+  mockGetOrganizationByWorkspaceId,
+  mockGetElementResponseMapping,
+  mockResolveStorageUrl,
+  mockGetTranslate,
+  mockCreateTransport,
+} = vi.hoisted(() => ({
+  mockRenderResponseFinishedEmail: vi.fn(),
+  mockGetOrganizationByWorkspaceId: vi.fn(),
+  mockGetElementResponseMapping: vi.fn(),
+  mockResolveStorageUrl: vi.fn(),
+  mockGetTranslate: vi.fn(),
+  mockCreateTransport: vi.fn(() => ({ sendMail: vi.fn() })),
+}));
+
+vi.mock("@formbricks/email", () => ({
+  renderResponseFinishedEmail: mockRenderResponseFinishedEmail,
+}));
+
+vi.mock("@/lib/organization/service", () => ({
+  getOrganizationByWorkspaceId: mockGetOrganizationByWorkspaceId,
+}));
+
+vi.mock("@/lib/responses", () => ({
+  getElementResponseMapping: mockGetElementResponseMapping,
+}));
+
+vi.mock("@/modules/storage/utils", () => ({
+  resolveStorageUrl: mockResolveStorageUrl,
+}));
+
+vi.mock("@/lingodotdev/server", () => ({
+  getTranslate: mockGetTranslate,
+}));
+
+// The real transport would try to reach the SMTP host from .env (localhost:1025, nothing listening).
+// Stub it so `sendEmail`'s side effect stays a no-op; the assertions only care about the render call.
+vi.mock("nodemailer", () => ({
+  createTransport: mockCreateTransport,
+}));
+
+const survey = { id: "survey1", name: "Survey", variables: [], hiddenFields: {} } as unknown as TSurvey;
+const response = { id: "response1", data: {}, variables: {} } as unknown as TResponse;
+
+describe("sendResponseFinishedEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTranslate.mockResolvedValue((key: string) => key);
+    mockGetElementResponseMapping.mockReturnValue([]);
+    mockRenderResponseFinishedEmail.mockResolvedValue("<html>rendered</html>");
+    mockResolveStorageUrl.mockImplementation((url: string) => `https://cdn.example.com${url}`);
+  });
+
+  // This is the exact regression: the organization's whitelabel logo was fetched but never
+  // threaded into the template, so the notification email always fell back to the hard-coded
+  // Formbricks logo regardless of what the organization had configured.
+  test("resolves the organization's whitelabel logo to an absolute URL", async () => {
+    mockGetOrganizationByWorkspaceId.mockResolvedValue({
+      id: "org1",
+      whitelabel: { logoUrl: "/storage/wsp123/public/logo--fid--abc.png" },
+    });
+
+    await sendResponseFinishedEmail("owner@example.com", "en-US", "workspace1", survey, response, 1);
+
+    expect(mockResolveStorageUrl).toHaveBeenCalledWith("/storage/wsp123/public/logo--fid--abc.png");
+    expect(mockRenderResponseFinishedEmail.mock.calls[0][0].logoUrl).toBe(
+      "https://cdn.example.com/storage/wsp123/public/logo--fid--abc.png"
+    );
+  });
+
+  test.each([
+    ["no whitelabel object", undefined],
+    ["a whitelabel object with no logo", {}],
+  ])("leaves the logo unset for %s, so the default Formbricks logo applies", async (_label, whitelabel) => {
+    mockGetOrganizationByWorkspaceId.mockResolvedValue({ id: "org1", whitelabel });
+
+    await sendResponseFinishedEmail("owner@example.com", "en-US", "workspace1", survey, response, 1);
+
+    expect(mockResolveStorageUrl).not.toHaveBeenCalled();
+    expect(mockRenderResponseFinishedEmail.mock.calls[0][0].logoUrl).toBeUndefined();
+  });
+});

--- a/packages/email/emails/survey/response-finished-email.tsx
+++ b/packages/email/emails/survey/response-finished-email.tsx
@@ -23,6 +23,7 @@ export interface ResponseFinishedEmailProps extends TEmailTemplateLegalProps {
   readonly workspaceId: string;
   readonly organization: TOrganization;
   readonly elements: ProcessedResponseElement[]; // Pre-processed data, not a function
+  readonly logoUrl?: string;
   readonly t?: TFunction;
 }
 
@@ -45,11 +46,12 @@ export function ResponseFinishedEmail({
   workspaceId,
   organization,
   elements,
+  logoUrl,
   t = mockT,
   ...legalProps
 }: ResponseFinishedEmailProps): React.JSX.Element {
   return (
-    <EmailTemplate t={t} {...legalProps}>
+    <EmailTemplate logoUrl={logoUrl} t={t} {...legalProps}>
       <Container>
         <Row>
           <Column>

--- a/packages/email/src/lib/render.test.ts
+++ b/packages/email/src/lib/render.test.ts
@@ -173,6 +173,33 @@ describe("legal footer", () => {
   });
 });
 
+describe("custom branding", () => {
+  test("response-finished notification falls back to the Formbricks logo when no organization logo is set", async () => {
+    const html = await renderResponseFinishedEmail({
+      ...exampleData.responseFinishedEmail,
+      elements: responseFinishedElements,
+      t,
+    });
+
+    expect(html).toContain('data-testid="default-logo-image"');
+    expect(html).not.toContain('data-testid="logo-image"');
+  });
+
+  test("response-finished notification renders the organization's custom logo when set", async () => {
+    const customLogoUrl = "https://example.com/custom-logo.png";
+    const html = await renderResponseFinishedEmail({
+      ...exampleData.responseFinishedEmail,
+      elements: responseFinishedElements,
+      logoUrl: customLogoUrl,
+      t,
+    });
+
+    expect(html).toContain('data-testid="logo-image"');
+    expect(html).toContain(customLogoUrl);
+    expect(html).not.toContain('data-testid="default-logo-image"');
+  });
+});
+
 describe("Tailwind render engine", () => {
   // `@react-email/tailwind` — not anything configured in this package — decides which
   // Tailwind version compiles the template classes. Pin that contract: these utilities


### PR DESCRIPTION
No ticket — follow-up from the product-inbox bug report behind #8817, which fixed the same logo gap for the workflow `send_email` action and survey Follow-Ups but explicitly called out that the response notification email was untouched.

## What & why

An organization's whitelabel logo is fetched by `sendResponseFinishedEmail` (`apps/web/modules/email/index.tsx`) via `getOrganizationByWorkspaceId`, but the value was never read back out of the `organization` object before rendering. `ResponseFinishedEmail` (`packages/email/emails/survey/response-finished-email.tsx`) had no `logoUrl` prop at all, so it always fell back to the hard-coded Formbricks logo in the shared `EmailTemplate`, regardless of what the organization had configured.

This is the same class of bug #8817 fixed for the workflow `send_email` step and survey Follow-Ups (`buildSurveyResponseEmailHtml`) — a relative `/storage/...` path needs `resolveStorageUrl` before it can be used as an `<img src>` in an email client. The fix here mirrors that pattern:

- `sendResponseFinishedEmail` now derives `logoUrl` from `organization.whitelabel?.logoUrl`, resolved through `resolveStorageUrl` (same helper, same fallback semantics: `undefined`/empty stays falsy so the default logo still applies).
- `ResponseFinishedEmail` now accepts a `logoUrl` prop and forwards it to `<EmailTemplate logoUrl={logoUrl} ...>`, matching `FollowUpEmail`'s existing signature.

## Breaking changes

- [ ] This PR contains breaking changes

None — additive optional prop; organizations without a whitelabel logo see no change (still the default Formbricks logo).

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `sendResponseFinishedEmail` resolves the org's whitelabel logo to an absolute URL and passes it to the template | unit (red on main) — `apps/web/modules/email/response-finished-email.test.ts`, `pnpm --filter @formbricks/web exec vitest run modules/email/response-finished-email.test.ts` | Fails on main (`renderResponseFinishedEmail` never called with a `logoUrl`); passes after the fix |
| `sendResponseFinishedEmail` leaves the logo unset when the org has no whitelabel logo, so the default Formbricks logo still renders | unit (guard) — same file | Passes before and after; guards the fallback path |
| `ResponseFinishedEmail`/`EmailTemplate` render the custom logo image when `logoUrl` is supplied, and the default Formbricks logo when it isn't | unit (guard) — `packages/email/src/lib/render.test.ts` › "custom branding" | Passes before and after — an existing `...legalProps` rest-spread happened to already forward an explicit `logoUrl` prop at the render layer even pre-fix, so this isn't the regression itself, but it guards the template's contract against a future refactor that removes that forwarding |
| Full unit suite unaffected | unit | `pnpm test` — 641 files / 8493 tests passed |
| Static checks clean on touched packages | n/a | `pnpm lint`, `pnpm typecheck`, `pnpm format:check` — clean, no new warnings |

**Open gaps**

- No live send / manual QA against a running app with real SMTP — not available in this sandboxed session. The unit coverage above exercises the exact code path (`sendResponseFinishedEmail` → `renderResponseFinishedEmail` → `EmailTemplate`) that production uses; a reviewer wanting visual confirmation can follow the same manual steps #8817 used (organization settings → Email customization → upload a logo → trigger a response notification).

**Risks**

- Nearby: `ResponseFinishedEmail` also renders response data, variables, hidden fields, and the unsubscribe links — untouched by this diff; full unit suite (8493 tests) passed with no new failures.
- Self-hosted deployments: the resolved absolute logo URL follows the public domain, same as every other storage URL in emails (identical to the #8817 fix).

---

> [!NOTE]
> **AI model used** — `claude-sonnet-5`, reasoning effort `high` (Claude Code).