### PR TITLE
feat: group question type by category in the block dropdowns (ENG-1777)

### DIFF
--- a/apps/web/modules/survey/editor/components/add-element-to-block-button.tsx
+++ b/apps/web/modules/survey/editor/components/add-element-to-block-button.tsx
@@ -7,16 +7,13 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { type Workspace } from "@formbricks/database/prisma-browser";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
-import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { addMultiLanguageLabels, extractLanguageCodes } from "@/lib/i18n/utils";
 import { addElementToBlock } from "@/modules/survey/editor/lib/blocks";
 import { scrollElementCardIntoView } from "@/modules/survey/editor/lib/utils";
 import {
-  getCXElementNameMap,
   getElementDefaults,
-  getElementIconMap,
-  getElementNameMap,
+  getGroupedElementTypes,
   universalElementPresets,
 } from "@/modules/survey/lib/elements";
 import { Button } from "@/modules/ui/components/button";
@@ -24,6 +21,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/modules/ui/components/dropdown-menu";
 
@@ -46,8 +45,7 @@ export const AddElementToBlockButton = ({
 }: AddElementToBlockButtonProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const availableElementTypes = isCxMode ? getCXElementNameMap(t) : getElementNameMap(t);
-  const ELEMENTS_ICON_MAP = getElementIconMap(t);
+  const groupedElementTypes = getGroupedElementTypes(t, isCxMode);
 
   const handleAddElement = (elementType: string) => {
     // Get language symbols and add multi-language support
@@ -91,11 +89,22 @@ export const AddElementToBlockButton = ({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        {Object.entries(availableElementTypes).map(([type, name]) => (
-          <DropdownMenuItem key={type} className="min-h-8" onClick={() => handleAddElement(type)}>
-            {ELEMENTS_ICON_MAP[type as TSurveyElementTypeEnum]}
-            <span className="ml-2">{name}</span>
-          </DropdownMenuItem>
+        {groupedElementTypes.map((group, index) => (
+          <div key={group.category.id}>
+            {index > 0 && <DropdownMenuSeparator />}
+            <DropdownMenuLabel className="pt-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
+              {group.category.label}
+            </DropdownMenuLabel>
+            {group.elements.map((elementType) => (
+              <DropdownMenuItem
+                key={elementType.id}
+                className="min-h-8"
+                onClick={() => handleAddElement(elementType.id)}>
+                <elementType.icon className="size-4" />
+                <span className="ml-2">{elementType.label}</span>
+              </DropdownMenuItem>
+            ))}
+          </div>
         ))}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/modules/survey/editor/components/editor-card-menu.tsx
+++ b/apps/web/modules/survey/editor/components/editor-card-menu.tsx
@@ -10,18 +10,15 @@ import { TSurveyBlockLogic } from "@formbricks/types/surveys/blocks";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyEndScreenCard, TSurveyRedirectUrlCard } from "@formbricks/types/surveys/types";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
-import {
-  getCXElementNameMap,
-  getElementDefaults,
-  getElementIconMap,
-  getElementNameMap,
-} from "@/modules/survey/lib/elements";
+import { getElementDefaults, getGroupedElementTypes } from "@/modules/survey/lib/elements";
 import { Button } from "@/modules/ui/components/button";
 import { ConfirmationModal } from "@/modules/ui/components/confirmation-modal";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -73,7 +70,6 @@ export const EditorCardMenu = ({
   isCxMode = false,
 }: EditorCardMenuProps) => {
   const { t } = useTranslation();
-  const ELEMENTS_ICON_MAP = getElementIconMap(t);
   const [logicWarningModal, setLogicWarningModal] = useState(false);
   const [changeToType, setChangeToType] = useState(() => {
     if (card.type !== "endScreen" && card.type !== "redirectToUrl") {
@@ -87,7 +83,7 @@ export const EditorCardMenu = ({
   const isDeleteDisabled =
     cardType === "element" ? elements.length === 1 : survey.type === "link" && survey.endings.length === 1;
 
-  const availableElementTypes = isCxMode ? getCXElementNameMap(t) : getElementNameMap(t);
+  const groupedElementTypes = getGroupedElementTypes(t, isCxMode);
 
   const changeElementType = (type?: TSurveyElementTypeEnum) => {
     if (!type) return;
@@ -237,25 +233,36 @@ export const EditorCardMenu = ({
                 </DropdownMenuSubTrigger>
 
                 <DropdownMenuSubContent className="ml-2">
-                  {Object.entries(availableElementTypes).map(([type, name]) => {
-                    if (type === card.type) return null;
-                    return (
-                      <DropdownMenuItem
-                        key={type}
-                        onClick={() => {
-                          setChangeToType(type as TSurveyElementTypeEnum);
-                          if ((card as EditorCardMenuSurveyElement).logic) {
-                            setLogicWarningModal(true);
-                            return;
-                          }
+                  {groupedElementTypes
+                    .map((group) => ({
+                      ...group,
+                      elements: group.elements.filter((elementType) => elementType.id !== card.type),
+                    }))
+                    .filter((group) => group.elements.length > 0)
+                    .map((group, index) => (
+                      <div key={group.category.id}>
+                        {index > 0 && <DropdownMenuSeparator />}
+                        <DropdownMenuLabel className="pt-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
+                          {group.category.label}
+                        </DropdownMenuLabel>
+                        {group.elements.map((elementType) => (
+                          <DropdownMenuItem
+                            key={elementType.id}
+                            onClick={() => {
+                              setChangeToType(elementType.id as TSurveyElementTypeEnum);
+                              if ((card as EditorCardMenuSurveyElement).logic) {
+                                setLogicWarningModal(true);
+                                return;
+                              }
 
-                          changeElementType(type as TSurveyElementTypeEnum);
-                        }}
-                        icon={ELEMENTS_ICON_MAP[type as TSurveyElementTypeEnum]}>
-                        <span className="ml-2">{name}</span>
-                      </DropdownMenuItem>
-                    );
-                  })}
+                              changeElementType(elementType.id as TSurveyElementTypeEnum);
+                            }}
+                            icon={<elementType.icon className="size-4" />}>
+                            <span className="ml-2">{elementType.label}</span>
+                          </DropdownMenuItem>
+                        ))}
+                      </div>
+                    ))}
                 </DropdownMenuSubContent>
               </DropdownMenuSub>
             )}
@@ -277,22 +284,28 @@ export const EditorCardMenu = ({
                 </DropdownMenuSubTrigger>
 
                 <DropdownMenuSubContent className="ml-2">
-                  {Object.entries(availableElementTypes).map(([type, name]) => {
-                    return (
-                      <DropdownMenuItem
-                        key={type}
-                        className="min-h-8"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          if (cardType === "element") {
-                            addElementCardBelow(type as TSurveyElementTypeEnum);
-                          }
-                        }}>
-                        {ELEMENTS_ICON_MAP[type as TSurveyElementTypeEnum]}
-                        <span className="ml-2">{name}</span>
-                      </DropdownMenuItem>
-                    );
-                  })}
+                  {groupedElementTypes.map((group, index) => (
+                    <div key={group.category.id}>
+                      {index > 0 && <DropdownMenuSeparator />}
+                      <DropdownMenuLabel className="pt-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
+                        {group.category.label}
+                      </DropdownMenuLabel>
+                      {group.elements.map((elementType) => (
+                        <DropdownMenuItem
+                          key={elementType.id}
+                          className="min-h-8"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (cardType === "element") {
+                              addElementCardBelow(elementType.id as TSurveyElementTypeEnum);
+                            }
+                          }}>
+                          <elementType.icon className="size-4" />
+                          <span className="ml-2">{elementType.label}</span>
+                        </DropdownMenuItem>
+                      ))}
+                    </div>
+                  ))}
                 </DropdownMenuSubContent>
               </DropdownMenuSub>
             )}

--- a/apps/web/modules/survey/lib/elements.tsx
+++ b/apps/web/modules/survey/lib/elements.tsx
@@ -368,6 +368,33 @@ export const getCXElementTypes = (t: TFunction) =>
     ].includes(elementType.id as TSurveyElementTypeEnum);
   });
 
+export type TElementCategoryGroup = {
+  category: TElementCategoryMeta;
+  elements: TElement[];
+};
+
+/**
+ * Groups the available element types by category, in the same category order and
+ * within-category order as the "Add Block" picker, omitting categories with no elements.
+ * Lets other element-type pickers (e.g. "Add question to block", "Change question type")
+ * reuse the same sections/ordering instead of rendering a flat list.
+ */
+export const getGroupedElementTypes = (t: TFunction, isCxMode = false): TElementCategoryGroup[] => {
+  const availableElementTypes = isCxMode ? getCXElementTypes(t) : getElementTypes(t);
+  const categories = getElementCategories(t);
+
+  const elementsByCategory = new Map<TElementCategory, TElement[]>();
+  for (const elementType of availableElementTypes) {
+    const group = elementsByCategory.get(elementType.category) ?? [];
+    group.push(elementType);
+    elementsByCategory.set(elementType.category, group);
+  }
+
+  return categories
+    .map((category) => ({ category, elements: elementsByCategory.get(category.id) ?? [] }))
+    .filter((group) => group.elements.length > 0);
+};
+
 export const getElementIconMap = (t: TFunction): Record<TSurveyElementTypeEnum, JSX.Element> =>
   getElementTypes(t).reduce(
     (prev, curr) => ({

--- a/apps/web/modules/ui/components/dropdown-menu/index.tsx
+++ b/apps/web/modules/ui/components/dropdown-menu/index.tsx
@@ -53,7 +53,7 @@ const DropdownMenuSubContent: React.ComponentType<DropdownMenuPrimitive.Dropdown
     <DropdownMenuPrimitive.SubContent
       ref={ref as any}
       className={cn(
-        "z-50 min-w-32 overflow-hidden rounded-lg border border-slate-200 bg-white p-1 font-medium text-slate-600 shadow-xs animate-in slide-in-from-left-1 hover:text-slate-700",
+        "z-50 max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] min-w-32 overflow-x-hidden overflow-y-auto rounded-lg border border-slate-200 bg-white p-1 font-medium text-slate-600 shadow-xs animate-in slide-in-from-left-1 hover:text-slate-700",
         className
       )}
       {...props}
@@ -74,7 +74,7 @@ const DropdownMenuContent: React.ComponentType<DropdownMenuPrimitive.DropdownMen
           ref={ref}
           sideOffset={sideOffset}
           className={cn(
-            "z-50 min-w-32 overflow-hidden rounded-lg border border-slate-200 bg-white p-1 font-medium text-slate-700 shadow-xs animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            "z-50 max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))] min-w-32 overflow-x-hidden overflow-y-auto rounded-lg border border-slate-200 bg-white p-1 font-medium text-slate-700 shadow-xs animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
             className
           )}
           {...props}


### PR DESCRIPTION
Fixes ENG-1777, Fixes ENG-2141

## What & why

The "Add Block" picker groups question types into labelled sections (Input, Choice, Rating & Scoring,
Contact, Content) in a fixed order. Two other pickers offering the exact same choice — the "Add question
to block" button, and the "Change question type" / "Add question below" submenus in a question's "..."
menu — rendered a flat, differently-ordered list instead, which read as inconsistent.

`elements.tsx` already exported the category config (`getElementCategories`) and the grouping logic used
by "Add Block"; it just wasn't reused anywhere else. This PR extracts that grouping into a shared
`getGroupedElementTypes(t, isCxMode)` helper and switches all three flat pickers to render the same
section headers, in the same order — no color coding, just the section name, per the ask.

While capturing before/after screenshots for that change, the "Add question to block" menu (17 items)
reproduced [ENG-2141](https://linear.app/formbricks/issue/ENG-2141/long-dropdown-menus-render-items-above-the-viewport-with-no-way-to)
exactly: `DropdownMenuContent`/`DropdownMenuSubContent` set `overflow-hidden` with no `max-height`, so when
Radix flips a long menu upward against a short viewport, the items that don't fit render **above** the
top of the screen with no scrollbar to reach them. Fixed by capping both at
`max-h-[min(20rem,var(--radix-dropdown-menu-content-available-height))]` with `overflow-y-auto` — the
same pattern the `Select` component already uses for this exact Radix limitation.

## Breaking changes

- [ ] This PR contains breaking changes

None

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| "Add question to block" groups items into Input / Choice / Rating & Scoring / Contact / Content, same order as "Add Block" | manual | Matches; see screenshots below |
| "Change question type" submenu groups items the same way (current type excluded from the list) | manual | Matches; see screenshots below |
| "Add question below" submenu groups items the same way | manual | Same rendering path as "Change question type" — verified visually, no separate screenshot |
| Long menus (17+ items) no longer render items above the viewport with no way to reach them (ENG-2141) | manual | Reproduced the ticket's exact repro steps (1280×720 window, "Add question to block"); see screenshots below |

| Before | After |
| --- | --- |
| ![Add question to block: flat, uncategorized list](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1777/add-question-to-block-before.png) | ![Add question to block: grouped into Input/Choice/Rating & Scoring/Contact/Content sections](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1777/add-question-to-block-after.png) |
| ![Change question type: flat, uncategorized submenu](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1777/change-question-type-before.png) | ![Change question type: grouped submenu matching Add Block](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1777/change-question-type-after.png) |
| ![ENG-2141: "Free text" rendered above the viewport at y=-25, unreachable](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1777/eng-2141-before.png) | ![ENG-2141: menu capped to the viewport height with a scrollbar, every item reachable](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1777/eng-2141-after.png) |

**Open gaps**

- No automated regression test guards the `max-height`/`overflow-y-auto` fix for ENG-2141 — a future edit
  to `dropdown-menu/index.tsx` that drops those classes wouldn't be caught by CI, only by manual QA.

**Risks**

- `DropdownMenuContent`/`DropdownMenuSubContent` are shared by every dropdown menu in the app (survey list
  actions, workflow list/canvas menus, the API key modal, chart/dashboard dropdowns, conditional logic,
  etc.). None currently render more than `20rem` of content in normal use, but any that do will now scroll
  instead of growing unbounded — worth a re-check if a reviewer knows of one that relies on that.
- `add-api-key-modal.tsx` already sets its own `max-h-[300px] overflow-y-auto` override on
  `DropdownMenuContent`; untouched by this change since the explicit `className` wins over the new default.

---

> [!NOTE]
> **AI model used** — `claude-sonnet-5` (Claude Code), reasoning effort `unknown`.
