### PR TITLE
fix(api): return the documented pagination meta from GET /management/responses

### DIFF
--- a/apps/web/modules/api/v2/management/responses/route.test.ts
+++ b/apps/web/modules/api/v2/management/responses/route.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { authenticatedApiClient } from "@/modules/api/v2/auth/authenticated-api-client";
+
+const { mockAuthenticatedApiClient, mockGetResponses, mockHandleApiError, mockSuccessResponse } = vi.hoisted(
+  () => ({
+    mockAuthenticatedApiClient: vi.fn(),
+    mockGetResponses: vi.fn(),
+    mockHandleApiError: vi.fn(),
+    mockSuccessResponse: vi.fn(),
+  })
+);
+
+vi.mock("@/modules/api/v2/auth/authenticated-api-client", () => ({
+  authenticatedApiClient: mockAuthenticatedApiClient,
+}));
+
+vi.mock("@/modules/api/v2/lib/response", () => ({
+  responses: {
+    createdResponse: mockSuccessResponse,
+    successResponse: mockSuccessResponse,
+  },
+}));
+
+vi.mock("@/modules/api/v2/lib/utils", () => ({
+  handleApiError: mockHandleApiError,
+}));
+
+vi.mock("./lib/response", () => ({
+  createResponseWithQuotaEvaluation: vi.fn(),
+  getResponses: mockGetResponses,
+}));
+
+vi.mock("@/app/lib/pipelines", () => ({
+  sendToPipeline: vi.fn(),
+}));
+
+vi.mock("@/modules/storage/utils", () => ({
+  resolveStorageUrlsInObject: (data: unknown) => data,
+  validateClientFileUploads: vi.fn(),
+}));
+
+const query = { limit: 2, skip: 10, sortBy: "createdAt", order: "desc" } as const;
+
+const buildRequest = () => new Request("http://localhost/api/v2/management/responses?limit=2&skip=10");
+
+describe("GET /management/responses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAuthenticatedApiClient.mockImplementation(
+      async ({ handler }: Parameters<typeof authenticatedApiClient>[0]) =>
+        await handler({
+          request: buildRequest(),
+          auditLog: undefined,
+          authentication: {
+            type: "apiKey",
+            apiKeyId: "apiKey123",
+            organizationId: "org123",
+            workspacePermissions: [{ workspaceId: "ws123", permission: "read", workspaceType: "production" }],
+            organizationAccess: { accessControl: { read: true, write: true } },
+          },
+          parsedInput: { query },
+        })
+    );
+    mockHandleApiError.mockImplementation((_request, error) => Response.json({ error }, { status: 400 }));
+    mockSuccessResponse.mockImplementation((body: unknown) => Response.json(body, { status: 200 }));
+  });
+
+  test("returns the pagination meta the service computed alongside the data", async () => {
+    mockGetResponses.mockResolvedValue({
+      ok: true,
+      data: {
+        data: [{ id: "res1", data: { q1: "a" } }],
+        meta: { total: 137, limit: 2, offset: 10 },
+      },
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(buildRequest() as any);
+    const body = await response.json();
+
+    expect(mockGetResponses).toHaveBeenCalledWith(["ws123"], query);
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      data: [{ id: "res1", data: { q1: "a" } }],
+      meta: { total: 137, limit: 2, offset: 10 },
+    });
+  });
+
+  test("surfaces the service error instead of an envelope", async () => {
+    mockGetResponses.mockResolvedValue({
+      ok: false,
+      error: { type: "internal_server_error", details: [{ field: "responses", issue: "boom" }] },
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(buildRequest() as any);
+
+    expect(mockSuccessResponse).not.toHaveBeenCalled();
+    expect(mockHandleApiError).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: "internal_server_error" })
+    );
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/web/modules/api/v2/management/responses/route.test.ts
+++ b/apps/web/modules/api/v2/management/responses/route.test.ts
@@ -34,8 +34,16 @@ vi.mock("@/app/lib/pipelines", () => ({
   sendToPipeline: vi.fn(),
 }));
 
+// Not an identity stub: the success case asserts the *rewritten* value, so the test fails if the
+// route stops piping each row's data through this.
 vi.mock("@/modules/storage/utils", () => ({
-  resolveStorageUrlsInObject: (data: unknown) => data,
+  resolveStorageUrlsInObject: (data: Record<string, unknown>) =>
+    Object.fromEntries(
+      Object.entries(data).map(([key, value]) => [
+        key,
+        value === "storage://private/file.png" ? "https://cdn.example.com/file.png" : value,
+      ])
+    ),
   validateClientFileUploads: vi.fn(),
 }));
 
@@ -72,7 +80,7 @@ describe("GET /management/responses", () => {
     mockGetResponses.mockResolvedValue({
       ok: true,
       data: {
-        data: [{ id: "res1", data: { q1: "a" } }],
+        data: [{ id: "res1", data: { q1: "a", upload: "storage://private/file.png" } }],
         meta: { total: 137, limit: 2, offset: 10 },
       },
     });
@@ -84,7 +92,7 @@ describe("GET /management/responses", () => {
     expect(mockGetResponses).toHaveBeenCalledWith(["ws123"], query);
     expect(response.status).toBe(200);
     expect(body).toEqual({
-      data: [{ id: "res1", data: { q1: "a" } }],
+      data: [{ id: "res1", data: { q1: "a", upload: "https://cdn.example.com/file.png" } }],
       meta: { total: 137, limit: 2, offset: 10 },
     });
   });

--- a/apps/web/modules/api/v2/management/responses/route.test.ts
+++ b/apps/web/modules/api/v2/management/responses/route.test.ts
@@ -56,7 +56,9 @@ describe("GET /management/responses", () => {
             type: "apiKey",
             apiKeyId: "apiKey123",
             organizationId: "org123",
-            workspacePermissions: [{ workspaceId: "ws123", permission: "read", workspaceType: "production" }],
+            workspacePermissions: [
+              { workspaceId: "ws123", workspaceName: "Test Workspace", permission: "read" },
+            ],
             organizationAccess: { accessControl: { read: true, write: true } },
           },
           parsedInput: { query },

--- a/apps/web/modules/api/v2/management/responses/route.ts
+++ b/apps/web/modules/api/v2/management/responses/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest } from "next/server";
-import { Response } from "@formbricks/database/prisma";
 import { sendToPipeline } from "@/app/lib/pipelines";
 import { getWorkspaceLegacyStoragePrefixes } from "@/lib/workspace/service";
 import { formatValidationErrorsForV2Api, validateResponseData } from "@/modules/api/lib/validation";
@@ -36,17 +35,15 @@ export const GET = async (request: NextRequest) =>
         ...new Set(authentication.workspacePermissions.map((permission) => permission.workspaceId)),
       ];
 
-      const workspaceResponses: Response[] = [];
       const res = await getResponses(workspaceIds, query);
 
       if (!res.ok) {
         return handleApiError(request, res.error);
       }
 
-      workspaceResponses.push(...res.data.data);
-
       return responses.successResponse({
-        data: workspaceResponses.map((r) => ({ ...r, data: resolveStorageUrlsInObject(r.data) })),
+        data: res.data.data.map((r) => ({ ...r, data: resolveStorageUrlsInObject(r.data) })),
+        meta: res.data.meta,
       });
     },
   });


