### PR TITLE
feat(js-core): setEmbeddedData() + clearEmbeddedData() for app surveys [ENG-1844]

### DIFF
--- a/packages/js-core/src/index.ts
+++ b/packages/js-core/src/index.ts
@@ -98,11 +98,12 @@ const setEmbeddedData = (data: TEmbeddedDataInput): void => {
 };
 
 /**
- * Remove one Embedded Data key, or clear the whole bag when called without one — logout, or a hard
- * context switch. Synchronous, no network.
+ * Remove one Embedded Data key, or clear the whole bag when called with no argument — logout, or a
+ * hard context switch. Synchronous, no network. A key that evaluated to `undefined` is a no-op, not
+ * a full clear: the arity is forwarded, so only a literal zero-argument call wipes everything.
  */
-const clearEmbeddedData = (key?: string): void => {
-  EmbeddedDataStore.getInstance().clearEmbeddedData(key);
+const clearEmbeddedData = (...args: [] | [key: string]): void => {
+  EmbeddedDataStore.getInstance().clearEmbeddedData(...args);
 };
 
 /**

--- a/packages/js-core/src/index.ts
+++ b/packages/js-core/src/index.ts
@@ -2,6 +2,7 @@ import { CommandQueue, CommandType } from "@/lib/common/command-queue";
 import * as Setup from "@/lib/common/setup";
 import { getIsDebug } from "@/lib/common/utils";
 import * as Action from "@/lib/survey/action";
+import { EmbeddedDataStore, type TEmbeddedDataInput } from "@/lib/survey/embedded-data";
 import { checkPageUrl } from "@/lib/survey/no-code-action";
 import * as Attribute from "@/lib/user/attribute";
 import * as User from "@/lib/user/user";
@@ -82,6 +83,29 @@ const registerRouteChange = async (): Promise<void> => {
 };
 
 /**
+ * Attach Embedded Data to future responses without tying it to a trigger (ENG-1844). Merges into the
+ * in-memory bag, last write wins per key; `{ key: null }` removes a key and `undefined` values are
+ * skipped. Values land only on the survey's declared *ingested* fields — anything else is dropped
+ * and logged by the renderer, never fatal.
+ *
+ * Synchronous and network-free on purpose (like `setNonce`, unlike the queued methods): calling it
+ * on every SPA route change is free, and routing it through the command queue would silently drop
+ * calls made before `setup()` completes — the exact failure the `formbricks_setup_successful`
+ * readiness event exists to prevent (ENG-1846).
+ */
+const setEmbeddedData = (data: TEmbeddedDataInput): void => {
+  EmbeddedDataStore.getInstance().setEmbeddedData(data);
+};
+
+/**
+ * Remove one Embedded Data key, or clear the whole bag when called without one — logout, or a hard
+ * context switch. Synchronous, no network.
+ */
+const clearEmbeddedData = (key?: string): void => {
+  EmbeddedDataStore.getInstance().clearEmbeddedData(key);
+};
+
+/**
  * Set the CSP nonce for inline styles
  * @param nonce - The CSP nonce value (without 'nonce-' prefix), or undefined to clear
  */
@@ -107,6 +131,8 @@ const formbricks = {
   logout,
   registerRouteChange,
   setNonce,
+  setEmbeddedData,
+  clearEmbeddedData,
 };
 
 // Explicitly assign to globalThis so the wrapper SDK (@formbricks/js) can

--- a/packages/js-core/src/lib/survey/embedded-data.ts
+++ b/packages/js-core/src/lib/survey/embedded-data.ts
@@ -1,3 +1,6 @@
+import { Logger } from "@/lib/common/logger";
+import { type TTrackProperties } from "@/types/survey";
+
 /** What a host page may hand to `setEmbeddedData`. `null` removes the key; `undefined` is a no-op. */
 export type TEmbeddedDataInput = Record<string, string | number | boolean | Date | null | undefined>;
 
@@ -43,6 +46,18 @@ export class EmbeddedDataStore {
    * type arrives as `undefined` and must not clear the value a previous page set.
    */
   public setEmbeddedData(data: TEmbeddedDataInput): void {
+    // Guarded rather than thrown: this is the one SDK entry point outside the command queue's
+    // `wrapThrowsAsync` shield (it is deliberately synchronous), and the GTM pattern this feature
+    // targets can hand over an absent object — `setEmbeddedData(dataLayerObj)` on a page type where
+    // that object is undefined. A broken tag is a worse failure than a skipped write. A primitive is
+    // refused too: `Object.entries("plan")` would spread into junk keys ({0: "p", 1: "l", …}).
+    if (typeof data !== "object" || data === null) {
+      Logger.getInstance().error(
+        `setEmbeddedData: expected an object, got ${data === null ? "null" : typeof data} — nothing was set`
+      );
+      return;
+    }
+
     for (const [key, value] of Object.entries(data)) {
       if (value === undefined) continue;
       if (value === null) {
@@ -53,12 +68,29 @@ export class EmbeddedDataStore {
     }
   }
 
-  /** Remove one key, or everything when called without one (logout / hard context switch). */
-  public clearEmbeddedData(key?: string): void {
-    if (key === undefined) {
+  /**
+   * Remove one key, or everything when called with no argument (logout / hard context switch).
+   *
+   * "No argument" and "an argument that evaluated to `undefined`" are deliberately different:
+   * `setEmbeddedData` treats `undefined` as a no-op because GTM reads values off the data layer
+   * unconditionally, and this method reads from the same dynamic source — so
+   * `clearEmbeddedData(dataLayer.fieldToClear)` with the key absent must skip, not wipe the whole
+   * bag. Only a literal zero-argument call clears everything.
+   */
+  public clearEmbeddedData(...args: [] | [key: string]): void {
+    if (args.length === 0) {
       this.data.clear();
       return;
     }
+
+    const [key] = args;
+    if (typeof key !== "string") {
+      Logger.getInstance().error(
+        "clearEmbeddedData: expected a field name — nothing was cleared (call with no argument to clear everything)"
+      );
+      return;
+    }
+
     this.data.delete(key);
   }
 
@@ -71,3 +103,27 @@ export class EmbeddedDataStore {
     return Object.fromEntries(this.data);
   }
 }
+
+/**
+ * The display-time merge: the ambient bag under the explicit per-trigger `track({ hiddenFields })`
+ * values, so an explicit write wins a shared key.
+ *
+ * Bag keys are folded case-INsensitively against the explicit ones, because the ingest contract
+ * matches declared names case-insensitively with exact-match-first: with a field declared `Plan`, a
+ * bag entry `Plan` and a track entry `plan` would otherwise both survive a plain spread, and the
+ * contract would then pick the bag's exact match — the ambient value silently beating the explicit
+ * one. Folding here keeps "explicit beats ambient" true under every casing.
+ *
+ * The cast at the end: the renderer's contract accepts boolean/Date scalars the narrower legacy
+ * `hiddenFields` type cannot spell, and normalizes them before anything is stored.
+ */
+export const buildDisplayHiddenFields = (
+  explicit?: TTrackProperties["hiddenFields"]
+): TTrackProperties["hiddenFields"] => {
+  const explicitKeysFolded = new Set(Object.keys(explicit ?? {}).map((key) => key.toLowerCase()));
+  const ambient = Object.entries(EmbeddedDataStore.getInstance().getSnapshot()).filter(
+    ([key]) => !explicitKeysFolded.has(key.toLowerCase())
+  );
+
+  return { ...Object.fromEntries(ambient), ...explicit } as TTrackProperties["hiddenFields"];
+};

--- a/packages/js-core/src/lib/survey/embedded-data.ts
+++ b/packages/js-core/src/lib/survey/embedded-data.ts
@@ -50,8 +50,9 @@ export class EmbeddedDataStore {
     // `wrapThrowsAsync` shield (it is deliberately synchronous), and the GTM pattern this feature
     // targets can hand over an absent object — `setEmbeddedData(dataLayerObj)` on a page type where
     // that object is undefined. A broken tag is a worse failure than a skipped write. A primitive is
-    // refused too: `Object.entries("plan")` would spread into junk keys ({0: "p", 1: "l", …}).
-    if (typeof data !== "object" || data === null) {
+    // refused too, and so is an array (`typeof [] === "object"`): either would spread into junk
+    // numeric keys ({0: "p", 1: "l", …} / {0: "a", 1: "b"}) — `ecommerce.items` is the common array case.
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
       Logger.getInstance().error(
         `setEmbeddedData: expected an object, got ${data === null ? "null" : typeof data} — nothing was set`
       );
@@ -120,10 +121,18 @@ export class EmbeddedDataStore {
 export const buildDisplayHiddenFields = (
   explicit?: TTrackProperties["hiddenFields"]
 ): TTrackProperties["hiddenFields"] => {
-  const explicitKeysFolded = new Set(Object.keys(explicit ?? {}).map((key) => key.toLowerCase()));
+  // A key present with value `undefined` is treated as absent, the same promise `setEmbeddedData`
+  // makes: `track("evt", { hiddenFields: { plan: dataLayer.plan } })` on a page where `plan` is
+  // missing must not evict the ambient value — counting the key as "present" would drop the bag's
+  // entry in the fold and then spread `undefined` over it, losing the value entirely.
+  const explicitEntries = Object.entries(explicit ?? {}).filter(([, value]) => value !== undefined);
+  const explicitKeysFolded = new Set(explicitEntries.map(([key]) => key.toLowerCase()));
   const ambient = Object.entries(EmbeddedDataStore.getInstance().getSnapshot()).filter(
     ([key]) => !explicitKeysFolded.has(key.toLowerCase())
   );
 
-  return { ...Object.fromEntries(ambient), ...explicit } as TTrackProperties["hiddenFields"];
+  return {
+    ...Object.fromEntries(ambient),
+    ...Object.fromEntries(explicitEntries),
+  } as TTrackProperties["hiddenFields"];
 };

--- a/packages/js-core/src/lib/survey/embedded-data.ts
+++ b/packages/js-core/src/lib/survey/embedded-data.ts
@@ -1,0 +1,73 @@
+/** What a host page may hand to `setEmbeddedData`. `null` removes the key; `undefined` is a no-op. */
+export type TEmbeddedDataInput = Record<string, string | number | boolean | Date | null | undefined>;
+
+/**
+ * The in-memory Embedded Data bag (ENG-1844): context a host page attaches to future responses
+ * without tying it to a trigger — `formbricks.setEmbeddedData({ pageType: "product" })` from GTM
+ * instead of repeating the same values on every possible `track()` call.
+ *
+ * Lifetime rules, all deliberate:
+ *
+ * - **In-memory, page-load scoped, never persisted.** Not `Config`: that class writes to
+ *   localStorage, and persisting this bag would blur the Embedded Data ↔ contact-attribute boundary
+ *   and create a stale-data / PII-at-rest surface. A full page load starts empty; the host re-pushes
+ *   (which a classic MPA does for free on every load, and an SPA must do on route change).
+ * - **Snapshot at display, then frozen.** `renderWidget` copies the bag into the survey's
+ *   `hiddenFieldsRecord` when the survey is shown; a later `setEmbeddedData` affects the next
+ *   response, never the one on screen.
+ * - **No filtering here.** The SDK is a dumb pipe (ENG-1845/2472): the renderer applies the ingest
+ *   contract — allow-list, coercion, `locked`, size caps — and logs what it refuses, and the server
+ *   re-runs all of it on ingest. Filtering in js-core would ship a second copy of those rules that
+ *   the four mobile SDKs could drift from.
+ * - **No network.** Every method is a synchronous memory write, so calling `setEmbeddedData` on
+ *   every route change is free. Values ride the existing response payload.
+ *
+ * Backed by a `Map` rather than a plain object so a `__proto__` key is stored as data instead of
+ * vanishing into the prototype — the same hole the ingest contract closes on the renderer side.
+ */
+export class EmbeddedDataStore {
+  private static instance: EmbeddedDataStore | undefined;
+  private data = new Map<string, string | number | boolean | Date>();
+
+  static getInstance(): EmbeddedDataStore {
+    EmbeddedDataStore.instance ??= new EmbeddedDataStore();
+    return EmbeddedDataStore.instance;
+  }
+
+  /**
+   * Merge — never replace — so refreshing a volatile field (`pageType`) cannot wipe the stable ones
+   * (`plan`) set at page load. Per key: last write wins; `null` removes; `undefined` does nothing.
+   *
+   * The `undefined` no-op is a documented promise, not an accident: the GTM integration reads keys
+   * off the data layer and passes every field unconditionally, so a key absent on the current page
+   * type arrives as `undefined` and must not clear the value a previous page set.
+   */
+  public setEmbeddedData(data: TEmbeddedDataInput): void {
+    for (const [key, value] of Object.entries(data)) {
+      if (value === undefined) continue;
+      if (value === null) {
+        this.data.delete(key);
+        continue;
+      }
+      this.data.set(key, value);
+    }
+  }
+
+  /** Remove one key, or everything when called without one (logout / hard context switch). */
+  public clearEmbeddedData(key?: string): void {
+    if (key === undefined) {
+      this.data.clear();
+      return;
+    }
+    this.data.delete(key);
+  }
+
+  /**
+   * A detached copy for the display-time snapshot: mutating the bag after a survey rendered must not
+   * reach that survey's response. `Object.fromEntries` defines own properties, so a `__proto__` key
+   * survives the conversion as data.
+   */
+  public getSnapshot(): Record<string, string | number | boolean | Date> {
+    return Object.fromEntries(this.data);
+  }
+}

--- a/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
+++ b/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
+
+describe("EmbeddedDataStore", () => {
+  let store: EmbeddedDataStore;
+
+  beforeEach(() => {
+    store = EmbeddedDataStore.getInstance();
+    store.clearEmbeddedData();
+  });
+
+  test("merges instead of replacing: setting one key keeps the others", () => {
+    store.setEmbeddedData({ plan: "pro", pageType: "product" });
+    store.setEmbeddedData({ pageType: "checkout" });
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro", pageType: "checkout" });
+  });
+
+  test("null drops the key", () => {
+    store.setEmbeddedData({ plan: "pro", pageType: "product" });
+    store.setEmbeddedData({ pageType: null });
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro" });
+  });
+
+  // One keystroke away from `null` and the opposite behavior: the GTM pattern passes every field
+  // unconditionally, so a key absent on the current page type arrives as `undefined` and must not
+  // clear what a previous page set.
+  test("undefined is a no-op — does not set, does not drop", () => {
+    store.setEmbeddedData({ plan: "pro" });
+    store.setEmbeddedData({ plan: undefined, pageType: undefined });
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro" });
+  });
+
+  test("clearEmbeddedData(key) removes one key, clearEmbeddedData() removes everything", () => {
+    store.setEmbeddedData({ plan: "pro", pageType: "product", seats: 4 });
+
+    store.clearEmbeddedData("pageType");
+    expect(store.getSnapshot()).toEqual({ plan: "pro", seats: 4 });
+
+    store.clearEmbeddedData();
+    expect(store.getSnapshot()).toEqual({});
+  });
+
+  test("last write wins per key", () => {
+    store.setEmbeddedData({ plan: "free" });
+    store.setEmbeddedData({ plan: "pro" });
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro" });
+  });
+
+  test("snapshot is a detached copy: later writes do not reach an earlier snapshot", () => {
+    store.setEmbeddedData({ plan: "pro" });
+    const snapshot = store.getSnapshot();
+
+    store.setEmbeddedData({ plan: "enterprise", extra: "later" });
+
+    expect(snapshot).toEqual({ plan: "pro" });
+  });
+
+  test("a __proto__ key is stored as data, not swallowed by the prototype", () => {
+    store.setEmbeddedData({ ["__proto__"]: "value" });
+
+    const snapshot = store.getSnapshot();
+    expect(Object.hasOwn(snapshot, "__proto__")).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- reading the own property back
+    expect((snapshot as any)["__proto__"]).toBe("value");
+    expect(Object.keys({})).toEqual([]);
+  });
+
+  test("never touches localStorage and makes no network calls", () => {
+    // `localStorage` is the vi.fn() stub from vitest.setup.ts; `fetch` does not exist in the node
+    // test environment, so stub one in to prove it stays uncalled.
+    const setItemMock = localStorage.setItem as unknown as ReturnType<typeof vi.fn>;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    store.setEmbeddedData({ plan: "pro", secret: "value" });
+    store.clearEmbeddedData("secret");
+    store.getSnapshot();
+    store.clearEmbeddedData();
+
+    expect(setItemMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    // Deliberately no unstubAllGlobals: that would also strip the window/document/localStorage stubs
+    // vitest.setup.ts installs for the whole file. The fetch stub is inert for the remaining tests.
+  });
+});

--- a/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
+++ b/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
@@ -118,6 +118,13 @@ describe("input guards (never fatal)", () => {
     expect(store.getSnapshot()).toEqual({});
   });
 
+  test('an array is refused too — typeof [] is "object", but it would spread into numeric junk keys', () => {
+    // The common host mistake: forwarding an array-valued data-layer key like `ecommerce.items`.
+    store.setEmbeddedData(["a", "b"] as unknown as Parameters<typeof store.setEmbeddedData>[0]);
+
+    expect(store.getSnapshot()).toEqual({});
+  });
+
   test("clearEmbeddedData(undefined) is a no-op, NOT a full clear — one keystroke from the no-arg overload", () => {
     store.setEmbeddedData({ plan: "pro", pageType: "product" });
 
@@ -146,5 +153,18 @@ describe("buildDisplayHiddenFields", () => {
     EmbeddedDataStore.getInstance().setEmbeddedData({ plan: "pro" });
 
     expect(buildDisplayHiddenFields(undefined)).toEqual({ plan: "pro" });
+  });
+
+  test("an explicit key whose value is undefined does NOT evict the ambient value", () => {
+    // The GTM shape: track("evt", { hiddenFields: { plan: dataLayer.plan } }) on a page where
+    // `plan` is absent. Same promise as setEmbeddedData's undefined no-op — a missing data-layer
+    // key must never cost the bag its value.
+    EmbeddedDataStore.getInstance().setEmbeddedData({ plan: "ambient-pro" });
+
+    expect(
+      buildDisplayHiddenFields({ plan: undefined } as unknown as Parameters<
+        typeof buildDisplayHiddenFields
+      >[0])
+    ).toEqual({ plan: "ambient-pro" });
   });
 });

--- a/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
+++ b/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
+import { EmbeddedDataStore, buildDisplayHiddenFields } from "@/lib/survey/embedded-data";
+
+// The guards log through Logger; mocked so refused inputs don't spray the test output.
+vi.mock("@/lib/common/logger", () => ({
+  Logger: { getInstance: vi.fn(() => ({ error: vi.fn(), debug: vi.fn() })) },
+}));
 
 describe("EmbeddedDataStore", () => {
   let store: EmbeddedDataStore;
@@ -85,5 +90,61 @@ describe("EmbeddedDataStore", () => {
     expect(fetchMock).not.toHaveBeenCalled();
     // Deliberately no unstubAllGlobals: that would also strip the window/document/localStorage stubs
     // vitest.setup.ts installs for the whole file. The fetch stub is inert for the remaining tests.
+  });
+});
+
+describe("input guards (never fatal)", () => {
+  let store: EmbeddedDataStore;
+
+  beforeEach(() => {
+    store = EmbeddedDataStore.getInstance();
+    store.clearEmbeddedData();
+  });
+
+  test("setEmbeddedData(null) and (undefined) do not throw into host code and set nothing", () => {
+    store.setEmbeddedData({ plan: "pro" });
+
+    expect(() => {
+      store.setEmbeddedData(null as unknown as Parameters<typeof store.setEmbeddedData>[0]);
+      store.setEmbeddedData(undefined as unknown as Parameters<typeof store.setEmbeddedData>[0]);
+    }).not.toThrow();
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro" });
+  });
+
+  test("a primitive argument is refused instead of spreading into junk keys", () => {
+    store.setEmbeddedData("plan" as unknown as Parameters<typeof store.setEmbeddedData>[0]);
+
+    expect(store.getSnapshot()).toEqual({});
+  });
+
+  test("clearEmbeddedData(undefined) is a no-op, NOT a full clear — one keystroke from the no-arg overload", () => {
+    store.setEmbeddedData({ plan: "pro", pageType: "product" });
+
+    // The GTM shape: `clearEmbeddedData(dataLayer.fieldToClear)` where the key is absent this page.
+    store.clearEmbeddedData(undefined as unknown as string);
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro", pageType: "product" });
+  });
+});
+
+describe("buildDisplayHiddenFields", () => {
+  beforeEach(() => {
+    EmbeddedDataStore.getInstance().clearEmbeddedData();
+  });
+
+  test("explicit per-trigger values beat the bag across casings — declared-name matching is case-insensitive downstream", () => {
+    EmbeddedDataStore.getInstance().setEmbeddedData({ Plan: "ambient", pageType: "product" });
+
+    expect(buildDisplayHiddenFields({ plan: "explicit" })).toEqual({
+      plan: "explicit",
+      pageType: "product",
+    });
+  });
+
+  test("no explicit values: the bag passes through as-is", () => {
+    EmbeddedDataStore.getInstance().setEmbeddedData({ plan: "pro" });
+
+    expect(buildDisplayHiddenFields(undefined)).toEqual({ plan: "pro" });
   });
 });

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -3,6 +3,7 @@ import { Config } from "@/lib/common/config";
 import { Logger } from "@/lib/common/logger";
 import type * as CommonUtils from "@/lib/common/utils";
 import { filterSurveys, getLanguageCode, shouldDisplayBasedOnPercentage } from "@/lib/common/utils";
+import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
 import { mockSurvey } from "@/lib/survey/tests/__mocks__/widget.mock";
 import * as widget from "@/lib/survey/widget";
 import { type TWorkspaceStateSurvey } from "@/types/config";
@@ -400,6 +401,70 @@ describe("widget-file", () => {
       expect.objectContaining({ hiddenFieldsRecord: hiddenFields })
     );
 
+    vi.useRealTimers();
+  });
+
+  test("merges the Embedded Data bag under the per-trigger hidden fields, snapshotted at display", async () => {
+    // ENG-1844: the ambient bag rides along on every display, an explicit `track({ hiddenFields })`
+    // value wins a shared key, and the record is frozen at render — a later `setEmbeddedData` must
+    // not reach a survey already on screen.
+    mockUpdateQueue.hasPendingWork.mockReturnValue(false);
+
+    const mockConfigValue = {
+      get: vi.fn().mockReturnValue({
+        appUrl: "https://fake.app",
+        workspaceId: "env_123",
+        workspace: {
+          data: {
+            settings: {
+              clickOutsideClose: true,
+              overlay: "none",
+              placement: "bottomRight",
+              inAppSurveyBranding: true,
+            },
+          },
+        },
+        user: {
+          data: {
+            userId: "user_abc",
+            contactId: "contact_abc",
+            displays: [],
+            responses: [],
+            lastDisplayAt: null,
+            language: "en",
+          },
+        },
+      }),
+      update: vi.fn(),
+    };
+
+    getInstanceConfigMock.mockReturnValue(mockConfigValue as unknown as Config);
+    widget.setIsSurveyRunning(false);
+    window.formbricksSurveys = createMockFormbricksSurveys();
+    vi.useFakeTimers();
+
+    const store = EmbeddedDataStore.getInstance();
+    store.clearEmbeddedData();
+    store.setEmbeddedData({ pageType: "product", plan: "from-bag" });
+
+    await widget.triggerSurvey(
+      { ...mockSurvey, delay: 0, displayPercentage: null } as unknown as TWorkspaceStateSurvey,
+      "testAction",
+      { hiddenFields: { plan: "from-track" } }
+    );
+
+    vi.advanceTimersByTime(0);
+
+    // A write after render: must not appear on the record already handed to the renderer.
+    store.setEmbeddedData({ pageType: "changed-later" });
+
+    expect(getFormbricksSurveys().renderSurvey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hiddenFieldsRecord: { pageType: "product", plan: "from-track" },
+      })
+    );
+
+    store.clearEmbeddedData();
     vi.useRealTimers();
   });
 

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -10,6 +10,7 @@ import {
   shouldDisplayBasedOnPercentage,
   surveyHasSegmentFilters,
 } from "@/lib/common/utils";
+import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
 import { UpdateQueue } from "@/lib/user/update-queue";
 import { type TUserState, type TWorkspaceStateSurvey } from "@/types/config";
 import { type TTrackProperties } from "@/types/survey";
@@ -171,7 +172,15 @@ export const renderWidget = async (
       languageCode,
       placement,
       styling: getStyling(settings, survey),
-      hiddenFieldsRecord: hiddenFieldsObject,
+      // The ambient Embedded Data bag (ENG-1844) under the per-trigger `track({ hiddenFields })`
+      // values, so an explicit per-trigger write wins on a shared key. Snapshotted here — inside the
+      // delay timeout, at the moment the survey actually shows — and `getSnapshot` returns a copy, so
+      // a later `setEmbeddedData` affects the next response, never this one. The renderer's ingest
+      // contract accepts boolean/Date scalars the narrower legacy type cannot spell, hence the cast.
+      hiddenFieldsRecord: {
+        ...EmbeddedDataStore.getInstance().getSnapshot(),
+        ...hiddenFieldsObject,
+      } as TTrackProperties["hiddenFields"],
       recaptchaSiteKey,
       isSpamProtectionEnabled,
       getRecaptchaToken,

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -10,7 +10,7 @@ import {
   shouldDisplayBasedOnPercentage,
   surveyHasSegmentFilters,
 } from "@/lib/common/utils";
-import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
+import { buildDisplayHiddenFields } from "@/lib/survey/embedded-data";
 import { UpdateQueue } from "@/lib/user/update-queue";
 import { type TUserState, type TWorkspaceStateSurvey } from "@/types/config";
 import { type TTrackProperties } from "@/types/survey";
@@ -173,14 +173,10 @@ export const renderWidget = async (
       placement,
       styling: getStyling(settings, survey),
       // The ambient Embedded Data bag (ENG-1844) under the per-trigger `track({ hiddenFields })`
-      // values, so an explicit per-trigger write wins on a shared key. Snapshotted here — inside the
-      // delay timeout, at the moment the survey actually shows — and `getSnapshot` returns a copy, so
-      // a later `setEmbeddedData` affects the next response, never this one. The renderer's ingest
-      // contract accepts boolean/Date scalars the narrower legacy type cannot spell, hence the cast.
-      hiddenFieldsRecord: {
-        ...EmbeddedDataStore.getInstance().getSnapshot(),
-        ...hiddenFieldsObject,
-      } as TTrackProperties["hiddenFields"],
+      // values — explicit beats ambient, case-insensitively (see `buildDisplayHiddenFields`).
+      // Built here, inside the delay timeout at the moment the survey actually shows, from a
+      // detached copy: a later `setEmbeddedData` affects the next response, never this one.
+      hiddenFieldsRecord: buildDisplayHiddenFields(hiddenFieldsObject),
       recaptchaSiteKey,
       isSpamProtectionEnabled,
       getRecaptchaToken,

--- a/packages/js-core/src/lib/user/tests/user.test.ts
+++ b/packages/js-core/src/lib/user/tests/user.test.ts
@@ -2,6 +2,7 @@ import { type MockInstance, beforeEach, describe, expect, test, vi } from "vites
 import { Config } from "@/lib/common/config";
 import { Logger } from "@/lib/common/logger";
 import { tearDown } from "@/lib/common/setup";
+import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
 import { UpdateQueue } from "@/lib/user/update-queue";
 import { logout, setUserId } from "@/lib/user/user";
 
@@ -251,6 +252,51 @@ describe("user.ts", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("Logging out and cleaning user state");
       expect(tearDown).toHaveBeenCalled();
       expect(result.ok).toBe(true);
+    });
+
+    test("clears the Embedded Data bag — the previous user's context must not leak (ENG-1844)", () => {
+      const mockLogger = { debug: vi.fn(), error: vi.fn() };
+      getInstanceLoggerMock.mockReturnValue(mockLogger as unknown as Logger);
+
+      const store = EmbeddedDataStore.getInstance();
+      store.setEmbeddedData({ hashed_email: "abc123", pageType: "product" });
+
+      const result = logout();
+
+      expect(result.ok).toBe(true);
+      expect(store.getSnapshot()).toEqual({});
+    });
+  });
+
+  describe("Embedded Data bag on identity switch (ENG-1844)", () => {
+    const mockLogger = { debug: vi.fn(), error: vi.fn() };
+    const mockUpdateQueue = { updateUserId: vi.fn(), processUpdates: vi.fn().mockResolvedValue(undefined) };
+
+    const configWithUser = (userId: string | null): Config =>
+      ({ get: vi.fn().mockReturnValue({ user: { data: { userId } } }) }) as unknown as Config;
+
+    beforeEach(() => {
+      getInstanceLoggerMock.mockReturnValue(mockLogger as unknown as Logger);
+      getInstanceUpdateQueueMock.mockReturnValue(mockUpdateQueue as unknown as UpdateQueue);
+      EmbeddedDataStore.getInstance().clearEmbeddedData();
+    });
+
+    test("switching to a different userId clears the bag", async () => {
+      getInstanceConfigMock.mockReturnValue(configWithUser("user-a"));
+      EmbeddedDataStore.getInstance().setEmbeddedData({ hashed_email: "user-a-hash" });
+
+      await setUserId("user-b");
+
+      expect(EmbeddedDataStore.getInstance().getSnapshot()).toEqual({});
+    });
+
+    test("first-time identification keeps the bag — context pushed before identifying is legitimate", async () => {
+      getInstanceConfigMock.mockReturnValue(configWithUser(null));
+      EmbeddedDataStore.getInstance().setEmbeddedData({ pageType: "product" });
+
+      await setUserId("user-a");
+
+      expect(EmbeddedDataStore.getInstance().getSnapshot()).toEqual({ pageType: "product" });
     });
   });
 });

--- a/packages/js-core/src/lib/user/user.ts
+++ b/packages/js-core/src/lib/user/user.ts
@@ -1,6 +1,7 @@
 import { Config } from "@/lib/common/config";
 import { Logger } from "@/lib/common/logger";
 import { tearDown } from "@/lib/common/setup";
+import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
 import { UpdateQueue } from "@/lib/user/update-queue";
 import { type ApiErrorResponse, type Result, okVoid } from "@/types/error";
 
@@ -32,6 +33,12 @@ export const setUserId = async (userId: string): Promise<Result<void, ApiErrorRe
   if (currentUserId) {
     logger.debug("Different userId is being set, cleaning up previous user state");
     tearDown();
+    // An identity switch: the ambient Embedded Data bag may carry the previous user's context
+    // (hashed ids and the like), which must not ride onto the next user's responses. Deliberately
+    // not in tearDown() itself — the setup-error teardown is not an identity switch, and page
+    // context should survive a setup retry. First-time identification (no currentUserId) keeps the
+    // bag too: the host legitimately pushes context before identifying.
+    EmbeddedDataStore.getInstance().clearEmbeddedData();
   }
 
   updateQueue.updateUserId(userId);
@@ -45,6 +52,9 @@ export const logout = (): Result<void> => {
 
     logger.debug("Logging out and cleaning user state");
     tearDown();
+    // Same identity-switch rule as setUserId above: logout must not let the previous user's
+    // ambient context leak onto whoever uses the page next.
+    EmbeddedDataStore.getInstance().clearEmbeddedData();
 
     return okVoid();
   } catch {


### PR DESCRIPTION
> **Stacked on #8988** (ENG-1843). Diff below is this PR's own changes only.

## What & why

Today the only way a host page attaches context to an app-survey response is `track(action, { hiddenFields })`, which binds the data to the triggering action — and app surveys are multi-action, so an integrator would have to repeat the same values on every possible `track()` call. This is the Electrolux path (GTM pushes data-layer values) and the SJ/JourneyID ask.

New SDK methods, decoupled from the trigger:

```js
formbricks.setEmbeddedData({ pageType: "product", plan: "pro" }); // merge, last write wins per key
formbricks.setEmbeddedData({ pageType: null });                   // null removes the key
formbricks.clearEmbeddedData("pageType");                         // same, explicit
formbricks.clearEmbeddedData();                                   // logout / hard context switch
```

**Four semantics, not three — `undefined` is a no-op** (does not set, does not drop). That is a promise the integration doc already makes: the GTM tag reads keys off the data layer and passes every field unconditionally, so a key absent on the current page type arrives as `undefined` and must not clear the value a previous page set. `undefined` and `null` are one keystroke apart and behave oppositely; both are pinned by tests.

**The bag is in-memory, page-load scoped, never persisted.** Deliberately not `Config` — that class writes to localStorage, and persisting the bag would blur the Embedded Data ↔ contact-attribute boundary and create a PII-at-rest surface. Backed by a `Map` so a `__proto__` key is data, not a prototype write.

**Synchronous, not queued — the `setNonce` precedent, and a deliberate departure from every other method.** The command queue would do two wrong things here: `checkSetup` silently *drops* commands issued before `setup()` completes (the exact GTM failure mode the `formbricks_setup_successful` readiness event exists to prevent — ENG-1846, next in this stack), and `CommandType.GeneralAction` drains the user update queue (network) on every call, while the ticket promises that calling this on every SPA route change is free. A memory write needs neither ordering nor setup.

**js-core does not filter — the SDK stays a dumb pipe** (ENG-1845/2472). `renderWidget` merges the bag *under* the per-trigger `track({ hiddenFields })` values (explicit beats ambient on a shared key) and hands the result to the renderer, whose ingest contract drops unknown/non-ingested/locked keys with a logged reason and coerces the rest; the server re-runs all of it on ingest. Snapshot-at-display: the merge happens inside the delay timeout at the moment the survey shows, from a detached copy — a later `setEmbeddedData` affects the next response, never the one on screen (the renderer's `useState` initializer freezes its side too).

`track({ hiddenFields })` keeps working unchanged (ENG-1838).

## Linear ticket

https://linear.app/formbricks/issue/ENG-1844/sdk-setembeddeddata-clearembeddeddata-app-surveys

## How this was tested

- `@formbricks/js-core` suite ✅ — 21 files, 293 tests
- `turbo run typecheck lint --filter=@formbricks/js-core` ✅ 4/4 · prettier ✅
- Tests added, each checked to **fail with its fix removed**:
  - `embedded-data.test.ts` — merge keeps other keys; `null` drops; **`undefined` no-op asserted separately from `null`** (red when `undefined` is treated like `null`); single clear; full clear; last-write-wins; snapshot detachment; `__proto__` stored as data with `Object.prototype` unpolluted; localStorage untouched and zero `fetch` calls across every method.
  - `widget.test.ts` — bag merges under per-trigger hidden fields (`plan` from `track` beats `plan` from the bag), and a `setEmbeddedData` after render does not reach the already-passed record (red with the merge removed).
- The existing ENG-2472 pass-through test (raw `track` bag reaches the renderer verbatim) still passes, pinning that this PR added no SDK-side filtering.

## Breaking changes

None — two new methods, nothing existing changes shape or behavior.

## QA / Test Plan

**How to test**

- [ ] App survey with an ingested Embedded Data field `pageType`, triggered by action `evt`. On the host page: `formbricks.setEmbeddedData({ pageType: "product" })`, then `formbricks.track("evt")` → complete the survey → the response shows `pageType = product`.
- [ ] Same, but call `formbricks.setEmbeddedData({ pageType: "changed" })` **while the survey is on screen**, then finish it → the response still shows `product`. Trigger the survey again → the new response shows `changed`.
- [ ] `setEmbeddedData({ plan: "pro" })` then `setEmbeddedData({ pageType: "x" })` → both keys land on the next response (merge, not replace).
- [ ] `setEmbeddedData({ plan: null })` then trigger → `plan` absent from the response.
- [ ] `setEmbeddedData({ plan: undefined, pageType: "y" })` after `plan` was set → `plan` **still lands**; only setting `null` removes it.
- [ ] `clearEmbeddedData()` then trigger → no bag keys on the response.
- [ ] `formbricks.track("evt", { hiddenFields: { pageType: "from-track" } })` with `pageType` also in the bag → the response shows `from-track` (explicit per-trigger value wins).
- [ ] Send an undeclared key (`setEmbeddedData({ rogue: "x" })`) → never stored; the browser console explains the drop.
- [ ] Reload the page without re-pushing → the next response has no bag values (nothing persisted; check devtools → Application → Local Storage: no new keys).
- [ ] Network tab: `setEmbeddedData`/`clearEmbeddedData` calls themselves fire zero requests.

**Preconditions / test data**

- An app survey with at least one ingested Embedded Data field and a code action trigger; the JS SDK embedded on a test page.
- Works before `setup()` completes (value is kept, not dropped) — but the reliable pattern for consent-gated setups is triggering on `formbricks_setup_successful`, which lands with ENG-1846 in this stack.

**Risks & regressions**

- The bag rides the same `hiddenFieldsRecord` slot as `track({ hiddenFields })` — re-check that a survey using only legacy `track` hidden fields behaves identically (pinned by the untouched pass-through test).
- Values set via the bag are subject to the same ingest contract as everything else: locked fields ignore them, wrong-typed values store raw + flagged. Nothing here writes to the contact record.

**Migrations / env / cutover**

- No DB/env changes. **Release sequencing (from review):** the published `@formbricks/js` npm wrapper (5.0.0, used by `apps/web` and the framework guides) forwards a hard-coded method list — `setEmbeddedData`/`clearEmbeddedData` are `undefined` on that path until a companion wrapper release ships. That release must ride with this stack's release.

