### PR TITLE
feat(embedded-data): URL params as typed ingestion — allow-list from the rows [ENG-1843]

### DIFF
--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -13,7 +13,10 @@ import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { CustomScriptsInjector } from "@/modules/survey/link/components/custom-scripts-injector";
 import { LinkSurveyWrapper } from "@/modules/survey/link/components/link-survey-wrapper";
 import { OfflineAlert } from "@/modules/survey/link/components/offline-alert";
-import { getHiddenFieldsFromSearchParams } from "@/modules/survey/link/lib/hidden-fields";
+import {
+  getHiddenFieldsFromSearchParams,
+  warnOnMissingIngestRows,
+} from "@/modules/survey/link/lib/hidden-fields";
 import { getPrefillValue } from "@/modules/survey/link/lib/prefill";
 import { getUserIdFromSearchParams } from "@/modules/survey/link/lib/user-id";
 import { getSurveyLanguageTag, getWebAppLocale, isRTLLanguage } from "@/modules/survey/link/lib/utils";
@@ -132,6 +135,7 @@ export const SurveyClientWrapper = ({
   // diagnostic while duplicating a rule that already has one home.
   const ingestedStorageKeys = getIngestedStorageKeys(survey);
   const hiddenFieldsRecord = useMemo(() => {
+    warnOnMissingIngestRows(ingestedStorageKeys, survey.hiddenFields.fieldIds ?? []);
     return getHiddenFieldsFromSearchParams(ingestedStorageKeys, searchParams);
     // eslint-disable-next-line react-hooks/use-memo -- migration ENG-1677
   }, [searchParams, JSON.stringify(ingestedStorageKeys)]);

--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Workspace } from "@formbricks/database/prisma-browser";
+import { getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { TResponseData } from "@formbricks/types/responses";
 import { TSurvey, TSurveyStyling } from "@formbricks/types/surveys/types";
 import { TWorkspaceStyling } from "@formbricks/types/workspace";
@@ -123,11 +124,17 @@ export const SurveyClientWrapper = ({
     }
   }, []);
 
-  // Extract hidden fields from URL parameters
+  // Extract ingestible Embedded Data from URL parameters.
+  //
+  // The allow-list is the survey's linked `ingested` rows, not the legacy `hiddenFields.fieldIds`
+  // column (ENG-1843). `locked` fields are deliberately included: the renderer's ingest contract
+  // drops their incoming values and logs why, and filtering them out here would silence that
+  // diagnostic while duplicating a rule that already has one home.
+  const ingestedStorageKeys = getIngestedStorageKeys(survey);
   const hiddenFieldsRecord = useMemo(() => {
-    return getHiddenFieldsFromSearchParams(survey.hiddenFields.fieldIds || [], searchParams);
+    return getHiddenFieldsFromSearchParams(ingestedStorageKeys, searchParams);
     // eslint-disable-next-line react-hooks/use-memo -- migration ENG-1677
-  }, [searchParams, JSON.stringify(survey.hiddenFields.fieldIds || [])]);
+  }, [searchParams, JSON.stringify(ingestedStorageKeys)]);
 
   // Include verified email in hidden fields if available
   const getVerifiedEmail = useMemo<Record<string, string> | null>(() => {

--- a/apps/web/modules/survey/link/lib/hidden-fields.test.ts
+++ b/apps/web/modules/survey/link/lib/hidden-fields.test.ts
@@ -64,11 +64,28 @@ describe("getHiddenFieldsFromSearchParams", () => {
     let warnSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
+      // This suite runs in the node environment (no window); the warns are browser-gated so they
+      // stay out of the operator's SSR log, so the browser is simulated here.
+      vi.stubGlobal("window", {});
       warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     });
 
     afterEach(() => {
       warnSpy.mockRestore();
+      vi.unstubAllGlobals();
+    });
+
+    test("stays quiet during SSR — the refusal must not land in the operator's server log", () => {
+      vi.unstubAllGlobals();
+
+      const record = getHiddenFieldsFromSearchParams(
+        ["Lang", "customerref"],
+        new URLSearchParams("lang=de&customerref=abc")
+      );
+
+      // Capture behavior is identical on the server pass; only the console line is gated.
+      expect(record).toEqual({ customerref: "abc" });
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     test("explains the refusal, naming the declared field and the param spelling that arrived", () => {
@@ -175,11 +192,21 @@ describe("warnOnMissingIngestRows", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    vi.stubGlobal("window", {});
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     warnSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  test("stays quiet during SSR", () => {
+    vi.unstubAllGlobals();
+
+    warnOnMissingIngestRows([], ["plan"]);
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("warns when the legacy column declares fields but no ingested rows exist — the dropped-join canary", () => {

--- a/apps/web/modules/survey/link/lib/hidden-fields.test.ts
+++ b/apps/web/modules/survey/link/lib/hidden-fields.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { FORBIDDEN_IDS, RESERVED_DECLARED_FIELD_NAMES } from "@formbricks/types/surveys/validation";
 import { getHiddenFieldsFromSearchParams } from "./hidden-fields";
 
@@ -59,6 +59,42 @@ describe("getHiddenFieldsFromSearchParams", () => {
   });
 
   describe("reserved params are never captured", () => {
+    // Stubbed for the whole block: the set-wide loops below each hit the refusal branch dozens of
+    // times, and the point of those tests is the empty record, not the console.
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test("explains the refusal, naming the declared field and the param spelling that arrived", () => {
+      // The two spellings differ on purpose: a survey declaring `Lang` is matched by `?lang=`, and an
+      // author grepping their own survey for the name needs to see the one they typed.
+      const params = new URLSearchParams("lang=de");
+
+      expect(getHiddenFieldsFromSearchParams(["Lang"], params)).toEqual({});
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('"Lang"');
+      expect(warnSpy.mock.calls[0][0]).toContain('"?lang="');
+      expect(warnSpy.mock.calls[0][0]).toContain("can never fill it");
+    });
+
+    test("stays quiet when the reserved param is absent, so an unused declaration is not nagged about", () => {
+      expect(getHiddenFieldsFromSearchParams(["lang"], new URLSearchParams("customerref=abc"))).toEqual({});
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test("stays quiet for a field it fills normally", () => {
+      expect(
+        getHiddenFieldsFromSearchParams(["customerref"], new URLSearchParams("customerref=abc"))
+      ).toEqual({ customerref: "abc" });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
     // `ZSurveyHiddenFields` rejects reserved names case-sensitively, so `Verify` and `UserId` are
     // names an already-stored survey can hold (the editor now refuses to create them).
     // Case-insensitive matching must not let them harvest the real reserved params - `?verify=<jwt>`

--- a/apps/web/modules/survey/link/lib/hidden-fields.test.ts
+++ b/apps/web/modules/survey/link/lib/hidden-fields.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { FORBIDDEN_IDS, RESERVED_DECLARED_FIELD_NAMES } from "@formbricks/types/surveys/validation";
-import { getHiddenFieldsFromSearchParams } from "./hidden-fields";
+import { getHiddenFieldsFromSearchParams, warnOnMissingIngestRows } from "./hidden-fields";
 
 describe("getHiddenFieldsFromSearchParams", () => {
   test("reads params that match a declared field exactly", () => {
@@ -168,5 +168,36 @@ describe("getHiddenFieldsFromSearchParams", () => {
         CustomerRef: "abc",
       });
     });
+  });
+});
+
+describe("warnOnMissingIngestRows", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("warns when the legacy column declares fields but no ingested rows exist — the dropped-join canary", () => {
+    warnOnMissingIngestRows([], ["plan", "language"]);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("no ingested Embedded Data rows");
+  });
+
+  test("stays quiet on a healthy survey (rows present)", () => {
+    warnOnMissingIngestRows(["plan"], ["plan"]);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("stays quiet on a survey that declares nothing at all", () => {
+    warnOnMissingIngestRows([], []);
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/modules/survey/link/lib/hidden-fields.ts
+++ b/apps/web/modules/survey/link/lib/hidden-fields.ts
@@ -4,6 +4,14 @@ import { RESERVED_DECLARED_FIELD_NAMES } from "@formbricks/types/surveys/validat
 type TSearchParamsWithKeys = Pick<URLSearchParams, "keys" | "get">;
 
 /**
+ * Both diagnostics below are for the survey author's browser console. This module also runs during
+ * SSR (the client component is server-rendered), where the same lines would land in the operator's
+ * Next log once per respondent — an audience that can do nothing with them. Capture behavior itself
+ * must stay identical on both passes; only the console output is browser-gated.
+ */
+const isBrowser = (): boolean => globalThis.window !== undefined;
+
+/**
  * Reads the survey's declared hidden fields out of the URL, tolerating case drift in the query
  * string: a survey declaring `CustomerRef` is filled by `?customerref=x` as well as `?CustomerRef=x`.
  *
@@ -40,9 +48,11 @@ export const getHiddenFieldsFromSearchParams = (
       // param, e.g. a grandfathered `source` field reached by an ordinary `?source=newsletter`.
       // Accepted: the console is the only channel that reaches someone who can fix the survey, and
       // the alternative is silence.
-      console.warn(
-        `Formbricks: "${declaredFieldId}" is reserved by the link survey URL contract, so "?${matchedParamKey}=" can never fill it. Rename the field to collect this value.`
-      );
+      if (isBrowser()) {
+        console.warn(
+          `Formbricks: "${declaredFieldId}" is reserved by the link survey URL contract, so "?${matchedParamKey}=" can never fill it. Rename the field to collect this value.`
+        );
+      }
       continue;
     }
 
@@ -66,7 +76,7 @@ export const getHiddenFieldsFromSearchParams = (
  * capturing with no output anywhere.
  */
 export const warnOnMissingIngestRows = (ingestedStorageKeys: string[], legacyFieldIds: string[]): void => {
-  if (ingestedStorageKeys.length === 0 && legacyFieldIds.length > 0) {
+  if (isBrowser() && ingestedStorageKeys.length === 0 && legacyFieldIds.length > 0) {
     console.warn(
       "Formbricks: this survey declares hidden fields but has no ingested Embedded Data rows, so no URL parameter can fill them."
     );

--- a/apps/web/modules/survey/link/lib/hidden-fields.ts
+++ b/apps/web/modules/survey/link/lib/hidden-fields.ts
@@ -35,8 +35,11 @@ export const getHiddenFieldsFromSearchParams = (
       // `preview`, `startAt`, `skipPrefilled`, `offlineSupport`, `suToken`) load fine as declared
       // field names in any casing - `lang` in particular is a name someone would plausibly pick.
       // Such a field is permanently empty from the URL, and without this line its owner has nothing
-      // to go on. Only reachable when the survey declares the name AND the param is present, so it
-      // is per-author actionable rather than per-respondent noise.
+      // to go on. Rare across surveys (needs the survey to declare the name AND the param to
+      // arrive) - but on an affected survey it does print for every visitor whose URL carries the
+      // param, e.g. a grandfathered `source` field reached by an ordinary `?source=newsletter`.
+      // Accepted: the console is the only channel that reaches someone who can fix the survey, and
+      // the alternative is silence.
       console.warn(
         `Formbricks: "${declaredFieldId}" is reserved by the link survey URL contract, so "?${matchedParamKey}=" can never fill it. Rename the field to collect this value.`
       );
@@ -48,4 +51,24 @@ export const getHiddenFieldsFromSearchParams = (
   }
 
   return fieldsRecord;
+};
+
+/**
+ * The client-side canary for a survey whose legacy hidden-field column is populated while its
+ * Embedded Data rows are missing — a dropped `embeddedDataLinks` join, or column/row drift. No
+ * production write path creates that state (ENG-2412 reconciles both in one transaction), which is
+ * exactly why it deserves a loud line when it appears anyway.
+ *
+ * This is the ONLY signal on the link path. ENG-1845's server-side missing-rows warning cannot fire
+ * here: the renderer submits the contract-filtered record, so with zero ingested rows the unknown
+ * keys never reach the server — and with an empty allow-list nothing reaches the client contract
+ * either, so its per-key console lines are silent too. Without this, such a survey simply stops
+ * capturing with no output anywhere.
+ */
+export const warnOnMissingIngestRows = (ingestedStorageKeys: string[], legacyFieldIds: string[]): void => {
+  if (ingestedStorageKeys.length === 0 && legacyFieldIds.length > 0) {
+    console.warn(
+      "Formbricks: this survey declares hidden fields but has no ingested Embedded Data rows, so no URL parameter can fill them."
+    );
+  }
 };

--- a/apps/web/modules/survey/link/lib/hidden-fields.ts
+++ b/apps/web/modules/survey/link/lib/hidden-fields.ts
@@ -29,7 +29,19 @@ export const getHiddenFieldsFromSearchParams = (
     // `?verify=<jwt>`, the email-verification credential read by `verify-email-gate.ts`, which would
     // then be written to the response and every export.
     // Checked on the resolved param key so no casing on either side gets through.
-    if (RESERVED_DECLARED_FIELD_NAMES.has(matchedParamKey.toLowerCase())) continue;
+    if (RESERVED_DECLARED_FIELD_NAMES.has(matchedParamKey.toLowerCase())) {
+      // Says so out loud rather than dropping in silence. `ZSurveyHiddenFields` only guards
+      // `FORBIDDEN_IDS`, and case-sensitively, so the six link-survey system params (`lang`,
+      // `preview`, `startAt`, `skipPrefilled`, `offlineSupport`, `suToken`) load fine as declared
+      // field names in any casing - `lang` in particular is a name someone would plausibly pick.
+      // Such a field is permanently empty from the URL, and without this line its owner has nothing
+      // to go on. Only reachable when the survey declares the name AND the param is present, so it
+      // is per-author actionable rather than per-respondent noise.
+      console.warn(
+        `Formbricks: "${declaredFieldId}" is reserved by the link survey URL contract, so "?${matchedParamKey}=" can never fill it. Rename the field to collect this value.`
+      );
+      continue;
+    }
 
     const answer = searchParams.get(matchedParamKey);
     if (answer) fieldsRecord[declaredFieldId] = answer;

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -29,7 +29,6 @@ import { TUploadFileConfig } from "@formbricks/types/storage";
 import { getLinkSurveyCardMaxWidth } from "@formbricks/types/styling";
 import { TSurveyBlock, TSurveyBlockLogic } from "@formbricks/types/surveys/blocks";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
-import { RESERVED_DECLARED_FIELD_NAMES } from "@formbricks/types/surveys/validation";
 import { BlockConditional } from "@/components/general/block-conditional";
 import { EndingCard } from "@/components/general/ending-card";
 import { ErrorComponent } from "@/components/general/error-component";
@@ -109,6 +108,18 @@ const INGEST_FLAG_MESSAGES: Record<TIngestFlagReason, string> = {
 };
 
 /**
+ * Keys the **product itself** puts into the incoming bag, so warning about them would fire once per
+ * respondent and tell a developer nothing. The link survey wrapper adds `verifiedEmail` on every load
+ * of an email-verified survey, and `FORBIDDEN_IDS` guarantees no survey can declare it — so it is
+ * always dropped as an unknown key. The server writes the real value from the token regardless.
+ *
+ * Deliberately **not** the whole of `RESERVED_DECLARED_FIELD_NAMES` (ENG-1843). That muted sixteen
+ * further names, every one of which a host can genuinely send by mistake — and those are exactly the
+ * ones worth reporting. Add to this set only when the product starts injecting another key itself.
+ */
+const SELF_INJECTED_KEYS = new Set(["verifiedemail"]);
+
+/**
  * Surfaces the ingest contract's verdicts, so a developer wiring up Embedded Data sees why a value
  * did not show up instead of guessing. Warnings, never errors: nothing here blocks a response.
  *
@@ -117,12 +128,7 @@ const INGEST_FLAG_MESSAGES: Record<TIngestFlagReason, string> = {
  */
 const logIngestResult = ({ dropped, flags }: TIngestResult): void => {
   for (const { key, reason } of dropped) {
-    // A reserved name is never actionable: `FORBIDDEN_IDS` means no survey *can* declare it, and the
-    // product injects some of these itself — a link survey with email verification puts
-    // `verifiedEmail` in this bag on every load, and the server writes it from the token regardless.
-    // Warning about it once per respondent is first-party noise that teaches developers to tune the
-    // channel out, which costs us the warnings that do matter.
-    if (RESERVED_DECLARED_FIELD_NAMES.has(key.toLowerCase())) continue;
+    if (SELF_INJECTED_KEYS.has(key.toLowerCase())) continue;
     console.warn(`Formbricks: "${key}" ${INGEST_DROP_MESSAGES[reason]}, so the value was ignored.`);
   }
   for (const { key, reason } of flags) {

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -1,11 +1,6 @@
 import { type JSX } from "preact";
 import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
-import {
-  type TIngestDropReason,
-  type TIngestFlagReason,
-  type TIngestResult,
-  applyIngestContract,
-} from "@formbricks/types/embedded-data-ingest";
+import { applyIngestContract } from "@formbricks/types/embedded-data-ingest";
 import {
   RESERVED_FIELD_CATALOG,
   coerceToEmbeddedDataType,
@@ -44,6 +39,7 @@ import { CardlessSurveyLayout } from "@/components/wrappers/cardless-survey-layo
 import { StackedCardsContainer } from "@/components/wrappers/stacked-cards-container";
 import { ApiClient } from "@/lib/api-client";
 import { type TWebSurveyMeta, createWebSurveyMetaSnapshot } from "@/lib/browser-context";
+import { INGEST_DROP_MESSAGES, logIngestResult } from "@/lib/ingest-logging";
 import { evaluateLogic, performActions } from "@/lib/logic";
 import {
   type SerializedSurveyState,
@@ -87,54 +83,6 @@ interface VariableStackEntry {
   questionId: string;
   variables: TResponseVariables;
 }
-
-/**
- * What the renderer says about each verdict. Phrased as what happened to the *incoming value*, never
- * as a claim about the response: a host surface can legitimately hand this component a key the survey
- * does not declare — the link page passes the verified email address alongside the URL params — and
- * the server writes that one itself, so "ignored here" is the honest report and "not stored" would
- * not be.
- */
-const INGEST_DROP_MESSAGES: Record<TIngestDropReason, string> = {
-  unknown_key: "is not an ingested Embedded Data field on this survey",
-  locked_field: "is locked and ignores values set from outside",
-  unsupported_value: "arrived as a value no Embedded Data field can hold",
-  element_id_collision: "is a question's id, so that question's answer owns the key",
-};
-
-const INGEST_FLAG_MESSAGES: Record<TIngestFlagReason, string> = {
-  coercion_failed: "did not match its declared type and was kept as text",
-  truncated: "was longer than the 16 KB limit and was truncated",
-};
-
-/**
- * Keys the **product itself** puts into the incoming bag, so warning about them would fire once per
- * respondent and tell a developer nothing. The link survey wrapper adds `verifiedEmail` on every load
- * of an email-verified survey, and `FORBIDDEN_IDS` guarantees no survey can declare it — so it is
- * always dropped as an unknown key. The server writes the real value from the token regardless.
- *
- * Deliberately **not** the whole of `RESERVED_DECLARED_FIELD_NAMES` (ENG-1843). That muted sixteen
- * further names, every one of which a host can genuinely send by mistake — and those are exactly the
- * ones worth reporting. Add to this set only when the product starts injecting another key itself.
- */
-const SELF_INJECTED_KEYS = new Set(["verifiedemail"]);
-
-/**
- * Surfaces the ingest contract's verdicts, so a developer wiring up Embedded Data sees why a value
- * did not show up instead of guessing. Warnings, never errors: nothing here blocks a response.
- *
- * Advisory only. The stored flags are the server's, recomputed on ingest from the same contract,
- * because a client-sent flag list could claim there was nothing to report.
- */
-const logIngestResult = ({ dropped, flags }: TIngestResult): void => {
-  for (const { key, reason } of dropped) {
-    if (SELF_INJECTED_KEYS.has(key.toLowerCase())) continue;
-    console.warn(`Formbricks: "${key}" ${INGEST_DROP_MESSAGES[reason]}, so the value was ignored.`);
-  }
-  for (const { key, reason } of flags) {
-    console.warn(`Formbricks: the value for "${key}" ${INGEST_FLAG_MESSAGES[reason]}.`);
-  }
-};
 
 export function Survey({
   appUrl,

--- a/packages/surveys/src/lib/ingest-logging.test.ts
+++ b/packages/surveys/src/lib/ingest-logging.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { RESERVED_DECLARED_FIELD_NAMES } from "@formbricks/types/surveys/validation";
+import { logIngestResult } from "./ingest-logging";
+
+describe("logIngestResult", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("mutes verifiedEmail in any casing — the one key the product injects itself", () => {
+    logIngestResult({
+      data: {},
+      dropped: [
+        { key: "verifiedEmail", reason: "unknown_key" },
+        { key: "verifiedemail", reason: "unknown_key" },
+        { key: "VERIFIEDEMAIL", reason: "unknown_key" },
+      ],
+      flags: [],
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The narrowing this pins (ENG-1843): the mute used to cover the whole of
+   * RESERVED_DECLARED_FIELD_NAMES, silencing sixteen names a host can genuinely send by mistake.
+   * Iterating the shared set (minus the one self-injected key) means re-widening the mute to it —
+   * the exact regression — goes red here without this test naming any list literal of its own.
+   */
+  test("every other reserved name warns — a host sending one by mistake must see why it vanished", () => {
+    const hostMistakableNames = [...RESERVED_DECLARED_FIELD_NAMES].filter((name) => name !== "verifiedemail");
+    expect(hostMistakableNames.length).toBeGreaterThan(0);
+
+    logIngestResult({
+      data: {},
+      dropped: hostMistakableNames.map((key) => ({ key, reason: "unknown_key" as const })),
+      flags: [],
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(hostMistakableNames.length);
+    expect(warnSpy.mock.calls[0][0]).toContain("is not an ingested Embedded Data field");
+  });
+
+  test("names the drop reason for ordinary keys", () => {
+    logIngestResult({
+      data: {},
+      dropped: [{ key: "plan", reason: "locked_field" }],
+      flags: [],
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('"plan"');
+    expect(warnSpy.mock.calls[0][0]).toContain("locked");
+  });
+
+  test("flags always warn — even on a self-injected key, a flagged value is actionable", () => {
+    logIngestResult({
+      data: {},
+      dropped: [],
+      flags: [{ key: "verifiedEmail", reason: "truncated" }],
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("truncated");
+  });
+});

--- a/packages/surveys/src/lib/ingest-logging.ts
+++ b/packages/surveys/src/lib/ingest-logging.ts
@@ -1,0 +1,55 @@
+import {
+  type TIngestDropReason,
+  type TIngestFlagReason,
+  type TIngestResult,
+} from "@formbricks/types/embedded-data-ingest";
+
+/**
+ * What the renderer says about each verdict. Phrased as what happened to the *incoming value*, never
+ * as a claim about the response: a host surface can legitimately hand the renderer a key the survey
+ * does not declare — the link page passes the verified email address alongside the URL params — and
+ * the server writes that one itself, so "ignored here" is the honest report and "not stored" would
+ * not be.
+ */
+export const INGEST_DROP_MESSAGES: Record<TIngestDropReason, string> = {
+  unknown_key: "is not an ingested Embedded Data field on this survey",
+  locked_field: "is locked and ignores values set from outside",
+  unsupported_value: "arrived as a value no Embedded Data field can hold",
+  element_id_collision: "is a question's id, so that question's answer owns the key",
+};
+
+const INGEST_FLAG_MESSAGES: Record<TIngestFlagReason, string> = {
+  coercion_failed: "did not match its declared type and was kept as text",
+  truncated: "was longer than the 16 KB limit and was truncated",
+};
+
+/**
+ * Keys the **product itself** puts into the incoming bag, so warning about them would fire once per
+ * respondent and tell a developer nothing. The link survey wrapper adds `verifiedEmail` on every load
+ * of an email-verified survey, and `FORBIDDEN_IDS` guarantees no survey can declare it — so it is
+ * always dropped as an unknown key. The server writes the real value from the token regardless.
+ *
+ * Deliberately **not** the whole of `RESERVED_DECLARED_FIELD_NAMES` (ENG-1843). That muted sixteen
+ * further names, every one of which a host can genuinely send by mistake — and those are exactly the
+ * ones worth reporting. Add to this set only when the product starts injecting another key itself.
+ * A `.ts` module rather than a constant inside the component, so this split is unit-testable and
+ * re-widening the mute goes red instead of shipping silently.
+ */
+const SELF_INJECTED_KEYS = new Set(["verifiedemail"]);
+
+/**
+ * Surfaces the ingest contract's verdicts, so a developer wiring up Embedded Data sees why a value
+ * did not show up instead of guessing. Warnings, never errors: nothing here blocks a response.
+ *
+ * Advisory only. The stored flags are the server's, recomputed on ingest from the same contract,
+ * because a client-sent flag list could claim there was nothing to report.
+ */
+export const logIngestResult = ({ dropped, flags }: TIngestResult): void => {
+  for (const { key, reason } of dropped) {
+    if (SELF_INJECTED_KEYS.has(key.toLowerCase())) continue;
+    console.warn(`Formbricks: "${key}" ${INGEST_DROP_MESSAGES[reason]}, so the value was ignored.`);
+  }
+  for (const { key, reason } of flags) {
+    console.warn(`Formbricks: the value for "${key}" ${INGEST_FLAG_MESSAGES[reason]}.`);
+  }
+};


### PR DESCRIPTION
## What & why

ENG-1843 formalises what hidden fields already do on link surveys: a declared ingested field takes its value from a URL query param. **Most of the ticket already shipped** — link surveys render through the same renderer that ENG-1845 (#8935) wired the ingest contract into, so typing, coercion, `locked`, collision protection and truncation all apply today. What was left is the allow-list source, and two diagnostics found while wiring it.

**1. The allow-list is now the Embedded Data rows, not the legacy column.** `survey-client-wrapper.tsx` fed `getHiddenFieldsFromSearchParams` from `survey.hiddenFields.fieldIds`; it now feeds it `getIngestedStorageKeys(survey)` — the same rows every other reader resolves against since ENG-2412. On any reachable survey state the two lists are identical (every write path reconciles rows and columns in one transaction), so stored outcomes don't change; what changes is that the ingest path stops depending on a column that only agrees with the rows by convention. This removes the last ingest-path reader of the legacy column (a prerequisite for ENG-2404). `locked` fields stay in the list on purpose: the renderer's contract drops their values *and logs why* — filtering here would silence that diagnostic.

**2. The reserved-param skip now says so.** `getHiddenFieldsFromSearchParams` dropped reserved params (`lang`, `preview`, `startAt`, `suToken`, …) with a bare `continue`. `ZSurveyHiddenFields` only guards `FORBIDDEN_IDS` (case-sensitively), so a stored survey can legitimately declare `lang` — and its owner got zero feedback on why `?lang=de` never fills it. Now the console explains it, naming both the declared spelling and the param that arrived. Only fires when the survey declares the name AND the param is present, so it is per-author actionable, not per-respondent noise.

**3. The renderer's warning suppression is narrowed from 17 names to 1.** ENG-1845 muted the whole of `RESERVED_DECLARED_FIELD_NAMES` in `logIngestResult` to silence `verifiedEmail` (which the product itself injects on every email-verified link survey load). That muted sixteen further names a host can genuinely send by mistake — exactly the ones worth reporting. The suppression is now a named `SELF_INJECTED_KEYS` set containing only `verifiedEmail`.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1843/url-params-as-typed-ingestion-link-surveys

## How this was tested

- `pnpm test` ✅ — 25/25 tasks, apps/web 599 files / 7797 tests, `@formbricks/surveys` 697
- `turbo run typecheck` ✅ 10/10 (`@formbricks/web`, `@formbricks/surveys`, `@formbricks/types`) · eslint on every changed file ✅ (the two pre-existing `react-hooks` warnings in `survey-client-wrapper.tsx` are unchanged — verified against the base revision) · prettier ✅
- Tests added (second commit, from the review round): `warnOnMissingIngestRows` — warns on the legacy-column-populated/rows-absent state, quiet on a healthy survey and on one declaring nothing.
- Tests added: the reserved-name warning (message names the declared spelling and the arrived param; checked to **fail with the fix removed**), quiet when the param is absent, quiet on a normal fill. The existing set-wide refusal loops now stub `console.warn`.
- Not re-tested manually: the URL fill path itself is covered by the existing e2e — `survey-reserved-fields.spec.ts` builds a survey with rows via prisma **and** the legacy column, opens `?url=…` and asserts the fill; it exercises exactly the swapped code path.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Link survey with a hidden field `plan`, publish → open `/s/<surveyId>?plan=gold`, submit → response shows `plan = gold` (unchanged behavior).
- [ ] Same survey, `?rogue=x` → value never stored, and **no console output** — an undeclared param is never read on the link path (only the declared ids are consulted), so there is nothing to drop. The SDK step below is where the console explains drops.
- [ ] Survey that declares a field named `lang` (must be created via API/DB — the editor refuses the name): open `/s/<surveyId>?lang=de` → the field stays empty **and the console now shows** `Formbricks: "lang" is reserved by the link survey URL contract, so "?lang=" can never fill it…`. Before this change: silently empty.
- [ ] Divergent-state canary (needs DB access): on a survey with hidden fields, delete its `SurveyEmbeddedData` rows but keep `hiddenFields.fieldIds`, load the link → console shows `Formbricks: this survey declares hidden fields but has no ingested Embedded Data rows…`. Restore the rows afterwards (or use a throwaway survey — saving it in the editor rewrites the rows from the empty column).
- [ ] Email-verified link survey: verify and load → **no** console warning about `verifiedEmail` (the one suppression that must survive).
- [ ] App survey via SDK: `formbricks.track("evt", { hiddenFields: { userId: "x" } })` → console now warns the key was ignored (previously muted).

**Preconditions / test data**

- A published link survey with at least one ingested Embedded Data field; API access (or DB) to declare a reserved-named field, since the editor blocks creating one.
- The `lang` step needs a survey in the grandfathered state: rows + `hiddenFields.fieldIds` both carrying the name.

**Risks & regressions**

- **A survey whose rows are missing ingests nothing from the URL** (legacy column populated, rows absent — a state no production write path produces since ENG-2412, and in which recall/logic/exports are already broken). The stored outcome is unchanged even there: the renderer's contract already dropped such values as `unknown_key`; only the client-side capture stops. **Correction from review:** the server-side ENG-1845 warning does *not* fire on this path — the renderer submits the contract-filtered record, so with zero rows the keys never reach the server, and with an empty allow-list nothing reaches the client contract either. That state previously at least produced per-key `unknown_key` console lines; this PR would have made it fully silent, so it now adds `warnOnMissingIngestRows` — a client console warning when the legacy column declares fields but no ingested rows exist. That line is the only signal anywhere on the link path.
- The narrowed suppression means hosts sending reserved names via `track({ hiddenFields })` start seeing warnings that were previously muted — intended, but new console output.
- Re-check: verified-email flow (no new console noise), link survey with case-variant param spellings (`?PLAN=gold` filling a field declared `plan`).

**Migrations / env / cutover**

- none