### PR DESCRIPTION
Fixes ENG-2622

## What & why

`GET /api/v2/management/responses` documented a pagination envelope it never returned.

`getResponses()` already runs a `prisma.response.count()` next to the `findMany` and returns
`ok({ data, meta: { total, limit, offset } })`. The GET handler dropped half of that: it pushed
`res.data.data` into a local `workspaceResponses` array and returned `successResponse({ data })`,
leaving `res.data.meta` on the floor. The dead local was what hid it — the array was the only reason
the code touched `res.data.data` instead of `res.data`.

Meanwhile `docs/api-v2-reference/openapi.yml` documents `{ data, meta: { total, limit, offset } }` for
that operation, so a client paging on `meta.total` read `null`. `total` is the useful one: without it
there is no way to learn a survey's response count except paging until a short page comes back.

The fix forwards the meta the service already computes — `successResponse` has always accepted a
`meta` argument. **Not** the other direction (deleting `meta` from the spec), because the spec is
generated from `responseWithMetaSchema`, the shared envelope every v2 list endpoint declares; webhooks
and contact-attribute-keys pass `res.data` straight through. Responses was the outlier, and it can't
pass through wholesale only because it rewrites storage URLs per row. `openapi.yml` is unchanged, so
no spec regeneration is needed.

<details>
<summary>Why no check could have caught this</summary>

