### PR TITLE
fix: guard the feedback dataset purge against double submission

### DIFF
--- a/apps/web/modules/ee/feedback-directory/components/feedback-directory-settings/purge-feedback-directory-data.tsx
+++ b/apps/web/modules/ee/feedback-directory/components/feedback-directory-settings/purge-feedback-directory-data.tsx
@@ -36,7 +36,7 @@ export const PurgeFeedbackDirectoryData = ({
   const { t } = useTranslation();
   const [isPurgeDialogOpen, setIsPurgeDialogOpen] = useState(false);
   const [confirmationName, setConfirmationName] = useState("");
-  const { mutateAsync: purgeDataset, isPending } = usePurgeFeedbackDataset();
+  const { purgeDatasetOnce, isPending } = usePurgeFeedbackDataset();
 
   const hasValidConfirmation = hasMatchingDatasetPurgeConfirmation(confirmationName, directoryName);
   // A dataset name has no length limit, so the *warning copy* shows a truncated one — the same
@@ -58,7 +58,9 @@ export const PurgeFeedbackDirectoryData = ({
     if (!hasValidConfirmation) return;
 
     try {
-      await purgeDataset({ datasetId: directoryId });
+      // Skipped because a purge is already in flight — the click that started it owns the outcome,
+      // so say nothing rather than raise a second toast for the same user action.
+      if (!(await purgeDatasetOnce(directoryId))) return;
       // "Started", not "done": the purge runs in the background, so the records are still there for
       // a moment after this resolves. Promising completion here would make the next screen look broken.
       toast.success(t("workspace.settings.feedback_directories.purge_started"));
@@ -135,9 +137,9 @@ export const PurgeFeedbackDirectoryData = ({
               // without stopPropagation, Enter here also reaches the outer form and saves the dataset
               // (toast "updated successfully", both dialogs close), regardless of what was typed.
               e.stopPropagation();
-              // Enter bypasses the footer button, which is the only thing carrying `isDeleting`, so
-              // without this a held Enter fires a second purge while the first is still in flight.
-              if (isPending) return;
+              // Enter bypasses the footer button, which is the only thing carrying `isDeleting` — a
+              // held Enter would otherwise fire a purge while the first is still in flight. The
+              // in-flight guard lives in usePurgeFeedbackDataset, which every path here goes through.
               await handlePurge();
             }}>
             <label htmlFor="purgeDatasetConfirmation">

--- a/apps/web/modules/ee/feedback-directory/hooks/use-purge-feedback-dataset.test.ts
+++ b/apps/web/modules/ee/feedback-directory/hooks/use-purge-feedback-dataset.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { type ReactNode, createElement } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { usePurgeFeedbackDataset } from "./use-purge-feedback-dataset";
+
+function createWrapper(queryClient: QueryClient) {
+  const Wrapper = ({ children }: Readonly<{ children: ReactNode }>) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+
+  Wrapper.displayName = "UsePurgeFeedbackDatasetTestWrapper";
+
+  return Wrapper;
+}
+
+function createQueryClient() {
+  return new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } });
+}
+
+function acceptedResponse() {
+  return {
+    ok: true,
+    status: 202,
+    json: async () => ({ data: { datasetId: "dataset_1", status: "accepted" } }),
+  } as unknown as Response;
+}
+
+describe("usePurgeFeedbackDataset", () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("sends one purge request and reports ownership of the outcome", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(acceptedResponse());
+
+    const { result } = renderHook(() => usePurgeFeedbackDataset(), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await expect(result.current.purgeDatasetOnce("dataset_1")).resolves.toBe(true);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(global.fetch).mock.calls[0][0]).toBe("/api/internal/feedback-datasets/dataset_1/purge");
+    expect(vi.mocked(global.fetch).mock.calls[0][1]).toMatchObject({ method: "POST" });
+  });
+
+  // ENG-2603: a double-click on Confirm ran the handler twice before React Query's `isPending`
+  // reached the disabled button, so one user action started two Hub purge jobs. Both calls are made
+  // without awaiting in between, which is what the two clicks do.
+  test("skips a second purge while the first is still in flight", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    vi.mocked(global.fetch).mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => usePurgeFeedbackDataset(), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    const first = result.current.purgeDatasetOnce("dataset_1");
+    const second = result.current.purgeDatasetOnce("dataset_1");
+
+    // React Query reaches `mutationFn` a few microtasks after `mutateAsync`, so assert only once
+    // both calls have had the chance to fetch — while the first request is still unsettled.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    await expect(second).resolves.toBe(false);
+
+    resolveFetch?.(acceptedResponse());
+
+    await expect(first).resolves.toBe(true);
+  });
+
+  test("allows a further purge once the first one has settled", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(acceptedResponse());
+
+    const { result } = renderHook(() => usePurgeFeedbackDataset(), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await expect(result.current.purgeDatasetOnce("dataset_1")).resolves.toBe(true);
+    await expect(result.current.purgeDatasetOnce("dataset_1")).resolves.toBe(true);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  // A rejected purge must release the guard too, otherwise a failed attempt would silently disable
+  // the button's only working retry path for the life of the dialog.
+  test("releases the guard when the request fails, so a retry still reaches the route", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: { code: "internal_server_error", message: "boom" } }),
+    } as unknown as Response);
+
+    const { result } = renderHook(() => usePurgeFeedbackDataset(), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await expect(result.current.purgeDatasetOnce("dataset_1")).rejects.toBeDefined();
+
+    vi.mocked(global.fetch).mockResolvedValue(acceptedResponse());
+
+    await expect(result.current.purgeDatasetOnce("dataset_1")).resolves.toBe(true);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("exposes the mutation's pending state", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    vi.mocked(global.fetch).mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => usePurgeFeedbackDataset(), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    expect(result.current.isPending).toBe(false);
+
+    const purge = result.current.purgeDatasetOnce("dataset_1");
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+
+    resolveFetch?.(acceptedResponse());
+    await purge;
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+  });
+});

