### PR TITLE
feat(js-core): SDK event bus — emit lifecycle events to the host page [ENG-1846]

### DIFF
--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -135,10 +135,19 @@ export const SurveyClientWrapper = ({
   // diagnostic while duplicating a rule that already has one home.
   const ingestedStorageKeys = getIngestedStorageKeys(survey);
   const hiddenFieldsRecord = useMemo(() => {
-    warnOnMissingIngestRows(ingestedStorageKeys, survey.hiddenFields.fieldIds ?? []);
     return getHiddenFieldsFromSearchParams(ingestedStorageKeys, searchParams);
     // eslint-disable-next-line react-hooks/use-memo -- migration ENG-1677
   }, [searchParams, JSON.stringify(ingestedStorageKeys)]);
+
+  // The diagnostic is a side effect, so it belongs in an effect rather than in the memo above: a memo
+  // body runs twice per mount under StrictMode, so this warning printed twice on every dev page load,
+  // and it would re-run on any `searchParams` change even though what it reports depends only on the
+  // survey. Keyed on content rather than array identity, like the memo above.
+  const legacyFieldIds = survey.hiddenFields.fieldIds ?? [];
+  useEffect(() => {
+    warnOnMissingIngestRows(ingestedStorageKeys, legacyFieldIds);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on content, not array identity
+  }, [JSON.stringify(ingestedStorageKeys), JSON.stringify(legacyFieldIds)]);
 
   // Include verified email in hidden fields if available
   const getVerifiedEmail = useMemo<Record<string, string> | null>(() => {

--- a/apps/web/playwright/js.spec.ts
+++ b/apps/web/playwright/js.spec.ts
@@ -1,10 +1,19 @@
 import { expect } from "@playwright/test";
 import http from "http";
+import { prisma } from "@formbricks/database";
 import { test } from "./lib/fixtures";
 import { gotoSurveyList, gotoSurveyTemplates } from "./lib/utils";
 import { useSelectedTemplate } from "./utils/helper";
 
 const HTML_TEMPLATE = `<head>
+  <script type="text/javascript">
+    // Registered before the SDK loads, which is the load order the event bus is designed for
+    // (ENG-1846): a host page must be able to subscribe without knowing when the SDK arrives.
+    window.formbricksEvents = [];
+    window.addEventListener("formbricks_response_submitted", function (e) {
+      window.formbricksEvents.push(e.detail);
+    });
+  </script>
   <script type="text/javascript">
     !(function () {
       var t = document.createElement("script");
@@ -101,6 +110,9 @@ test.describe("JS Package Test", async () => {
       page.getByRole("button", { name: "Publish", exact: true }).click(),
     ]);
 
+    const surveyId = /\/surveys\/([^/]+)\/summary/.exec(page.url())?.[1];
+    if (!surveyId) throw new Error(`Unable to parse surveyId from ${page.url()}`);
+
     await page.goto("http://localhost:3004");
     await expect(page.locator("#formbricks-modal-container")).toHaveCount(1, { timeout: 120000 });
     await expect(
@@ -126,6 +138,32 @@ test.describe("JS Package Test", async () => {
     await page.getByTestId("loading-spinner").waitFor({ state: "hidden" });
     await page.waitForLoadState("networkidle");
     await page.waitForTimeout(5000);
+
+    // The `responseId` on the bus is the PERSISTED id (ENG-1846). This is the only level that can
+    // prove it: the id is minted by the server, so `onResponseCreated`/`onFinished` can only carry it
+    // by firing from the response queue's creation ack — and the renderer that passes it lives in a
+    // .tsx, which the repo does not unit-test. Asserted against the stored row rather than for
+    // self-consistency, so a client-minted or dropped id fails here.
+    await test.step("the submitted event carries the persisted responseId", async () => {
+      const events = await page.evaluate(
+        () =>
+          (window as unknown as { formbricksEvents: { responseId?: string; finished?: boolean }[] })
+            .formbricksEvents
+      );
+
+      const storedResponse = await prisma.response.findFirst({
+        where: { surveyId },
+        orderBy: { createdAt: "desc" },
+        select: { id: true },
+      });
+      expect(storedResponse).not.toBeNull();
+
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.some((event) => event.finished === true)).toBe(true);
+      for (const event of events) {
+        expect(event.responseId).toBe(storedResponse?.id);
+      }
+    });
 
     // Validate displays and response
     await page.goto("/");

--- a/packages/js-core/src/lib/common/events.ts
+++ b/packages/js-core/src/lib/common/events.ts
@@ -72,7 +72,14 @@ export const emitFormbricksEvent = (event: TFormbricksEventName, payload: TFormb
     // `.push`. GTM's own snippet only ever creates an array, and its loaded state keeps the array
     // and swaps the `push` method, so `Array.isArray` stays true on every real GTM page.
     if (!Array.isArray(window.dataLayer)) window.dataLayer = [];
-    window.dataLayer.push({ event, formbricks: { ...EMPTY_DATALAYER_PAYLOAD, ...payload } });
+    // Undefined-valued keys are stripped before the merge: `TFormbricksEventPayload` admits
+    // `undefined` (the widened callbacks type `responseId` optional), and a key PRESENT with value
+    // `undefined` would replace the `null` sentinel in the spread — re-opening the recursive-merge
+    // bleed the sentinel exists to stop.
+    const definedPayload = Object.fromEntries(
+      Object.entries(payload).filter(([, value]) => value !== undefined)
+    );
+    window.dataLayer.push({ event, formbricks: { ...EMPTY_DATALAYER_PAYLOAD, ...definedPayload } });
   } catch (error) {
     console.error(`Formbricks: failed to push "${event}" to the dataLayer`, error);
   }

--- a/packages/js-core/src/lib/common/events.ts
+++ b/packages/js-core/src/lib/common/events.ts
@@ -35,12 +35,45 @@ export type TFormbricksEventName = (typeof FORMBRICKS_EVENTS)[keyof typeof FORMB
 
 export type TFormbricksEventPayload = Record<string, string | number | boolean | undefined>;
 
+/**
+ * Every key the event contract can carry, `null` where an event does not set it. The dataLayer push
+ * always carries the FULL set because GTM's data model merges pushes recursively — a partial push
+ * would let a previous event's `formbricks.responseId` or `formbricks.finished` bleed into a later
+ * event's reads (survey A's `responseId` resolving under survey B's `formbricks_survey_shown`).
+ * Pushing `null` overwrites the merged value; omitting the key would not. `CustomEvent.detail` has
+ * no merge semantics, so it carries only the event's own keys.
+ */
+const EMPTY_DATALAYER_PAYLOAD: Record<string, null> = {
+  workspaceId: null,
+  surveyId: null,
+  responseId: null,
+  finished: null,
+  action: null,
+};
+
 export const emitFormbricksEvent = (event: TFormbricksEventName, payload: TFormbricksEventPayload): void => {
   // js-core is imported by SSR bundles; emitting is meaningless (and crashes) off the browser.
   if (globalThis.window === undefined) return;
 
-  window.dispatchEvent(new CustomEvent<TFormbricksEventPayload>(event, { detail: payload }));
+  // Both transports run host-owned code — the page's event listeners, and `dataLayer.push`, which
+  // GTM replaces with its own function once it loads. The emitter's call sites sit at the head of
+  // SDK-critical paths (display bookkeeping, the response queue's ack), so a host-page throw here
+  // must never escape: it would cost us display state or mark a persisted response as failed. Each
+  // transport is isolated separately so one failing cannot silence the other.
+  try {
+    window.dispatchEvent(new CustomEvent<TFormbricksEventPayload>(event, { detail: payload }));
+  } catch (error) {
+    console.error(`Formbricks: a "${event}" event listener threw`, error);
+  }
 
-  window.dataLayer = window.dataLayer ?? [];
-  window.dataLayer.push({ event, formbricks: payload });
+  try {
+    // `Array.isArray`, not `?? []`: a host page that set `window.dataLayer = {}` (a hand-rolled
+    // shim, or another vendor reusing the name) survives nullish coalescing and then throws on
+    // `.push`. GTM's own snippet only ever creates an array, and its loaded state keeps the array
+    // and swaps the `push` method, so `Array.isArray` stays true on every real GTM page.
+    if (!Array.isArray(window.dataLayer)) window.dataLayer = [];
+    window.dataLayer.push({ event, formbricks: { ...EMPTY_DATALAYER_PAYLOAD, ...payload } });
+  } catch (error) {
+    console.error(`Formbricks: failed to push "${event}" to the dataLayer`, error);
+  }
 };

--- a/packages/js-core/src/lib/common/events.ts
+++ b/packages/js-core/src/lib/common/events.ts
@@ -1,0 +1,46 @@
+/**
+ * The SDK's outbound event bus (ENG-1846): lifecycle signals the host page can react to — fire
+ * GA/GTM tags, link session replays, and (most importantly) know when the SDK is ready, which is
+ * what makes a consent-delayed `setup()` integrable without polling for `window.formbricks`.
+ *
+ * Every event goes out on two transports:
+ *
+ * 1. **A `CustomEvent` on `window` — always.** The in-house pattern for host-facing signals
+ *    (`formbricks:onFilePick`, the route-change events) and vendor-neutral: nothing accumulates,
+ *    and no global we do not own is touched.
+ * 2. **A `window.dataLayer.push` — via the standard GTM idiom** (`window.dataLayer = window.dataLayer
+ *    || []`). The idiom survives load order: if GTM initialises after us it drains what is already
+ *    queued, whereas pushing only when the array exists would silently drop every event emitted
+ *    before GTM loads. Cost, accepted knowingly: a site with no GTM gets a `dataLayer` array that
+ *    accumulates small event objects with nothing draining it.
+ *
+ * One underscored name per event, identical on both transports, published to integrators — the
+ * constants hold the full literal so the string a customer's GTM trigger matches is greppable here.
+ *
+ * The payload is nested under a `formbricks` key on the dataLayer (instead of spread flat) because
+ * GTM's Data Layer Variables read a *merged* model: a flat `action` or `finished` would persist
+ * across pushes and collide with the host's own keys — `action` in particular is one of the most
+ * common keys in any ecommerce dataLayer. `CustomEvent.detail` gives the same isolation for free.
+ *
+ * No PII: payloads carry ids and the `finished` boolean, never response content or scores.
+ */
+export const FORMBRICKS_EVENTS = {
+  setupSuccessful: "formbricks_setup_successful",
+  actionTracked: "formbricks_action_tracked",
+  surveyShown: "formbricks_survey_shown",
+  responseSubmitted: "formbricks_response_submitted",
+} as const;
+
+export type TFormbricksEventName = (typeof FORMBRICKS_EVENTS)[keyof typeof FORMBRICKS_EVENTS];
+
+export type TFormbricksEventPayload = Record<string, string | number | boolean | undefined>;
+
+export const emitFormbricksEvent = (event: TFormbricksEventName, payload: TFormbricksEventPayload): void => {
+  // js-core is imported by SSR bundles; emitting is meaningless (and crashes) off the browser.
+  if (globalThis.window === undefined) return;
+
+  window.dispatchEvent(new CustomEvent<TFormbricksEventPayload>(event, { detail: payload }));
+
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push({ event, formbricks: payload });
+};

--- a/packages/js-core/src/lib/common/setup.ts
+++ b/packages/js-core/src/lib/common/setup.ts
@@ -1,6 +1,7 @@
 import { Config } from "@/lib/common/config";
 import { JS_LOCAL_STORAGE_KEY } from "@/lib/common/constants";
 import { addCleanupEventListeners, addEventListeners } from "@/lib/common/event-listeners";
+import { FORMBRICKS_EVENTS, emitFormbricksEvent } from "@/lib/common/events";
 import { Logger } from "@/lib/common/logger";
 import { getIsSetup, setIsSetup } from "@/lib/common/status";
 import { filterSurveys, getIsDebug, isNowExpired, wrapThrows } from "@/lib/common/utils";
@@ -335,6 +336,16 @@ export const setup = async (
 
   setIsSetup(true);
   logger.debug("Set up complete");
+
+  // The readiness signal (ENG-1846): a consent-gated setup means `window.formbricks` may not exist
+  // at page load, so a GTM tag firing `setEmbeddedData` on page load silently drops its value — the
+  // host triggers on this event instead. Emitted here, at the single point every *fresh* setup
+  // converges on, and nowhere else: the "already set up" and missing-config early returns above
+  // return `okVoid()` without reaching this line, so a repeated `setup()` call cannot double-fire
+  // the host's tags.
+  // `effectiveId`, not `config.get().workspaceId`: the input is what this setup just ran with, and
+  // it is already resolved through the legacy `environmentId` shim above.
+  emitFormbricksEvent(FORMBRICKS_EVENTS.setupSuccessful, { workspaceId: effectiveId });
 
   return okVoid();
 };

--- a/packages/js-core/src/lib/common/tests/events.test.ts
+++ b/packages/js-core/src/lib/common/tests/events.test.ts
@@ -88,6 +88,28 @@ describe("emitFormbricksEvent", () => {
     });
   });
 
+  test("a payload key present with value undefined falls back to the null sentinel, not undefined", () => {
+    // `responseId` is typed optional by the widened callbacks, so an emit can carry it as an
+    // explicit undefined. If that survived the merge it would replace the null sentinel — and GTM's
+    // recursive merge would keep an EARLIER event's responseId readable under this event's trigger.
+    emitFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, {
+      surveyId: "survey_1",
+      responseId: undefined,
+      finished: true,
+    });
+
+    expect(window.dataLayer?.[0]).toEqual({
+      event: "formbricks_response_submitted",
+      formbricks: {
+        workspaceId: null,
+        action: null,
+        surveyId: "survey_1",
+        responseId: null,
+        finished: true,
+      },
+    });
+  });
+
   test("a non-array dataLayer (a host shim) is replaced instead of throwing on .push", () => {
     (window as { dataLayer?: unknown }).dataLayer = {};
 

--- a/packages/js-core/src/lib/common/tests/events.test.ts
+++ b/packages/js-core/src/lib/common/tests/events.test.ts
@@ -34,11 +34,19 @@ describe("emitFormbricksEvent", () => {
     });
 
     // Nested under `formbricks`, never spread flat: GTM merges pushes, so a flat `finished` or
-    // `action` would collide with the host's own dataLayer keys.
+    // `action` would collide with the host's own dataLayer keys. And the FULL key set every time,
+    // nulls included: GTM merges recursively, so an omitted key would leave a previous event's
+    // value readable under this event's trigger.
     expect(window.dataLayer).toEqual([
       {
         event: "formbricks_response_submitted",
-        formbricks: { surveyId: "survey_1", responseId: "response_1", finished: true },
+        formbricks: {
+          workspaceId: null,
+          action: null,
+          surveyId: "survey_1",
+          responseId: "response_1",
+          finished: true,
+        },
       },
     ]);
   });
@@ -53,7 +61,13 @@ describe("emitFormbricksEvent", () => {
     expect(window.dataLayer).toHaveLength(2);
     expect(window.dataLayer[1]).toEqual({
       event: "formbricks_action_tracked",
-      formbricks: { action: "clicked_demo" },
+      formbricks: {
+        workspaceId: null,
+        surveyId: null,
+        responseId: null,
+        finished: null,
+        action: "clicked_demo",
+      },
     });
   });
 
@@ -64,7 +78,51 @@ describe("emitFormbricksEvent", () => {
     expect(event.detail).toEqual({ workspaceId: "ws_1" });
     expect(window.dataLayer?.[0]).toEqual({
       event: "formbricks_setup_successful",
-      formbricks: { workspaceId: "ws_1" },
+      formbricks: {
+        workspaceId: "ws_1",
+        surveyId: null,
+        responseId: null,
+        finished: null,
+        action: null,
+      },
     });
+  });
+
+  test("a non-array dataLayer (a host shim) is replaced instead of throwing on .push", () => {
+    (window as { dataLayer?: unknown }).dataLayer = {};
+
+    expect(() => {
+      emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+    }).not.toThrow();
+
+    expect(Array.isArray(window.dataLayer)).toBe(true);
+    expect(window.dataLayer).toHaveLength(1);
+  });
+
+  test("a throwing event listener cannot silence the dataLayer transport", () => {
+    dispatchEventMock.mockImplementationOnce(() => {
+      throw new Error("host listener exploded");
+    });
+
+    expect(() => {
+      emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+    }).not.toThrow();
+
+    expect(window.dataLayer).toHaveLength(1);
+  });
+
+  test("a throwing dataLayer.push (GTM replaces it with host-owned code) never escapes into SDK flow", () => {
+    const poisoned: Record<string, unknown>[] = [];
+    poisoned.push = () => {
+      throw new Error("host push exploded");
+    };
+    window.dataLayer = poisoned;
+
+    expect(() => {
+      emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+    }).not.toThrow();
+
+    // The CustomEvent transport still fired: the two are isolated separately.
+    expect(dispatchEventMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/js-core/src/lib/common/tests/events.test.ts
+++ b/packages/js-core/src/lib/common/tests/events.test.ts
@@ -1,0 +1,70 @@
+import { type Mock, beforeEach, describe, expect, test } from "vitest";
+import { FORMBRICKS_EVENTS, emitFormbricksEvent } from "@/lib/common/events";
+
+const dispatchEventMock = window.dispatchEvent as unknown as Mock;
+
+describe("emitFormbricksEvent", () => {
+  beforeEach(() => {
+    // The emitter creates `window.dataLayer` when absent; start every test from that state.
+    delete (window as { dataLayer?: unknown }).dataLayer;
+  });
+
+  test("every event name carries the formbricks_ namespace — the string GTM triggers match", () => {
+    for (const name of Object.values(FORMBRICKS_EVENTS)) {
+      expect(name).toMatch(/^formbricks_/);
+    }
+  });
+
+  test("dispatches a CustomEvent on window with the payload as detail", () => {
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+
+    expect(dispatchEventMock).toHaveBeenCalledTimes(1);
+    const event = dispatchEventMock.mock.calls[0][0] as CustomEvent;
+    expect(event.type).toBe("formbricks_survey_shown");
+    expect(event.detail).toEqual({ surveyId: "survey_1" });
+  });
+
+  test("creates window.dataLayer when absent and pushes the nested envelope", () => {
+    expect(window.dataLayer).toBeUndefined();
+
+    emitFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, {
+      surveyId: "survey_1",
+      responseId: "response_1",
+      finished: true,
+    });
+
+    // Nested under `formbricks`, never spread flat: GTM merges pushes, so a flat `finished` or
+    // `action` would collide with the host's own dataLayer keys.
+    expect(window.dataLayer).toEqual([
+      {
+        event: "formbricks_response_submitted",
+        formbricks: { surveyId: "survey_1", responseId: "response_1", finished: true },
+      },
+    ]);
+  });
+
+  test("appends to a pre-existing dataLayer, never replaces it — the host's queued events survive", () => {
+    const hostEntry = { event: "host_event", cart: "abc" };
+    window.dataLayer = [hostEntry];
+
+    emitFormbricksEvent(FORMBRICKS_EVENTS.actionTracked, { action: "clicked_demo" });
+
+    expect(window.dataLayer[0]).toBe(hostEntry);
+    expect(window.dataLayer).toHaveLength(2);
+    expect(window.dataLayer[1]).toEqual({
+      event: "formbricks_action_tracked",
+      formbricks: { action: "clicked_demo" },
+    });
+  });
+
+  test("both transports fire for one emit, carrying the same payload", () => {
+    emitFormbricksEvent(FORMBRICKS_EVENTS.setupSuccessful, { workspaceId: "ws_1" });
+
+    const event = dispatchEventMock.mock.calls[0][0] as CustomEvent;
+    expect(event.detail).toEqual({ workspaceId: "ws_1" });
+    expect(window.dataLayer?.[0]).toEqual({
+      event: "formbricks_setup_successful",
+      formbricks: { workspaceId: "ws_1" },
+    });
+  });
+});

--- a/packages/js-core/src/lib/common/tests/setup.test.ts
+++ b/packages/js-core/src/lib/common/tests/setup.test.ts
@@ -108,6 +108,28 @@ describe("setup.ts", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("Already set up, skipping setup.");
     });
 
+    test("the already-setup early return does NOT re-emit formbricks_setup_successful", async () => {
+      // The event's exactly-once guarantee is structural: the emit sits at the tail every fresh
+      // setup converges on, and this branch returns before reaching it. A re-fire would re-trigger
+      // every GTM tag listening for readiness.
+      delete (window as { dataLayer?: unknown }).dataLayer;
+      getInstanceLoggerMock.mockReturnValue(mockLogger as unknown as Logger);
+      setIsSetup(true);
+
+      const result = await setup({ workspaceId: "ws_id", appUrl: "https://my.url" });
+
+      expect(result.ok).toBe(true);
+      expect(window.dataLayer).toBeUndefined();
+    });
+
+    test("a failed setup (missing field) does not emit formbricks_setup_successful", async () => {
+      delete (window as { dataLayer?: unknown }).dataLayer;
+      const result = await setup({ appUrl: "https://my.url" });
+
+      expect(result.ok).toBe(false);
+      expect(window.dataLayer).toBeUndefined();
+    });
+
     test("fails if no environmentId or workspaceId is provided", async () => {
       const result = await setup({ appUrl: "https://my.url" });
       expect(result.ok).toBe(false);
@@ -134,6 +156,7 @@ describe("setup.ts", () => {
     });
 
     test("succeeds with workspaceId instead of environmentId", async () => {
+      delete (window as { dataLayer?: unknown }).dataLayer;
       const mockConfig = {
         get: vi.fn().mockReturnValue(undefined),
         resetConfig: vi.fn(),
@@ -166,6 +189,11 @@ describe("setup.ts", () => {
           workspaceId: "ws_123",
         })
       );
+      // ENG-1846: the readiness signal fires exactly once, at the tail every fresh setup converges
+      // on, carrying the resolved workspace id.
+      expect(window.dataLayer).toEqual([
+        { event: "formbricks_setup_successful", formbricks: { workspaceId: "ws_123" } },
+      ]);
     });
 
     test("prefers workspaceId over environmentId when both provided", async () => {

--- a/packages/js-core/src/lib/common/tests/setup.test.ts
+++ b/packages/js-core/src/lib/common/tests/setup.test.ts
@@ -192,7 +192,16 @@ describe("setup.ts", () => {
       // ENG-1846: the readiness signal fires exactly once, at the tail every fresh setup converges
       // on, carrying the resolved workspace id.
       expect(window.dataLayer).toEqual([
-        { event: "formbricks_setup_successful", formbricks: { workspaceId: "ws_123" } },
+        {
+          event: "formbricks_setup_successful",
+          formbricks: {
+            workspaceId: "ws_123",
+            surveyId: null,
+            responseId: null,
+            finished: null,
+            action: null,
+          },
+        },
       ]);
     });
 

--- a/packages/js-core/src/lib/survey/action.ts
+++ b/packages/js-core/src/lib/survey/action.ts
@@ -1,4 +1,5 @@
 import { Config } from "@/lib/common/config";
+import { FORMBRICKS_EVENTS, emitFormbricksEvent } from "@/lib/common/events";
 import { Logger } from "@/lib/common/logger";
 import { triggerSurvey } from "@/lib/survey/widget";
 import { type InvalidCodeError, type NetworkError, type Result, err, okVoid } from "@/types/error";
@@ -22,6 +23,10 @@ export const trackAction = async (
   const aliasName = alias ?? name;
 
   logger.debug(`Formbricks: Action "${aliasName}" tracked`);
+
+  // The shared path under both code and no-code actions, so every tracked action reaches the host
+  // exactly once — whether or not it triggers a survey (funnel analytics wants the misses too).
+  emitFormbricksEvent(FORMBRICKS_EVENTS.actionTracked, { action: aliasName });
 
   // get a list of surveys that are collecting insights
   const activeSurveys = appConfig.get().filteredSurveys;

--- a/packages/js-core/src/lib/survey/tests/action.test.ts
+++ b/packages/js-core/src/lib/survey/tests/action.test.ts
@@ -106,6 +106,20 @@ describe("survey/action.ts", () => {
       expect(triggerSurvey).toHaveBeenCalledWith(mockSurvey, "testAction", undefined);
     });
 
+    test("emits formbricks_action_tracked for every tracked action, even without a matching survey", async () => {
+      // ENG-1846: funnel analytics wants the misses too — the emit sits on the shared trackAction
+      // path, above the survey-matching loop.
+      delete (window as { dataLayer?: unknown }).dataLayer;
+      mockConfig.get.mockReturnValue({ filteredSurveys: [] });
+
+      const result = await trackAction("testAction", "aliasedCode");
+
+      expect(result.ok).toBe(true);
+      expect(window.dataLayer).toEqual([
+        { event: "formbricks_action_tracked", formbricks: { action: "aliasedCode" } },
+      ]);
+    });
+
     test("handles multiple matching surveys", async () => {
       const mockSurveys = [
         {

--- a/packages/js-core/src/lib/survey/tests/action.test.ts
+++ b/packages/js-core/src/lib/survey/tests/action.test.ts
@@ -116,7 +116,16 @@ describe("survey/action.ts", () => {
 
       expect(result.ok).toBe(true);
       expect(window.dataLayer).toEqual([
-        { event: "formbricks_action_tracked", formbricks: { action: "aliasedCode" } },
+        {
+          event: "formbricks_action_tracked",
+          formbricks: {
+            workspaceId: null,
+            surveyId: null,
+            responseId: null,
+            finished: null,
+            action: "aliasedCode",
+          },
+        },
       ]);
     });
 

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -911,15 +911,16 @@ describe("widget-file", () => {
       callbacks.onResponseCreated("resp_123");
       callbacks.onFinished("resp_123");
 
+      const base = { workspaceId: null, surveyId: null, responseId: null, finished: null, action: null };
       expect(window.dataLayer).toEqual([
-        { event: "formbricks_survey_shown", formbricks: { surveyId: mockSurvey.id } },
+        { event: "formbricks_survey_shown", formbricks: { ...base, surveyId: mockSurvey.id } },
         {
           event: "formbricks_response_submitted",
-          formbricks: { surveyId: mockSurvey.id, responseId: "resp_123", finished: false },
+          formbricks: { ...base, surveyId: mockSurvey.id, responseId: "resp_123", finished: false },
         },
         {
           event: "formbricks_response_submitted",
-          formbricks: { surveyId: mockSurvey.id, responseId: "resp_123", finished: true },
+          formbricks: { ...base, surveyId: mockSurvey.id, responseId: "resp_123", finished: true },
         },
       ]);
     });

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -858,6 +858,73 @@ describe("widget-file", () => {
     vi.useRealTimers();
   });
 
+  describe("lifecycle events to the host page (ENG-1846)", () => {
+    const renderAndGetEventCallbacks = async (): Promise<{
+      onDisplayCreated: () => void;
+      onResponseCreated: (responseId?: string) => void;
+      onFinished: (responseId?: string) => void;
+    }> => {
+      const mockConfigValue = {
+        get: vi.fn().mockReturnValue({
+          appUrl: "https://fake.app",
+          workspaceId: "env_123",
+          workspace: {
+            data: {
+              settings: { clickOutsideClose: true, overlay: "none", placement: "bottomRight" },
+            },
+          },
+          user: {
+            data: {
+              userId: null,
+              contactId: "contact_abc",
+              displays: [],
+              responses: [],
+              lastDisplayAt: null,
+            },
+          },
+        }),
+        update: vi.fn(),
+      };
+
+      getInstanceConfigMock.mockReturnValue(mockConfigValue as unknown as Config);
+      (filterSurveys as Mock).mockReturnValue([]);
+      widget.setIsSurveyRunning(false);
+      window.formbricksSurveys = createMockFormbricksSurveys();
+
+      vi.useFakeTimers();
+      await widget.renderWidget({ ...mockSurvey, delay: 0 } as unknown as TWorkspaceStateSurvey);
+      vi.advanceTimersByTime(0);
+      vi.useRealTimers();
+
+      return (getFormbricksSurveys().renderSurvey as Mock).mock.calls[0][0] as {
+        onDisplayCreated: () => void;
+        onResponseCreated: (responseId?: string) => void;
+        onFinished: (responseId?: string) => void;
+      };
+    };
+
+    test("survey_shown on display; response_submitted with the acked responseId on create and finish", async () => {
+      delete (window as { dataLayer?: unknown }).dataLayer;
+      const callbacks = await renderAndGetEventCallbacks();
+
+      callbacks.onDisplayCreated();
+      callbacks.onResponseCreated("resp_123");
+      callbacks.onFinished("resp_123");
+
+      expect(window.dataLayer).toEqual([
+        { event: "formbricks_survey_shown", formbricks: { surveyId: mockSurvey.id } },
+        {
+          event: "formbricks_response_submitted",
+          formbricks: { surveyId: mockSurvey.id, responseId: "resp_123", finished: false },
+        },
+        {
+          event: "formbricks_response_submitted",
+          formbricks: { surveyId: mockSurvey.id, responseId: "resp_123", finished: true },
+        },
+      ]);
+    });
+  });
+
   describe("post-interaction segment refresh", () => {
     // Renders the widget and returns the interaction callbacks handed to renderSurvey, so each test can
     // trigger onDisplayCreated / onResponseCreated / onFinished directly and assert whether a refresh

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -1,5 +1,6 @@
 import { Config } from "@/lib/common/config";
 import { CONTAINER_ID } from "@/lib/common/constants";
+import { FORMBRICKS_EVENTS, emitFormbricksEvent } from "@/lib/common/events";
 import { Logger } from "@/lib/common/logger";
 import { executeRecaptcha, loadRecaptchaScript } from "@/lib/common/recaptcha";
 import { TimeoutStack } from "@/lib/common/timeout-stack";
@@ -185,6 +186,8 @@ export const renderWidget = async (
       isSpamProtectionEnabled,
       getRecaptchaToken,
       onDisplayCreated: () => {
+        emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: survey.id });
+
         const existingDisplays = config.get().user.data.displays;
         const newDisplay = { surveyId: survey.id, createdAt: new Date() };
         const displays = existingDisplays.length ? [...existingDisplays, newDisplay] : [newDisplay];
@@ -214,7 +217,16 @@ export const renderWidget = async (
         // trigger evaluates. The display is already persisted (fires after createDisplay).
         refreshSegmentsAfterInteraction(previousConfig.user.data.userId, survey, "onDisplay");
       },
-      onResponseCreated: () => {
+      onResponseCreated: (responseId?: string) => {
+        // finished: false — completion gets its own emit in onFinished below. `responseId` arrives
+        // from the renderer's server-ack seam (ENG-1846 widened the callback), so it is real, not
+        // client-minted; it is what lets the host link a session replay to this response.
+        emitFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, {
+          surveyId: survey.id,
+          responseId,
+          finished: false,
+        });
+
         const responses = config.get().user.data.responses;
         const newPersonState: TUserState = {
           ...config.get().user,
@@ -238,7 +250,13 @@ export const renderWidget = async (
         // a single refresh covering "started". The "completed X" case is handled in onFinished below.
         refreshSegmentsAfterInteraction(config.get().user.data.userId, survey, "onResponse");
       },
-      onFinished: () => {
+      onFinished: (responseId?: string) => {
+        emitFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, {
+          surveyId: survey.id,
+          responseId,
+          finished: true,
+        });
+
         // Survey completion flips "have completed X" (and clears "have not completed X") segments.
         // onFinished only fires after the finished response has been sent to the backend (it is gated
         // on isResponseSendingFinished), so the server recompute sees finished=true — no race. Without

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -182,8 +182,6 @@ export const renderWidget = async (
       isSpamProtectionEnabled,
       getRecaptchaToken,
       onDisplayCreated: () => {
-        emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: survey.id });
-
         const existingDisplays = config.get().user.data.displays;
         const newDisplay = { surveyId: survey.id, createdAt: new Date() };
         const displays = existingDisplays.length ? [...existingDisplays, newDisplay] : [newDisplay];
@@ -212,17 +210,14 @@ export const renderWidget = async (
         // coalesced) so interaction targeting is current by the time this survey closes and the next
         // trigger evaluates. The display is already persisted (fires after createDisplay).
         refreshSegmentsAfterInteraction(previousConfig.user.data.userId, survey, "onDisplay");
+
+        // Emitted LAST, after the SDK's own bookkeeping: the caller swallows throws, so anything the
+        // emitter reaches on the host page must never be able to skip the display update above —
+        // that would leave display caps evaluating stale state and the survey re-showing. The
+        // emitter guards its transports too; this ordering is the second wall.
+        emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: survey.id });
       },
       onResponseCreated: (responseId?: string) => {
-        // finished: false — completion gets its own emit in onFinished below. `responseId` arrives
-        // from the renderer's server-ack seam (ENG-1846 widened the callback), so it is real, not
-        // client-minted; it is what lets the host link a session replay to this response.
-        emitFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, {
-          surveyId: survey.id,
-          responseId,
-          finished: false,
-        });
-
         const responses = config.get().user.data.responses;
         const newPersonState: TUserState = {
           ...config.get().user,
@@ -245,20 +240,31 @@ export const renderWidget = async (
         // once, on the first answer (not on subsequent question submits — see survey.tsx), so this is
         // a single refresh covering "started". The "completed X" case is handled in onFinished below.
         refreshSegmentsAfterInteraction(config.get().user.data.userId, survey, "onResponse");
-      },
-      onFinished: (responseId?: string) => {
+
+        // finished: false — completion gets its own emit in onFinished below. `responseId` comes
+        // from the renderer's server-ack seam (ENG-1846 widened the callback), so it is real, not
+        // client-minted — it is what lets the host link a session replay to this response. Emitted
+        // last for the same reason as in onDisplayCreated: this callback runs inside the response
+        // queue's try block, and a host-page throw here would mark a persisted response as failed.
         emitFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, {
           surveyId: survey.id,
           responseId,
-          finished: true,
+          finished: false,
         });
-
+      },
+      onFinished: (responseId?: string) => {
         // Survey completion flips "have completed X" (and clears "have not completed X") segments.
         // onFinished only fires after the finished response has been sent to the backend (it is gated
         // on isResponseSendingFinished), so the server recompute sees finished=true — no race. Without
         // this, a multi-question survey would only refresh at onResponseCreated (finished=false), so
         // "completed X → show Y" targeting would never fire until the person-state TTL expired.
         refreshSegmentsAfterInteraction(config.get().user.data.userId, survey, "onFinished");
+
+        emitFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, {
+          surveyId: survey.id,
+          responseId,
+          finished: true,
+        });
       },
       onClose: closeSurvey,
       getSetIsResponseSendingFinished: (_f: (value: boolean) => void) => undefined,

--- a/packages/js-core/src/vite-env.d.ts
+++ b/packages/js-core/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 declare global {
   interface Window {
+    /** GTM's data layer. We push via the standard `window.dataLayer = window.dataLayer || []` idiom. */
+    dataLayer?: Record<string, unknown>[];
     __formbricksNonce?: string;
     formbricksSurveys?: {
       renderSurvey: (options: unknown) => void;

--- a/packages/js-core/vitest.setup.ts
+++ b/packages/js-core/vitest.setup.ts
@@ -31,6 +31,9 @@ const windowMock = {
   },
   setInterval: vi.fn(),
   clearInterval: vi.fn(),
+  // The event bus (lib/common/events.ts) dispatches on window; a plain vi.fn() keeps every suite
+  // that transitively emits from crashing, and event tests assert on this mock directly.
+  dispatchEvent: vi.fn(),
 };
 
 // Stub globals

--- a/packages/surveys/src/components/general/render-survey.tsx
+++ b/packages/surveys/src/components/general/render-survey.tsx
@@ -67,8 +67,8 @@ export function RenderSurvey(props: SurveyContainerProps) {
         {...props}
         clickOutside={hasOverlay ? props.clickOutside : true}
         onClose={close}
-        onFinished={() => {
-          props.onFinished?.();
+        onFinished={(responseId?: string) => {
+          props.onFinished?.(responseId);
 
           if (props.mode !== "inline") {
             onFinishedTimeoutRef.current = setTimeout(

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -288,7 +288,15 @@ export function Survey({
           },
           onResponseCreated: (responseId) => {
             void persistSurveyStateSnapshot({ responseId });
-            triggerResponseCreatedOnce(responseId);
+            try {
+              triggerResponseCreatedOnce(responseId);
+            } catch (error) {
+              // This runs inside ResponseQueue.sendResponse's try block, and the callback reaches
+              // host-supplied code (js-core's event bus → the host page). A throw here would be
+              // caught as a SEND failure — the respondent shown an error and a retry for a response
+              // the server already created. Never let a host page do that.
+              console.error("Formbricks: onResponseCreated handler threw", error);
+            }
           },
         },
         surveyState

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -235,6 +235,24 @@ export function Survey({
     [offlinePersistEnabled, survey.id]
   );
 
+  // `onResponseCreateOrUpdate` runs on every question submit, but a response is only *created* on the
+  // first submit — later submits update it. `onResponseCreated` must therefore fire once, not per
+  // question, otherwise a 5-question survey triggers 5 downstream `/user` refreshes in js-core.
+  //
+  // Fired from the queue's server-ack seam below (not at enqueue time) so it can carry the persisted
+  // `responseId` — the id is minted by the server, so an event that carries it can only fire after
+  // the ack (ENG-1846). Same post-ack semantics as `onDisplayCreated`, which fires after
+  // createDisplay. Preview mode never reaches the queue and fires this without an id at submit time.
+  const responseCreatedRef = useRef(false);
+  const triggerResponseCreatedOnce = useCallback(
+    (responseId?: string) => {
+      if (responseCreatedRef.current) return;
+      responseCreatedRef.current = true;
+      void onResponseCreated?.(responseId);
+    },
+    [onResponseCreated]
+  );
+
   const responseQueue = useMemo(() => {
     if (appUrl && workspaceId && surveyState) {
       return new ResponseQueue(
@@ -270,6 +288,7 @@ export function Survey({
           },
           onResponseCreated: (responseId) => {
             void persistSurveyStateSnapshot({ responseId });
+            triggerResponseCreatedOnce(responseId);
           },
         },
         surveyState
@@ -285,6 +304,7 @@ export function Survey({
     surveyState,
     offlinePersistEnabled,
     persistSurveyStateSnapshot,
+    triggerResponseCreatedOnce,
     survey.id,
   ]);
 
@@ -520,11 +540,6 @@ export function Survey({
   // Create display on mount. When offline persistence is enabled, wait for progress
   // restoration so we can skip creating a new display if a session was restored.
   const displayCreatedRef = useRef(false);
-
-  // `onResponseCreateOrUpdate` runs on every question submit, but a response is only *created* on the
-  // first submit — later submits update it. `onResponseCreated` must therefore fire once, not per
-  // question, otherwise a 5-question survey triggers 5 downstream `/user` refreshes in js-core.
-  const responseCreatedRef = useRef(false);
 
   useEffect(() => {
     if (offlinePersistEnabled && !progressRestored) return;
@@ -1005,14 +1020,6 @@ export function Survey({
 
   const getWebSurveyMeta = useCallback((): TWebSurveyMeta => webSurveyMetaRef.current?.() ?? {}, []);
 
-  // Fire onResponseCreated exactly once per survey lifecycle. The queue creates the response on the
-  // first add and updates it on later submits, so a multi-question survey must not re-trigger it.
-  const triggerResponseCreatedOnce = useCallback(() => {
-    if (responseCreatedRef.current) return;
-    responseCreatedRef.current = true;
-    onResponseCreated?.();
-  }, [onResponseCreated]);
-
   const onResponseCreateOrUpdate = useCallback(
     async (responseUpdate: TResponseUpdate) => {
       // Always trigger the onResponse callback even in preview mode
@@ -1067,8 +1074,7 @@ export function Survey({
           // straight back.
           hiddenFields: ingestedFieldsRecord,
         });
-
-        triggerResponseCreatedOnce();
+        // No trigger here: the queue's onResponseCreated ack fires it with the persisted responseId.
       }
     },
     [
@@ -1184,7 +1190,9 @@ export function Survey({
     if (isResponseSendingFinished && isSurveyFinished) {
       // Post a message to the parent window indicating that the survey is completed.
       window.parent.postMessage("formbricksSurveyCompleted", "*"); // NOSONAR typescript:S2819 // We can't check the targetOrigin here because we don't know the parent window's origin.
-      onFinished?.();
+      // Gated on isResponseSendingFinished, so outside preview/offline the ack has landed and the
+      // queue has stamped the persisted responseId onto surveyState (ENG-1846).
+      onFinished?.(surveyState?.responseId ?? undefined);
     }
   }, [isResponseSendingFinished, isSurveyFinished, onFinished]);
 

--- a/packages/types/formbricks-surveys.ts
+++ b/packages/types/formbricks-surveys.ts
@@ -14,7 +14,11 @@ export interface SurveyBaseProps {
   getSetResponseData?: (getSetResponseData: (value: TResponseData) => void) => void;
   onDisplay?: () => Promise<void>;
   onResponse?: (response: TResponseUpdate) => void;
-  onFinished?: () => void;
+  /**
+   * Fires when the finished response has been sent. `responseId` is the persisted id when one exists
+   * (it always does outside preview/offline, since this is gated on the send completing) — ENG-1846.
+   */
+  onFinished?: (responseId?: string) => void;
   onClose?: () => void;
   onRetry?: () => void;
   autoFocus?: boolean;
@@ -57,7 +61,12 @@ export interface SurveyContainerProps extends Omit<SurveyBaseProps, "onFileUploa
   userId?: string;
   contactId?: string;
   onDisplayCreated?: () => void | Promise<void>;
-  onResponseCreated?: () => void | Promise<void>;
+  /**
+   * Fires once per survey lifecycle when the response exists. Outside preview mode that is the
+   * server's creation ack, so `responseId` is the persisted id (ENG-1846 — the host uses it to link
+   * session replays); in preview mode it fires at submit time with no id, since nothing is stored.
+   */
+  onResponseCreated?: (responseId?: string) => void | Promise<void>;
   onFileUpload?: (file: TJsFileUploadParams["file"], config?: TUploadFileConfig) => Promise<string>;
   onOpenExternalURL?: (url: string) => void | Promise<void>;
   mode?: "modal" | "inline";


### PR DESCRIPTION
> **Stacked on #8989** (ENG-1844), which sits on #8988 (ENG-1843). Diff below is this PR's own changes only.

## What & why

The SDK is a black box to the host page: nothing announces that setup finished, that a survey showed, or that a response landed. That forces the two integration hacks this PR retires — polling `if (window.formbricks)` in a 100 ms interval (our own GTM doc ships that pattern today), and the `postMessage` listener customers run on confirmation pages. It also makes `setEmbeddedData` (#8989) unreliable under consent-gated setup: a GTM tag firing at page load hits an undefined global and the value silently vanishes.

Four lifecycle events, a general bus rather than a single hook:

| Event | Fires | Payload |
| --- | --- | --- |
| `formbricks_setup_successful` | fresh `setup()` completes | `{ workspaceId }` |
| `formbricks_action_tracked` | any code/no-code action, hit or miss | `{ action }` |
| `formbricks_survey_shown` | display created | `{ surveyId }` |
| `formbricks_response_submitted` | response acked (`finished: false`) and finished (`finished: true`) | `{ surveyId, responseId, finished }` |

The names are a **committed external contract**: the data-mapping doc sent to Electrolux publishes all four, and their UAT already has a GTM trigger on `formbricks_setup_successful`. Constants hold the full literals so a customer's trigger string greps to one place.

**Two transports per event.** A `CustomEvent` on `window` — always; the in-house pattern (`formbricks:onFilePick`) and vendor-neutral. Plus a dataLayer push via the standard idiom `window.dataLayer = window.dataLayer || []` — the idiom survives load order (GTM drains the pre-created array on init), where pushing only-if-present would silently drop every event emitted before GTM loads. Cost, accepted: a GTM-less site accumulates small event objects nobody drains.

**The dataLayer payload is nested** — `{ event, formbricks: { … } }` — not spread flat. GTM's Data Layer Variables read a *merged* model, so a flat `action` or `finished` persists across pushes and collides with the host's own keys (`action` is everywhere in ecommerce dataLayers). This is a deliberate deviation from the payload *sketch* in the customer doc, which marks payloads as still open; Sean needs a heads-up before he builds the `response_submitted` tag (his existing `setup_successful` trigger matches on the event name only and is unaffected).

**Exactly-once for the readiness event is structural, not flag-based:** the emit sits at the single tail every *fresh* setup converges on in `setup.ts`; the already-set-up and missing-config early returns never reach it, so a repeated `setup()` cannot re-fire the host's tags.

**The one contract change: `responseId` now reaches the host.** `onResponseCreated` fired at enqueue time, before the server ever minted an id. It now fires (still exactly once, same guard) from the ResponseQueue's creation ack, widened to `(responseId?: string)` — same post-ack semantics `onDisplayCreated` already has, and the only way `response_submitted` can carry the persisted id that links a ContentSquare replay. `onFinished` is widened the same way (it is gated on the send finishing, so the id exists by then). Both widenings are additive; preview mode keeps firing at submit time with no id, since nothing is stored. This touches `packages/types` + `packages/surveys`, so the surveys bundle needs the rebuild dance when testing manually.

**App surveys only.** Link surveys never load js-core — they render through the web app. No events fire there; a separate ticket if ever wanted.

**No PII:** ids and the `finished` boolean, never response content or scores — per the ticket's consent note and ENG-1842's Anonymize direction.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1846/sdk-event-bus-emit-lifecycle-events-to-the-host-page

## How this was tested

- `@formbricks/js-core` ✅ 22 files / 302 tests · `@formbricks/surveys` ✅ 697 · full `pnpm test` ✅ 25/25 tasks
- **E2E (added in review): `js.spec.ts` now pins that `formbricks_response_submitted` carries the
  PERSISTED `responseId`**, asserted against the stored `Response` row. This closes the one gap a
  reviewer found: reverting `onFinished?.(surveyState?.responseId ?? undefined)` to `onFinished?.()`
  previously left all 701 `packages/surveys` tests green, because the producer lives in a `.tsx` (not
  unit-tested here) and js-core's `widget.test.ts` feeds `"resp_123"` to a callback it mocks itself —
  it exercises the consumer, never the renderer that supplies the id. Added as a `test.step` to the
  existing SDK journey rather than a new spec: the survey is already created, displayed and completed
  there, so it costs one `page.evaluate` and one query, not a browser. Checked to go red with the fix
  reverted.
- `turbo run typecheck lint` ✅ for js-core, surveys, types **and** `@formbricks/web` (the widened callbacks are consumed by `SurveyInline`/preview — zero-arg handlers remain assignable) · prettier ✅
- Tests added, the two structural ones checked to **fail with their fix removed**:
  - `events.test.ts` — CustomEvent type + `detail`; dataLayer created when absent; **a pre-existing dataLayer is appended to, never replaced** (a seeded host entry survives — the failure that would wipe a customer's queued events); the nested envelope; every name starts with `formbricks_`; both transports carry the same payload.
  - `setup.test.ts` — fresh setup emits exactly once with the resolved `workspaceId` (red with the emit removed); the already-set-up early return does **not** re-emit; a failed setup emits nothing.
  - `action.test.ts` — emits for a tracked action even when no survey matches (the emit sits above the matching loop).
  - `widget.test.ts` — `survey_shown` on display; `response_submitted` with the acked `responseId`, `finished: false` then `true` (red with the emit removed).
- Existing suites pin the regressions that matter: all 697 surveys tests pass with the `onResponseCreated` fire point moved, and the js-core segment-refresh tests still drive the same callbacks.

## Breaking changes

None — new events only; `onResponseCreated`/`onFinished` widen with an optional parameter, so every existing implementation keeps compiling and behaving. The one observable shift: `onResponseCreated` now fires on the server ack rather than at enqueue (milliseconds later on a healthy network), matching `onDisplayCreated`'s existing post-ack semantics.

## QA / Test Plan

**How to test**

- [ ] Page with the JS SDK and this snippet before `setup()`: `window.addEventListener("formbricks_setup_successful", (e) => console.log(e.detail))` → after `setup()` completes, the console logs `{ workspaceId }`, and `window.dataLayer` contains `{ event: "formbricks_setup_successful", formbricks: { workspaceId } }`.
- [ ] Call `formbricks.setup()` a second time → **no** second event (check `window.dataLayer` length).
- [ ] `formbricks.track("some-action")` for an action that triggers no survey → `formbricks_action_tracked` still fires with `{ action }`.
- [ ] Trigger an app survey → `formbricks_survey_shown` with `{ surveyId }` when it appears.
- [ ] Answer the first question → `formbricks_response_submitted` with `{ surveyId, responseId, finished: false }`, where `responseId` matches the response later visible in the app.
- [ ] Finish the survey → the same event again with `finished: true` and the same `responseId`.
- [ ] GTM readiness handshake (the Electrolux pattern): delay `setup()` behind a consent prompt, put a GTM Custom Event trigger on `formbricks_setup_successful` whose tag calls `formbricks.setEmbeddedData({...})` → the values land on the next response. This is the integration the event exists for.
- [ ] Pre-seed `window.dataLayer = [{ event: "host" }]` before the SDK loads → after events fire, the host entry is still index 0.
- [ ] No GTM on the page at all → everything above still works via `addEventListener`; `window.dataLayer` exists and grows only with our events.

**Preconditions / test data**

- An app survey with a code-action trigger; the JS SDK on a test page; GTM (or Tag Assistant preview) for the handshake step.
- Link surveys intentionally emit nothing — verify no `formbricks_*` events on a link survey page.

**Also in this PR (review follow-up)**

- `warnOnMissingIngestRows` moved out of the `useMemo` body in `survey-client-wrapper.tsx` into a
  `useEffect` keyed on the rows and the legacy column. A memo body is not a defined place for a side
  effect, and its deps included `searchParams`, which has nothing to do with what the diagnostic
  reports. Scope stated honestly: this does **not** reduce the duplicate line in dev — measured before
  and after, it prints twice per mount either way, because StrictMode double-invokes effects just as
  it does memo bodies. Hygiene and correct dependencies, not a fix for the duplication.

**Risks & regressions**

- `onResponseCreated` timing moved from enqueue to server ack. js-core's own bookkeeping (responses array, segment refresh) now runs on ack — on a healthy network milliseconds later; if the create request ultimately fails, the bookkeeping (correctly) never runs for a response that was never stored. Re-check "have responded"-style segment targeting right after a first answer.
- Mobile SDKs (ENG-2472) read the same renderer contract — the widened callbacks are the shape they should adopt.
- The `postMessage("formbricksSurveyCompleted")` hack is deliberately left in place; removing it is a separate deprecation once integrators migrate.

**Migrations / env / cutover**

- none. Docs for the events land with ENG-1849 (the existing GTM doc's polling example should be replaced by the readiness event).

