### PR TITLE
fix(sso): strip the live local auth factors on SSO recovery (backport 5.3)

### DIFF
--- a/apps/web/app/api/auth/sso/recovery/complete/route.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import { logger } from "@formbricks/logger";
 import { verifySsoRelinkIntent } from "@/lib/jwt";
-import { deleteSessionBySessionToken } from "@/modules/auth/lib/auth-session-repository";
 import { getSession } from "@/modules/auth/lib/session";
 import {
   BETTER_AUTH_SESSION_COOKIE_NAMES,
   getSessionTokenFromCookieHeader,
 } from "@/modules/auth/lib/session-cookie";
+import { revokeSessionByToken } from "@/modules/auth/lib/session-revocation";
 import { completeSsoRecovery, getSsoRecoveryFailureRedirectUrl } from "@/modules/ee/sso/lib/sso-recovery";
 
 const clearSessionCookies = (response: NextResponse) => {
@@ -31,7 +31,9 @@ const buildFailedRecoveryResponse = async (request: Request, callbackUrl?: strin
   }
 
   try {
-    await deleteSessionBySessionToken(sessionToken);
+    // Through the two-store revocation, not a raw Prisma delete: sessions live in Redis too, and a
+    // DB-only delete would leave this one resolvable by `getSession` until its TTL (ENG-2557).
+    await revokeSessionByToken(sessionToken);
   } catch (error) {
     logger.error(error, "Failed to delete SSO recovery session after recovery completion error");
   }
@@ -52,6 +54,8 @@ export const GET = async (request: Request) => {
     const callbackUrl = await completeSsoRecovery({
       intentToken,
       sessionUserId: session?.user.id,
+      // Spared by the post-commit session sweep, so the redirect below still lands signed in.
+      sessionToken: getSessionTokenFromCookieHeader(request.headers.get("cookie")) ?? undefined,
     });
 
     return NextResponse.redirect(callbackUrl);

--- a/apps/web/lib/user/password.test.ts
+++ b/apps/web/lib/user/password.test.ts
@@ -2,12 +2,13 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { InvalidInputError } from "@formbricks/types/errors";
 import { verifyPassword } from "@/modules/auth/lib/utils";
-import { getCredentialPasswordHash, verifyUserPassword } from "./password";
+import { getCredentialPasswordHash, hasCredentialAccount, verifyUserPassword } from "./password";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
     account: {
       findUnique: vi.fn(),
+      count: vi.fn(),
     },
   },
 }));
@@ -73,5 +74,27 @@ describe("user password helpers", () => {
     await expect(verifyUserPassword("sso-user", "plain-password")).rejects.toThrow(InvalidInputError);
 
     expect(mockVerifyPassword).not.toHaveBeenCalled();
+  });
+
+  test("hasCredentialAccount uses Better Auth's own credential-account predicate", async () => {
+    vi.mocked(prisma.account.count).mockResolvedValue(1);
+
+    await expect(hasCredentialAccount("user-1")).resolves.toBe(true);
+    // The same four-column predicate Better Auth's `findCredentialAccount` uses. Anything broader would
+    // answer "may reset" for a row `resetPassword` cannot then find, which turns into a unique-constraint
+    // collision on its create branch rather than a reset.
+    expect(prisma.account.count).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        provider: "credential",
+        providerAccountId: "user-1",
+      },
+    });
+  });
+
+  test("hasCredentialAccount is false for an SSO-only user", async () => {
+    vi.mocked(prisma.account.count).mockResolvedValue(0);
+
+    await expect(hasCredentialAccount("user-2")).resolves.toBe(false);
   });
 });

--- a/apps/web/lib/user/password.ts
+++ b/apps/web/lib/user/password.ts
@@ -32,3 +32,36 @@ export const verifyUserPassword = async (userId: string, password: string): Prom
 
   return await verifyPassword(password, passwordHash);
 };
+
+/**
+ * Whether the user has a Better Auth `credential` Account row at all — i.e. whether they are (or once
+ * were) a password user, independently of whether a password is currently set on it.
+ *
+ * Deliberately the SAME predicate Better Auth's own credential-account lookup uses on this branch —
+ * `userId`, provider `credential`, and `accountId` equal to the user id. That match matters because this
+ * answers "may this user reset a password?", and the only consumer of the answer is `resetPassword`,
+ * which locates the row with that exact predicate: erring broader would return true for a row whose key
+ * has drifted, the reset would then take its create-a-row branch, and that can collide with
+ * `@@unique([provider, providerAccountId])` — a 500 instead of a reset.
+ *
+ * Note this is the opposite trade-off from the SSO-recovery strip, which scopes by `userId` alone on
+ * purpose: a strip must never miss a live hash, so over-matching is the safe direction there. Here
+ * over-matching promises something the next call cannot deliver, so under-matching is. Same schema, two
+ * different questions.
+ *
+ * NOTE: no `issuer` clause here, unlike `main`. Better Auth 1.6.23 on this release branch has no issuer
+ * concept and `Account` has no `issuer` column — the namespace arrived in 1.7 (main / release/5.4, where
+ * this reads `issuer: createLocalAccountIssuer("credential")`). This is therefore the exact-match
+ * predicate for THIS branch's Better Auth, not a loosened one.
+ */
+export const hasCredentialAccount = reactCache(async (userId: string): Promise<boolean> => {
+  const count = await prisma.account.count({
+    where: {
+      userId,
+      provider: "credential",
+      providerAccountId: userId,
+    },
+  });
+
+  return count > 0;
+});

--- a/apps/web/modules/auth/forgot-password/actions.test.ts
+++ b/apps/web/modules/auth/forgot-password/actions.test.ts
@@ -7,12 +7,47 @@ import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { forgotPasswordAction } from "./actions";
 
+const mocks = vi.hoisted(() => ({
+  hasCredentialAccount: vi.fn(),
+  // Held in a box and exposed through a getter below so a single test can flip it: `EMAIL_AUTH_ENABLED` is
+  // a const import in the action, and the getter keeps the live binding readable per call.
+  emailAuthEnabled: { value: true },
+  // The wrapper is applied once at module import, so `vi.resetAllMocks()` in beforeEach would wipe the
+  // call history before any test could read it. A plain array on the hoisted object survives the reset.
+  auditWrapperArgs: [] as [string, string][],
+}));
+
 const allowedRateLimitResponse = { allowed: true };
