### PR TITLE
fix(surveys): stop announcing the public-API name placeholder on app surveys (backport #8982 to release/5.4)

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.test.ts
@@ -3,6 +3,7 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { PUBLIC_API_SURVEY_NAME_PLACEHOLDER } from "@formbricks/types/js-constants";
 import { getWorkspaceStateData } from "./data";
 
 vi.mock("server-only", () => ({}));
@@ -120,7 +121,7 @@ describe("getWorkspaceStateData", () => {
       surveys: [
         {
           ...mockWorkspaceData.surveys[0],
-          name: "[deprecated] survey name omitted from public API - will be removed soon",
+          name: PUBLIC_API_SURVEY_NAME_PLACEHOLDER,
         },
       ],
       actionClasses: mockWorkspaceData.actionClasses,

--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
@@ -9,6 +9,7 @@ import {
   TJsWorkspaceStateSurvey,
   TJsWorkspaceStateWorkspaceSetting,
 } from "@formbricks/types/js";
+import { PUBLIC_API_SURVEY_NAME_PLACEHOLDER } from "@formbricks/types/js-constants";
 import { type TBaseFilters, buildSurveyInteractionRefreshMap } from "@formbricks/types/segment";
 import { toLegacyLanguageCodes } from "@/lib/i18n/utils";
 import { validateInputs } from "@/lib/utils/validate";
@@ -283,7 +284,7 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
 
       return {
         ...transformed,
-        name: "[deprecated] survey name omitted from public API - will be removed soon",
+        name: PUBLIC_API_SURVEY_NAME_PLACEHOLDER,
         segment: sanitizedSegment,
         ...(interactionRefresh ? { interactionRefresh } : {}),
       };

--- a/packages/surveys/src/components/general/render-survey.tsx
+++ b/packages/surveys/src/components/general/render-survey.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { SurveyContainerProps } from "@formbricks/types/formbricks-surveys";
-import { hasSurveyInstructions } from "@/lib/survey-page";
+import { getSurveyDisplayName, hasSurveyInstructions } from "@/lib/survey-page";
 import { getSurveyLanguageTag, isRTLLanguage } from "@/lib/utils";
 import { SurveyContainer } from "../wrappers/survey-container";
 import { Survey } from "./survey";
@@ -106,7 +106,7 @@ export function RenderSurvey(props: Readonly<SurveyContainerProps>) {
       onClose={close}
       isOpen={isOpen}
       dir={dir}
-      surveyName={props.survey.name}
+      surveyName={getSurveyDisplayName(props.survey.name)}
       hasInstructions={hasSurveyInstructions(props.survey)}
       lang={languageTag}>
       <Survey

--- a/packages/surveys/src/lib/survey-page.ts
+++ b/packages/surveys/src/lib/survey-page.ts
@@ -1,4 +1,7 @@
+// Imported from the dependency-free constants module rather than from `./js`: a value import of
+// `@formbricks/types/js` pulls its zod schema graph into the widget bundle (+94 kB on the UMD build).
 import { type TJsWorkspaceStateSurvey } from "@formbricks/types/js";
+import { PUBLIC_API_SURVEY_NAME_PLACEHOLDER } from "@formbricks/types/js-constants";
 
 /** Id of the visually-hidden region holding the survey's persistent instructions. */
 export const SURVEY_INSTRUCTIONS_ID = "fb__survey-instructions";
@@ -41,6 +44,26 @@ export const getSurveyPagePosition = (
   // Not a block: an ending card, or an id that no longer resolves after the survey was edited
   // mid-session. The last page either way.
   return { index: total, total };
+};
+
+/**
+ * The survey name to show a respondent, or `undefined` when there is none to show.
+ *
+ * A survey delivered by the JS widget is fetched from the public client API, which deliberately
+ * replaces every name with a placeholder so names are not exposed over an unauthenticated endpoint
+ * (ENG-808). That placeholder is an internal deprecation notice, so rendering it is worse than
+ * rendering nothing: it became the dialog's accessible name and its only heading on every app
+ * survey, which is what a screen reader then announced. Treat it as "this survey has no name" and
+ * let the callers fall back the way they already do for a survey rendered without one.
+ *
+ * Link surveys are unaffected — their name comes from the server component, never from this
+ * endpoint, so it never matches the placeholder.
+ *
+ * Also drops a name that is only whitespace, which would name the dialog with nothing at all.
+ */
+export const getSurveyDisplayName = (name: string | undefined): string | undefined => {
+  if (!name || name === PUBLIC_API_SURVEY_NAME_PLACEHOLDER) return undefined;
+  return name.trim().length > 0 ? name : undefined;
 };
 
 /**

--- a/packages/types/js-constants.ts
+++ b/packages/types/js-constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Constants shared between the public client API and the JS widget that consumes it.
+ *
+ * This module deliberately imports nothing. Its consumers include `@formbricks/surveys`, whose
+ * bundle every respondent of an app survey downloads, and importing a *value* from `./js` instead
+ * would drag that module's zod schema graph into the bundle — measured at +94 kB on the UMD build.
+ * Keep it dependency-free, and keep constants the widget needs here rather than in `./js`.
+ */
+
+/**
+ * The string the public client API substitutes for every survey name it returns, so that survey
+ * names are not exposed over an unauthenticated endpoint (ENG-808).
+ *
+ * It is a marker, not text anyone should ever read: it lives here rather than inline at the
+ * substitution site so the widget can recognise it and refuse to render it. Change it in one place
+ * or the widget stops recognising it — see `getSurveyDisplayName` in `@formbricks/surveys`.
+ */
+export const PUBLIC_API_SURVEY_NAME_PLACEHOLDER =
+  "[deprecated] survey name omitted from public API - will be removed soon";


### PR DESCRIPTION
Ref ENG-2617

Backport of #8982 to `release/5.4`. Cherry-picked from `e2c7097` (squash commit on `main`), applied with no conflicts, then trimmed to backport policy — minimal, single-purpose, no net-new tests.

## What & why

- On an app-type survey delivered by the js-core widget, the modal's accessible name and its `sr-only` `h1` both read `[deprecated] survey name omitted from public API - will be removed soon` — so that sentence is what a screen reader announces as the dialog's name and as its only heading, for every app-survey respondent.
- The widget reads its surveys from the public client API, which deliberately substitutes that fixed placeholder for every survey name so names aren't exposed over an unauthenticated endpoint. The dialog name and the heading both came from `survey.name` and neither accounted for the substitution.
- `getSurveyDisplayName` returns `undefined` for the placeholder — and for a missing or whitespace-only name — so the renderer falls back to the generic `Survey Dialog` label it already uses for a survey rendered without a name. `RenderSurvey` routes `survey.name` through it, which is the single choke point feeding the dialog's `aria-label`, the `sr-only` `h1`, the `role="form"` landmark and `aria-describedby`.
- The placeholder becomes a shared constant so the API side and the widget can't drift. It lives in a dependency-free `packages/types/js-constants.ts` rather than in `types/js.ts`, because a *value* import of `types/js` drags that module's zod schema graph into the widget bundle — measured at +94 kB on the UMD build on #8982, against 140 bytes for the leaf module.
- Link surveys are unaffected — their name comes from the server component, never from this endpoint.

### Files changed (5)

| File | Change |
| --- | --- |
| `packages/types/js-constants.ts` | new dependency-free module holding `PUBLIC_API_SURVEY_NAME_PLACEHOLDER` |
| `packages/surveys/src/lib/survey-page.ts` | new `getSurveyDisplayName` helper |
| `packages/surveys/src/components/general/render-survey.tsx` | routes `survey.name` through the helper |
| `apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts` | substitutes via the shared constant instead of an inline literal |
| `apps/web/.../lib/data.test.ts` | pre-existing test, updated to assert against the constant (kept — policy keeps edits to existing tests) |

`@formbricks/types` exports `./*` → `./*.ts`, so the new module resolves with no package.json change.

### Dropped relative to #8982

- The four net-new `getSurveyDisplayName` cases added to `packages/surveys/src/lib/survey-page.test.ts` — net-new cases; the file is restored to its `release/5.4` state, so its 17 pre-existing tests are untouched.
- The two net-new assertions added to the existing widget journey in `apps/web/playwright/js.spec.ts` — also net-new; that spec is restored to its `release/5.4` state.

Both were the checks that proved the fix on `main`; see Open gaps.

## Breaking changes

- [ ] This PR contains breaking changes

None. The public client API's response is byte-identical — the placeholder is referenced through a constant instead of an inline literal. No API/SDK shape, endpoint, env var, config key or default changes, and no deployer action. The only behaviour change is what assistive tech reads out in the rendered widget.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The whole surveys package still passes after restoring its spec to the release state | unit (guard): `pnpm exec vitest run` in `packages/surveys` | 29 files, 721 passed. `main` reports 725 — the difference is exactly the 4 dropped cases, and no pre-existing test regressed |
| The public client API still substitutes the placeholder, now via the shared constant, so the two cannot drift | unit (guard): `pnpm exec vitest run "app/api/v1/client/[workspaceId]/environment/lib/data.test.ts"` in `apps/web` | 18/18 passed |
| The new module resolves and type-checks from both consumers (widget and web API) | manual: `pnpm typecheck --filter=@formbricks/surveys --filter=@formbricks/types`, then `--filter=@formbricks/web` | Both green; web 12/12 tasks. This is the check that would catch the `types` export map not covering a new file |
| Formatting and lint match repo style | manual: repo pre-commit hooks (`prettier --write` + `lint-staged-eslint`) ran on commit, then `prettier --check` on all 5 changed files | Hooks clean, no bypass; "All matched files use Prettier code style!" |
| The placeholder guard itself, the +94 kB bundle finding, and the widget behaviour end-to-end | manual, inherited from #8982 | Verified there on identical source bytes — mutation-tested guard (reverting it turned the case red: 1 failed / 724 passed), UMD bundle 971,447 B → 971,587 B (+140 B), and the real API → widget → dialog path |

**Open gaps**

- **The two checks that actually prove this fix were dropped as net-new**, so on this branch nothing automated would catch the placeholder leaking back in: the mutation-tested `getSurveyDisplayName` cases, and the Playwright assertions on the real API → widget → dialog path. That path is the only place the API, the widget and the dialog are wired together. If you would rather have those two than the smaller delta, say so and I will bring them back — this is the one open gap I would actually push back on the policy for.
- Playwright was not run here (no Docker daemon in this environment, so Postgres/Redis cannot boot) — and with the assertions dropped it would not cover this behaviour anyway.
- As on #8982: the `sr-only` `h1` is now absent on widget-delivered surveys, since there is no name to put in it. That is the intended fallback and matches documented preview behaviour, but it means WCAG 2.4.6's top-level heading is not present on that delivery path. Restoring a real heading needs an API-side decision about exposing survey names to the public client endpoint, out of scope for a QA fix.
- Screen-reader behaviour was verified by reading accessibility attributes, not by listening with an actual screen reader.

**Risks**

- Inline (non-modal) app surveys delivered by the widget lose their `role="form"` landmark, since the container only declares the role once there is a name to give it. That is the pre-existing, deliberate behaviour for an unnamed survey, but it is a change on that path.
- `getSurveyDisplayName` matches the placeholder **exactly**; editing the API-side string without updating the shared constant starts the leak again. The shared constant exists to prevent that, and both call sites import it — but with the drift-pinning test dropped here, nothing on this branch enforces it.