### PR TITLE
fix(sso): strip the live local auth factors on SSO recovery (backport 5.3)

### DIFF
--- a/apps/web/app/api/auth/sso/recovery/complete/route.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import { logger } from "@formbricks/logger";
 import { verifySsoRelinkIntent } from "@/lib/jwt";
-import { deleteSessionBySessionToken } from "@/modules/auth/lib/auth-session-repository";
 import { getSession } from "@/modules/auth/lib/session";
 import {
   BETTER_AUTH_SESSION_COOKIE_NAMES,
   getSessionTokenFromCookieHeader,
 } from "@/modules/auth/lib/session-cookie";
+import { revokeSessionByToken } from "@/modules/auth/lib/session-revocation";
 import { completeSsoRecovery, getSsoRecoveryFailureRedirectUrl } from "@/modules/ee/sso/lib/sso-recovery";
 
 const clearSessionCookies = (response: NextResponse) => {
@@ -31,7 +31,9 @@ const buildFailedRecoveryResponse = async (request: Request, callbackUrl?: strin
   }
 
   try {
-    await deleteSessionBySessionToken(sessionToken);
+    // Through the two-store revocation, not a raw Prisma delete: sessions live in Redis too, and a
+    // DB-only delete would leave this one resolvable by `getSession` until its TTL (ENG-2557).
+    await revokeSessionByToken(sessionToken);
   } catch (error) {
     logger.error(error, "Failed to delete SSO recovery session after recovery completion error");
   }

--- a/apps/web/app/api/auth/sso/recovery/complete/route.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.ts
@@ -52,6 +52,8 @@ export const GET = async (request: Request) => {
     const callbackUrl = await completeSsoRecovery({
       intentToken,
       sessionUserId: session?.user.id,
+      // Spared by the post-commit session sweep, so the redirect below still lands signed in.
+      sessionToken: getSessionTokenFromCookieHeader(request.headers.get("cookie")) ?? undefined,
     });
 
     return NextResponse.redirect(callbackUrl);

--- a/apps/web/lib/user/password.test.ts
+++ b/apps/web/lib/user/password.test.ts
@@ -2,12 +2,13 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { InvalidInputError } from "@formbricks/types/errors";
 import { verifyPassword } from "@/modules/auth/lib/utils";
-import { getCredentialPasswordHash, verifyUserPassword } from "./password";
+import { getCredentialPasswordHash, hasCredentialAccount, verifyUserPassword } from "./password";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
     account: {
       findUnique: vi.fn(),
+      count: vi.fn(),
     },
   },
 }));
@@ -73,5 +74,25 @@ describe("user password helpers", () => {
     await expect(verifyUserPassword("sso-user", "plain-password")).rejects.toThrow(InvalidInputError);
 
     expect(mockVerifyPassword).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Scoped by owner, not by the `(provider, providerAccountId)` key `getCredentialPasswordHash` uses: those
+   * are account-KEY columns and a drifted key is a real failure mode here (ENG-2555), so a key-filtered
+   * existence check could report "no credential account" for a user who has one.
+   */
+  test("hasCredentialAccount counts the user's credential rows by userId, not by account key", async () => {
+    vi.mocked(prisma.account.count).mockResolvedValue(1);
+
+    await expect(hasCredentialAccount("user-1")).resolves.toBe(true);
+    expect(prisma.account.count).toHaveBeenCalledWith({
+      where: { userId: "user-1", provider: "credential" },
+    });
+  });
+
+  test("hasCredentialAccount is false for an SSO-only user", async () => {
+    vi.mocked(prisma.account.count).mockResolvedValue(0);
+
+    await expect(hasCredentialAccount("user-2")).resolves.toBe(false);
   });
 });

--- a/apps/web/lib/user/password.ts
+++ b/apps/web/lib/user/password.ts
@@ -32,3 +32,20 @@ export const verifyUserPassword = async (userId: string, password: string): Prom
 
   return await verifyPassword(password, passwordHash);
 };
+
+/**
+ * Whether the user has a Better Auth `credential` Account row at all — i.e. whether they are (or once
+ * were) a password user, independently of whether a password is currently set on it.
+ *
+ * Scoped by `userId` rather than the `(provider, providerAccountId)` key that `getCredentialPasswordHash`
+ * uses: `providerAccountId` and `issuer` are account-KEY columns, and a drifted key is a real failure mode
+ * in this schema (ENG-2555). Owner-scoping still cannot reach another user's row, and it does not go blind
+ * when a key column is wrong.
+ */
+export const hasCredentialAccount = reactCache(async (userId: string): Promise<boolean> => {
+  const count = await prisma.account.count({
+    where: { userId, provider: "credential" },
+  });
+
+  return count > 0;
+});

--- a/apps/web/lib/user/password.ts
+++ b/apps/web/lib/user/password.ts
@@ -41,6 +41,12 @@ export const verifyUserPassword = async (userId: string, password: string): Prom
  * uses: `providerAccountId` and `issuer` are account-KEY columns, and a drifted key is a real failure mode
  * in this schema (ENG-2555). Owner-scoping still cannot reach another user's row, and it does not go blind
  * when a key column is wrong.
