### PR TITLE
fix(surveys): stop announcing the public-API name placeholder on app surveys [ENG-2617]

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.test.ts
@@ -3,6 +3,7 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { PUBLIC_API_SURVEY_NAME_PLACEHOLDER } from "@formbricks/types/js-constants";
 import { getWorkspaceStateData } from "./data";
 
 vi.mock("server-only", () => ({}));
@@ -120,7 +121,7 @@ describe("getWorkspaceStateData", () => {
       surveys: [
         {
           ...mockWorkspaceData.surveys[0],
-          name: "[deprecated] survey name omitted from public API - will be removed soon",
+          name: PUBLIC_API_SURVEY_NAME_PLACEHOLDER,
         },
       ],
       actionClasses: mockWorkspaceData.actionClasses,

--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
@@ -9,6 +9,7 @@ import {
   TJsWorkspaceStateSurvey,
   TJsWorkspaceStateWorkspaceSetting,
 } from "@formbricks/types/js";
+import { PUBLIC_API_SURVEY_NAME_PLACEHOLDER } from "@formbricks/types/js-constants";
 import { type TBaseFilters, buildSurveyInteractionRefreshMap } from "@formbricks/types/segment";
 import { toLegacyLanguageCodes } from "@/lib/i18n/utils";
 import { validateInputs } from "@/lib/utils/validate";
@@ -283,7 +284,7 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
 
       return {
         ...transformed,
-        name: "[deprecated] survey name omitted from public API - will be removed soon",
+        name: PUBLIC_API_SURVEY_NAME_PLACEHOLDER,
         segment: sanitizedSegment,
         ...(interactionRefresh ? { interactionRefresh } : {}),
       };

--- a/apps/web/playwright/js.spec.ts
+++ b/apps/web/playwright/js.spec.ts
@@ -103,6 +103,16 @@ test.describe("JS Package Test", async () => {
 
     await page.goto("http://localhost:3004");
     await expect(page.locator("#formbricks-modal-container")).toHaveCount(1, { timeout: 120000 });
+
+    // The widget reads the survey from the public client API, which substitutes a placeholder for
+    // every survey name so names are not exposed over an unauthenticated endpoint. This is the only
+    // place the real API, the widget and the dialog are wired together, so it is the only place that
+    // can catch the placeholder leaking into what a screen reader announces: the dialog falls back
+    // to its generic name instead, and no heading carries the placeholder either.
+    const widget = page.locator("#formbricks-modal-container");
+    await expect(widget.getByRole("dialog")).toHaveAttribute("aria-label", "Survey Dialog");
+    await expect(widget.getByText(/\[deprecated] survey name omitted/)).toHaveCount(0);
+
     await expect(
       page.locator("#questionCard-0").getByRole("link", { name: "Powered by Formbricks" })
     ).toBeVisible();

--- a/packages/surveys/src/components/general/render-survey.tsx
+++ b/packages/surveys/src/components/general/render-survey.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { SurveyContainerProps } from "@formbricks/types/formbricks-surveys";
-import { hasSurveyInstructions } from "@/lib/survey-page";
+import { getSurveyDisplayName, hasSurveyInstructions } from "@/lib/survey-page";
 import { getSurveyLanguageTag, isRTLLanguage } from "@/lib/utils";
 import { SurveyContainer } from "../wrappers/survey-container";
 import { Survey } from "./survey";
@@ -106,7 +106,7 @@ export function RenderSurvey(props: Readonly<SurveyContainerProps>) {
       onClose={close}
       isOpen={isOpen}
       dir={dir}
-      surveyName={props.survey.name}
+      surveyName={getSurveyDisplayName(props.survey.name)}
       hasInstructions={hasSurveyInstructions(props.survey)}
       lang={languageTag}>
       <Survey

--- a/packages/surveys/src/lib/survey-page.test.ts
+++ b/packages/surveys/src/lib/survey-page.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import type { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
-import { getSurveyPagePosition, hasSurveyInstructions } from "./survey-page";
+import { PUBLIC_API_SURVEY_NAME_PLACEHOLDER } from "@formbricks/types/js-constants";
+import { getSurveyDisplayName, getSurveyPagePosition, hasSurveyInstructions } from "./survey-page";
 
 const block = (id: string) => ({ id, name: id, elements: [] });
 
@@ -123,5 +124,30 @@ describe("hasSurveyInstructions", () => {
         makeSurvey({ welcomeCardEnabled: false, welcomeCardSubheader: { default: "Take a minute." } })
       )
     ).toBe(true);
+  });
+});
+
+describe("getSurveyDisplayName", () => {
+  test("keeps a real survey name", () => {
+    expect(getSurveyDisplayName("Product feedback")).toBe("Product feedback");
+  });
+
+  test("drops the public client API's placeholder", () => {
+    // An app survey is fetched from the public client API, which substitutes this for every name.
+    // Rendering it would announce an internal deprecation notice as the dialog's accessible name.
+    expect(getSurveyDisplayName(PUBLIC_API_SURVEY_NAME_PLACEHOLDER)).toBeUndefined();
+  });
+
+  test("drops a missing or empty name", () => {
+    expect(getSurveyDisplayName(undefined)).toBeUndefined();
+    expect(getSurveyDisplayName("")).toBeUndefined();
+    expect(getSurveyDisplayName("   ")).toBeUndefined();
+  });
+
+  test("keeps a name that merely contains the placeholder as a substring", () => {
+    // Only an exact match is the API's substitution; anything else is a name someone chose.
+    expect(getSurveyDisplayName(`Re: ${PUBLIC_API_SURVEY_NAME_PLACEHOLDER}`)).toBe(
+      `Re: ${PUBLIC_API_SURVEY_NAME_PLACEHOLDER}`
+    );
   });
 });

--- a/packages/surveys/src/lib/survey-page.ts
+++ b/packages/surveys/src/lib/survey-page.ts
@@ -1,4 +1,7 @@
+// Imported from the dependency-free constants module rather than from `./js`: a value import of
+// `@formbricks/types/js` pulls its zod schema graph into the widget bundle (+94 kB on the UMD build).
 import { type TJsWorkspaceStateSurvey } from "@formbricks/types/js";
+import { PUBLIC_API_SURVEY_NAME_PLACEHOLDER } from "@formbricks/types/js-constants";
 
 /** Id of the visually-hidden region holding the survey's persistent instructions. */
 export const SURVEY_INSTRUCTIONS_ID = "fb__survey-instructions";
@@ -41,6 +44,26 @@ export const getSurveyPagePosition = (
   // Not a block: an ending card, or an id that no longer resolves after the survey was edited
   // mid-session. The last page either way.
   return { index: total, total };
+};
+
+/**
+ * The survey name to show a respondent, or `undefined` when there is none to show.
+ *
+ * A survey delivered by the JS widget is fetched from the public client API, which deliberately
+ * replaces every name with a placeholder so names are not exposed over an unauthenticated endpoint
+ * (ENG-808). That placeholder is an internal deprecation notice, so rendering it is worse than
+ * rendering nothing: it became the dialog's accessible name and its only heading on every app
+ * survey, which is what a screen reader then announced. Treat it as "this survey has no name" and
+ * let the callers fall back the way they already do for a survey rendered without one.
+ *
+ * Link surveys are unaffected — their name comes from the server component, never from this
+ * endpoint, so it never matches the placeholder.
+ *
+ * Also drops a name that is only whitespace, which would name the dialog with nothing at all.
+ */
+export const getSurveyDisplayName = (name: string | undefined): string | undefined => {
+  if (!name || name === PUBLIC_API_SURVEY_NAME_PLACEHOLDER) return undefined;
+  return name.trim().length > 0 ? name : undefined;
 };
 
 /**

--- a/packages/types/js-constants.ts
+++ b/packages/types/js-constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Constants shared between the public client API and the JS widget that consumes it.
+ *
+ * This module deliberately imports nothing. Its consumers include `@formbricks/surveys`, whose
+ * bundle every respondent of an app survey downloads, and importing a *value* from `./js` instead
+ * would drag that module's zod schema graph into the bundle — measured at +94 kB on the UMD build.
+ * Keep it dependency-free, and keep constants the widget needs here rather than in `./js`.
+ */
+
+/**
+ * The string the public client API substitutes for every survey name it returns, so that survey
+ * names are not exposed over an unauthenticated endpoint (ENG-808).
+ *
+ * It is a marker, not text anyone should ever read: it lives here rather than inline at the
+ * substitution site so the widget can recognise it and refuse to render it. Change it in one place
+ * or the widget stops recognising it — see `getSurveyDisplayName` in `@formbricks/surveys`.
+ */
+export const PUBLIC_API_SURVEY_NAME_PLACEHOLDER =
+  "[deprecated] survey name omitted from public API - will be removed soon";


### PR DESCRIPTION
Fixes ENG-2617

## What & why

On an app-type survey delivered by the js-core widget, the modal's accessible name and its `sr-only` `h1` both read `[deprecated] survey name omitted from public API - will be removed soon` instead of the survey's name — so that sentence is what a screen reader announces as the dialog's name and as its only heading.

The widget reads its surveys from the public client API, which deliberately substitutes that fixed placeholder for every survey name so names aren't exposed over an unauthenticated endpoint (ENG-808). The dialog name and the heading added for ENG-2334 are both taken from `survey.name`, and neither accounted for the substitution. Link surveys are unaffected — their name comes from the server component, never from this endpoint.

- `getSurveyDisplayName` (new, in `packages/surveys/src/lib/survey-page.ts`) returns `undefined` for the placeholder — and for a missing or whitespace-only name — so the renderer treats it as "this survey has no name" and falls back to the generic `Survey Dialog` label it already uses for a survey rendered without one (previews).
- `RenderSurvey` passes `survey.name` through that helper. It's the single choke point: `surveyName` reaches the dialog's `aria-label`, the `sr-only` `h1`, the `role="form"` landmark and `aria-describedby` from this one prop.
- The placeholder string becomes a shared constant so the API side and the widget cannot drift apart. It lives in a new **dependency-free** `packages/types/js-constants.ts` rather than in `types/js.ts`: a *value* import of `types/js` drags that module's zod schema graph into the widget bundle — measured at **+94 kB** on the UMD build every app-survey respondent downloads. The leaf module costs 140 bytes.

## Breaking changes

- [ ] This PR contains breaking changes

None. The public client API's response is byte-identical — the placeholder is now referenced through a constant instead of an inline literal. Nothing changes for API/SDK consumers or self-hosters; the only behaviour change is what assistive tech reads out in the rendered widget.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The placeholder is not treated as a survey name (and a real name, including one that merely contains the placeholder, still is) | unit (mutation) | 4 cases in `packages/surveys/src/lib/survey-page.test.ts`. The code under test is new, so mutation is the honest strength: reverting the guard at `packages/surveys/src/lib/survey-page.ts:65` to `if (!name) return undefined;` turns *"drops the public client API's placeholder"* red — `pnpm --filter @formbricks/surveys test` → **1 failed / 724 passed**; restored → **725 passed (29 files)**. |
| End-to-end, against the real public client API: the widget's dialog is not named with the placeholder | e2e | Two assertions added to the **existing** widget journey in `apps/web/playwright/js.spec.ts` (no new spec): the dialog's `aria-label` is `Survey Dialog`, and no node in the widget carries the placeholder text. Red on main by construction — that's exactly the string main renders. Not executed locally, see Open gaps. |
| The public client API still substitutes the placeholder — the security behaviour ENG-808 added is untouched | unit (guard) | `apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.test.ts` now asserts against the shared constant rather than a copied literal, so the two can't drift. 18/18 pass. |
| The widget bundle does not grow | manual | Built `@formbricks/surveys` on each revision: baseline UMD **971,447 B** → this PR **971,587 B** (**+140 B**). An earlier revision importing the constant from `@formbricks/types/js` measured **1,065,940 B** (**+94 kB, +9.7%**) — that measurement is why the constant lives in a leaf module. |

Full gates on the final tree: `pnpm typecheck` 27/27, `pnpm lint` 0 errors, `pnpm format:check` clean, `pnpm test` 26/26 tasks (8,529 web + 725 surveys).

**Open gaps**

- **Playwright was not run.** This environment has no Docker daemon, so Postgres/Redis can't boot and the suite can't start. The two new `js.spec.ts` assertions are therefore unverified locally and rest on the PR's Playwright job — worth a look at that job's result before merging, since it's the only check that exercises the real API → widget → dialog path this bug lives on.
- **The `sr-only` `h1` is now absent on widget-delivered surveys**, because there is no name to put in it. That is the fallback the ticket asks for and matches the documented preview behaviour, but it means WCAG 2.4.6's top-level heading is not present on that delivery path — the placeholder was never a heading worth having, so this is strictly better than before, not complete. Restoring a real heading there requires an API-side decision about exposing survey names to the public client endpoint (the deliberate ENG-808 trade-off), which is out of scope for a QA fix.
- Screen-reader verification was done by reading the accessibility attributes, not by listening with an actual screen reader.

**Risks**

- Inline (non-modal) app surveys delivered by the widget lose their `role="form"` landmark, since the container only declares the role once there is a name to give it. That's the pre-existing, deliberate behaviour for an unnamed survey — an unnamed form landmark is noise in a landmark list — but it is a change on that path, and it goes away on its own if survey names ever become available to the widget.
- `getSurveyDisplayName` matches the placeholder **exactly**; if the API-side string is ever edited without updating the shared constant, the placeholder starts leaking again. That's the failure mode the shared constant exists to prevent, and both call sites now import it.