### PR TITLE
feat(helm): support Hub workload scheduling

### DIFF
--- a/charts/formbricks/templates/hub-deployment.yaml
+++ b/charts/formbricks/templates/hub-deployment.yaml
@@ -28,6 +28,22 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: hub
     spec:
+      {{- with .Values.hub.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.deployment.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.deployment.imagePullSecrets | nindent 8 }}

--- a/charts/formbricks/templates/hub-migration-job.yaml
+++ b/charts/formbricks/templates/hub-migration-job.yaml
@@ -33,6 +33,22 @@ spec:
         app.kubernetes.io/component: hub-migration
     spec:
       restartPolicy: Never
+      {{- with .Values.hub.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -1005,6 +1005,12 @@ hub:
   #   TRANSLATION_DEFAULT_LANGUAGE: en-US
   env: {}
 
+  # Scheduling constraints shared by the Hub API and its migration Job.
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+
   # Optional autoscaling for the Hub API deployment.
   autoscaling:
     enabled: false


### PR DESCRIPTION
No Linear ticket: this is a deployment prerequisite for the Artemis staging clone.

## What & why

The Hub API and Hub migration Job could not be constrained to a dedicated tainted node pool. This adds the same optional node selector, toleration, affinity, and topology-spread interfaces already used by the other chart workloads. Defaults remain empty, so existing releases render unchanged.

## Breaking changes

- [ ] This PR contains breaking changes

None. The chart interface is additive and every new value defaults to the prior scheduling behaviour.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Hub API and migration inherit dedicated-pool scheduling | unit (guard): `helm template` with Artemis selector/toleration values | Both rendered pod specs contain the expected selector and `NoSchedule` toleration |
| Existing staging output remains stable | manual: byte-for-byte render comparison using refreshed `origin/main` chart and current staging values | No rendered staging differences |
| Chart remains valid with defaults | unit (guard): `helm lint charts/formbricks` | Passed |

**Open gaps**

- Full Artemis deployment remains gated in the linked infra/GitOps rollout.

**Risks**

- A malformed environment overlay could still target a nonexistent pool; GitOps validates every Artemis workload separately.

---

> [!NOTE]
> **AI model used** — `unknown`, reasoning effort `unknown`.