--- a/apps/web/modules/ee/feedback-directory/hooks/use-purge-feedback-dataset.ts
+++ b/apps/web/modules/ee/feedback-directory/hooks/use-purge-feedback-dataset.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
+import { useCallback, useRef } from "react";
 import { purgeFeedbackDataset } from "@/modules/ee/feedback-directory/lib/api-client";
 
 /**
@@ -9,8 +10,41 @@ import { purgeFeedbackDataset } from "@/modules/ee/feedback-directory/lib/api-cl
  * There is deliberately no optimistic update and nothing to invalidate: the purge runs in the
  * background on the Hub and this screen lists datasets, not records, so there is no local state that
  * "records are gone" would be true of yet. Success here means *accepted*.
+ *
+ * The hook — not the caller — owns "one purge at a time". `isPending` cannot carry that guard:
+ * React Query notifies its observers through a scheduled task, so the re-render that disables the
+ * confirm button lands *after* the second click of a double-click has already run the handler, and
+ * two `POST …/purge` requests start two Hub jobs for one user action (ENG-2603). A ref flips
+ * synchronously, inside the first click's handler, so the second click never gets past it.
  */
-export const usePurgeFeedbackDataset = () =>
-  useMutation({
+export const usePurgeFeedbackDataset = () => {
+  const isPurgingRef = useRef(false);
+  const { mutateAsync, isPending } = useMutation({
     mutationFn: (variables: { datasetId: string }) => purgeFeedbackDataset(variables.datasetId),
   });
+
+  /**
+   * Start a purge unless one is already in flight.
+   *
+   * Resolves to `true` when this call sent the request and owns the outcome, `false` when it was
+   * skipped because an earlier call is still running — the caller should then stay silent rather
+   * than report a second outcome for the same user action. Rejects exactly as `mutateAsync` does,
+   * so the caller's error handling is unchanged.
+   */
+  const purgeDatasetOnce = useCallback(
+    async (datasetId: string): Promise<boolean> => {
+      if (isPurgingRef.current) return false;
+      isPurgingRef.current = true;
+
+      try {
+        await mutateAsync({ datasetId });
+        return true;
+      } finally {
+        isPurgingRef.current = false;
+      }
+    },
+    [mutateAsync]
+  );
+
+  return { purgeDatasetOnce, isPending };
+};


### PR DESCRIPTION
Fixes ENG-2603

## What & why

Double-clicking **Delete all records** in the feedback dataset purge confirmation dialog sent two `POST /api/internal/feedback-datasets/{datasetId}/purge` requests, so one user action started two Hub purge jobs over the same tenant. The purge is idempotent, so the end state is the same — the cost is a redundant background job on a potentially large dataset.

The footer button already carries `disabled={isDeleting}`, but `isPending` cannot be relied on as the guard. React Query's `notifyManager` schedules observer notifications through `systemSetTimeoutZero` (`@tanstack/query-core/build/modern/notifyManager.js:3`, v5.99.2), so the re-render that disables the button is deferred by a macrotask. Measured in this repo's harness: `isPending` is `false` synchronously after `purgeDatasetOnce` and still `false` after a microtask, then `true` after exactly one macrotask.

That leaves a one-macrotask window in which a second invocation still gets through — and the `if (isPending) return` in the dialog's inner form (the held-Enter path) had exactly the same window. The window is narrow: a human double-click, with 60–300 ms between clicks, would normally land after the button is already disabled. What realistically hits it is clicks dispatched programmatically in immediate succession — which is how ENG-2603 was found, during automated QA of ENG-2569 — or a commit deprioritized under load in a heavy tree like the settings modal.

The fix closes the window rather than narrowing it:

- `usePurgeFeedbackDataset` now owns "one purge at a time" behind a `useRef` that flips **synchronously**, before the first `await`, inside the first click's handler.
- It exposes `purgeDatasetOnce(datasetId)`, which resolves `true` when the call actually sent the request and `false` when it was skipped. `PurgeFeedbackDirectoryData` returns early on `false`, so the skipped click stays silent instead of raising a second "purge started" toast for the same action. Rejections pass through unchanged, so the existing `DOMException`/abort handling is untouched.
- The release sits in a `finally`, so a failed attempt still allows a retry, and `AbortSignal.timeout(15_000)` in `purgeFeedbackDataset` bounds the worst case — the ref cannot get stuck `true`.
- The now-redundant `isPending` check in the inner form's `onSubmit` is dropped — every path goes through the hook's guard.

`isPending` is still returned and still drives the button's loading state; only the correctness of the guard moved.

## Breaking changes

- [ ] This PR contains breaking changes

None — the change is internal to one client hook and its single caller. No API, route, payload, env var or config key is touched; the request the route receives is unchanged, there is just one of it.

## Migrations & env

- none

## How this was tested

Every row below is the same spec file — `apps/web/modules/ee/feedback-directory/hooks/use-purge-feedback-dataset.test.ts` — run with:

```
pnpm --filter @formbricks/web exec vitest run modules/ee/feedback-directory/hooks/use-purge-feedback-dataset.test.ts
```

Mutated `file:line` references are against `apps/web/modules/ee/feedback-directory/hooks/use-purge-feedback-dataset.ts`. Each mutation below was applied, run, and reverted; the quoted failure is the observed output.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Two `purgeDatasetOnce` calls made without awaiting in between (what two clicks inside the window do) send exactly one `POST …/purge`, and the second resolves `false` | unit (mutation) | "skips a second purge while the first is still in flight". Mutation: delete the guard at `use-purge-feedback-dataset.ts:36` (`if (isPurgingRef.current) return false;`) → fails with `expected "vi.fn()" to be called 1 times, but got 2 times`. |
| A single purge sends one `POST /api/internal/feedback-datasets/{id}/purge` and reports ownership of the outcome | unit (guard) | "sends one purge request and reports ownership of the outcome". Asserts the URL and method, so a change to the request shape breaks it. |
| The guard releases once the first purge settles, so a later purge in the same dialog still works | unit (mutation) | "allows a further purge once the first one has settled". Mutation: remove the release at `use-purge-feedback-dataset.ts:43` (`isPurgingRef.current = false;` inside the `finally`) → this row and the next both fail with `expected false to be true`. |
| A rejected purge still releases the guard, so retrying after an error reaches the route | unit (mutation) | "releases the guard when the request fails, so a retry still reaches the route". Mutation: move `use-purge-feedback-dataset.ts:43` out of the `finally` and onto the success path (before `return true` at line 41) → fails with `expected false to be true`, while the three preceding rows still pass — so this row is what pins the release to `finally` specifically. |
| `isPending` still flips true/false around the request, so the confirm button keeps its loading state | unit (guard) | "exposes the mutation's pending state". |
| The `isPending` window this fix closes is exactly one macrotask | manual | Throwaway probe rendering the hook and sampling `result.current.isPending` at each tick: `false` synchronously, `false` after one microtask, `true` after macrotask 1 (and 2, 3, 4). Matches `notifyManager`'s `systemSetTimeoutZero` scheduler. Probe was deleted, not committed. |

**Open gaps**

- No E2E row. Reaching this dialog needs an org with the `feedbackDirectories` entitlement, which the Playwright fixtures do not currently provision, so a browser-level double-click is not covered. The unit spec exercises the same handler contract two in-window clicks hit (two invocations before the first settles), which is the part the fix changes; what it cannot show is the click-to-handler wiring in `DeleteDialog`, which this PR does not touch.
- **The original double-click was not reproduced by hand in a browser.** The macrotask window above is measured, and it is sufficient to explain a programmatic double-click, but I have not demonstrated that a *human* double-click in the real settings modal lands inside it. If someone wants that nailed down, the repro is step 4 of ENG-2603 with the Network panel open. The guard is correct either way — it removes a real window regardless of how often that window is hit — but treat the "how it was triggered in QA" story as inference, not established fact.

**Risks**

- The skipped call now returns early *before* `handleDialogOpenChange(false)`, so a duplicate click no longer contributes to closing the dialog. The first click still closes it on success, so the visible outcome is unchanged; if the dialog ever appeared to stay open after a purge, this early return is where to look.
- The dropped `if (isPending) return` in the inner form means the held-Enter path relies entirely on the hook's ref. If Enter ever stops routing through `handlePurge`, the guard stops applying to it.
- Not closed by this PR: a 15 s client abort followed by a user retry can still produce two POSTs. The existing code already treats that as safe and idempotent, and this PR does not change it.

---

> [!NOTE]
> **AI model used** — Claude Code; the exact model id is withheld by this session's policy, reasoning effort `high`.