+ *
+ * One consequence of erring broad, since this answers a "may they?" question rather than "is there a live
+ * hash?": Better Auth's `resetPassword` locates the row via `findCredentialAccount`, which filters on
+ * `issuer` and `accountId` too. For a row whose key has drifted this returns true, the reset then takes
+ * its create-a-row branch and can collide with `@@unique([provider, providerAccountId])` — a 500 on the
+ * reset rather than a security problem, and louder than silently refusing the user a password.
  */
 export const hasCredentialAccount = reactCache(async (userId: string): Promise<boolean> => {
   const count = await prisma.account.count({

--- a/apps/web/modules/auth/forgot-password/actions.test.ts
+++ b/apps/web/modules/auth/forgot-password/actions.test.ts
@@ -15,6 +15,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 const allowedRateLimitResponse = { allowed: true };
+
+/** Fresh audit context per call — the action writes `userId` / `suppressEvent` onto it. */
+let auditLoggingCtx: Record<string, unknown>;
+const callAction = (input: { email: string } = { email: "test@example.com" }) => {
+  auditLoggingCtx = {};
+  return forgotPasswordAction({ ctx: { auditLoggingCtx }, parsedInput: input } as any);
+};
 const RESET_REDIRECT = "http://localhost:3000/auth/forgot-password/reset";
 
 vi.mock("@/lib/constants", () => ({
@@ -29,6 +36,12 @@ vi.mock("@/lib/constants", () => ({
 // `lib/crypto`, which reads ENCRYPTION_KEY from the (fully replaced) constants mock at import time.
 vi.mock("@/lib/user/password", () => ({
   hasCredentialAccount: mocks.hasCredentialAccount,
+}));
+
+// Passthrough so the handler runs directly, matching modules/ee/billing/actions.test.ts. Importing the
+// real handler would drag the audit-log graph (and its POSTHOG_KEY constant read) into this suite.
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_action, _target, fn) => fn),
 }));
 
 vi.mock("@/modules/core/rate-limit/helpers", () => ({
@@ -84,7 +97,7 @@ describe("forgotPasswordAction", () => {
     test("applies rate limiting (with the right config) before looking up the user", async () => {
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
 
-      await forgotPasswordAction({ parsedInput: validInput } as any);
+      await callAction(validInput);
 
       expect(applyIPRateLimit).toHaveBeenCalledWith(rateLimitConfigs.auth.forgotPassword);
       expect(applyIPRateLimit).toHaveBeenCalledBefore(getUserByEmail as any);
@@ -95,7 +108,7 @@ describe("forgotPasswordAction", () => {
         new Error("Maximum number of requests reached. Please try again later.")
       );
 
-      await expect(forgotPasswordAction({ parsedInput: validInput } as any)).rejects.toThrow(
+      await expect(callAction(validInput)).rejects.toThrow(
         "Maximum number of requests reached. Please try again later."
       );
 
@@ -109,7 +122,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       expect(getUserByEmail).toHaveBeenCalledWith(validInput.email);
       expect(auth.api.requestPasswordReset).toHaveBeenCalledWith({
@@ -123,7 +136,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue(null);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();
       expect(result).toEqual({ success: true });
@@ -134,7 +147,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
       mocks.hasCredentialAccount.mockResolvedValue(false);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();
       expect(result).toEqual({ success: true });
@@ -155,7 +168,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
       mocks.hasCredentialAccount.mockResolvedValue(true);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       expect(mocks.hasCredentialAccount).toHaveBeenCalledWith(mockUser.id);
       expect(auth.api.requestPasswordReset).toHaveBeenCalledWith({
@@ -170,7 +183,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
       mocks.hasCredentialAccount.mockResolvedValue(true);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       // Handing a password back where the operator disabled credential auth would be the "sign in around
       // the IdP" bypass that switching it off exists to prevent.
@@ -181,11 +194,50 @@ describe("forgotPasswordAction", () => {
     test("does not need the credential lookup for an email-identity user", async () => {
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
 
-      await forgotPasswordAction({ parsedInput: validInput } as any);
+      await callAction(validInput);
 
       // Short-circuits on `identityProvider === "email"`, so the extra query never runs for the common case.
       expect(mocks.hasCredentialAccount).not.toHaveBeenCalled();
       expect(auth.api.requestPasswordReset).toHaveBeenCalledOnce();
+    });
+  });
+
+  /**
+   * The action answers `{ success: true }` whether or not a reset was actually requested, so the audit
+   * wrapper cannot tell the two apart on its own — without `suppressEvent` it would record a
+   * `passwordReset` for an address that never got one. Same false-record problem as duplicate sign-up
+   * (ENG-2091), and these pin both directions.
+   */
+  describe("Audit record", () => {
+    beforeEach(() => {
+      vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
+    });
+
+    test("targets the audited event at the user when a reset is actually requested", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
+
+      await callAction(validInput);
+
+      expect(auditLoggingCtx.userId).toBe(mockUser.id);
+      expect(auditLoggingCtx.suppressEvent).toBeUndefined();
+    });
+
+    test("suppresses the event for an address with no account", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue(null);
+
+      await callAction(validInput);
+
+      expect(auditLoggingCtx.suppressEvent).toBe(true);
+      expect(auditLoggingCtx.userId).toBeUndefined();
+    });
+
+    test("suppresses the event for a user with no password to reset", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(false);
+
+      await callAction(validInput);
+
+      expect(auditLoggingCtx.suppressEvent).toBe(true);
     });
   });
 
@@ -195,7 +247,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
       vi.mocked(auth.api.requestPasswordReset).mockRejectedValue(new Error("BA request failed"));
 
-      await expect(forgotPasswordAction({ parsedInput: validInput } as any)).resolves.toEqual({
+      await expect(callAction(validInput)).resolves.toEqual({
         success: true,
       });
       expect(logger.error).toHaveBeenCalledWith(
@@ -208,9 +260,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockRejectedValue(new Error("Database error"));
 
-      await expect(forgotPasswordAction({ parsedInput: validInput } as any)).rejects.toThrow(
-        "Database error"
-      );
+      await expect(callAction(validInput)).rejects.toThrow("Database error");
     });
   });
 
@@ -219,7 +269,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue(null);
 
-      expect(await forgotPasswordAction({ parsedInput: validInput } as any)).toEqual({ success: true });
+      expect(await callAction(validInput)).toEqual({ success: true });
     });
 
     test("always returns success for an SSO user and never requests a reset", async () => {
@@ -227,7 +277,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "github" } as any);
       mocks.hasCredentialAccount.mockResolvedValue(false);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       expect(result).toEqual({ success: true });
       expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();

--- a/apps/web/modules/auth/forgot-password/actions.test.ts
+++ b/apps/web/modules/auth/forgot-password/actions.test.ts
@@ -12,6 +12,9 @@ const mocks = vi.hoisted(() => ({
   // Held in a box and exposed through a getter below so a single test can flip it: `EMAIL_AUTH_ENABLED` is
   // a const import in the action, and the getter keeps the live binding readable per call.
   emailAuthEnabled: { value: true },
+  // The wrapper is applied once at module import, so `vi.resetAllMocks()` in beforeEach would wipe the
+  // call history before any test could read it. A plain array on the hoisted object survives the reset.
+  auditWrapperArgs: [] as [string, string][],
 }));
 
 const allowedRateLimitResponse = { allowed: true };
@@ -41,7 +44,10 @@ vi.mock("@/lib/user/password", () => ({
 // Passthrough so the handler runs directly, matching modules/ee/billing/actions.test.ts. Importing the
 // real handler would drag the audit-log graph (and its POSTHOG_KEY constant read) into this suite.
 vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
-  withAuditLogging: vi.fn((_action, _target, fn) => fn),
+  withAuditLogging: vi.fn((action: string, target: string, fn: unknown) => {
+    mocks.auditWrapperArgs.push([action, target]);
+    return fn;
+  }),
 }));
 
 vi.mock("@/modules/core/rate-limit/helpers", () => ({
@@ -87,6 +93,9 @@ describe("forgotPasswordAction", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mocks.emailAuthEnabled.value = true;
+    // `vi.resetAllMocks()` does not touch this, so reset it here too: a future test that asserts on
+    // `auditLoggingCtx` without calling `callAction` would otherwise read the previous test's object.
+    auditLoggingCtx = {};
   });
 
   afterEach(() => {
@@ -231,6 +240,27 @@ describe("forgotPasswordAction", () => {
       expect(auditLoggingCtx.userId).toBeUndefined();
     });
 
+    /**
+     * Without this the whole audit story is unobserved: `withAuditLogging` is mocked as a passthrough and
+     * `actionClient.action` returns the handler, so deleting the wrapper from the action entirely would
+     * leave every other test in this file green — including the ones below. This is the only assertion
+     * that the event is emitted under the right action and target at all.
+     */
+    test("wires the wrapper with the right audit action and target", () => {
+      expect(mocks.auditWrapperArgs).toContainEqual(["passwordReset", "user"]);
+    });
+
+    test("suppresses the event when the reset email fails to send", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
+      vi.mocked(auth.api.requestPasswordReset).mockRejectedValue(new Error("smtp down"));
+
+      const result = await callAction(validInput);
+
+      // The action still reports success, so an unsuppressed event would claim a link was mailed.
+      expect(result).toEqual({ success: true });
+      expect(auditLoggingCtx.suppressEvent).toBe(true);
+    });
+
     test("suppresses the event for a user with no password to reset", async () => {
       vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
       mocks.hasCredentialAccount.mockResolvedValue(false);
@@ -254,6 +284,16 @@ describe("forgotPasswordAction", () => {
         expect.objectContaining({ userId: mockUser.id }),
         "Password reset request failed"
       );
+    });
+
+    test("still reports success when the credential lookup throws", async () => {
+      vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
+      vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockRejectedValue(new Error("db down"));
+
+      // The whole point of the fail-closed catch: no reset, no escaping error.
+      await expect(callAction(validInput)).resolves.toEqual({ success: true });
+      expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();
     });
 
     test("propagates a user-lookup error", async () => {

--- a/apps/web/modules/auth/forgot-password/actions.test.ts
+++ b/apps/web/modules/auth/forgot-password/actions.test.ts
@@ -7,12 +7,28 @@ import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { forgotPasswordAction } from "./actions";
 
+const mocks = vi.hoisted(() => ({
+  hasCredentialAccount: vi.fn(),
+  // Held in a box and exposed through a getter below so a single test can flip it: `EMAIL_AUTH_ENABLED` is
+  // a const import in the action, and the getter keeps the live binding readable per call.
+  emailAuthEnabled: { value: true },
+}));
+
 const allowedRateLimitResponse = { allowed: true };
 const RESET_REDIRECT = "http://localhost:3000/auth/forgot-password/reset";
 
 vi.mock("@/lib/constants", () => ({
+  get EMAIL_AUTH_ENABLED() {
+    return mocks.emailAuthEnabled.value;
+  },
   PASSWORD_RESET_DISABLED: false,
   WEBAPP_URL: "http://localhost:3000",
+}));
+
+// Mocked at the module boundary rather than letting the real one load: `lib/user/password` pulls in
+// `lib/crypto`, which reads ENCRYPTION_KEY from the (fully replaced) constants mock at import time.
+vi.mock("@/lib/user/password", () => ({
+  hasCredentialAccount: mocks.hasCredentialAccount,
 }));
 
 vi.mock("@/modules/core/rate-limit/helpers", () => ({
@@ -57,6 +73,7 @@ describe("forgotPasswordAction", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mocks.emailAuthEnabled.value = true;
   });
 
   afterEach(() => {
@@ -112,14 +129,63 @@ describe("forgotPasswordAction", () => {
       expect(result).toEqual({ success: true });
     });
 
-    test("does not request a reset for a non-email identity provider", async () => {
+    test("does not request a reset for an SSO user with no credential account", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(false);
 
       const result = await forgotPasswordAction({ parsedInput: validInput } as any);
 
       expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();
       expect(result).toEqual({ success: true });
+    });
+  });
+
+  /**
+   * SSO recovery is one-way: it flips `identityProvider` to the SSO provider and nothing flips it back,
+   * while clearing the password it found. Gated on `identityProvider` alone these users could never ask
+   * for a reset again, so the surviving credential `Account` row is what lets them back in (ENG-2557).
+   */
+  describe("Recovered SSO users (ENG-2557)", () => {
+    beforeEach(() => {
+      vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
+    });
+
+    test("requests a reset for an SSO-identity user who still has a credential account", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(true);
+
+      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+
+      expect(mocks.hasCredentialAccount).toHaveBeenCalledWith(mockUser.id);
+      expect(auth.api.requestPasswordReset).toHaveBeenCalledWith({
+        body: { email: mockUser.email, redirectTo: RESET_REDIRECT },
+        headers: expect.any(Headers),
+      });
+      expect(result).toEqual({ success: true });
+    });
+
+    test("stays shut on an SSO-only instance, even with a credential account present", async () => {
+      mocks.emailAuthEnabled.value = false;
+      vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(true);
+
+      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+
+      // Handing a password back where the operator disabled credential auth would be the "sign in around
+      // the IdP" bypass that switching it off exists to prevent.
+      expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+
+    test("does not need the credential lookup for an email-identity user", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
+
+      await forgotPasswordAction({ parsedInput: validInput } as any);
+
+      // Short-circuits on `identityProvider === "email"`, so the extra query never runs for the common case.
+      expect(mocks.hasCredentialAccount).not.toHaveBeenCalled();
+      expect(auth.api.requestPasswordReset).toHaveBeenCalledOnce();
     });
   });
 
@@ -159,6 +225,7 @@ describe("forgotPasswordAction", () => {
     test("always returns success for an SSO user and never requests a reset", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "github" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(false);
 
       const result = await forgotPasswordAction({ parsedInput: validInput } as any);
 

--- a/apps/web/modules/auth/forgot-password/actions.ts
+++ b/apps/web/modules/auth/forgot-password/actions.ts
@@ -28,7 +28,10 @@ import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
  *
  * Kept as narrow as that problem, deliberately: gating on the credential row rather than on
  * `emailVerified` means this action grants nothing to a user who has only ever signed in via SSO, and
- * `EMAIL_AUTH_ENABLED` switches the second arm off entirely on an SSO-only instance.
+ * `EMAIL_AUTH_ENABLED` switches the second arm off entirely on an SSO-only instance. Note that gate
+ * covers only the second arm — an `identityProvider === "email"` user still receives reset mail on an
+ * SSO-only instance, which is pre-existing behaviour this change deliberately leaves alone. So the flag
+ * here is about not *widening* that surface, not about closing it.
  *
  * Both are belt-and-braces rather than the enforcement boundary, and it is worth not mistaking one for
  * the other. Better Auth's native `POST /api/auth/request-password-reset` is mounted by the `[...all]`
@@ -52,9 +55,11 @@ const canResetPassword = async (user: {
   try {
     return await hasCredentialAccount(user.id);
   } catch (error) {
-    // Fail closed, and do not let this escape: the action's contract is an unconditional
-    // `{ success: true }` (enumeration safety), so a DB error here must not turn into a server error
-    // that answers "this address exists" by being shaped differently from the miss case.
+    // Fail closed rather than letting this escape. Note the action's `{ success: true }` is not an
+    // absolute invariant — `getUserByEmail` above it is unguarded and its `DatabaseError` is not an
+    // expected error, so it surfaces as a server error. That is address-independent, so it is not an
+    // enumeration oracle; this catch just avoids adding a second, narrower failure mode on a path that
+    // only runs for non-email identity providers.
     logger.error({ error, userId: user.id }, "Credential-account lookup failed during password reset");
     return false;
   }
@@ -85,6 +90,10 @@ export const forgotPasswordAction = actionClient.inputSchema(ZForgotPasswordActi
           headers: await headers(),
         });
       } catch (error) {
+        // The send failed but the action still answers `{ success: true }`, so without suppressing here
+        // the trail would claim a reset link was mailed to this user — the same false record the `else`
+        // branch guards, in the other direction. SMTP being down should not read as "we mailed them".
+        ctx.auditLoggingCtx.suppressEvent = true;
         logger.error({ error, userId: user.id }, "Password reset request failed");
       }
     } else {

--- a/apps/web/modules/auth/forgot-password/actions.ts
+++ b/apps/web/modules/auth/forgot-password/actions.ts
@@ -25,14 +25,39 @@ import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
  * unwired. The surviving credential `Account` row identifies them: recovery nulls the password, it does
  * not delete the row.
  *
- * Kept as narrow as that problem, deliberately. Gating on the credential row rather than on
- * `emailVerified` means a user who has ONLY ever signed in via SSO has no such row and gains nothing here,
- * and `EMAIL_AUTH_ENABLED` switches the second arm off entirely on an SSO-only instance — where handing
- * back a password would be the "sign in around the IdP, and around whatever the IdP enforces" bypass that
- * turning `emailAndPassword.enabled` off exists to prevent.
+ * Kept as narrow as that problem, deliberately: gating on the credential row rather than on
+ * `emailVerified` means this action grants nothing to a user who has only ever signed in via SSO, and
+ * `EMAIL_AUTH_ENABLED` switches the second arm off entirely on an SSO-only instance.
+ *
+ * Both are belt-and-braces rather than the enforcement boundary, and it is worth not mistaking one for
+ * the other. Better Auth's native `POST /api/auth/request-password-reset` is mounted by the `[...all]`
+ * catch-all unconditionally — it is NOT gated on `emailAndPassword.enabled` — and its `resetPassword`
+ * CREATES a credential row when none exists. So a password can be minted for any registered address
+ * regardless of this action. What actually contains that is `/sign-in/email`, which IS gated, so a minted
+ * password is unusable on an SSO-only instance. This relaxation therefore grants no reach that was not
+ * already there; it just stops the UI lying to a recovered user.
  */
-const canResetPassword = async (user: { id: string; identityProvider: IdentityProvider }): Promise<boolean> =>
-  user.identityProvider === "email" || (EMAIL_AUTH_ENABLED && (await hasCredentialAccount(user.id)));
+const canResetPassword = async (user: {
+  id: string;
+  identityProvider: IdentityProvider;
+}): Promise<boolean> => {
+  if (user.identityProvider === "email") {
+    return true;
+  }
+  if (!EMAIL_AUTH_ENABLED) {
+    return false;
+  }
+
+  try {
+    return await hasCredentialAccount(user.id);
+  } catch (error) {
+    // Fail closed, and do not let this escape: the action's contract is an unconditional
+    // `{ success: true }` (enumeration safety), so a DB error here must not turn into a server error
+    // that answers "this address exists" by being shaped differently from the miss case.
+    logger.error({ error, userId: user.id }, "Credential-account lookup failed during password reset");
+    return false;
+  }
+};
 
 const ZForgotPasswordAction = z.object({
   email: ZUserEmail,

--- a/apps/web/modules/auth/forgot-password/actions.ts
+++ b/apps/web/modules/auth/forgot-password/actions.ts
@@ -2,15 +2,37 @@
 
 import { headers } from "next/headers";
 import { z } from "zod";
+import type { IdentityProvider } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { OperationNotAllowedError } from "@formbricks/types/errors";
 import { ZUserEmail } from "@formbricks/types/user";
-import { PASSWORD_RESET_DISABLED, WEBAPP_URL } from "@/lib/constants";
+import { EMAIL_AUTH_ENABLED, PASSWORD_RESET_DISABLED, WEBAPP_URL } from "@/lib/constants";
+import { hasCredentialAccount } from "@/lib/user/password";
 import { actionClient } from "@/lib/utils/action-client";
 import { auth } from "@/modules/auth/lib/auth";
 import { getUserByEmail } from "@/modules/auth/lib/user";
 import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+
+/**
+ * Whether this user has a password to reset. Pure SSO users do not, and are silently skipped — Better
+ * Auth's request endpoint is enumeration-safe and the action always reports success either way.
+ *
+ * The second arm exists because SSO recovery is one-way (ENG-2557): completing it flips
+ * `identityProvider` to the SSO provider and nothing ever flips it back, while the recovery also clears
+ * the password it found. Gated on `identityProvider` alone, those users could never ask for a reset again
+ * — locked to an IdP they might lose access to, with `auth.api.setPassword` being `serverOnly` and
+ * unwired. The surviving credential `Account` row identifies them: recovery nulls the password, it does
+ * not delete the row.
+ *
+ * Kept as narrow as that problem, deliberately. Gating on the credential row rather than on
+ * `emailVerified` means a user who has ONLY ever signed in via SSO has no such row and gains nothing here,
+ * and `EMAIL_AUTH_ENABLED` switches the second arm off entirely on an SSO-only instance — where handing
+ * back a password would be the "sign in around the IdP, and around whatever the IdP enforces" bypass that
+ * turning `emailAndPassword.enabled` off exists to prevent.
+ */
+const canResetPassword = async (user: { id: string; identityProvider: IdentityProvider }): Promise<boolean> =>
+  user.identityProvider === "email" || (EMAIL_AUTH_ENABLED && (await hasCredentialAccount(user.id)));
 
 const ZForgotPasswordAction = z.object({
   email: ZUserEmail,
@@ -27,9 +49,7 @@ export const forgotPasswordAction = actionClient
 
     const user = await getUserByEmail(parsedInput.email);
 
-    // Only credential (email-identity) users have a password to reset; SSO users are silently skipped.
-    // Better Auth's request endpoint is itself enumeration-safe, and we always return success below.
-    if (user && user.identityProvider === "email") {
+    if (user && (await canResetPassword(user))) {
       try {
         await auth.api.requestPasswordReset({
           body: { email: user.email, redirectTo: `${WEBAPP_URL}/auth/forgot-password/reset` },

--- a/apps/web/modules/auth/forgot-password/actions.ts
+++ b/apps/web/modules/auth/forgot-password/actions.ts
@@ -13,6 +13,7 @@ import { auth } from "@/modules/auth/lib/auth";
 import { getUserByEmail } from "@/modules/auth/lib/user";
 import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 
 /**
  * Whether this user has a password to reset. Pure SSO users do not, and are silently skipped — Better
@@ -63,9 +64,8 @@ const ZForgotPasswordAction = z.object({
   email: ZUserEmail,
 });
 
-export const forgotPasswordAction = actionClient
-  .inputSchema(ZForgotPasswordAction)
-  .action(async ({ parsedInput }) => {
+export const forgotPasswordAction = actionClient.inputSchema(ZForgotPasswordAction).action(
+  withAuditLogging("passwordReset", "user", async ({ ctx, parsedInput }) => {
     await applyIPRateLimit(rateLimitConfigs.auth.forgotPassword);
 
     if (PASSWORD_RESET_DISABLED) {
@@ -75,6 +75,10 @@ export const forgotPasswordAction = actionClient
     const user = await getUserByEmail(parsedInput.email);
 
     if (user && (await canResetPassword(user))) {
+      // Target the audited event at the account the reset was requested for. The ACTOR stays
+      // `UNKNOWN_DATA` because this action is unauthenticated by design — which is the honest record:
+      // someone who knows the address asked for a reset.
+      ctx.auditLoggingCtx.userId = user.id;
       try {
         await auth.api.requestPasswordReset({
           body: { email: user.email, redirectTo: `${WEBAPP_URL}/auth/forgot-password/reset` },
@@ -83,7 +87,15 @@ export const forgotPasswordAction = actionClient
       } catch (error) {
         logger.error({ error, userId: user.id }, "Password reset request failed");
       }
+    } else {
+      // No reset was requested — unknown address, or a user with no password to reset. The action still
+      // answers `{ success: true }` to stay enumeration-safe, so without this the wrapper's fixed
+      // `passwordReset` action would record a reset that never happened (the same false-record problem
+      // `suppressEvent` was added for on duplicate sign-up, ENG-2091). A thrown failure is audited
+      // regardless, so this cannot hide one.
+      ctx.auditLoggingCtx.suppressEvent = true;
     }
 
     return { success: true };
-  });
+  })
+);

--- a/apps/web/modules/auth/lib/auth-session-repository.test.ts
+++ b/apps/web/modules/auth/lib/auth-session-repository.test.ts
@@ -2,12 +2,13 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
-import { deleteSessionBySessionToken } from "./auth-session-repository";
+import { deleteSessionBySessionToken, getSessionTokensByUserId } from "./auth-session-repository";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
     session: {
       deleteMany: vi.fn(),
+      findMany: vi.fn(),
     },
   },
 }));
@@ -64,5 +65,24 @@ describe("auth-session-repository", () => {
     );
 
     await expect(deleteSessionBySessionToken(sessionToken)).rejects.toThrow(DatabaseError);
+  });
+
+  test("lists every session token for a user", async () => {
+    vi.mocked(prisma.session.findMany).mockResolvedValue([
+      { sessionToken: "token-a" },
+      { sessionToken: "token-b" },
+    ] as never);
+
+    await expect(getSessionTokensByUserId("user_1")).resolves.toEqual(["token-a", "token-b"]);
+    expect(prisma.session.findMany).toHaveBeenCalledWith({
+      where: { userId: "user_1" },
+      select: { sessionToken: true },
+    });
+  });
+
+  test("returns an empty list for a user with no sessions", async () => {
+    vi.mocked(prisma.session.findMany).mockResolvedValue([] as never);
+
+    await expect(getSessionTokensByUserId("user_1")).resolves.toEqual([]);
   });
 });

--- a/apps/web/modules/auth/lib/auth-session-repository.test.ts
+++ b/apps/web/modules/auth/lib/auth-session-repository.test.ts
@@ -17,15 +17,17 @@ describe("auth-session-repository", () => {
     vi.clearAllMocks();
   });
 
-  test("lists every session token for a user", async () => {
+  test("lists a user's unexpired session tokens", async () => {
     vi.mocked(prisma.session.findMany).mockResolvedValue([
       { sessionToken: "token-a" },
       { sessionToken: "token-b" },
     ] as never);
 
     await expect(getSessionTokensByUserId("user_1")).resolves.toEqual(["token-a", "token-b"]);
+    // Expired rows are excluded on purpose: the count feeds the SSO-recovery audit event, where it is
+    // read as "how many sessions the squatter was holding".
     expect(prisma.session.findMany).toHaveBeenCalledWith({
-      where: { userId: "user_1" },
+      where: { userId: "user_1", expires: { gt: expect.any(Date) } },
       select: { sessionToken: true },
     });
   });

--- a/apps/web/modules/auth/lib/auth-session-repository.test.ts
+++ b/apps/web/modules/auth/lib/auth-session-repository.test.ts
@@ -2,69 +2,19 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
-import { deleteSessionBySessionToken, getSessionTokensByUserId } from "./auth-session-repository";
+import { getSessionTokensByUserId } from "./auth-session-repository";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
     session: {
-      deleteMany: vi.fn(),
       findMany: vi.fn(),
     },
   },
 }));
 
 describe("auth-session-repository", () => {
-  const sessionToken = "session-token-cm8z6bn2q000008l34h8g7k9m";
-
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  test("deletes the session matching the given token", async () => {
-    vi.mocked(prisma.session.deleteMany).mockResolvedValue({ count: 1 });
-
-    const result = await deleteSessionBySessionToken(sessionToken);
-
-    expect(result).toBe(1);
-    expect(prisma.session.deleteMany).toHaveBeenCalledWith({
-      where: { sessionToken },
-    });
-  });
-
-  test("returns zero when no session matches the token", async () => {
-    vi.mocked(prisma.session.deleteMany).mockResolvedValue({ count: 0 });
-
-    const result = await deleteSessionBySessionToken(sessionToken);
-
-    expect(result).toBe(0);
-  });
-
-  test("uses the provided transaction client when available", async () => {
-    const txDeleteMany = vi.fn().mockResolvedValue({ count: 1 });
-    const tx = {
-      session: {
-        deleteMany: txDeleteMany,
-      },
-    } as unknown as Prisma.TransactionClient;
-
-    const result = await deleteSessionBySessionToken(sessionToken, tx);
-
-    expect(result).toBe(1);
-    expect(txDeleteMany).toHaveBeenCalledWith({
-      where: { sessionToken },
-    });
-    expect(prisma.session.deleteMany).not.toHaveBeenCalled();
-  });
-
-  test("wraps prisma known errors in DatabaseError", async () => {
-    vi.mocked(prisma.session.deleteMany).mockRejectedValue(
-      new Prisma.PrismaClientKnownRequestError("database failed", {
-        code: "P2021",
-        clientVersion: "test",
-      })
-    );
-
-    await expect(deleteSessionBySessionToken(sessionToken)).rejects.toThrow(DatabaseError);
   });
 
   test("lists every session token for a user", async () => {
@@ -84,5 +34,13 @@ describe("auth-session-repository", () => {
     vi.mocked(prisma.session.findMany).mockResolvedValue([] as never);
 
     await expect(getSessionTokensByUserId("user_1")).resolves.toEqual([]);
+  });
+
+  test("wraps prisma known errors in DatabaseError", async () => {
+    vi.mocked(prisma.session.findMany).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("boom", { code: "P2024", clientVersion: "7.x" })
+    );
+
+    await expect(getSessionTokensByUserId("user_1")).rejects.toThrow(DatabaseError);
   });
 });

--- a/apps/web/modules/auth/lib/auth-session-repository.ts
+++ b/apps/web/modules/auth/lib/auth-session-repository.ts
@@ -25,14 +25,11 @@ const handleDatabaseError = (error: unknown): never => {
  * reads the `active-sessions-<userId>` index out of `secondaryStorage` and returns an empty list when
  * that key is missing or evicted — which would silently revoke nothing.
  */
-export const getSessionTokensByUserId = async (
-  userId: string,
-  tx?: Prisma.TransactionClient
-): Promise<string[]> => {
+export const getSessionTokensByUserId = async (userId: string): Promise<string[]> => {
   validateInputs([userId, z.string().min(1)]);
 
   try {
-    const sessions = await getDbClient(tx).session.findMany({
+    const sessions = await getDbClient().session.findMany({
       where: {
         userId,
         // Expired rows are already unusable, and including them would inflate the revocation count that

--- a/apps/web/modules/auth/lib/auth-session-repository.ts
+++ b/apps/web/modules/auth/lib/auth-session-repository.ts
@@ -17,25 +17,6 @@ const handleDatabaseError = (error: unknown): never => {
   throw error;
 };
 
-export const deleteSessionBySessionToken = async (
-  sessionToken: string,
-  tx?: Prisma.TransactionClient
-): Promise<number> => {
-  validateInputs([sessionToken, z.string().min(1)]);
-
-  try {
-    const result = await getDbClient(tx).session.deleteMany({
-      where: {
-        sessionToken,
-      },
-    });
-
-    return result.count;
-  } catch (error) {
-    return handleDatabaseError(error);
-  }
-};
-
 /**
  * Every session token belonging to a user, read from Postgres.
  *

--- a/apps/web/modules/auth/lib/auth-session-repository.ts
+++ b/apps/web/modules/auth/lib/auth-session-repository.ts
@@ -35,3 +35,33 @@ export const deleteSessionBySessionToken = async (
     return handleDatabaseError(error);
   }
 };
+
+/**
+ * Every session token belonging to a user, read from Postgres.
+ *
+ * Postgres is the authoritative enumeration source here, deliberately: `session.storeSessionInDatabase`
+ * is on (auth.ts), so every session has a row, whereas Better Auth's own `internalAdapter.listSessions`
+ * reads the `active-sessions-<userId>` index out of `secondaryStorage` and returns an empty list when
+ * that key is missing or evicted — which would silently revoke nothing.
+ */
+export const getSessionTokensByUserId = async (
+  userId: string,
+  tx?: Prisma.TransactionClient
+): Promise<string[]> => {
+  validateInputs([userId, z.string().min(1)]);
+
+  try {
+    const sessions = await getDbClient(tx).session.findMany({
+      where: {
+        userId,
+      },
+      select: {
+        sessionToken: true,
+      },
+    });
+
+    return sessions.map((session) => session.sessionToken);
+  } catch (error) {
+    return handleDatabaseError(error);
+  }
+};

--- a/apps/web/modules/auth/lib/auth-session-repository.ts
+++ b/apps/web/modules/auth/lib/auth-session-repository.ts
@@ -18,7 +18,7 @@ const handleDatabaseError = (error: unknown): never => {
 };
 
 /**
- * Every session token belonging to a user, read from Postgres.
+ * Every UNEXPIRED session token belonging to a user, read from Postgres.
  *
  * Postgres is the authoritative enumeration source here, deliberately: `session.storeSessionInDatabase`
  * is on (auth.ts), so every session has a row, whereas Better Auth's own `internalAdapter.listSessions`
@@ -35,6 +35,10 @@ export const getSessionTokensByUserId = async (
     const sessions = await getDbClient(tx).session.findMany({
       where: {
         userId,
+        // Expired rows are already unusable, and including them would inflate the revocation count that
+        // lands in the SSO-recovery audit event — the one place that number is read as "how many
+        // sessions the squatter was holding".
+        expires: { gt: new Date() },
       },
       select: {
         sessionToken: true,

--- a/apps/web/modules/auth/lib/session-revocation.test.ts
+++ b/apps/web/modules/auth/lib/session-revocation.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { getSessionTokensByUserId } from "@/modules/auth/lib/auth-session-repository";
-import { revokeUserSessionsExcept } from "@/modules/auth/lib/session-revocation";
+import { revokeSessionByToken, revokeUserSessionsExcept } from "@/modules/auth/lib/session-revocation";
 
 const mocks = vi.hoisted(() => ({
   deleteSessions: vi.fn(),
@@ -75,5 +75,18 @@ describe("revokeUserSessionsExcept", () => {
     // Not `internalAdapter.listSessions`: under `secondaryStorage` that reads only the
     // `active-sessions-<userId>` Redis index and returns [] if it was evicted, revoking nothing.
     expect(getSessionTokensByUserId).toHaveBeenCalledWith("user_1");
+  });
+});
+
+describe("revokeSessionByToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.deleteSessions.mockResolvedValue(undefined);
+  });
+
+  test("revokes the one session through the adapter, so both stores are cleared", async () => {
+    await revokeSessionByToken("token-a");
+
+    expect(mocks.deleteSessions).toHaveBeenCalledWith(["token-a"]);
   });
 });

--- a/apps/web/modules/auth/lib/session-revocation.test.ts
+++ b/apps/web/modules/auth/lib/session-revocation.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getSessionTokensByUserId } from "@/modules/auth/lib/auth-session-repository";
+import { revokeUserSessionsExcept } from "@/modules/auth/lib/session-revocation";
+
+const mocks = vi.hoisted(() => ({
+  deleteSessions: vi.fn(),
+}));
+
+vi.mock("@/modules/auth/lib/auth-session-repository", () => ({
+  getSessionTokensByUserId: vi.fn(),
+}));
+
+vi.mock("@/modules/auth/lib/auth", () => ({
+  auth: {
+    $context: Promise.resolve({
+      internalAdapter: { deleteSessions: mocks.deleteSessions },
+    }),
+  },
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+describe("revokeUserSessionsExcept", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.deleteSessions.mockResolvedValue(undefined);
+  });
+
+  /**
+   * The whole point of this helper: sessions live in Postgres AND Redis, and `findSession` reads Redis
+   * first. Going through Better Auth's `deleteSessions` is what clears both — a bare Prisma delete would
+   * leave every revoked session still resolvable by `auth.api.getSession`.
+   */
+  test("revokes through Better Auth's adapter, so both session stores are cleared", async () => {
+    vi.mocked(getSessionTokensByUserId).mockResolvedValue(["token-a", "token-b"]);
+
+    const revoked = await revokeUserSessionsExcept({ userId: "user_1" });
+
+    expect(mocks.deleteSessions).toHaveBeenCalledWith(["token-a", "token-b"]);
+    expect(revoked).toBe(2);
+  });
+
+  test("spares the caller's own session", async () => {
+    vi.mocked(getSessionTokensByUserId).mockResolvedValue(["token-a", "keep-me", "token-b"]);
+
+    const revoked = await revokeUserSessionsExcept({ userId: "user_1", keepSessionToken: "keep-me" });
+
+    expect(mocks.deleteSessions).toHaveBeenCalledWith(["token-a", "token-b"]);
+    expect(revoked).toBe(2);
+  });
+
+  test("does not touch the adapter when the only session is the one being kept", async () => {
+    vi.mocked(getSessionTokensByUserId).mockResolvedValue(["keep-me"]);
+
+    const revoked = await revokeUserSessionsExcept({ userId: "user_1", keepSessionToken: "keep-me" });
+
+    expect(mocks.deleteSessions).not.toHaveBeenCalled();
+    expect(revoked).toBe(0);
+  });
+
+  test("is a no-op for a user with no sessions", async () => {
+    vi.mocked(getSessionTokensByUserId).mockResolvedValue([]);
+
+    expect(await revokeUserSessionsExcept({ userId: "user_1" })).toBe(0);
+    expect(mocks.deleteSessions).not.toHaveBeenCalled();
+  });
+
+  test("enumerates from Postgres, which is the store that always has every session", async () => {
+    vi.mocked(getSessionTokensByUserId).mockResolvedValue(["token-a"]);
+
+    await revokeUserSessionsExcept({ userId: "user_1" });
+
+    // Not `internalAdapter.listSessions`: under `secondaryStorage` that reads only the
+    // `active-sessions-<userId>` Redis index and returns [] if it was evicted, revoking nothing.
+    expect(getSessionTokensByUserId).toHaveBeenCalledWith("user_1");
+  });
+});

--- a/apps/web/modules/auth/lib/session-revocation.test.ts
+++ b/apps/web/modules/auth/lib/session-revocation.test.ts
@@ -60,6 +60,33 @@ describe("revokeUserSessionsExcept", () => {
     expect(revoked).toBe(0);
   });
 
+  /**
+   * Fail-safe direction: `keepSessionToken` is only ever SUBTRACTED from the user's own token set, so an
+   * absent or foreign value can only over-revoke the caller's sessions — never under-revoke, and never
+   * reach another user. These two pin that, because the opposite would be a real hole.
+   */
+  test("sweeps the caller too when no token is supplied", async () => {
+    vi.mocked(getSessionTokensByUserId).mockResolvedValue(["token-a", "token-b"]);
+
+    const revoked = await revokeUserSessionsExcept({ userId: "user_1", keepSessionToken: undefined });
+
+    expect(mocks.deleteSessions).toHaveBeenCalledWith(["token-a", "token-b"]);
+    expect(revoked).toBe(2);
+  });
+
+  test("a token belonging to someone else spares nothing and reaches nothing", async () => {
+    vi.mocked(getSessionTokensByUserId).mockResolvedValue(["token-a", "token-b"]);
+
+    const revoked = await revokeUserSessionsExcept({
+      userId: "user_1",
+      keepSessionToken: "some-other-users-token",
+    });
+
+    // Everything of user_1's goes; the foreign token is never passed to the adapter.
+    expect(mocks.deleteSessions).toHaveBeenCalledWith(["token-a", "token-b"]);
+    expect(revoked).toBe(2);
+  });
+
   test("is a no-op for a user with no sessions", async () => {
     vi.mocked(getSessionTokensByUserId).mockResolvedValue([]);
 

--- a/apps/web/modules/auth/lib/session-revocation.ts
+++ b/apps/web/modules/auth/lib/session-revocation.ts
@@ -1,0 +1,45 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { getSessionTokensByUserId } from "@/modules/auth/lib/auth-session-repository";
+
+/**
+ * Revoke every session a user holds except one, across BOTH session stores.
+ *
+ * Sessions live in two places (see `auth.ts`): Postgres, because `session.storeSessionInDatabase` is
+ * required for the forward-auth proxies, and Redis via `secondaryStorage`. `findSession` consults Redis
+ * first, so a bare `prisma.session.deleteMany()` is NOT a revocation — it leaves the session fully valid
+ * for `auth.api.getSession` while breaking only the proxy path, which is strictly worse than doing
+ * nothing. Better Auth's `internalAdapter.deleteSessions` clears both: `secondaryStorage.delete(token)`
+ * per token, then the rows.
+ *
+ * Enumeration comes from Postgres (`getSessionTokensByUserId`) rather than `internalAdapter.listSessions`,
+ * which under `secondaryStorage` reads only the `active-sessions-<userId>` index and returns an empty
+ * list if that key was evicted — silently revoking nothing.
+ *
+ * `auth` is imported dynamically on purpose: `auth.ts` → `better-auth-hooks.ts` → `sso-recovery.ts`, so a
+ * static import here would close an import cycle for this module's callers. Same reason `auth.ts` reaches
+ * for `await import("@/modules/email")`.
+ *
+ * @returns the number of sessions revoked.
+ */
+export const revokeUserSessionsExcept = async ({
+  userId,
+  keepSessionToken,
+}: {
+  userId: string;
+  keepSessionToken?: string;
+}): Promise<number> => {
+  const tokens = (await getSessionTokensByUserId(userId)).filter((token) => token !== keepSessionToken);
+
+  if (tokens.length === 0) {
+    return 0;
+  }
+
+  const { auth } = await import("@/modules/auth/lib/auth");
+  const ctx = await auth.$context;
+  await ctx.internalAdapter.deleteSessions(tokens);
+
+  logger.info({ userId, revoked: tokens.length }, "Revoked user sessions");
+
+  return tokens.length;
+};

--- a/apps/web/modules/auth/lib/session-revocation.ts
+++ b/apps/web/modules/auth/lib/session-revocation.ts
@@ -48,3 +48,14 @@ export const revokeUserSessionsExcept = async ({
 
   return tokens.length;
 };
+
+/**
+ * Revoke one session by its (unsigned) token, across both stores. Same rationale as above — a raw
+ * Prisma delete leaves the Redis copy resolvable by `getSession` until its TTL — for callers that hold a
+ * token rather than a user id, like the SSO-recovery failure path killing the session its cookie names.
+ */
+export const revokeSessionByToken = async (sessionToken: string): Promise<void> => {
+  const { auth } = await import("@/modules/auth/lib/auth");
+  const ctx = await auth.$context;
+  await ctx.internalAdapter.deleteSessions([sessionToken]);
+};

--- a/apps/web/modules/auth/lib/session-revocation.ts
+++ b/apps/web/modules/auth/lib/session-revocation.ts
@@ -16,6 +16,11 @@ import { getSessionTokensByUserId } from "@/modules/auth/lib/auth-session-reposi
  * which under `secondaryStorage` reads only the `active-sessions-<userId>` index and returns an empty
  * list if that key was evicted — silently revoking nothing.
  *
+ * Known residual, shared with `revokeSessionsOnPasswordReset`: `cookieCache` serves a still-valid
+ * `session_data` cookie from its signature alone, so a revoked session's holder keeps a cached session
+ * for up to `cookieCache.maxAge` (5 min in auth.ts) without ever hitting either store. Stateless by
+ * design upstream; revocation here is effective at the stores and complete once the cache expires.
+ *
  * `auth` is imported dynamically on purpose: `auth.ts` → `better-auth-hooks.ts` → `sso-recovery.ts`, so a
  * static import here would close an import cycle for this module's callers. Same reason `auth.ts` reaches
  * for `await import("@/modules/email")`.

--- a/apps/web/modules/auth/lib/session-revocation.ts
+++ b/apps/web/modules/auth/lib/session-revocation.ts
@@ -19,7 +19,17 @@ import { getSessionTokensByUserId } from "@/modules/auth/lib/auth-session-reposi
  * Known residual, shared with `revokeSessionsOnPasswordReset`: `cookieCache` serves a still-valid
  * `session_data` cookie from its signature alone, so a revoked session's holder keeps a cached session
  * for up to `cookieCache.maxAge` (5 min in auth.ts) without ever hitting either store. Stateless by
- * design upstream; revocation here is effective at the stores and complete once the cache expires.
+ * design upstream (ENG-2591).
+ *
+ * Do not read that as "5 minutes of exposure": the window is bounded but what can be done inside it is
+ * not. A still-cached session can mint an API key or complete an OAuth authorization, neither of which
+ * expires with the session. That is why the ENG-2557 strip revokes OAuth grants in its transaction
+ * rather than relying on the sweep alone.
+ *
+ * One upstream wrinkle: `deleteSessions` prunes the per-token keys and the rows but does not rewrite the
+ * `active-sessions-<userId>` index, so `auth.api.listSessions` keeps listing revoked sessions until their
+ * TTL. No security consequence — `getSession` needs the per-token key, which is gone — but an "active
+ * sessions" view lies immediately after a revocation.
  *
  * `auth` is imported dynamically on purpose: `auth.ts` → `better-auth-hooks.ts` → `sso-recovery.ts`, so a
  * static import here would close an import cycle for this module's callers. Same reason `auth.ts` reaches

--- a/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { resetDb } from "@/integration/reset-db";
+import { ENCRYPTION_KEY, WEBAPP_URL } from "@/lib/constants";
+import { symmetricEncrypt } from "@/lib/crypto";
+import { createSsoRelinkIntent } from "@/lib/jwt";
+import { auth } from "@/modules/auth/lib/auth";
+import { completeSsoRecovery } from "@/modules/ee/sso/lib/sso-recovery";
+import { sendPasswordResetLinkEmail } from "@/modules/email";
+
+/**
+ * The real red-green proof for ENG-2557, against real Postgres and real Redis.
+ *
+ * The bug was invisible to the unit suite for a reason worth restating: the control looked present, wrote
+ * to `User.password` / `User.twoFactorSecret`, and asserted exactly that — but ENG-1054 had moved both
+ * factors elsewhere, so it stripped nothing. Only a test that drives Better Auth's own sign-in against a
+ * real database can tell "the password is gone" from "we nulled a column nobody reads".
+ *
+ * Every security assertion here therefore goes through `auth.api.*` rather than reading columns.
+ */
+
+// EMAIL_VERIFICATION_DISABLED differs between environments — `0` in a dev `.env`, `1` in the `.env.example`
+// CI copies — and `auth.ts` turns it into `requireEmailVerification` at import time. Pinning it keeps this
+// file identical everywhere, and `1` is deliberately the *vulnerable* posture: it is what lets an account
+// with an unproven address hold a live session, which is the state the session sweep exists for.
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  EMAIL_VERIFICATION_DISABLED: true,
+  // A dev `.env` ships PASSWORD_RESET_DISABLED=1 (CI's fixups flip it); the lockout test below drives a
+  // real reset, so pin it open.
+  PASSWORD_RESET_DISABLED: false,
+}));
+
+// Fires inside setImmediate and calls getClientIpFromHeaders() outside a request scope.
+vi.mock("@/modules/ee/audit-logs/lib/handler", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/ee/audit-logs/lib/handler")>()),
+  queueAuditEventBackground: vi.fn(async () => undefined),
+}));
+
+const ATTACKER_PASSWORD = "Passw0rd!squatter";
+const VICTIM_EMAIL = "victim@example.com";
+
+/**
+ * Only the session-token cookie from a sign-in response, deliberately dropping `session_data`: with
+ * `cookieCache` enabled, `getSession` serves a still-valid `session_data` cookie straight from its
+ * signature without consulting Redis or Postgres. Carrying it along would make every revocation
+ * assertion below pass OR fail for the wrong reason — the cache window (5 min) is a documented residual
+ * of any revocation here, `revokeSessionsOnPasswordReset` included, not something these tests can bind.
+ */
+const sessionTokenCookie = (response: Response): string => {
+  const cookie = response.headers
+    .getSetCookie()
+    .map((setCookie) => setCookie.split(";")[0])
+    .find((pair) => pair.startsWith("formbricks.session_token="));
+  expect(cookie).toBeTruthy();
+  return cookie!;
+};
+
+const signIn = (password: string): Promise<Response> =>
+  auth.api.signInEmail({ body: { email: VICTIM_EMAIL, password }, asResponse: true });
+
+/**
+ * The squatter's starting state: an account on someone else's address, with a working password and an
+ * unproven email. Built through `signUpEmail` rather than by hand on purpose — 1.7 filters
+ * `findCredentialAccount` on `issuer`, so a hand-seeded credential row would reject a *correct* password
+ * and every assertion below would pass for the wrong reason.
+ *
+ * Deliberately does NOT enrol 2FA: for a `twoFactorEnabled` user Better Auth's sign-in hook deletes the
+ * just-minted session and answers with a challenge instead, so any test that needs a real session cookie
+ * from `signIn` must enrol 2FA only AFTER minting it (`enrollTwoFactor` below).
+ */
+const seedUnprovenAccountWithPassword = async () => {
+  await auth.api.signUpEmail({
+    body: { email: VICTIM_EMAIL, password: ATTACKER_PASSWORD, name: "Squatter" },
+    asResponse: true,
+  });
+  const user = await prisma.user.findUniqueOrThrow({ where: { email: VICTIM_EMAIL } });
+  expect(user.emailVerified).toBe(false);
+
+  return user;
+};
+
+/**
+ * A 2FA enrolment in both stores, the shape `enableTwoFactorAuth` leaves behind. The `TwoFactor` row's
+ * contents never need to verify (assertions only count rows), but the LEGACY columns must be genuinely
+ * decryptable: the backfill shim re-encodes them on sign-in inside a swallow-all try/catch, so a
+ * placeholder there would make the resurrection assertion below pass because the shim crashed, not
+ * because recovery disarmed it.
+ */
+const enrollTwoFactor = async (userId: string) => {
+  await prisma.twoFactor.create({
+    data: { userId, secret: "encrypted-secret", backupCodes: "encrypted-backup-codes" },
+  });
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      twoFactorEnabled: true,
+      twoFactorSecret: symmetricEncrypt("JBSWY3DPEHPK3PXP", ENCRYPTION_KEY),
+      backupCodes: symmetricEncrypt(JSON.stringify(["aaaaabbbbb", "cccccddddd"]), ENCRYPTION_KEY),
+    },
+  });
+};
+
+/** The session the recovery link mints, which completion runs on and the sweep must spare. */
+const createRecoverySession = async (userId: string): Promise<string> => {
+  const ctx = await auth.$context;
+  const session = await ctx.internalAdapter.createSession(userId, false);
+  return session.token;
+};
+
+const runRecovery = (user: { id: string; email: string }, sessionToken: string) =>
+  completeSsoRecovery({
+    intentToken: createSsoRelinkIntent({
+      userId: user.id,
+      email: user.email,
+      provider: "google",
+      providerAccountId: "google-sub-recovery-1",
+      callbackUrl: WEBAPP_URL,
+    }),
+    sessionUserId: user.id,
+    sessionToken,
+  });
+
+beforeEach(async () => {
+  await resetDb();
+  vi.mocked(sendPasswordResetLinkEmail).mockClear();
+});
+
+describe("SSO recovery strips the live local auth factors (real Postgres + Redis)", () => {
+  test("the squatter's password no longer authenticates after the address is proven", async () => {
+    const user = await seedUnprovenAccountWithPassword();
+
+    // Anti-vacuity: the password genuinely signs in before recovery. Without this the assertion below
+    // can pass because the fixture silently failed — the exact failure mode that let this ship.
+    expect((await signIn(ATTACKER_PASSWORD)).status).toBe(200);
+    // Test-only cleanup of the precondition session's row, so this test asserts only the password strip
+    // and stays green even if the session sweep were to regress (it has its own tests below).
+    await prisma.session.deleteMany({});
+
+    await runRecovery(user, await createRecoverySession(user.id));
+
+    // Pre-fix this was 200: the strip nulled `User.password` while the live hash sat on `Account`.
+    expect((await signIn(ATTACKER_PASSWORD)).status).toBe(401);
+    // A rejection alone can be right for the wrong reason, so also check nothing was minted: the
+    // recovery session must be the only one that exists.
+    expect(await prisma.session.count({ where: { userId: user.id } })).toBe(1);
+  });
+
+  test("the 2FA enrolment does not survive on an account that changed hands", async () => {
+    const user = await seedUnprovenAccountWithPassword();
+    await enrollTwoFactor(user.id);
+
+    await runRecovery(user, await createRecoverySession(user.id));
+
+    // Pre-fix this was 1. Dormant rather than exploitable (Better Auth gates its challenge on
+    // `user.twoFactorEnabled`, which the legacy update already cleared), but a stale TOTP secret and
+    // backup codes must not outlive the handover.
+    expect(await prisma.twoFactor.count({ where: { userId: user.id } })).toBe(0);
+    // The legacy columns stay null too: `better-auth-two-factor-backfill` rebuilds a `TwoFactor` row from
+    // them on the next credential sign-in, so leaving them set would re-arm the factor.
+    const after = await prisma.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.twoFactorEnabled).toBe(false);
+    expect(after.twoFactorSecret).toBeNull();
+    expect(after.backupCodes).toBeNull();
+  });
+
+  test("a session the squatter was holding stops resolving, in both session stores", async () => {
+    const user = await seedUnprovenAccountWithPassword();
+    const squatterCookie = sessionTokenCookie(await signIn(ATTACKER_PASSWORD));
+    expect(await auth.api.getSession({ headers: { cookie: squatterCookie } })).not.toBeNull();
+
+    await runRecovery(user, await createRecoverySession(user.id));
+
+    // `getSession` reads Redis first, so this is the assertion a raw `prisma.session.deleteMany()` would
+    // fail: it would clear the row and leave the session perfectly valid here.
+    expect(await auth.api.getSession({ headers: { cookie: squatterCookie } })).toBeNull();
+  });
+
+  test("the recovering user's own session is spared, so the redirect stays signed in", async () => {
+    const user = await seedUnprovenAccountWithPassword();
+    await signIn(ATTACKER_PASSWORD); // a second session, to be swept
+    const recoverySessionToken = await createRecoverySession(user.id);
+
+    await runRecovery(user, recoverySessionToken);
+
+    const remaining = await prisma.session.findMany({ where: { userId: user.id } });
+    expect(remaining.map((session) => session.sessionToken)).toEqual([recoverySessionToken]);
+  });
+
+  /**
+   * Recovery flips `identityProvider` to the SSO provider and nothing ever flips it back, so without this
+   * the fix would trade a takeover for a lockout: no password, and no way to ask for one.
+   */
+  test("a recovered user can still get a password back", async () => {
+    const user = await seedUnprovenAccountWithPassword();
+    await enrollTwoFactor(user.id);
+
+    await runRecovery(user, await createRecoverySession(user.id));
+
+    // The credential row survives with a null password — that row is what identifies them as a password
+    // user to `forgotPasswordAction` after `identityProvider` has moved on.
+    const credential = await prisma.account.findFirstOrThrow({
+      where: { userId: user.id, provider: "credential" },
+    });
+    expect(credential.password).toBeNull();
+
+    await auth.api.requestPasswordReset({
+      body: { email: VICTIM_EMAIL, redirectTo: `${WEBAPP_URL}/auth/forgot-password/reset` },
+    });
+    const [{ verifyLink }] = vi.mocked(sendPasswordResetLinkEmail).mock.calls.at(-1)!;
+    // Better Auth builds `${baseURL}/reset-password/${token}?callbackURL=…`, so the token is a path
+    // segment — reading it as a query param yields null and the reset below would fail as unauthenticated.
+    const token = new URL(verifyLink).pathname.split("/").pop();
+    expect(token).toBeTruthy();
+
+    const newPassword = "Passw0rd!rightful-owner";
+    await auth.api.resetPassword({ body: { newPassword, token: token! } });
+
+    expect((await signIn(newPassword)).status).toBe(200);
+    expect((await signIn(ATTACKER_PASSWORD)).status).toBe(401);
+
+    // The resurrection channel: that successful credential sign-in is exactly when the backfill shim
+    // (`better-auth-two-factor-backfill`) would rebuild a `TwoFactor` row from the legacy `User` columns.
+    // Recovery cleared both halves — the row AND the legacy columns — so nothing may come back. This is
+    // the assertion that goes red if a refactor ever drops the "redundant" legacy nulls from the strip.
+    expect(await prisma.twoFactor.count({ where: { userId: user.id } })).toBe(0);
+  });
+
+  test("an already-proven account keeps its password, sessions and 2FA", async () => {
+    const user = await seedUnprovenAccountWithPassword();
+    await prisma.user.update({ where: { id: user.id }, data: { emailVerified: true } });
+    // Mint the owner's session BEFORE enrolling 2FA — after enrolment, `signIn` answers with a 2FA
+    // challenge instead of a session cookie.
+    const ownerCookie = sessionTokenCookie(await signIn(ATTACKER_PASSWORD));
+    expect(await auth.api.getSession({ headers: { cookie: ownerCookie } })).not.toBeNull();
+    await enrollTwoFactor(user.id);
+
+    await runRecovery(user, await createRecoverySession(user.id));
+
+    // Linking another provider to a legitimate account must not strip it or sign it out everywhere.
+    // With 2FA enrolled, a correct password now yields the challenge (still 200; a stripped password
+    // would 401 before the 2FA hook runs), so the 200 proves the credential survived.
+    expect((await signIn(ATTACKER_PASSWORD)).status).toBe(200);
+    expect(await auth.api.getSession({ headers: { cookie: ownerCookie } })).not.toBeNull();
+    expect(await prisma.twoFactor.count({ where: { userId: user.id } })).toBe(1);
+    const after = await prisma.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(after.twoFactorEnabled).toBe(true);
+  });
+});

--- a/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
@@ -210,6 +210,55 @@ describe("SSO recovery strips the live local auth factors (real Postgres + Redis
   });
 
   /**
+   * The persistence that outlives every session. `oauthProvider` is registered unconditionally with open
+   * dynamic client registration and a 30-day refresh token, and both token tables' `session` FK is
+   * `onDelete: SetNull` — so sweeping sessions blanks the liveness check instead of failing it. Revoking
+   * is the only thing that actually stops them.
+   */
+  test("OAuth grants the account minted do not survive recovery", async () => {
+    const user = await seedUnprovenAccountWithPassword();
+    const client = await prisma.oauthClient.create({
+      data: {
+        clientId: "mcp-client-live-1",
+        name: "smoke client",
+        redirectUris: [`${WEBAPP_URL}/cb`],
+        disabled: false,
+      },
+    });
+    const refresh = await prisma.oauthRefreshToken.create({
+      data: {
+        token: "refresh-token-live-1",
+        clientId: client.clientId,
+        userId: user.id,
+        scopes: ["openid"],
+        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+        createdAt: new Date(),
+      },
+    });
+    await prisma.oauthAccessToken.create({
+      data: {
+        token: "access-token-live-1",
+        clientId: client.clientId,
+        userId: user.id,
+        refreshId: refresh.id,
+        scopes: ["openid"],
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+        createdAt: new Date(),
+      },
+    });
+
+    await runRecovery(user, await createRecoverySession(user.id));
+
+    // `revoked` is the column both of Better Auth's introspection paths actually honour.
+    const [access, refreshed] = await Promise.all([
+      prisma.oauthAccessToken.findFirstOrThrow({ where: { userId: user.id } }),
+      prisma.oauthRefreshToken.findFirstOrThrow({ where: { userId: user.id } }),
+    ]);
+    expect(access.revoked).not.toBeNull();
+    expect(refreshed.revoked).not.toBeNull();
+  });
+
+  /**
    * Recovery flips `identityProvider` to the SSO provider and nothing ever flips it back, so without this
    * the fix would trade a takeover for a lockout: no password, and no way to ask for one.
    */

--- a/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
@@ -5,6 +5,7 @@ import { ENCRYPTION_KEY, WEBAPP_URL } from "@/lib/constants";
 import { symmetricEncrypt } from "@/lib/crypto";
 import { createSsoRelinkIntent } from "@/lib/jwt";
 import { auth } from "@/modules/auth/lib/auth";
+import { getSessionTokenFromCookieHeader } from "@/modules/auth/lib/session-cookie";
 import { completeSsoRecovery } from "@/modules/ee/sso/lib/sso-recovery";
 import { sendPasswordResetLinkEmail } from "@/modules/email";
 
@@ -174,6 +175,27 @@ describe("SSO recovery strips the live local auth factors (real Postgres + Redis
     // `getSession` reads Redis first, so this is the assertion a raw `prisma.session.deleteMany()` would
     // fail: it would clear the row and leave the session perfectly valid here.
     expect(await auth.api.getSession({ headers: { cookie: squatterCookie } })).toBeNull();
+  });
+
+  /**
+   * Binds the seam the route relies on and nothing else exercises live: `route.ts` derives
+   * `keepSessionToken` from the request cookie via `getSessionTokenFromCookieHeader`, and the sweep
+   * compares it against `Session.sessionToken` rows. Better Auth signs its cookie as
+   * `token.signature` — if the helper ever returned the signed form (or the secret resolution drifted
+   * from auth.ts's), the filter would match nothing and recovery would sign its own caller out.
+   */
+  test("the route's cookie-derived keep-token matches the stored session token", async () => {
+    const user = await seedUnprovenAccountWithPassword();
+    const cookie = sessionTokenCookie(await signIn(ATTACKER_PASSWORD));
+
+    const keepToken = getSessionTokenFromCookieHeader(cookie);
+
+    expect(keepToken).toBeTruthy();
+    const stored = await prisma.session.findMany({
+      where: { userId: user.id },
+      select: { sessionToken: true },
+    });
+    expect(stored.map((row) => row.sessionToken)).toContain(keepToken);
   });
 
   test("the recovering user's own session is spared, so the redirect stays signed in", async () => {

--- a/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
@@ -215,7 +215,21 @@ describe("SSO recovery strips the live local auth factors (real Postgres + Redis
    * `onDelete: SetNull` — so sweeping sessions blanks the liveness check instead of failing it. Revoking
    * is the only thing that actually stops them.
    */
-  test("OAuth grants the account minted do not survive recovery", async () => {
+  /**
+   * The refresh token is the persistence that outlives every session: `oauthProvider` is registered
+   * unconditionally with open dynamic client registration and a 30-day refresh lifetime, and both token
+   * tables' `session` FK is `onDelete: SetNull`, so sweeping sessions blanks the liveness check instead
+   * of failing it. Revoking is the only thing that stops it, and `handleRefreshTokenGrant` reads
+   * `revoked`, so this asserts a value the grant path genuinely consults.
+   *
+   * Access tokens are deliberately NOT asserted here. Our config sets `resources` and never sets
+   * `disableJwtPlugin`, so every access token is a self-contained JWT that is signed and never
+   * persisted, and `/api/mcp` verifies bearers against JWKS without reading the table. Seeding a row
+   * production never writes and asserting its column would be exactly the "assert a column nothing
+   * reads" mistake this whole file exists to catch. The 15-minute JWT residual is called out in the
+   * strip's docblock and in the PR's open gaps instead.
+   */
+  test("the refresh token and consent do not survive recovery", async () => {
     const user = await seedUnprovenAccountWithPassword();
     const client = await prisma.oauthClient.create({
       data: {
@@ -225,7 +239,7 @@ describe("SSO recovery strips the live local auth factors (real Postgres + Redis
         disabled: false,
       },
     });
-    const refresh = await prisma.oauthRefreshToken.create({
+    await prisma.oauthRefreshToken.create({
       data: {
         token: "refresh-token-live-1",
         clientId: client.clientId,
@@ -235,27 +249,23 @@ describe("SSO recovery strips the live local auth factors (real Postgres + Redis
         createdAt: new Date(),
       },
     });
-    await prisma.oauthAccessToken.create({
+    // Consent is what lets `/authorize` skip the consent screen, so leaving it would let a
+    // still-cookie-cached session mint a replacement refresh token and undo the revocation.
+    await prisma.oauthConsent.create({
       data: {
-        token: "access-token-live-1",
         clientId: client.clientId,
         userId: user.id,
-        refreshId: refresh.id,
         scopes: ["openid"],
-        expiresAt: new Date(Date.now() + 15 * 60 * 1000),
         createdAt: new Date(),
+        updatedAt: new Date(),
       },
     });
 
     await runRecovery(user, await createRecoverySession(user.id));
 
-    // `revoked` is the column both of Better Auth's introspection paths actually honour.
-    const [access, refreshed] = await Promise.all([
-      prisma.oauthAccessToken.findFirstOrThrow({ where: { userId: user.id } }),
-      prisma.oauthRefreshToken.findFirstOrThrow({ where: { userId: user.id } }),
-    ]);
-    expect(access.revoked).not.toBeNull();
+    const refreshed = await prisma.oauthRefreshToken.findFirstOrThrow({ where: { userId: user.id } });
     expect(refreshed.revoked).not.toBeNull();
+    expect(await prisma.oauthConsent.count({ where: { userId: user.id } })).toBe(0);
   });
 
   /**

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -262,10 +262,11 @@ describe("sso-recovery", () => {
     });
     // The OAuth grants the account minted while unproven: a refresh token outlives every session, so
     // the sweep is incomplete without this.
-    expect(txOauthAccessUpdateMany).toHaveBeenCalledWith({
-      where: { userId: "user_1", revoked: null },
-      data: { revoked: expect.any(Date) },
-    });
+    //
+    // Access tokens are deliberately NOT written on this release line: `oauthAccessToken` has no
+    // `revoked` column before 5.4. Pinned as an explicit non-call rather than an absent assertion, so a
+    // later backport that re-adds the write fails here instead of failing to compile.
+    expect(txOauthAccessUpdateMany).not.toHaveBeenCalled();
     expect(txOauthRefreshUpdateMany).toHaveBeenCalledWith({
       where: { userId: "user_1", revoked: null },
       data: { revoked: expect.any(Date) },
@@ -280,7 +281,7 @@ describe("sso-recovery", () => {
         newObject: expect.objectContaining({
           credentialPasswordsCleared: 1,
           twoFactorRowsRemoved: 1,
-          oauthGrantsRevoked: 3,
+          oauthGrantsRevoked: 2,
           oauthConsentsRevoked: 1,
           sessionsRevoked: 2,
         }),

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -394,8 +394,12 @@ describe("sso-recovery", () => {
         }),
       })
     );
+    // `action` discriminator is load-bearing: `toHaveBeenCalledWith` passes when ANY call matches, so
+    // without it this would be satisfied by any other queued event lacking the key, and could go green
+    // without ever proving the completion event omits it.
     expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
       expect.objectContaining({
+        action: "sso_recovery_completed",
         newObject: expect.not.objectContaining({ sessionsRevoked: expect.anything() }),
       })
     );

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -91,6 +91,7 @@ describe("sso-recovery", () => {
   const txAccountUpdateMany = vi.fn();
   const txOauthAccessUpdateMany = vi.fn();
   const txOauthRefreshUpdateMany = vi.fn();
+  const txOauthConsentDeleteMany = vi.fn();
   // Both new stores belong in the stub: post-ENG-1054 the password lives on `Account` and the 2FA secret
   // in `TwoFactor`, so a strip that only touched `user` is exactly the bug ENG-2557 fixed.
   const tx = {
@@ -109,6 +110,9 @@ describe("sso-recovery", () => {
     oauthRefreshToken: {
       updateMany: txOauthRefreshUpdateMany,
     },
+    oauthConsent: {
+      deleteMany: txOauthConsentDeleteMany,
+    },
   };
 
   beforeEach(() => {
@@ -117,6 +121,7 @@ describe("sso-recovery", () => {
     txAccountUpdateMany.mockResolvedValue({ count: 1 });
     txOauthAccessUpdateMany.mockResolvedValue({ count: 1 });
     txOauthRefreshUpdateMany.mockResolvedValue({ count: 2 });
+    txOauthConsentDeleteMany.mockResolvedValue({ count: 1 });
     vi.mocked(revokeUserSessionsExcept).mockResolvedValue(2);
     vi.mocked(prisma.$transaction).mockImplementation(
       async (callback: (txClient: Prisma.TransactionClient) => Promise<unknown>) =>
@@ -265,6 +270,9 @@ describe("sso-recovery", () => {
       where: { userId: "user_1", revoked: null },
       data: { revoked: expect.any(Date) },
     });
+    // Consent too: `/authorize` skips the consent screen when a row exists, so leaving it would let a
+    // still-cookie-cached session mint a replacement refresh token and undo the revocation above.
+    expect(txOauthConsentDeleteMany).toHaveBeenCalledWith({ where: { userId: "user_1" } });
     expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "sso_recovery_completed",
@@ -273,6 +281,7 @@ describe("sso-recovery", () => {
           credentialPasswordsCleared: 1,
           twoFactorRowsRemoved: 1,
           oauthGrantsRevoked: 3,
+          oauthConsentsRevoked: 1,
           sessionsRevoked: 2,
         }),
       })
@@ -317,6 +326,7 @@ describe("sso-recovery", () => {
     expect(txAccountUpdateMany).not.toHaveBeenCalled();
     expect(txOauthAccessUpdateMany).not.toHaveBeenCalled();
     expect(txOauthRefreshUpdateMany).not.toHaveBeenCalled();
+    expect(txOauthConsentDeleteMany).not.toHaveBeenCalled();
     // A proven account is a legitimate one: linking another provider to it must not sign its other
     // sessions out, and must not report a strip that did not happen.
     expect(revokeUserSessionsExcept).not.toHaveBeenCalled();

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
+import { revokeUserSessionsExcept } from "@/modules/auth/lib/session-revocation";
 import { finalizeSuccessfulSignIn } from "@/modules/auth/lib/sign-in-tracking";
 import { buildVerificationRequestedPath } from "@/modules/auth/lib/verification-links";
 import { sendVerificationEmail } from "@/modules/email";
@@ -35,6 +36,10 @@ vi.mock("@/lib/jwt", () => ({
   createEmailToken: mocks.createEmailToken,
   createSsoRelinkIntent: mocks.createSsoRelinkIntent,
   verifySsoRelinkIntent: mocks.verifySsoRelinkIntent,
+}));
+
+vi.mock("@/modules/auth/lib/session-revocation", () => ({
+  revokeUserSessionsExcept: vi.fn(),
 }));
 
 vi.mock("@/modules/auth/lib/sign-in-tracking", () => ({
@@ -82,14 +87,27 @@ vi.mock("./account-linking", () => ({
 
 describe("sso-recovery", () => {
   const txUserUpdate = vi.fn();
+  const txTwoFactorDeleteMany = vi.fn();
+  const txAccountUpdateMany = vi.fn();
+  // Both new stores belong in the stub: post-ENG-1054 the password lives on `Account` and the 2FA secret
+  // in `TwoFactor`, so a strip that only touched `user` is exactly the bug ENG-2557 fixed.
   const tx = {
     user: {
       update: txUserUpdate,
+    },
+    twoFactor: {
+      deleteMany: txTwoFactorDeleteMany,
+    },
+    account: {
+      updateMany: txAccountUpdateMany,
     },
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    txTwoFactorDeleteMany.mockResolvedValue({ count: 1 });
+    txAccountUpdateMany.mockResolvedValue({ count: 1 });
+    vi.mocked(revokeUserSessionsExcept).mockResolvedValue(2);
     vi.mocked(prisma.$transaction).mockImplementation(
       async (callback: (txClient: Prisma.TransactionClient) => Promise<unknown>) =>
         await callback(tx as unknown as Prisma.TransactionClient)
@@ -187,21 +205,21 @@ describe("sso-recovery", () => {
       id: "user_1",
       email: "john.doe@example.com",
       locale: "en-US",
-      emailVerified: null,
+      emailVerified: false,
       isActive: true,
       identityProvider: "email",
       identityProviderAccountId: null,
-      password: "hashed-password",
-      twoFactorEnabled: true,
-      twoFactorSecret: "encrypted-secret",
-      backupCodes: "encrypted-codes",
     } as any);
 
     const callbackUrl = await completeSsoRecovery({
       intentToken: "test-intent",
       sessionUserId: "user_1",
+      sessionToken: "current-session-token",
     });
 
+    // Exact-match on purpose: the legacy nulls are load-bearing, not leftovers. `better-auth-two-factor-backfill`
+    // re-materialises a `TwoFactor` row from `twoFactorEnabled && twoFactorSecret` on the next credential
+    // sign-in, so dropping them from this payload would let the stripped factor come back.
     expect(txUserUpdate).toHaveBeenCalledWith({
       where: {
         id: "user_1",
@@ -214,6 +232,30 @@ describe("sso-recovery", () => {
         twoFactorSecret: null,
       },
     });
+    // The live stores, which the pre-ENG-2557 implementation never touched.
+    expect(txTwoFactorDeleteMany).toHaveBeenCalledWith({ where: { userId: "user_1" } });
+    // Scoped by owner, NOT by `providerAccountId`/`issuer`: those are account-key columns and a drifted key
+    // (ENG-2555) would make a key-filtered query walk past a row still holding a live hash.
+    expect(txAccountUpdateMany).toHaveBeenCalledWith({
+      where: { userId: "user_1", provider: "credential" },
+      data: { password: null },
+    });
+    // Post-commit, sparing the caller's own session so the redirect still lands signed in.
+    expect(revokeUserSessionsExcept).toHaveBeenCalledWith({
+      userId: "user_1",
+      keepSessionToken: "current-session-token",
+    });
+    expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sso_recovery_completed",
+        status: "success",
+        newObject: expect.objectContaining({
+          credentialPasswordsCleared: 1,
+          twoFactorRowsRemoved: 1,
+          sessionsRevoked: 2,
+        }),
+      })
+    );
     expect(syncSsoIdentityForUser).toHaveBeenCalledWith({
       userId: "user_1",
       provider: "google",
@@ -237,23 +279,94 @@ describe("sso-recovery", () => {
       id: "user_1",
       email: "john.doe@example.com",
       locale: "en-US",
-      emailVerified: new Date("2024-01-01T00:00:00.000Z"),
+      emailVerified: true,
       isActive: true,
       identityProvider: "email",
       identityProviderAccountId: null,
-      password: "hashed-password",
-      twoFactorEnabled: true,
-      twoFactorSecret: "encrypted-secret",
-      backupCodes: "encrypted-codes",
     } as any);
 
     await completeSsoRecovery({
       intentToken: "test-intent",
       sessionUserId: "user_1",
+      sessionToken: "current-session-token",
     });
 
     expect(txUserUpdate).not.toHaveBeenCalled();
+    expect(txTwoFactorDeleteMany).not.toHaveBeenCalled();
+    expect(txAccountUpdateMany).not.toHaveBeenCalled();
+    // A proven account is a legitimate one: linking another provider to it must not sign its other
+    // sessions out, and must not report a strip that did not happen.
+    expect(revokeUserSessionsExcept).not.toHaveBeenCalled();
+    expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sso_recovery_completed",
+        newObject: expect.not.objectContaining({ credentialPasswordsCleared: expect.anything() }),
+      })
+    );
     expect(syncSsoIdentityForUser).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * The guard keys on `emailVerified` alone. It used to also require `identityProvider === "email"`, but
+   * that column is denormalized onto `User` by an `account.create.after` hook, so a security control
+   * resting on it goes silently dead if it ever drifts. An unproven address is unproven whatever the
+   * denormalized column happens to say.
+   */
+  test("strips an unverified account even when identityProvider says otherwise", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "john.doe@example.com",
+      locale: "en-US",
+      emailVerified: false,
+      isActive: true,
+      identityProvider: "google",
+      identityProviderAccountId: "provider-account-1",
+    } as any);
+
+    await completeSsoRecovery({
+      intentToken: "test-intent",
+      sessionUserId: "user_1",
+      sessionToken: "current-session-token",
+    });
+
+    expect(txAccountUpdateMany).toHaveBeenCalledWith({
+      where: { userId: "user_1", provider: "credential" },
+      data: { password: null },
+    });
+    expect(txTwoFactorDeleteMany).toHaveBeenCalledOnce();
+    expect(revokeUserSessionsExcept).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * The strip has already committed by the time sessions are swept, so a revocation failure must not undo
+   * it or fail the recovery — the user would be left with a stripped password and no way through.
+   */
+  test("still completes recovery when the session sweep fails", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "john.doe@example.com",
+      locale: "en-US",
+      emailVerified: false,
+      isActive: true,
+      identityProvider: "email",
+      identityProviderAccountId: null,
+    } as any);
+    vi.mocked(revokeUserSessionsExcept).mockRejectedValue(new Error("redis unavailable"));
+
+    const callbackUrl = await completeSsoRecovery({
+      intentToken: "test-intent",
+      sessionUserId: "user_1",
+      sessionToken: "current-session-token",
+    });
+
+    expect(callbackUrl).toBe("http://localhost:3000/environments/env_1");
+    expect(txAccountUpdateMany).toHaveBeenCalledOnce();
+    expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sso_recovery_completed",
+        newObject: expect.objectContaining({ credentialPasswordsCleared: 1, sessionsRevoked: 0 }),
+      })
+    );
   });
 
   test("rejects recovery when the signed-in user does not match the intent owner", async () => {

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -89,6 +89,8 @@ describe("sso-recovery", () => {
   const txUserUpdate = vi.fn();
   const txTwoFactorDeleteMany = vi.fn();
   const txAccountUpdateMany = vi.fn();
+  const txOauthAccessUpdateMany = vi.fn();
+  const txOauthRefreshUpdateMany = vi.fn();
   // Both new stores belong in the stub: post-ENG-1054 the password lives on `Account` and the 2FA secret
   // in `TwoFactor`, so a strip that only touched `user` is exactly the bug ENG-2557 fixed.
   const tx = {
@@ -101,12 +103,20 @@ describe("sso-recovery", () => {
     account: {
       updateMany: txAccountUpdateMany,
     },
+    oauthAccessToken: {
+      updateMany: txOauthAccessUpdateMany,
+    },
+    oauthRefreshToken: {
+      updateMany: txOauthRefreshUpdateMany,
+    },
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
     txTwoFactorDeleteMany.mockResolvedValue({ count: 1 });
     txAccountUpdateMany.mockResolvedValue({ count: 1 });
+    txOauthAccessUpdateMany.mockResolvedValue({ count: 1 });
+    txOauthRefreshUpdateMany.mockResolvedValue({ count: 2 });
     vi.mocked(revokeUserSessionsExcept).mockResolvedValue(2);
     vi.mocked(prisma.$transaction).mockImplementation(
       async (callback: (txClient: Prisma.TransactionClient) => Promise<unknown>) =>
@@ -245,6 +255,16 @@ describe("sso-recovery", () => {
       userId: "user_1",
       keepSessionToken: "current-session-token",
     });
+    // The OAuth grants the account minted while unproven: a refresh token outlives every session, so
+    // the sweep is incomplete without this.
+    expect(txOauthAccessUpdateMany).toHaveBeenCalledWith({
+      where: { userId: "user_1", revoked: null },
+      data: { revoked: expect.any(Date) },
+    });
+    expect(txOauthRefreshUpdateMany).toHaveBeenCalledWith({
+      where: { userId: "user_1", revoked: null },
+      data: { revoked: expect.any(Date) },
+    });
     expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "sso_recovery_completed",
@@ -252,6 +272,7 @@ describe("sso-recovery", () => {
         newObject: expect.objectContaining({
           credentialPasswordsCleared: 1,
           twoFactorRowsRemoved: 1,
+          oauthGrantsRevoked: 3,
           sessionsRevoked: 2,
         }),
       })
@@ -294,6 +315,8 @@ describe("sso-recovery", () => {
     expect(txUserUpdate).not.toHaveBeenCalled();
     expect(txTwoFactorDeleteMany).not.toHaveBeenCalled();
     expect(txAccountUpdateMany).not.toHaveBeenCalled();
+    expect(txOauthAccessUpdateMany).not.toHaveBeenCalled();
+    expect(txOauthRefreshUpdateMany).not.toHaveBeenCalled();
     // A proven account is a legitimate one: linking another provider to it must not sign its other
     // sessions out, and must not report a strip that did not happen.
     expect(revokeUserSessionsExcept).not.toHaveBeenCalled();
@@ -361,10 +384,19 @@ describe("sso-recovery", () => {
 
     expect(callbackUrl).toBe("http://localhost:3000/environments/env_1");
     expect(txAccountUpdateMany).toHaveBeenCalledOnce();
+    // A failed sweep must NOT be recorded as "0 sessions revoked" — same number, opposite incident.
     expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "sso_recovery_completed",
-        newObject: expect.objectContaining({ credentialPasswordsCleared: 1, sessionsRevoked: 0 }),
+        newObject: expect.objectContaining({
+          credentialPasswordsCleared: 1,
+          sessionRevocationFailed: true,
+        }),
+      })
+    );
+    expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        newObject: expect.not.objectContaining({ sessionsRevoked: expect.anything() }),
       })
     );
   });

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -195,21 +195,21 @@ const reclaimUnverifiedLocalAuthIfNeeded = async ({
   // ACCESS tokens are a different story, and worth stating plainly rather than implying this covers them.
   // Our config sets `resources` and never sets `disableJwtPlugin`, so `isJwtAccessToken` is always true
   // and every access token is a self-contained JWT: `createJwtAccessToken` signs without persisting, so
-  // there is normally no row here to update, and `/api/mcp` verifies bearers against JWKS
-  // (`modules/mcp/auth.ts`) without reading this table at all. Upstream's own revoke endpoint says as
-  // much — "JWT access tokens are self-contained and cannot be revoked server-side". The write below is
-  // therefore defence for the opaque-token configuration only; the residual is that a squatter's JWT
-  // stays valid for up to `accessTokenExpiresIn` (15 min) after recovery. Shortening that, or checking
-  // revocation at the resource server, is the only thing that would close it.
+  // there is normally no row here at all, and `/api/mcp` verifies bearers against JWKS
+  // (`modules/mcp/auth.ts`) without reading this table. Upstream's own revoke endpoint says as much —
+  // "JWT access tokens are self-contained and cannot be revoked server-side".
+  //
+  // This release line has no `oauthAccessToken.revoked` column — it arrives with 5.4 — so unlike on
+  // `main` there is no access-token write here. Nothing is lost by that: the column would only ever have
+  // mattered for an opaque-token configuration this build does not run, and the residual is identical
+  // either way — a squatter's JWT stays valid for up to `accessTokenExpiresIn` (15 min) after recovery.
+  // Shortening that, or checking revocation at the resource server, is the only thing that would close
+  // it. The refresh token above is the persistence that actually outlives the session, and it is revoked.
   //
   // Consent goes too: `/authorize` skips the consent screen when a matching `oauthConsent` row exists,
   // so leaving it would let a still-cookie-cached session (see session-revocation.ts) silently mint a
   // fresh 30-day refresh token and undo the revocation above.
   const revokedAt = new Date();
-  const accessRows = await tx.oauthAccessToken.updateMany({
-    where: { userId: user.id, revoked: null },
-    data: { revoked: revokedAt },
-  });
   const refreshRows = await tx.oauthRefreshToken.updateMany({
     where: { userId: user.id, revoked: null },
     data: { revoked: revokedAt },
@@ -219,7 +219,7 @@ const reclaimUnverifiedLocalAuthIfNeeded = async ({
   return {
     credentialPasswordsCleared: credentialRows.count,
     twoFactorRowsRemoved: twoFactorRows.count,
-    oauthGrantsRevoked: accessRows.count + refreshRows.count,
+    oauthGrantsRevoked: refreshRows.count,
     oauthConsentsRevoked: consentRows.count,
   };
 };

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -47,7 +47,8 @@ const queueSsoRecoveryAuditEvent = ({
   callbackUrl?: string;
   failureReason?: string;
   reclaimed?: TReclaimOutcome;
-  sessionsRevoked?: number;
+  /** `null` means the sweep threw — deliberately not conflated with "there were none". */
+  sessionsRevoked?: number | null;
 }) => {
   queueAuditEventBackground({
     action,
@@ -70,7 +71,10 @@ const queueSsoRecoveryAuditEvent = ({
         ? {
             credentialPasswordsCleared: reclaimed.credentialPasswordsCleared,
             twoFactorRowsRemoved: reclaimed.twoFactorRowsRemoved,
-            sessionsRevoked: sessionsRevoked ?? 0,
+            oauthGrantsRevoked: reclaimed.oauthGrantsRevoked,
+            // `sessionsRevoked: 0` and "the sweep failed" are the same number but opposite incidents,
+            // and this is the field a responder reads to confirm the squatter was actually kicked out.
+            ...(sessionsRevoked === null ? { sessionRevocationFailed: true } : { sessionsRevoked }),
           }
         : {}),
     },
@@ -84,6 +88,7 @@ const queueSsoRecoveryAuditEvent = ({
 type TReclaimOutcome = {
   credentialPasswordsCleared: number;
   twoFactorRowsRemoved: number;
+  oauthGrantsRevoked: number;
 } | null;
 
 /**
@@ -142,7 +147,14 @@ const reclaimUnverifiedLocalAuthIfNeeded = async ({
 }): Promise<TReclaimOutcome> => {
   // Keyed on `emailVerified` alone. The old guard also required `identityProvider === "email"`, but that
   // column is denormalized onto `User` by an `account.create.after` hook — resting a security control on a
-  // denormalized value means drift silently disables it. "Never proved this address" is the whole test.
+  // denormalized value means drift silently disables it.
+  //
+  // Worth being honest about the limit of this test: `emailVerified` is a one-bit latch, and it says the
+  // address was proven, NOT that the account's local factors were ever proven by their owner. Anyone who
+  // knows the account's password can have Better Auth re-send a verification mail (`sendOnSignIn`), so a
+  // single victim click flips this and the strip below stops firing. That is the pre-hijacking vector in
+  // ENG-2562, tracked separately, and closing it means invalidating the credential at verification time
+  // too — not a different guard here.
   if (user.emailVerified) {
     return null;
   }
@@ -168,9 +180,28 @@ const reclaimUnverifiedLocalAuthIfNeeded = async ({
     data: { password: null },
   });
 
+  // MCP OAuth grants the account minted while its address was unproven. Without this the sweep is
+  // incomplete in the one direction that outlives it: `oauthProvider` is registered unconditionally
+  // (auth.ts) with open dynamic client registration, so a holder of a live session can bank a refresh
+  // token good for 30 days — far longer than the session revoked below, and unreachable by it because
+  // both token tables' `session` FK is `onDelete: SetNull`, which blanks the liveness check rather than
+  // failing it. `revoked` is the field both introspection paths actually honour.
+  const revokedAt = new Date();
+  const [accessRows, refreshRows] = [
+    await tx.oauthAccessToken.updateMany({
+      where: { userId: user.id, revoked: null },
+      data: { revoked: revokedAt },
+    }),
+    await tx.oauthRefreshToken.updateMany({
+      where: { userId: user.id, revoked: null },
+      data: { revoked: revokedAt },
+    }),
+  ];
+
   return {
     credentialPasswordsCleared: credentialRows.count,
     twoFactorRowsRemoved: twoFactorRows.count,
+    oauthGrantsRevoked: accessRows.count + refreshRows.count,
   };
 };
 
@@ -419,7 +450,7 @@ export const completeSsoRecovery = async ({
   // After commit, never inside the transaction: Better Auth resolves its adapter from its own
   // AsyncLocalStorage, so this would run outside `tx` and outlive a rollback. Best-effort for the same
   // reason the strip must not be undone by a revocation failure — it has already committed.
-  let sessionsRevoked = 0;
+  let sessionsRevoked: number | null = 0;
   if (reclaimed) {
     try {
       sessionsRevoked = await revokeUserSessionsExcept({
@@ -427,6 +458,7 @@ export const completeSsoRecovery = async ({
         keepSessionToken: sessionToken,
       });
     } catch (error) {
+      sessionsRevoked = null;
       logger.error(
         { error, userId: user.id },
         "Failed to revoke sessions after reclaiming unverified local auth"

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -72,6 +72,7 @@ const queueSsoRecoveryAuditEvent = ({
             credentialPasswordsCleared: reclaimed.credentialPasswordsCleared,
             twoFactorRowsRemoved: reclaimed.twoFactorRowsRemoved,
             oauthGrantsRevoked: reclaimed.oauthGrantsRevoked,
+            oauthConsentsRevoked: reclaimed.oauthConsentsRevoked,
             // `sessionsRevoked: 0` and "the sweep failed" are the same number but opposite incidents,
             // and this is the field a responder reads to confirm the squatter was actually kicked out.
             ...(sessionsRevoked === null ? { sessionRevocationFailed: true } : { sessionsRevoked }),
@@ -89,6 +90,7 @@ type TReclaimOutcome = {
   credentialPasswordsCleared: number;
   twoFactorRowsRemoved: number;
   oauthGrantsRevoked: number;
+  oauthConsentsRevoked: number;
 } | null;
 
 /**
@@ -185,23 +187,40 @@ const reclaimUnverifiedLocalAuthIfNeeded = async ({
   // (auth.ts) with open dynamic client registration, so a holder of a live session can bank a refresh
   // token good for 30 days — far longer than the session revoked below, and unreachable by it because
   // both token tables' `session` FK is `onDelete: SetNull`, which blanks the liveness check rather than
-  // failing it. `revoked` is the field both introspection paths actually honour.
+  // failing it.
+  //
+  // The REFRESH token is the one that matters and the one this actually stops: `handleRefreshTokenGrant`
+  // reads `revoked`, so revoking it ends the 30-day persistence.
+  //
+  // ACCESS tokens are a different story, and worth stating plainly rather than implying this covers them.
+  // Our config sets `resources` and never sets `disableJwtPlugin`, so `isJwtAccessToken` is always true
+  // and every access token is a self-contained JWT: `createJwtAccessToken` signs without persisting, so
+  // there is normally no row here to update, and `/api/mcp` verifies bearers against JWKS
+  // (`modules/mcp/auth.ts`) without reading this table at all. Upstream's own revoke endpoint says as
+  // much — "JWT access tokens are self-contained and cannot be revoked server-side". The write below is
+  // therefore defence for the opaque-token configuration only; the residual is that a squatter's JWT
+  // stays valid for up to `accessTokenExpiresIn` (15 min) after recovery. Shortening that, or checking
+  // revocation at the resource server, is the only thing that would close it.
+  //
+  // Consent goes too: `/authorize` skips the consent screen when a matching `oauthConsent` row exists,
+  // so leaving it would let a still-cookie-cached session (see session-revocation.ts) silently mint a
+  // fresh 30-day refresh token and undo the revocation above.
   const revokedAt = new Date();
-  const [accessRows, refreshRows] = [
-    await tx.oauthAccessToken.updateMany({
-      where: { userId: user.id, revoked: null },
-      data: { revoked: revokedAt },
-    }),
-    await tx.oauthRefreshToken.updateMany({
-      where: { userId: user.id, revoked: null },
-      data: { revoked: revokedAt },
-    }),
-  ];
+  const accessRows = await tx.oauthAccessToken.updateMany({
+    where: { userId: user.id, revoked: null },
+    data: { revoked: revokedAt },
+  });
+  const refreshRows = await tx.oauthRefreshToken.updateMany({
+    where: { userId: user.id, revoked: null },
+    data: { revoked: revokedAt },
+  });
+  const consentRows = await tx.oauthConsent.deleteMany({ where: { userId: user.id } });
 
   return {
     credentialPasswordsCleared: credentialRows.count,
     twoFactorRowsRemoved: twoFactorRows.count,
     oauthGrantsRevoked: accessRows.count + refreshRows.count,
+    oauthConsentsRevoked: consentRows.count,
   };
 };
 

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -5,6 +5,7 @@ import type { Account } from "@formbricks/types/auth";
 import { WEBAPP_URL } from "@/lib/constants";
 import { createEmailToken, createSsoRelinkIntent, verifySsoRelinkIntent } from "@/lib/jwt";
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
+import { revokeUserSessionsExcept } from "@/modules/auth/lib/session-revocation";
 import { finalizeSuccessfulSignIn } from "@/modules/auth/lib/sign-in-tracking";
 import { buildVerificationRequestedPath } from "@/modules/auth/lib/verification-links";
 import { queueAuditEventBackground } from "@/modules/ee/audit-logs/lib/handler";
@@ -35,6 +36,8 @@ const queueSsoRecoveryAuditEvent = ({
   provider,
   callbackUrl,
   failureReason,
+  reclaimed,
+  sessionsRevoked,
 }: {
   action: "sso_recovery_started" | "sso_recovery_completed" | "sso_recovery_failed";
   status: "success" | "failure";
@@ -43,6 +46,8 @@ const queueSsoRecoveryAuditEvent = ({
   provider: string;
   callbackUrl?: string;
   failureReason?: string;
+  reclaimed?: TReclaimOutcome;
+  sessionsRevoked?: number;
 }) => {
   queueAuditEventBackground({
     action,
@@ -57,39 +62,98 @@ const queueSsoRecoveryAuditEvent = ({
       provider,
       ...(callbackUrl ? { callbackUrl } : {}),
       ...(failureReason ? { failureReason } : {}),
+      // The one moment an account can change hands, so record what was taken away rather than only that
+      // recovery succeeded. Marker keys in `newObject` are the house idiom (`passwordResetMarker`,
+      // `twoFactorAuth: "disabled"`); `redactPII` matches exact lowercased keys, so these survive while
+      // `email` above is redacted.
+      ...(reclaimed
+        ? {
+            credentialPasswordsCleared: reclaimed.credentialPasswordsCleared,
+            twoFactorRowsRemoved: reclaimed.twoFactorRowsRemoved,
+            sessionsRevoked: sessionsRevoked ?? 0,
+          }
+        : {}),
     },
   });
 };
 
-const SSO_RECOVERY_USER_SELECT = {
-  ...LINKED_SSO_LOOKUP_SELECT,
-  backupCodes: true,
-  password: true,
-  twoFactorEnabled: true,
-  twoFactorSecret: true,
-} as const;
+/**
+ * What `reclaimUnverifiedLocalAuthIfNeeded` actually removed, for the audit record. `null` means the
+ * account was already proven and nothing was touched.
+ */
+type TReclaimOutcome = {
+  credentialPasswordsCleared: number;
+  twoFactorRowsRemoved: number;
+} | null;
 
-type TSsoRecoveryUser = Prisma.UserGetPayload<{
-  select: typeof SSO_RECOVERY_USER_SELECT;
-}>;
-
+/**
+ * Strip the local auth factors of an account whose email was never proven, at the moment an SSO identity
+ * proves it (ENG-554, ENG-2557).
+ *
+ * The threat: an attacker registers on a victim's address, sets a password, and is held out only by
+ * `requireEmailVerification`. Recovery then sets `emailVerified: true` — removing the very thing keeping
+ * them out — so the untrusted factors have to go with it. The proof authorising this is NOT the IdP's
+ * assertion: `startSsoRecovery` mails the address on record and completion requires the session that link
+ * mints, plus `sessionUserId === intent.userId`. Upstream Better Auth does the same thing in
+ * `revoke-unproven-account-access.mjs` for magic-link and email-OTP.
+ *
+ * THE FACTORS LIVE IN TWO PLACES EACH, and this is where ENG-2557 came from: the original control (#7755)
+ * predates ENG-1054, which moved the password to `Account.password` and 2FA into the `TwoFactor` table.
+ * It kept nulling the legacy `User` columns only, so post-cutover it stripped nothing at all — for any
+ * user created after the cutover those columns are already null, because `signUpEmail` never writes them.
+ * A mitigation that reads as present and does nothing is worse than none; write BOTH stores.
+ *
+ * The legacy `User` nulls are therefore kept deliberately, not left as dead code:
+ * `better-auth-two-factor-backfill.ts` re-materialises a `TwoFactor` row from
+ * `twoFactorEnabled && twoFactorSecret` on every successful credential sign-in, so dropping them would let
+ * a later sign-in re-arm the attacker's factor. Both halves together disarm it twice.
+ *
+ * Two deliberate shapes worth not "simplifying":
+ *
+ * - The password is NULLED, not the row deleted. Sign-in behaviour is identical either way
+ *   (`!currentPassword` → the same 401 after the same dummy hash), but the surviving row is what marks
+ *   this user as a credential user, which is what lets `forgotPasswordAction` still offer them a reset —
+ *   recovery flips `identityProvider` to the SSO provider and nothing ever flips it back, so deleting the
+ *   row would lock them out of every password route with no self-service way back.
+ * - The `where` is scoped by `userId`, NOT by `providerAccountId` / `issuer`, even though Better Auth's own
+ *   `findCredentialAccount` filters on all four. Those are account-KEY columns and a drifted key is a real
+ *   failure mode here (ENG-2555 was exactly that): a row whose key drifted still holds a live hash, and a
+ *   query filtering on the key would walk straight past it. Owner-scoping cannot reach another user's row
+ *   and does not go blind.
+ *
+ * The 2FA half is the weaker of the two, and worth stating honestly: Better Auth gates its challenge on
+ * `user.twoFactorEnabled`, which the legacy update already clears, so the orphaned `TwoFactor` row was
+ * never reachable at sign-in. Removing it is about not leaving a stale TOTP secret and backup codes at rest
+ * on an account that has changed hands — not a live bypass.
+ *
+ * Sessions are revoked by the caller, after commit — Better Auth resolves its adapter from its own
+ * AsyncLocalStorage, so a revocation issued in here would execute outside `tx` and survive a rollback.
+ *
+ * Not locked against concurrent recoveries (upstream takes a DB advisory lock for its equivalent). Every
+ * write here is idempotent — two `deleteMany`/`updateMany` calls and an update to fixed values — so a race
+ * converges on the same state rather than corrupting it.
+ */
 const reclaimUnverifiedLocalAuthIfNeeded = async ({
   tx,
   user,
 }: {
   tx: Prisma.TransactionClient;
-  user: TSsoRecoveryUser;
-}) => {
-  if (user.identityProvider !== "email" || user.emailVerified) {
-    return;
+  user: TSsoLookupUser;
+}): Promise<TReclaimOutcome> => {
+  // Keyed on `emailVerified` alone. The old guard also required `identityProvider === "email"`, but that
+  // column is denormalized onto `User` by an `account.create.after` hook — resting a security control on a
+  // denormalized value means drift silently disables it. "Never proved this address" is the whole test.
+  if (user.emailVerified) {
+    return null;
   }
 
-  // Inbox ownership is now proven, so strip any untrusted local auth factors before the SSO
-  // account becomes the canonical way back in.
+  // Sequential, not `Promise.all`: an interactive transaction is bound to a single connection, so
+  // parallel writes on `tx` buy nothing here and only risk interleaving.
+  //
+  // The legacy columns: the 2FA pair is load-bearing (see the backfill note above); `password` is a no-op
+  // for post-cutover users and kept only so a pre-cutover row cannot survive here.
   await tx.user.update({
-    where: {
-      id: user.id,
-    },
+    where: { id: user.id },
     data: {
       backupCodes: null,
       emailVerified: true,
@@ -98,6 +162,16 @@ const reclaimUnverifiedLocalAuthIfNeeded = async ({
       twoFactorSecret: null,
     },
   });
+  const twoFactorRows = await tx.twoFactor.deleteMany({ where: { userId: user.id } });
+  const credentialRows = await tx.account.updateMany({
+    where: { userId: user.id, provider: "credential" },
+    data: { password: null },
+  });
+
+  return {
+    credentialPasswordsCleared: credentialRows.count,
+    twoFactorRowsRemoved: twoFactorRows.count,
+  };
 };
 
 const createSsoRecoveryCompletionUrl = (intentToken: string): string => {
@@ -198,9 +272,15 @@ export const startSsoRecovery = async ({
 export const completeSsoRecovery = async ({
   intentToken,
   sessionUserId,
+  sessionToken,
 }: {
   intentToken: string;
   sessionUserId?: string;
+  /**
+   * The recovering user's own session token, so the post-commit revocation can spare it. Everything else
+   * the account accrued while its address was unproven is swept.
+   */
+  sessionToken?: string;
 }): Promise<string> => {
   let intent: ReturnType<typeof verifySsoRelinkIntent>;
 
@@ -285,7 +365,7 @@ export const completeSsoRecovery = async ({
     where: {
       id: intent.userId,
     },
-    select: SSO_RECOVERY_USER_SELECT,
+    select: LINKED_SSO_LOOKUP_SELECT,
   });
 
   if (user?.email !== intent.email) {
@@ -308,8 +388,8 @@ export const completeSsoRecovery = async ({
     throw new Error(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
   }
 
-  await prisma.$transaction(async (tx) => {
-    await reclaimUnverifiedLocalAuthIfNeeded({
+  const reclaimed = await prisma.$transaction(async (tx) => {
+    const outcome = await reclaimUnverifiedLocalAuthIfNeeded({
       tx,
       user,
     });
@@ -326,7 +406,33 @@ export const completeSsoRecovery = async ({
       account: recoveryAccount,
       tx,
     });
+
+    return outcome;
   });
+
+  // Only when factors were actually stripped: this is the account changing hands, so any session the
+  // squatter still holds has to go. Reachable in practice because `signUpEmail` writes
+  // `emailVerified: false` regardless of `requireEmailVerification`, so on an instance with
+  // EMAIL_VERIFICATION_DISABLED=1 (the shipped .env.example and docker-compose default) an unproven
+  // account can sign in and hold a live session for up to SESSION_MAX_AGE.
+  //
+  // After commit, never inside the transaction: Better Auth resolves its adapter from its own
+  // AsyncLocalStorage, so this would run outside `tx` and outlive a rollback. Best-effort for the same
+  // reason the strip must not be undone by a revocation failure — it has already committed.
+  let sessionsRevoked = 0;
+  if (reclaimed) {
+    try {
+      sessionsRevoked = await revokeUserSessionsExcept({
+        userId: user.id,
+        keepSessionToken: sessionToken,
+      });
+    } catch (error) {
+      logger.error(
+        { error, userId: user.id },
+        "Failed to revoke sessions after reclaiming unverified local auth"
+      );
+    }
+  }
 
   try {
     await finalizeSuccessfulSignIn({
@@ -353,6 +459,8 @@ export const completeSsoRecovery = async ({
     email: user.email,
     provider,
     callbackUrl: intent.callbackUrl,
+    reclaimed,
+    sessionsRevoked,
   });
 
   return getValidatedCallbackUrl(intent.callbackUrl, WEBAPP_URL) ?? WEBAPP_URL;


### PR DESCRIPTION
## What & why

Backport of #8962 to `release/5.3` — **the line production runs** (5.3.4). The affected range is 5.2.0–5.3.4, so this is the branch where the vulnerability is actually live; #8969 covers `release/5.4`, which is not yet GA.

SSO verify-before-link recovery is supposed to strip a recovered account's local auth factors before the SSO identity becomes the way back in. The strip was written before ENG-1054 moved the credential to `Account.password` and 2FA into the `TwoFactor` table, and was never updated — so post-cutover it nulled three already-null legacy `User` columns and stripped nothing, while reading in code as though it did. An attacker who set a password on an unverified account keeps that password across the victim's recovery. Root cause, blame and the full evidence are on #8962 and the ticket.

**Seven of the original eight commits, byte-identical.** The five source files the fix touches are identical between `release/5.3` and `main`, so seven commits cherry-picked with zero conflicts and the tree matches #8962's reviewed commit 7-of-8 (`fbb8c2b6a`) exactly across all eleven files.

**Two deliberate deviations, both forced by this line being on Better Auth 1.6.23:**

1. **The eighth commit is dropped** (`match Better Auth's own credential-account predicate`). It filters `hasCredentialAccount` on `issuer: createLocalAccountIssuer("credential")`, and 1.6 has no `Account.issuer` column — the column and that `@better-auth/core/db` export both arrive with 1.7. This is not a compromise: 1.6's own `findCredentialAccount` doesn't filter on `issuer` either, so the pre-`63ef4bd21` predicate is the *correct* one here.
2. **The access-token revocation is removed** (one commit, `bc44adc3c`). `oauthAccessToken.revoked` also arrives with 5.4, so the write does not compile here — the typecheck caught this, not review. Nothing is lost: every access token is a self-contained JWT that `createJwtAccessToken` signs without persisting, and `/api/mcp` verifies bearers against JWKS without reading that table, so the column would only ever have mattered for an opaque-token configuration this build does not run. **The refresh token — the 30-day persistence that actually outlives the session — is still revoked, as is consent.** The residual is identical to `main`'s: a squatter's JWT stays valid for up to `accessTokenExpiresIn` (15 min).

`oauthRefreshToken.revoked`, `Account.password`, `TwoFactor` and all four `oauth*` models are present on this line, and `internalAdapter.deleteSessions` exists in 1.6.23 (`dist/db/internal-adapter.mjs:408`) with the same array-of-tokens signature and the same `secondaryStorage`-then-rows semantics the session sweep depends on — so nothing else needed adapting.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2557

## How this was tested

Run in a worktree cut from `origin/release/5.3` with the dependency graph built (12/12), against Better Auth 1.6.23:

- **Typecheck** ✅ `pnpm -C apps/web run typecheck` — clean. This is what found deviation 2 above; the first run failed with two `TS2353` errors on `oauthAccessTokenWhereInput` having no `revoked` property.
- **Unit** ✅ `npx vitest run modules/auth modules/ee/sso lib/user` — **548 passed / 51 files**, no failures. The five directly touched test files are 50/50.
- **Mutation, 2 applied and reverted** — because deviation 2 required editing a test, a green suite alone was not adequate evidence that it still binds the fix:
  - neutering the credential strip (`data: { password: null }` → `data: {}` in `sso-recovery.ts`) → **2 tests red**
  - dropping the refresh-token revocation → **1 test red**
  - both reverted → 13/13 green again
- **Not run locally: the integration suite.** It needs a Postgres provisioned from *this* branch's schema, and pointing it at another worktree's container clones that branch's schema instead — which produces ~20 schema-shape failures that look like regressions and aren't. CI provisions its own DB from this PR's schema and is the authoritative signal; the `Better Auth integration tests` job here is what to read.
- Everything else derives from #8962, whose own suites passed 18/18 on `1473fceb8`: the live before/after through real HTTP (**200 → 401**, `Account.password` present → null) and fourteen mutations.

## Breaking changes

None — no API/SDK shape, endpoint, route, env var, config key or default changes, and no deployer action. The behaviour change is the security fix itself.

## QA / Test Plan

**How to test**

- [ ] **The core fix.** On an instance with SSO configured and email verification **required**: register a local account with an address you control but do *not* verify it, and note the password. Then complete SSO sign-in with that same address (the verify-before-link recovery flow) and let it link. Now return to `/auth/login` and try the original email + password → **expected: sign-in is refused** (invalid-credentials, no session). Before this fix the same attempt signs in successfully.
- [ ] **The recovered user can still get a password back.** As that user, go to `/auth/forgot-password`, request a reset for the address → **expected: the reset email arrives**, the link sets a new password, and the new password signs in while the old one is still refused. (This is the lockout the fix deliberately avoids by nulling the password rather than deleting the credential row.)
- [ ] **2FA does not survive.** Repeat the first step with 2FA enabled on the unverified account before recovery → **expected: after recovery, sign-in via SSO does not prompt for a 2FA code, and no 2FA remains configured on the account.**
- [ ] **The caller stays signed in.** At the end of the recovery redirect → **expected: you land signed in**, not bounced to the login page. Other sessions that account held elsewhere should be signed out (check from a second browser signed in as that account before recovery → it should be logged out).
- [ ] **An already-verified account is untouched.** Take an account whose email *is* verified and with a working password, and complete SSO sign-in for it → **expected: nothing is stripped** — the password still signs in and 2FA, if configured, still applies.
- [ ] **Edge case — recovery failure.** If the recovery completion fails (e.g. an expired/invalid `intent` token on `/api/auth/sso/recovery/complete`) → **expected: redirect to `/auth/login?error=oauth_account_not_linked`, and the session that request carried is no longer valid.**

**Preconditions / test data**

- An enterprise licence, since SSO is licence-gated — without one no SSO buttons render and the provider callback 403s.
- An SSO provider configured (Google is easiest) and `EMAIL_VERIFICATION_DISABLED` unset/`0`, i.e. verification **required** — that is the posture where this matters.
- A mail catcher (or real inbox) for the reset-email step.
- Two accounts: one unverified-with-password (the attacker-shaped case) and one verified-with-password (the control).
- Cloud and self-host behave identically here; no feature flag gates the fix.

**Risks & regressions**

- **Sign-in and password reset for existing password users** — the strip now actually writes, so re-check that an ordinary, never-recovered password user still signs in and can still reset.
- **A "dead column" cleanup could silently re-open the 2FA half.** The legacy `User` nulls are load-bearing while the `better-auth-two-factor-backfill` shim exists — it re-materialises a `TwoFactor` row from `twoFactorEnabled && twoFactorSecret` on every successful credential sign-in, so dropping them would let the next sign-in re-arm a factor recovery had just removed. Ordering recorded on ENG-1826.
- **Simplifying the null into a row delete re-introduces a lockout** — a recovered user would have no password *and* no way to ask for one. Bound by the second QA step above.
- **A legitimate recovered user loses their MCP tokens** and must re-authorize. Correct for a handover, but a real consequence.
- **Revocation is not instantaneous**: `cookieCache` (`maxAge: 5 * 60`) answers `getSession` from a signed cookie without consulting either store, so a revoked session's holder can keep a cached session for up to 5 minutes. Upstream by design, true of every revocation path; filed as ENG-2591.
- **Merge order:** keep this draft until #8962 merges, so a release branch never carries a fix `main` does not. All three need to land — the release lines do not inherit from `main`.

**Migrations / env / cutover**

- none