In `responseWithMetaSchema`, `meta` and all three fields under it are `.optional()`. A body with no
`meta` key at all is schema-valid, so the Schemathesis contract gate was green before this PR and is
green after it — it cannot distinguish the two envelopes. That is why the drift survived to a manual
check against a running instance rather than being caught on a PR.

Making `meta` required would close that hole for every v2 list endpoint at once, but it's a change to
shared types with its own blast radius, so it's noted on the ticket rather than done here.

</details>

## Breaking changes

- [ ] This PR contains breaking changes

None — purely additive. A key appears where consumers previously read `undefined`, and it is the key
the published spec already told them to expect, so no integration has to change.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| GET returns `{ data, meta: { total, limit, offset } }`, with the service's `total` intact | unit (red on main) | New `route.test.ts` asserts the whole envelope with `toEqual`, not a subset, so a future drop of `meta` fails instead of passing. Confirmed it can fail: deleting `route.ts:46` gives `expected { data: [ … ] } to deeply equal { Object (data, meta) }`. Rerun: `node ../../node_modules/.bin/vitest run modules/api/v2/management/responses/route.test.ts` from `apps/web` |
| Storage URLs are still resolved per row while mapping off `res.data.data` | unit (mutation) | The mock rewrites one distinct value (`storage://private/file.png` → a CDN URL) and the success case asserts the **rewritten** value, so dropping the `resolveStorageUrlsInObject` call fails the test rather than passing. Confirmed by mutating `route.ts:45` to a bare `res.data.data`: `- "upload": "https://cdn.example.com/file.png" / + "upload": "storage://private/file.png"`. (First version used an identity mock and could not fail — caught in review.) |
| A service error still goes to `handleApiError` and emits no envelope | unit (guard) | Second case asserts `successResponse` was never called and the `internal_server_error` reaches `handleApiError` — the error path shares the `res.data` access being changed |
| Nothing else regressed in the module | unit (guard) | 9 files / 82 tests under `modules/api/v2/management/responses` pass |

**Open gaps**

- The **fix** is not verified against a live instance — this worktree has no running app or DB. The
  **bug** was (body had only `data`); the corrected body is proven at the route level only. Cheap to
  confirm on staging with any API key: `curl` the endpoint and check `meta.total` is a number.
- No E2E, deliberately: per AGENTS.md a route's response shape belongs in a route test, and the
  Playwright job is paid on every PR forever.
- No contract-test signal either way, for the schema reason in the fold above.

**Risks**

- `meta` is always fully populated, not sometimes-present: `limit` and `skip` carry `prefault`s in
  `ZGetFilter`, so both are numbers after parsing, and `total` is always computed. A consumer will not
  see a partial `meta`.
- If anything downstream was relying on the response body having exactly one key, it would notice. I
  found no such consumer — this is the public management API, and our own clients don't call it.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code desktop, Agent SDK 0.3.237), reasoning effort `xhigh`.