+
+/** Fresh audit context per call — the action writes `userId` / `suppressEvent` onto it. */
+let auditLoggingCtx: Record<string, unknown>;
+const callAction = (input: { email: string } = { email: "test@example.com" }) => {
+  auditLoggingCtx = {};
+  return forgotPasswordAction({ ctx: { auditLoggingCtx }, parsedInput: input } as any);
+};
 const RESET_REDIRECT = "http://localhost:3000/auth/forgot-password/reset";
 
 vi.mock("@/lib/constants", () => ({
+  get EMAIL_AUTH_ENABLED() {
+    return mocks.emailAuthEnabled.value;
+  },
   PASSWORD_RESET_DISABLED: false,
   WEBAPP_URL: "http://localhost:3000",
+}));
+
+// Mocked at the module boundary rather than letting the real one load: `lib/user/password` pulls in
+// `lib/crypto`, which reads ENCRYPTION_KEY from the (fully replaced) constants mock at import time.
+vi.mock("@/lib/user/password", () => ({
+  hasCredentialAccount: mocks.hasCredentialAccount,
+}));
+
+// Passthrough so the handler runs directly, matching modules/ee/billing/actions.test.ts. Importing the
+// real handler would drag the audit-log graph (and its POSTHOG_KEY constant read) into this suite.
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((action: string, target: string, fn: unknown) => {
+    mocks.auditWrapperArgs.push([action, target]);
+    return fn;
+  }),
 }));
 
 vi.mock("@/modules/core/rate-limit/helpers", () => ({
@@ -57,6 +92,10 @@ describe("forgotPasswordAction", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mocks.emailAuthEnabled.value = true;
+    // `vi.resetAllMocks()` does not touch this, so reset it here too: a future test that asserts on
+    // `auditLoggingCtx` without calling `callAction` would otherwise read the previous test's object.
+    auditLoggingCtx = {};
   });
 
   afterEach(() => {
@@ -67,7 +106,7 @@ describe("forgotPasswordAction", () => {
     test("applies rate limiting (with the right config) before looking up the user", async () => {
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
 
-      await forgotPasswordAction({ parsedInput: validInput } as any);
+      await callAction(validInput);
 
       expect(applyIPRateLimit).toHaveBeenCalledWith(rateLimitConfigs.auth.forgotPassword);
       expect(applyIPRateLimit).toHaveBeenCalledBefore(getUserByEmail as any);
@@ -78,7 +117,7 @@ describe("forgotPasswordAction", () => {
         new Error("Maximum number of requests reached. Please try again later.")
       );
 
-      await expect(forgotPasswordAction({ parsedInput: validInput } as any)).rejects.toThrow(
+      await expect(callAction(validInput)).rejects.toThrow(
         "Maximum number of requests reached. Please try again later."
       );
 
@@ -92,7 +131,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       expect(getUserByEmail).toHaveBeenCalledWith(validInput.email);
       expect(auth.api.requestPasswordReset).toHaveBeenCalledWith({
@@ -106,20 +145,129 @@ describe("forgotPasswordAction", () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue(null);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
-    test("does not request a reset for a non-email identity provider", async () => {
+    test("does not request a reset for an SSO user with no credential account", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(false);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();
       expect(result).toEqual({ success: true });
+    });
+  });
+
+  /**
+   * SSO recovery is one-way: it flips `identityProvider` to the SSO provider and nothing flips it back,
+   * while clearing the password it found. Gated on `identityProvider` alone these users could never ask
+   * for a reset again, so the surviving credential `Account` row is what lets them back in (ENG-2557).
+   */
+  describe("Recovered SSO users (ENG-2557)", () => {
+    beforeEach(() => {
+      vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
+    });
+
+    test("requests a reset for an SSO-identity user who still has a credential account", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(true);
+
+      const result = await callAction(validInput);
+
+      expect(mocks.hasCredentialAccount).toHaveBeenCalledWith(mockUser.id);
+      expect(auth.api.requestPasswordReset).toHaveBeenCalledWith({
+        body: { email: mockUser.email, redirectTo: RESET_REDIRECT },
+        headers: expect.any(Headers),
+      });
+      expect(result).toEqual({ success: true });
+    });
+
+    test("stays shut on an SSO-only instance, even with a credential account present", async () => {
+      mocks.emailAuthEnabled.value = false;
+      vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(true);
+
+      const result = await callAction(validInput);
+
+      // Handing a password back where the operator disabled credential auth would be the "sign in around
+      // the IdP" bypass that switching it off exists to prevent.
+      expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+
+    test("does not need the credential lookup for an email-identity user", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
+
+      await callAction(validInput);
+
+      // Short-circuits on `identityProvider === "email"`, so the extra query never runs for the common case.
+      expect(mocks.hasCredentialAccount).not.toHaveBeenCalled();
+      expect(auth.api.requestPasswordReset).toHaveBeenCalledOnce();
+    });
+  });
+
+  /**
+   * The action answers `{ success: true }` whether or not a reset was actually requested, so the audit
+   * wrapper cannot tell the two apart on its own — without `suppressEvent` it would record a
+   * `passwordReset` for an address that never got one. Same false-record problem as duplicate sign-up
+   * (ENG-2091), and these pin both directions.
+   */
+  describe("Audit record", () => {
+    beforeEach(() => {
+      vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
+    });
+
+    test("targets the audited event at the user when a reset is actually requested", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
+
+      await callAction(validInput);
+
+      expect(auditLoggingCtx.userId).toBe(mockUser.id);
+      expect(auditLoggingCtx.suppressEvent).toBeUndefined();
+    });
+
+    test("suppresses the event for an address with no account", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue(null);
+
+      await callAction(validInput);
+
+      expect(auditLoggingCtx.suppressEvent).toBe(true);
+      expect(auditLoggingCtx.userId).toBeUndefined();
+    });
+
+    /**
+     * Without this the whole audit story is unobserved: `withAuditLogging` is mocked as a passthrough and
+     * `actionClient.action` returns the handler, so deleting the wrapper from the action entirely would
+     * leave every other test in this file green — including the ones below. This is the only assertion
+     * that the event is emitted under the right action and target at all.
+     */
+    test("wires the wrapper with the right audit action and target", () => {
+      expect(mocks.auditWrapperArgs).toContainEqual(["passwordReset", "user"]);
+    });
+
+    test("suppresses the event when the reset email fails to send", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
+      vi.mocked(auth.api.requestPasswordReset).mockRejectedValue(new Error("smtp down"));
+
+      const result = await callAction(validInput);
+
+      // The action still reports success, so an unsuppressed event would claim a link was mailed.
+      expect(result).toEqual({ success: true });
+      expect(auditLoggingCtx.suppressEvent).toBe(true);
+    });
+
+    test("suppresses the event for a user with no password to reset", async () => {
+      vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(false);
+
+      await callAction(validInput);
+
+      expect(auditLoggingCtx.suppressEvent).toBe(true);
     });
   });
 
@@ -129,7 +277,7 @@ describe("forgotPasswordAction", () => {
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
       vi.mocked(auth.api.requestPasswordReset).mockRejectedValue(new Error("BA request failed"));
 
-      await expect(forgotPasswordAction({ parsedInput: validInput } as any)).resolves.toEqual({
+      await expect(callAction(validInput)).resolves.toEqual({
         success: true,
       });
       expect(logger.error).toHaveBeenCalledWith(
@@ -138,13 +286,21 @@ describe("forgotPasswordAction", () => {
       );
     });
 
+    test("still reports success when the credential lookup throws", async () => {
+      vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
+      vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "google" } as any);
+      mocks.hasCredentialAccount.mockRejectedValue(new Error("db down"));
+
+      // The whole point of the fail-closed catch: no reset, no escaping error.
+      await expect(callAction(validInput)).resolves.toEqual({ success: true });
+      expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();
+    });
+
     test("propagates a user-lookup error", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockRejectedValue(new Error("Database error"));
 
-      await expect(forgotPasswordAction({ parsedInput: validInput } as any)).rejects.toThrow(
-        "Database error"
-      );
+      await expect(callAction(validInput)).rejects.toThrow("Database error");
     });
   });
 
@@ -153,14 +309,15 @@ describe("forgotPasswordAction", () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue(null);
 
-      expect(await forgotPasswordAction({ parsedInput: validInput } as any)).toEqual({ success: true });
+      expect(await callAction(validInput)).toEqual({ success: true });
     });
 
     test("always returns success for an SSO user and never requests a reset", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(allowedRateLimitResponse);
       vi.mocked(getUserByEmail).mockResolvedValue({ ...mockUser, identityProvider: "github" } as any);
+      mocks.hasCredentialAccount.mockResolvedValue(false);
 
-      const result = await forgotPasswordAction({ parsedInput: validInput } as any);
+      const result = await callAction(validInput);
 
       expect(result).toEqual({ success: true });
       expect(auth.api.requestPasswordReset).not.toHaveBeenCalled();

--- a/apps/web/modules/auth/forgot-password/actions.ts
+++ b/apps/web/modules/auth/forgot-password/actions.ts
@@ -2,23 +2,75 @@
 
 import { headers } from "next/headers";
 import { z } from "zod";
+import type { IdentityProvider } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { OperationNotAllowedError } from "@formbricks/types/errors";
 import { ZUserEmail } from "@formbricks/types/user";
-import { PASSWORD_RESET_DISABLED, WEBAPP_URL } from "@/lib/constants";
+import { EMAIL_AUTH_ENABLED, PASSWORD_RESET_DISABLED, WEBAPP_URL } from "@/lib/constants";
+import { hasCredentialAccount } from "@/lib/user/password";
 import { actionClient } from "@/lib/utils/action-client";
 import { auth } from "@/modules/auth/lib/auth";
 import { getUserByEmail } from "@/modules/auth/lib/user";
 import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
+
+/**
+ * Whether this user has a password to reset. Pure SSO users do not, and are silently skipped — Better
+ * Auth's request endpoint is enumeration-safe and the action always reports success either way.
+ *
+ * The second arm exists because SSO recovery is one-way (ENG-2557): completing it flips
+ * `identityProvider` to the SSO provider and nothing ever flips it back, while the recovery also clears
+ * the password it found. Gated on `identityProvider` alone, those users could never ask for a reset again
+ * — locked to an IdP they might lose access to, with `auth.api.setPassword` being `serverOnly` and
+ * unwired. The surviving credential `Account` row identifies them: recovery nulls the password, it does
+ * not delete the row.
+ *
+ * Kept as narrow as that problem, deliberately: gating on the credential row rather than on
+ * `emailVerified` means this action grants nothing to a user who has only ever signed in via SSO, and
+ * `EMAIL_AUTH_ENABLED` switches the second arm off entirely on an SSO-only instance. Note that gate
+ * covers only the second arm — an `identityProvider === "email"` user still receives reset mail on an
+ * SSO-only instance, which is pre-existing behaviour this change deliberately leaves alone. So the flag
+ * here is about not *widening* that surface, not about closing it.
+ *
+ * Both are belt-and-braces rather than the enforcement boundary, and it is worth not mistaking one for
+ * the other. Better Auth's native `POST /api/auth/request-password-reset` is mounted by the `[...all]`
+ * catch-all unconditionally — it is NOT gated on `emailAndPassword.enabled` — and its `resetPassword`
+ * CREATES a credential row when none exists. So a password can be minted for any registered address
+ * regardless of this action. What actually contains that is `/sign-in/email`, which IS gated, so a minted
+ * password is unusable on an SSO-only instance. This relaxation therefore grants no reach that was not
+ * already there; it just stops the UI lying to a recovered user.
+ */
+const canResetPassword = async (user: {
+  id: string;
+  identityProvider: IdentityProvider;
+}): Promise<boolean> => {
+  if (user.identityProvider === "email") {
+    return true;
+  }
+  if (!EMAIL_AUTH_ENABLED) {
+    return false;
+  }
+
+  try {
+    return await hasCredentialAccount(user.id);
+  } catch (error) {
+    // Fail closed rather than letting this escape. Note the action's `{ success: true }` is not an
+    // absolute invariant — `getUserByEmail` above it is unguarded and its `DatabaseError` is not an
+    // expected error, so it surfaces as a server error. That is address-independent, so it is not an
+    // enumeration oracle; this catch just avoids adding a second, narrower failure mode on a path that
+    // only runs for non-email identity providers.
+    logger.error({ error, userId: user.id }, "Credential-account lookup failed during password reset");
+    return false;
+  }
+};
 
 const ZForgotPasswordAction = z.object({
   email: ZUserEmail,
 });
 
-export const forgotPasswordAction = actionClient
-  .inputSchema(ZForgotPasswordAction)
-  .action(async ({ parsedInput }) => {
+export const forgotPasswordAction = actionClient.inputSchema(ZForgotPasswordAction).action(
+  withAuditLogging("passwordReset", "user", async ({ ctx, parsedInput }) => {
     await applyIPRateLimit(rateLimitConfigs.auth.forgotPassword);
 
     if (PASSWORD_RESET_DISABLED) {
@@ -27,18 +79,32 @@ export const forgotPasswordAction = actionClient
 
     const user = await getUserByEmail(parsedInput.email);
 
-    // Only credential (email-identity) users have a password to reset; SSO users are silently skipped.
-    // Better Auth's request endpoint is itself enumeration-safe, and we always return success below.
-    if (user && user.identityProvider === "email") {
+    if (user && (await canResetPassword(user))) {
+      // Target the audited event at the account the reset was requested for. The ACTOR stays
+      // `UNKNOWN_DATA` because this action is unauthenticated by design — which is the honest record:
+      // someone who knows the address asked for a reset.
+      ctx.auditLoggingCtx.userId = user.id;
       try {
         await auth.api.requestPasswordReset({
           body: { email: user.email, redirectTo: `${WEBAPP_URL}/auth/forgot-password/reset` },
           headers: await headers(),
         });
       } catch (error) {
+        // The send failed but the action still answers `{ success: true }`, so without suppressing here
+        // the trail would claim a reset link was mailed to this user — the same false record the `else`
+        // branch guards, in the other direction. SMTP being down should not read as "we mailed them".
+        ctx.auditLoggingCtx.suppressEvent = true;
         logger.error({ error, userId: user.id }, "Password reset request failed");
       }
+    } else {
+      // No reset was requested — unknown address, or a user with no password to reset. The action still
+      // answers `{ success: true }` to stay enumeration-safe, so without this the wrapper's fixed
+      // `passwordReset` action would record a reset that never happened (the same false-record problem
+      // `suppressEvent` was added for on duplicate sign-up, ENG-2091). A thrown failure is audited
+      // regardless, so this cannot hide one.
+      ctx.auditLoggingCtx.suppressEvent = true;
     }
 
     return { success: true };
-  });
+  })
+);

--- a/apps/web/modules/auth/lib/auth-session-repository.test.ts
+++ b/apps/web/modules/auth/lib/auth-session-repository.test.ts
@@ -2,67 +2,47 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
-import { deleteSessionBySessionToken } from "./auth-session-repository";
+import { getSessionTokensByUserId } from "./auth-session-repository";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
     session: {
-      deleteMany: vi.fn(),
+      findMany: vi.fn(),
     },
   },
 }));
 
 describe("auth-session-repository", () => {
-  const sessionToken = "session-token-cm8z6bn2q000008l34h8g7k9m";
-
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  test("deletes the session matching the given token", async () => {
-    vi.mocked(prisma.session.deleteMany).mockResolvedValue({ count: 1 });
+  test("lists a user's unexpired session tokens", async () => {
+    vi.mocked(prisma.session.findMany).mockResolvedValue([
+      { sessionToken: "token-a" },
+      { sessionToken: "token-b" },
+    ] as never);
 
-    const result = await deleteSessionBySessionToken(sessionToken);
-
-    expect(result).toBe(1);
-    expect(prisma.session.deleteMany).toHaveBeenCalledWith({
-      where: { sessionToken },
+    await expect(getSessionTokensByUserId("user_1")).resolves.toEqual(["token-a", "token-b"]);
+    // Expired rows are excluded on purpose: the count feeds the SSO-recovery audit event, where it is
+    // read as "how many sessions the squatter was holding".
+    expect(prisma.session.findMany).toHaveBeenCalledWith({
+      where: { userId: "user_1", expires: { gt: expect.any(Date) } },
+      select: { sessionToken: true },
     });
   });
 
-  test("returns zero when no session matches the token", async () => {
-    vi.mocked(prisma.session.deleteMany).mockResolvedValue({ count: 0 });
+  test("returns an empty list for a user with no sessions", async () => {
+    vi.mocked(prisma.session.findMany).mockResolvedValue([] as never);
 
-    const result = await deleteSessionBySessionToken(sessionToken);
-
-    expect(result).toBe(0);
-  });
-
-  test("uses the provided transaction client when available", async () => {
-    const txDeleteMany = vi.fn().mockResolvedValue({ count: 1 });
-    const tx = {
-      session: {
-        deleteMany: txDeleteMany,
-      },
-    } as unknown as Prisma.TransactionClient;
-
-    const result = await deleteSessionBySessionToken(sessionToken, tx);
-
-    expect(result).toBe(1);
-    expect(txDeleteMany).toHaveBeenCalledWith({
-      where: { sessionToken },
-    });
-    expect(prisma.session.deleteMany).not.toHaveBeenCalled();
+    await expect(getSessionTokensByUserId("user_1")).resolves.toEqual([]);
   });
 
   test("wraps prisma known errors in DatabaseError", async () => {
-    vi.mocked(prisma.session.deleteMany).mockRejectedValue(
-      new Prisma.PrismaClientKnownRequestError("database failed", {
-        code: "P2021",
-        clientVersion: "test",
-      })
+    vi.mocked(prisma.session.findMany).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("boom", { code: "P2024", clientVersion: "7.x" })
     );
 
-    await expect(deleteSessionBySessionToken(sessionToken)).rejects.toThrow(DatabaseError);
+    await expect(getSessionTokensByUserId("user_1")).rejects.toThrow(DatabaseError);
   });
 });

--- a/apps/web/modules/auth/lib/auth-session-repository.ts
+++ b/apps/web/modules/auth/lib/auth-session-repository.ts
@@ -1,13 +1,9 @@
 import "server-only";
 import { z } from "zod";
 import { prisma } from "@formbricks/database";
-import { Prisma, PrismaClient } from "@formbricks/database/prisma";
+import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
 import { validateInputs } from "@/lib/utils/validate";
-
-type TAuthSessionDbClient = PrismaClient | Prisma.TransactionClient;
-
-const getDbClient = (tx?: Prisma.TransactionClient): TAuthSessionDbClient => tx ?? prisma;
 
 const handleDatabaseError = (error: unknown): never => {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -17,20 +13,32 @@ const handleDatabaseError = (error: unknown): never => {
   throw error;
 };
 
-export const deleteSessionBySessionToken = async (
-  sessionToken: string,
-  tx?: Prisma.TransactionClient
-): Promise<number> => {
-  validateInputs([sessionToken, z.string().min(1)]);
+/**
+ * Every UNEXPIRED session token belonging to a user, read from Postgres.
+ *
+ * Postgres is the authoritative enumeration source here, deliberately: `session.storeSessionInDatabase`
+ * is on (auth.ts), so every session has a row, whereas Better Auth's own `internalAdapter.listSessions`
+ * reads the `active-sessions-<userId>` index out of `secondaryStorage` and returns an empty list when
+ * that key is missing or evicted — which would silently revoke nothing.
+ */
+export const getSessionTokensByUserId = async (userId: string): Promise<string[]> => {
+  validateInputs([userId, z.string().min(1)]);
 
   try {
-    const result = await getDbClient(tx).session.deleteMany({
+    const sessions = await prisma.session.findMany({
       where: {
-        sessionToken,
+        userId,
+        // Expired rows are already unusable, and including them would inflate the revocation count that
+        // lands in the SSO-recovery audit event — the one place that number is read as "how many
+        // sessions the squatter was holding".
+        expires: { gt: new Date() },
+      },
+      select: {
+        sessionToken: true,
       },
     });
 
-    return result.count;
+    return sessions.map((session) => session.sessionToken);
   } catch (error) {
     return handleDatabaseError(error);
   }

--- a/apps/web/modules/auth/lib/session-revocation.ts
+++ b/apps/web/modules/auth/lib/session-revocation.ts
@@ -1,0 +1,82 @@
+import "server-only";
+import { z } from "zod";
+import { logger } from "@formbricks/logger";
+import { validateInputs } from "@/lib/utils/validate";
+import { getSessionTokensByUserId } from "@/modules/auth/lib/auth-session-repository";
+
+/**
+ * Revoke every session a user holds except one, across BOTH session stores.
+ *
+ * Sessions live in two places (see `auth.ts`): Postgres, because `session.storeSessionInDatabase` is
+ * required for the forward-auth proxies, and Redis via `secondaryStorage`. `findSession` consults Redis
+ * first, so a bare `prisma.session.deleteMany()` is NOT a revocation — it leaves the session fully valid
+ * for `auth.api.getSession` while breaking only the proxy path, which is strictly worse than doing
+ * nothing. Better Auth's `internalAdapter.deleteSessions` clears both: `secondaryStorage.delete(token)`
+ * per token, then the rows.
+ *
+ * Enumeration comes from Postgres (`getSessionTokensByUserId`) rather than `internalAdapter.listSessions`,
+ * which under `secondaryStorage` reads only the `active-sessions-<userId>` index and returns an empty
+ * list if that key was evicted — silently revoking nothing.
+ *
+ * Known residual, shared with `revokeSessionsOnPasswordReset`: `cookieCache` serves a still-valid
+ * `session_data` cookie from its signature alone, so a revoked session's holder keeps a cached session
+ * for up to `cookieCache.maxAge` (5 min in auth.ts) without ever hitting either store. Stateless by
+ * design upstream (ENG-2591).
+ *
+ * Do not read that as "5 minutes of exposure": the window is bounded but what can be done inside it is
+ * not. A still-cached session can mint an API key or complete an OAuth authorization, neither of which
+ * expires with the session. That is why the ENG-2557 strip revokes OAuth grants in its transaction
+ * rather than relying on the sweep alone.
+ *
+ * One upstream wrinkle: `deleteSessions` prunes the per-token keys and the rows but does not rewrite the
+ * `active-sessions-<userId>` index, so `auth.api.listSessions` keeps listing revoked sessions until their
+ * TTL. No security consequence — `getSession` needs the per-token key, which is gone — but an "active
+ * sessions" view lies immediately after a revocation.
+ *
+ * `auth` is imported dynamically on purpose: `auth.ts` → `better-auth-hooks.ts` → `sso-recovery.ts`, so a
+ * static import here would close an import cycle for this module's callers. Same reason `auth.ts` reaches
+ * for `await import("@/modules/email")`.
+ *
+ * @returns the number of sessions revoked.
+ */
+export const revokeUserSessionsExcept = async ({
+  userId,
+  keepSessionToken,
+}: {
+  userId: string;
+  keepSessionToken?: string;
+}): Promise<number> => {
+  const tokens = (await getSessionTokensByUserId(userId)).filter((token) => token !== keepSessionToken);
+
+  if (tokens.length === 0) {
+    return 0;
+  }
+
+  const { auth } = await import("@/modules/auth/lib/auth");
+  const ctx = await auth.$context;
+  await ctx.internalAdapter.deleteSessions(tokens);
+
+  logger.info({ userId, revoked: tokens.length }, "Revoked user sessions");
+
+  return tokens.length;
+};
+
+/**
+ * Revoke one session by its (unsigned) token, across both stores. Same rationale as above — a raw
+ * Prisma delete leaves the Redis copy resolvable by `getSession` until its TTL — for callers that hold a
+ * token rather than a user id, like the SSO-recovery failure path killing the session its cookie names.
+ */
+export const revokeSessionByToken = async (sessionToken: string): Promise<void> => {
+  // Restores the guard the retired `deleteSessionBySessionToken` carried. Not reachable from the one
+  // caller today — the recovery-completion route returns early on a missing cookie — but this is an
+  // exported helper in an auth module, and a blank token would reach `secondaryStorage.delete("")` plus a
+  // `deleteMany` on `token IN ('')`: a no-op that reports a successful revocation, which is the worst
+  // failure mode this function has. `.trim()` before `.min(1)` is deliberately stricter than the original
+  // `min(1)`, since a whitespace-only token is exactly as meaningless as an empty one and session tokens
+  // are opaque values that never contain whitespace.
+  validateInputs([sessionToken, z.string().trim().min(1)]);
+
+  const { auth } = await import("@/modules/auth/lib/auth");
+  const ctx = await auth.$context;
+  await ctx.internalAdapter.deleteSessions([sessionToken]);
+};

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
+import { revokeUserSessionsExcept } from "@/modules/auth/lib/session-revocation";
 import { finalizeSuccessfulSignIn } from "@/modules/auth/lib/sign-in-tracking";
 import { buildVerificationRequestedPath } from "@/modules/auth/lib/verification-links";
 import { sendVerificationEmail } from "@/modules/email";
@@ -35,6 +36,10 @@ vi.mock("@/lib/jwt", () => ({
   createEmailToken: mocks.createEmailToken,
   createSsoRelinkIntent: mocks.createSsoRelinkIntent,
   verifySsoRelinkIntent: mocks.verifySsoRelinkIntent,
+}));
+
+vi.mock("@/modules/auth/lib/session-revocation", () => ({
+  revokeUserSessionsExcept: vi.fn(),
 }));
 
 vi.mock("@/modules/auth/lib/sign-in-tracking", () => ({
@@ -82,14 +87,37 @@ vi.mock("./account-linking", () => ({
 
 describe("sso-recovery", () => {
   const txUserUpdate = vi.fn();
+  const txTwoFactorDeleteMany = vi.fn();
+  const txAccountUpdateMany = vi.fn();
+  const txOauthRefreshUpdateMany = vi.fn();
+  const txOauthConsentDeleteMany = vi.fn();
+  // Both new stores belong in the stub: post-ENG-1054 the password lives on `Account` and the 2FA secret
+  // in `TwoFactor`, so a strip that only touched `user` is exactly the bug ENG-2557 fixed.
   const tx = {
     user: {
       update: txUserUpdate,
+    },
+    twoFactor: {
+      deleteMany: txTwoFactorDeleteMany,
+    },
+    account: {
+      updateMany: txAccountUpdateMany,
+    },
+    oauthRefreshToken: {
+      updateMany: txOauthRefreshUpdateMany,
+    },
+    oauthConsent: {
+      deleteMany: txOauthConsentDeleteMany,
     },
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    txTwoFactorDeleteMany.mockResolvedValue({ count: 1 });
+    txAccountUpdateMany.mockResolvedValue({ count: 1 });
+    txOauthRefreshUpdateMany.mockResolvedValue({ count: 2 });
+    txOauthConsentDeleteMany.mockResolvedValue({ count: 1 });
+    vi.mocked(revokeUserSessionsExcept).mockResolvedValue(2);
     vi.mocked(prisma.$transaction).mockImplementation(
       async (callback: (txClient: Prisma.TransactionClient) => Promise<unknown>) =>
         await callback(tx as unknown as Prisma.TransactionClient)
@@ -187,21 +215,21 @@ describe("sso-recovery", () => {
       id: "user_1",
       email: "john.doe@example.com",
       locale: "en-US",
-      emailVerified: null,
+      emailVerified: false,
       isActive: true,
       identityProvider: "email",
       identityProviderAccountId: null,
-      password: "hashed-password",
-      twoFactorEnabled: true,
-      twoFactorSecret: "encrypted-secret",
-      backupCodes: "encrypted-codes",
     } as any);
 
     const callbackUrl = await completeSsoRecovery({
       intentToken: "test-intent",
       sessionUserId: "user_1",
+      sessionToken: "current-session-token",
     });
 
+    // Exact-match on purpose: the legacy nulls are load-bearing, not leftovers. `better-auth-two-factor-backfill`
+    // re-materialises a `TwoFactor` row from `twoFactorEnabled && twoFactorSecret` on the next credential
+    // sign-in, so dropping them from this payload would let the stripped factor come back.
     expect(txUserUpdate).toHaveBeenCalledWith({
       where: {
         id: "user_1",
@@ -214,6 +242,41 @@ describe("sso-recovery", () => {
         twoFactorSecret: null,
       },
     });
+    // The live stores, which the pre-ENG-2557 implementation never touched.
+    expect(txTwoFactorDeleteMany).toHaveBeenCalledWith({ where: { userId: "user_1" } });
+    // Scoped by owner, NOT by `providerAccountId`/`issuer`: those are account-key columns and a drifted key
+    // (ENG-2555) would make a key-filtered query walk past a row still holding a live hash.
+    expect(txAccountUpdateMany).toHaveBeenCalledWith({
+      where: { userId: "user_1", provider: "credential" },
+      data: { password: null },
+    });
+    // Post-commit, sparing the caller's own session so the redirect still lands signed in.
+    expect(revokeUserSessionsExcept).toHaveBeenCalledWith({
+      userId: "user_1",
+      keepSessionToken: "current-session-token",
+    });
+    // The OAuth grants the account minted while unproven: a refresh token outlives every session, so
+    // the sweep is incomplete without this.
+    expect(txOauthRefreshUpdateMany).toHaveBeenCalledWith({
+      where: { userId: "user_1", revoked: null },
+      data: { revoked: expect.any(Date) },
+    });
+    // Consent too: `/authorize` skips the consent screen when a row exists, so leaving it would let a
+    // still-cookie-cached session mint a replacement refresh token and undo the revocation above.
+    expect(txOauthConsentDeleteMany).toHaveBeenCalledWith({ where: { userId: "user_1" } });
+    expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sso_recovery_completed",
+        status: "success",
+        newObject: expect.objectContaining({
+          credentialPasswordsCleared: 1,
+          twoFactorRowsRemoved: 1,
+          oauthRefreshTokensRevoked: 2,
+          oauthConsentsRevoked: 1,
+          sessionsRevoked: 2,
+        }),
+      })
+    );
     expect(syncSsoIdentityForUser).toHaveBeenCalledWith({
       userId: "user_1",
       provider: "google",
@@ -237,23 +300,109 @@ describe("sso-recovery", () => {
       id: "user_1",
       email: "john.doe@example.com",
       locale: "en-US",
-      emailVerified: new Date("2024-01-01T00:00:00.000Z"),
+      emailVerified: true,
       isActive: true,
       identityProvider: "email",
       identityProviderAccountId: null,
-      password: "hashed-password",
-      twoFactorEnabled: true,
-      twoFactorSecret: "encrypted-secret",
-      backupCodes: "encrypted-codes",
     } as any);
 
     await completeSsoRecovery({
       intentToken: "test-intent",
       sessionUserId: "user_1",
+      sessionToken: "current-session-token",
     });
 
     expect(txUserUpdate).not.toHaveBeenCalled();
+    expect(txTwoFactorDeleteMany).not.toHaveBeenCalled();
+    expect(txAccountUpdateMany).not.toHaveBeenCalled();
+    expect(txOauthRefreshUpdateMany).not.toHaveBeenCalled();
+    expect(txOauthConsentDeleteMany).not.toHaveBeenCalled();
+    // A proven account is a legitimate one: linking another provider to it must not sign its other
+    // sessions out, and must not report a strip that did not happen.
+    expect(revokeUserSessionsExcept).not.toHaveBeenCalled();
+    expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sso_recovery_completed",
+        newObject: expect.not.objectContaining({ credentialPasswordsCleared: expect.anything() }),
+      })
+    );
     expect(syncSsoIdentityForUser).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * The guard keys on `emailVerified` alone. It used to also require `identityProvider === "email"`, but
+   * that column is denormalized onto `User` by an `account.create.after` hook, so a security control
+   * resting on it goes silently dead if it ever drifts. An unproven address is unproven whatever the
+   * denormalized column happens to say.
+   */
+  test("strips an unverified account even when identityProvider says otherwise", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "john.doe@example.com",
+      locale: "en-US",
+      emailVerified: false,
+      isActive: true,
+      identityProvider: "google",
+      identityProviderAccountId: "provider-account-1",
+    } as any);
+
+    await completeSsoRecovery({
+      intentToken: "test-intent",
+      sessionUserId: "user_1",
+      sessionToken: "current-session-token",
+    });
+
+    expect(txAccountUpdateMany).toHaveBeenCalledWith({
+      where: { userId: "user_1", provider: "credential" },
+      data: { password: null },
+    });
+    expect(txTwoFactorDeleteMany).toHaveBeenCalledOnce();
+    expect(revokeUserSessionsExcept).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * The strip has already committed by the time sessions are swept, so a revocation failure must not undo
+   * it or fail the recovery — the user would be left with a stripped password and no way through.
+   */
+  test("still completes recovery when the session sweep fails", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "john.doe@example.com",
+      locale: "en-US",
+      emailVerified: false,
+      isActive: true,
+      identityProvider: "email",
+      identityProviderAccountId: null,
+    } as any);
+    vi.mocked(revokeUserSessionsExcept).mockRejectedValue(new Error("redis unavailable"));
+
+    const callbackUrl = await completeSsoRecovery({
+      intentToken: "test-intent",
+      sessionUserId: "user_1",
+      sessionToken: "current-session-token",
+    });
+
+    expect(callbackUrl).toBe("http://localhost:3000/environments/env_1");
+    expect(txAccountUpdateMany).toHaveBeenCalledOnce();
+    // A failed sweep must NOT be recorded as "0 sessions revoked" — same number, opposite incident.
+    expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sso_recovery_completed",
+        newObject: expect.objectContaining({
+          credentialPasswordsCleared: 1,
+          sessionRevocationFailed: true,
+        }),
+      })
+    );
+    // `action` discriminator is load-bearing: `toHaveBeenCalledWith` passes when ANY call matches, so
+    // without it this would be satisfied by any other queued event lacking the key, and could go green
+    // without ever proving the completion event omits it.
+    expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sso_recovery_completed",
+        newObject: expect.not.objectContaining({ sessionsRevoked: expect.anything() }),
+      })
+    );
   });
 
   test("rejects recovery when the signed-in user does not match the intent owner", async () => {

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -5,6 +5,7 @@ import type { Account } from "@formbricks/types/auth";
 import { WEBAPP_URL } from "@/lib/constants";
 import { createEmailToken, createSsoRelinkIntent, verifySsoRelinkIntent } from "@/lib/jwt";
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
+import { revokeUserSessionsExcept } from "@/modules/auth/lib/session-revocation";
 import { finalizeSuccessfulSignIn } from "@/modules/auth/lib/sign-in-tracking";
 import { buildVerificationRequestedPath } from "@/modules/auth/lib/verification-links";
 import { queueAuditEventBackground } from "@/modules/ee/audit-logs/lib/handler";
@@ -35,6 +36,8 @@ const queueSsoRecoveryAuditEvent = ({
   provider,
   callbackUrl,
   failureReason,
+  reclaimed,
+  sessionsRevoked,
 }: {
   action: "sso_recovery_started" | "sso_recovery_completed" | "sso_recovery_failed";
   status: "success" | "failure";
@@ -43,6 +46,9 @@ const queueSsoRecoveryAuditEvent = ({
   provider: string;
   callbackUrl?: string;
   failureReason?: string;
+  reclaimed?: TReclaimOutcome;
+  /** `null` means the sweep threw — deliberately not conflated with "there were none". */
+  sessionsRevoked?: number | null;
 }) => {
   queueAuditEventBackground({
     action,
@@ -57,39 +63,130 @@ const queueSsoRecoveryAuditEvent = ({
       provider,
       ...(callbackUrl ? { callbackUrl } : {}),
       ...(failureReason ? { failureReason } : {}),
+      // The one moment an account can change hands, so record what was taken away rather than only that
+      // recovery succeeded. Marker keys in `newObject` are the house idiom (`passwordResetMarker`,
+      // `twoFactorAuth: "disabled"`); `redactPII` matches exact lowercased keys, so these survive while
+      // `email` above is redacted.
+      ...(reclaimed
+        ? {
+            credentialPasswordsCleared: reclaimed.credentialPasswordsCleared,
+            twoFactorRowsRemoved: reclaimed.twoFactorRowsRemoved,
+            oauthRefreshTokensRevoked: reclaimed.oauthRefreshTokensRevoked,
+            oauthConsentsRevoked: reclaimed.oauthConsentsRevoked,
+            // `sessionsRevoked: 0` and "the sweep failed" are the same number but opposite incidents,
+            // and this is the field a responder reads to confirm the squatter was actually kicked out.
+            ...(sessionsRevoked === null ? { sessionRevocationFailed: true } : { sessionsRevoked }),
+          }
+        : {}),
     },
   });
 };
 
-const SSO_RECOVERY_USER_SELECT = {
-  ...LINKED_SSO_LOOKUP_SELECT,
-  backupCodes: true,
-  password: true,
-  twoFactorEnabled: true,
-  twoFactorSecret: true,
-} as const;
+/**
+ * What `reclaimUnverifiedLocalAuthIfNeeded` actually removed, for the audit record. `null` means the
+ * account was already proven and nothing was touched.
+ */
+type TReclaimOutcome = {
+  credentialPasswordsCleared: number;
+  twoFactorRowsRemoved: number;
+  oauthRefreshTokensRevoked: number;
+  oauthConsentsRevoked: number;
+} | null;
 
-type TSsoRecoveryUser = Prisma.UserGetPayload<{
-  select: typeof SSO_RECOVERY_USER_SELECT;
-}>;
-
+/**
+ * Strip the local auth factors of an account whose email was never proven, at the moment an SSO identity
+ * proves it (ENG-554, ENG-2557).
+ *
+ * The threat: an attacker registers on a victim's address, sets a password, and is held out only by
+ * `requireEmailVerification`. Recovery then sets `emailVerified: true` — removing the very thing keeping
+ * them out — so the untrusted factors have to go with it. The proof authorising this is NOT the IdP's
+ * assertion: `startSsoRecovery` mails the address on record and completion requires the session that link
+ * mints, plus `sessionUserId === intent.userId`. Upstream Better Auth does the same thing in
+ * `revoke-unproven-account-access.mjs` for magic-link and email-OTP.
+ *
+ * THE FACTORS LIVE IN TWO PLACES EACH, and this is where ENG-2557 came from: the original control (#7755)
+ * predates ENG-1054, which moved the password to `Account.password` and 2FA into the `TwoFactor` table.
+ * It kept nulling the legacy `User` columns only, so post-cutover it stripped nothing at all — for any
+ * user created after the cutover those columns are already null, because `signUpEmail` never writes them.
+ * A mitigation that reads as present and does nothing is worse than none; write BOTH stores.
+ *
+ * The legacy `User` nulls are therefore kept deliberately, not left as dead code:
+ * `better-auth-two-factor-backfill.ts` re-materialises a `TwoFactor` row from
+ * `twoFactorEnabled && twoFactorSecret` on every successful credential sign-in, so dropping them would let
+ * a later sign-in re-arm the attacker's factor. Both halves together disarm it twice.
+ *
+ * Two deliberate shapes worth not "simplifying":
+ *
+ * - The password is NULLED, not the row deleted. Sign-in behaviour is identical either way
+ *   (`!currentPassword` → the same 401 after the same dummy hash), but the surviving row is what marks
+ *   this user as a credential user, which is what lets `forgotPasswordAction` still offer them a reset —
+ *   recovery flips `identityProvider` to the SSO provider and nothing ever flips it back, so deleting the
+ *   row would lock them out of every password route with no self-service way back.
+ * - The `where` is scoped by `userId`, NOT by `providerAccountId`, even though Better Auth's own
+ *   `findCredentialAccount` filters on all four. Those are account-KEY columns and a drifted key is a real
+ *   failure mode here (ENG-2555 was exactly that): a row whose key drifted still holds a live hash, and a
+ *   query filtering on the key would walk straight past it. Owner-scoping cannot reach another user's row
+ *   and does not go blind.
+ *
+ * The 2FA half is the weaker of the two, and worth stating honestly: Better Auth gates its challenge on
+ * `user.twoFactorEnabled`, which the legacy update already clears, so the orphaned `TwoFactor` row was
+ * never reachable at sign-in. Removing it is about not leaving a stale TOTP secret and backup codes at rest
+ * on an account that has changed hands — not a live bypass.
+ *
+ * Sessions are revoked by the caller, after commit — Better Auth resolves its adapter from its own
+ * AsyncLocalStorage, so a revocation issued in here would execute outside `tx` and survive a rollback.
+ *
+ * Not locked against concurrent recoveries (upstream takes a DB advisory lock for its equivalent). Every
+ * write here is idempotent — two `deleteMany`/`updateMany` calls and an update to fixed values — so a race
+ * converges on the same state rather than corrupting it.
+ */
 const reclaimUnverifiedLocalAuthIfNeeded = async ({
   tx,
   user,
 }: {
   tx: Prisma.TransactionClient;
-  user: TSsoRecoveryUser;
-}) => {
-  if (user.identityProvider !== "email" || user.emailVerified) {
-    return;
+  user: TSsoLookupUser;
+}): Promise<TReclaimOutcome> => {
+  // Keyed on `emailVerified` alone. The old guard also required `identityProvider === "email"`, but that
+  // column is denormalized onto `User` by an `account.create.after` hook — resting a security control on a
+  // denormalized value means drift silently disables it.
+  //
+  // Worth being honest about the limit of this test: `emailVerified` is a one-bit latch, and it says the
+  // address was proven, NOT that the account's local factors were ever proven by their owner. Anyone who
+  // knows the account's password can have Better Auth re-send a verification mail (`sendOnSignIn`), so a
+  // single victim click flips this and the strip below stops firing. That is the pre-hijacking vector in
+  // ENG-2562, tracked separately, and closing it means invalidating the credential at verification time
+  // too — not a different guard here.
+  //
+  // The INVERSE case matters just as much and is not hypothetical: `requireEmailVerification` is
+  // `!EMAIL_VERIFICATION_DISABLED` (auth.ts) and `EMAIL_VERIFICATION_DISABLED=1` ships as the default in
+  // `.env.example` and `docker/docker-compose.yml`. The verification mail still goes out but blocks
+  // nothing, so on a default self-hosted install a user has no reason to click it and `emailVerified`
+  // stays false for the life of the account. This guard's population there is not squatters — it is
+  // every credential user who never bothered.
+  //
+  // For them a first-time SSO sign-in runs recovery and permanently removes their second factor: the
+  // `TwoFactor` row goes, and the legacy `twoFactorEnabled`/`twoFactorSecret` nulls below (kept
+  // deliberately, so the backfill shim cannot re-arm an attacker's factor) are exactly what stop it
+  // being re-armed for a legitimate owner either. They can recover the password via
+  // `forgotPasswordAction`, and then hold a one-factor account where two were enrolled, without being
+  // told. Correct for a squatter, a silent downgrade for the owner.
+  //
+  // Left as-is on purpose: there is no signal here that separates the two populations, and weakening the
+  // guard would reopen the takeover. What is missing is telling the user — mail them what was removed and
+  // prompt re-enrolment. That needs a new transactional template, so it is tracked separately rather than
+  // widened into a fix that backports to two release branches.
+  if (user.emailVerified) {
+    return null;
   }
 
-  // Inbox ownership is now proven, so strip any untrusted local auth factors before the SSO
-  // account becomes the canonical way back in.
+  // Sequential, not `Promise.all`: an interactive transaction is bound to a single connection, so
+  // parallel writes on `tx` buy nothing here and only risk interleaving.
+  //
+  // The legacy columns: the 2FA pair is load-bearing (see the backfill note above); `password` is a no-op
+  // for post-cutover users and kept only so a pre-cutover row cannot survive here.
   await tx.user.update({
-    where: {
-      id: user.id,
-    },
+    where: { id: user.id },
     data: {
       backupCodes: null,
       emailVerified: true,
@@ -98,6 +195,49 @@ const reclaimUnverifiedLocalAuthIfNeeded = async ({
       twoFactorSecret: null,
     },
   });
+  const twoFactorRows = await tx.twoFactor.deleteMany({ where: { userId: user.id } });
+  const credentialRows = await tx.account.updateMany({
+    where: { userId: user.id, provider: "credential" },
+    data: { password: null },
+  });
+
+  // MCP OAuth grants the account minted while its address was unproven. Without this the sweep is
+  // incomplete in the one direction that outlives it: `oauthProvider` is registered unconditionally
+  // (auth.ts) with open dynamic client registration, so a holder of a live session can bank a refresh
+  // token good for 30 days — far longer than the session revoked below, and unreachable by it because
+  // both token tables' `session` FK is `onDelete: SetNull`, which blanks the liveness check rather than
+  // failing it.
+  //
+  // The REFRESH token is the one that matters and the one this actually stops: `handleRefreshTokenGrant`
+  // reads `revoked`, so revoking it ends the 30-day persistence.
+  //
+  // ACCESS tokens are NOT revoked on this release branch: `oauthAccessToken` has no `revoked` column
+  // here, so there is nothing to write. On `main` that write exists, and it is worth being clear that it
+  // buys almost nothing anyway — our config sets `resources` and never sets `disableJwtPlugin`, so
+  // `isJwtAccessToken` is always true and every access token is a self-contained JWT that
+  // `createJwtAccessToken` signs without persisting, and `/api/mcp` verifies bearers against JWKS
+  // (`modules/mcp/auth.ts`) without reading that table at all. Upstream's own revoke endpoint says as
+  // much — "JWT access tokens are self-contained and cannot be revoked server-side". So the behavioural
+  // residual is identical to `main`: a squatter's JWT stays valid for up to `accessTokenExpiresIn`
+  // (15 min) after recovery. Shortening that, or checking revocation at the resource server, is the only
+  // thing that would close it.
+  //
+  // Consent goes too: `/authorize` skips the consent screen when a matching `oauthConsent` row exists,
+  // so leaving it would let a still-cookie-cached session (see session-revocation.ts) silently mint a
+  // fresh 30-day refresh token and undo the revocation above.
+  const revokedAt = new Date();
+  const refreshRows = await tx.oauthRefreshToken.updateMany({
+    where: { userId: user.id, revoked: null },
+    data: { revoked: revokedAt },
+  });
+  const consentRows = await tx.oauthConsent.deleteMany({ where: { userId: user.id } });
+
+  return {
+    credentialPasswordsCleared: credentialRows.count,
+    twoFactorRowsRemoved: twoFactorRows.count,
+    oauthRefreshTokensRevoked: refreshRows.count,
+    oauthConsentsRevoked: consentRows.count,
+  };
 };
 
 const createSsoRecoveryCompletionUrl = (intentToken: string): string => {
@@ -198,9 +338,15 @@ export const startSsoRecovery = async ({
 export const completeSsoRecovery = async ({
   intentToken,
   sessionUserId,
+  sessionToken,
 }: {
   intentToken: string;
   sessionUserId?: string;
+  /**
+   * The recovering user's own session token, so the post-commit revocation can spare it. Everything else
+   * the account accrued while its address was unproven is swept.
+   */
+  sessionToken?: string;
 }): Promise<string> => {
   let intent: ReturnType<typeof verifySsoRelinkIntent>;
 
@@ -285,7 +431,7 @@ export const completeSsoRecovery = async ({
     where: {
       id: intent.userId,
     },
-    select: SSO_RECOVERY_USER_SELECT,
+    select: LINKED_SSO_LOOKUP_SELECT,
   });
 
   if (user?.email !== intent.email) {
@@ -308,8 +454,8 @@ export const completeSsoRecovery = async ({
     throw new Error(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
   }
 
-  await prisma.$transaction(async (tx) => {
-    await reclaimUnverifiedLocalAuthIfNeeded({
+  const reclaimed = await prisma.$transaction(async (tx) => {
+    const outcome = await reclaimUnverifiedLocalAuthIfNeeded({
       tx,
       user,
     });
@@ -326,7 +472,34 @@ export const completeSsoRecovery = async ({
       account: recoveryAccount,
       tx,
     });
+
+    return outcome;
   });
+
+  // Only when factors were actually stripped: this is the account changing hands, so any session the
+  // squatter still holds has to go. Reachable in practice because `signUpEmail` writes
+  // `emailVerified: false` regardless of `requireEmailVerification`, so on an instance with
+  // EMAIL_VERIFICATION_DISABLED=1 (the shipped .env.example and docker-compose default) an unproven
+  // account can sign in and hold a live session for up to SESSION_MAX_AGE.
+  //
+  // After commit, never inside the transaction: Better Auth resolves its adapter from its own
+  // AsyncLocalStorage, so this would run outside `tx` and outlive a rollback. Best-effort for the same
+  // reason the strip must not be undone by a revocation failure — it has already committed.
+  let sessionsRevoked: number | null = 0;
+  if (reclaimed) {
+    try {
+      sessionsRevoked = await revokeUserSessionsExcept({
+        userId: user.id,
+        keepSessionToken: sessionToken,
+      });
+    } catch (error) {
+      sessionsRevoked = null;
+      logger.error(
+        { error, userId: user.id },
+        "Failed to revoke sessions after reclaiming unverified local auth"
+      );
+    }
+  }
 
   try {
     await finalizeSuccessfulSignIn({
@@ -353,6 +526,8 @@ export const completeSsoRecovery = async ({
     email: user.email,
     provider,
     callbackUrl: intent.callbackUrl,
+    reclaimed,
+    sessionsRevoked,
   });
 
   return getValidatedCallbackUrl(intent.callbackUrl, WEBAPP_URL) ?? WEBAPP_URL;


### PR DESCRIPTION
Ref ENG-2557

Backport of #8962 to `release/5.3`. Sibling of #8998 (5.4).

## What & why

SSO verify-before-link recovery stripped a recovered account's local auth factors by nulling the **legacy** `User.password` / `User.twoFactorSecret` / `User.backupCodes` columns. ENG-1054 moved the live credential to `Account.password` and 2FA into the `TwoFactor` table, so post-cutover the strip wrote to columns nothing reads — it cleared nothing while reading, in code, as though it did. An attacker who pre-registered on the victim's address kept a working password across the victim's own recovery.

This is the minimal single-fix backport of that change per the backport policy.

**Cherry-picked commit:** `17ab4165c06b02a26f903f4b570362bb0508e83f` (squash merge of #8962), applied with `-x`. **No conflicts** — but 5.3 needed two adaptations that 5.4 did not. Both are dependency-forced and neither changes behaviour; details below.

## Adaptations for this branch

**Please review these two specifically — they are the only places this diff differs from what merged to `main`.**

| # | What | Why | Behavioural effect |
| --- | --- | --- | --- |
| 1 | Access-token revocation dropped (`tx.oauthAccessToken.updateMany`), along with its `oauthAccessTokensRevoked` outcome field, audit field and unit assertions | `oauthAccessToken` has **no `revoked` column** on this branch | **None.** Our config sets `resources` and never sets `disableJwtPlugin`, so every access token is a self-contained JWT that `createJwtAccessToken` signs without persisting, and `/api/mcp` verifies bearers against JWKS without reading that table. The write is a no-op on `main` too — upstream's own revoke endpoint says JWT access tokens "cannot be revoked server-side". The **refresh**-token revocation, which is what actually ends the 30-day persistence, is kept |
| 2 | `hasCredentialAccount` drops the `issuer: createLocalAccountIssuer("credential")` clause | Better Auth is **1.6.23** here vs **1.7.0** on `main`/5.4. The issuer namespace arrived in 1.7; `@better-auth/core/db` does not export `createLocalAccountIssuer`, `Account` has no `issuer` column, and the installed 1.6.23 internal adapter contains **zero** occurrences of `issuer` | **None.** The remaining predicate (`userId` + `provider: "credential"` + `providerAccountId: userId`) is the *exact* match for 1.6.23's own credential-account lookup — this is not a loosened predicate. Both were caught by typecheck, not guessed |

Residual after #1 is unchanged from `main`: a squatter's JWT stays valid for up to `accessTokenExpiresIn` (15 min).

<details>
<summary>Files changed (10)</summary>

- `apps/web/modules/ee/sso/lib/sso-recovery.ts` — the strip itself, session sweep, OAuth refresh/consent revocation, audit detail
- `apps/web/modules/auth/lib/session-revocation.ts` — **new**, revocation via `internalAdapter.deleteSessions` so Redis and Postgres both drop the session
- `apps/web/modules/auth/lib/auth-session-repository.ts` — `deleteSessionBySessionToken` removed (no remaining production caller)
- `apps/web/app/api/auth/sso/recovery/complete/route.ts` — failure path routed through the same revocation
- `apps/web/modules/auth/forgot-password/actions.ts` — recognises a recovered SSO user by their nulled credential row, and audits the request
- `apps/web/lib/user/password.ts` — credential-row helper
- 4 pre-existing test files updated: `password.test.ts`, `forgot-password/actions.test.ts`, `auth-session-repository.test.ts`, `sso-recovery.test.ts`

</details>

**Dropped per the backport policy (no net-new tests):**

- `apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts` (net-new, 324 lines — needs real Postgres + Redis)
- `apps/web/modules/auth/lib/session-revocation.test.ts` (net-new, 128 lines)

Edits to the four **pre-existing** test files are kept, since the implementation change would otherwise leave them failing. Both dropped files remain on `main` under #8962.

## Breaking changes

- [ ] This PR contains breaking changes

None — no API/SDK shape, endpoint, route, env var, config key or default changes, and no deployer action.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The fix compiles against this branch's schema and Better Auth | typecheck | `pnpm --filter @formbricks/web typecheck` → **exit 0, zero `error TS` lines**. This is the load-bearing check here: it is what surfaced *both* adaptations above (`TS2305` on `createLocalAccountIssuer`, `TS2353` on `Account.issuer`, and the missing `oauthAccessToken.revoked`) rather than them being found by eye |
| The retained tests still pass | unit (guard) | `pnpm vitest run lib/user/password.test.ts modules/auth/forgot-password/actions.test.ts modules/auth/lib/auth-session-repository.test.ts modules/ee/sso/lib/sso-recovery.test.ts` → **4 files, 42 tests passed**, exit 0 |
| Lint and formatting | lint | `eslint` on the 10 changed files → **exit 0**, no output; `prettier --check` → "All matched files use Prettier code style!" |
| Adaptation #2 is an exact predicate, not a loosened one | manual | Confirmed `grep -c issuer` on the installed `better-auth@1.6.23` `dist/db/internal-adapter.mjs` returns **0**, and that `Account` in this branch's `packages/database/schema/main.prisma` has no `issuer` field |

<details>
<summary>Command output</summary>

```
$ pnpm --filter @formbricks/web typecheck
Generating route types...
✓ Types generated successfully
TYPECHECK EXIT = 0
error TS lines: 0

$ pnpm vitest run <4 files>
 Test Files  4 passed (4)
      Tests  42 passed (42)
VITEST EXIT = 0

$ eslint <10 changed files>
ESLINT EXIT = 0   (no output)

$ prettier --check <10 changed files>
Checking formatting...
All matched files use Prettier code style!
```

</details>

**Open gaps**

- **The integration proof does not travel with this branch.** The strongest evidence for #8962 was `sso-recovery.integration.test.ts` against real Postgres and Redis — dropped here per the no-net-new-tests policy, so on 5.3 the behaviour rests on the typecheck plus the unit tests above. The behavioural verification (including the live before/after showing HTTP 200 → 401) was done on `main` in #8962.
- **`session-revocation.ts` ships without its unit test** on this branch, for the same reason.
- **No live run on a 5.3 stack.** Worth weighing more here than on 5.4, since this branch's diff is *not* byte-identical to the verified `main` version — see the two adaptations. Both are removals of code that is inert on this branch rather than rewrites of the fix, and typecheck plus the retained unit tests cover them, but a reviewer who wants belt-and-braces should exercise SSO recovery on a 5.3 stack.

**Risks**

- **Recovery now genuinely removes factors, where before it removed nothing.** That is the fix, but on `EMAIL_VERIFICATION_DISABLED=1` — the shipped default — the guard's population includes legitimate unverified users, who lose their second factor silently. Tracked as ENG-2633; not changed here, since no signal separates them from a squatter and weakening the guard reopens the takeover.
- **A recovered user's MCP tokens are revoked** and must be re-authorized.
- **API keys are not in the sweep** (ENG-2634), and a JWT access token stays valid for up to 15 minutes — both documented residuals from #8962, unchanged here.
- **If 5.3 ever takes Better Auth 1.7**, adaptation #2 should be reverted to the `main` form so the predicate keeps matching upstream.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code), reasoning effort `unknown`.
