### PR TITLE
fix(helm): support balanced background embedding requests

### DIFF
--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -128,6 +128,8 @@ jobs:
           ! grep -q 'hub-embeddings-background:8080/v1' "$render_dir/hub-embeddings-legacy.yaml"
           grep -A1 'name: EMBEDDING_BATCH_SIZE' "$render_dir/hub-embeddings-legacy.yaml" | grep -q 'value: "1"'
           grep -A1 'name: EMBEDDING_BATCH_MAX_WAIT_MS' "$render_dir/hub-embeddings-legacy.yaml" | grep -q 'value: "25"'
+          test "$(grep -c 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-legacy.yaml")" -eq 1
+          grep -A1 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-legacy.yaml" | grep -q 'value: "false"'
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \
@@ -137,6 +139,8 @@ jobs:
             --set-string hub.embeddings.background.batchSize=8 \
             --set-string hub.embeddings.background.batchMaxWaitMs=25 \
             --set-string hub.embeddings.background.batchMaxInFlight=3 \
+            --set-string hub.embeddings.background.httpDisableKeepAlives=true \
+            --set-string hub.worker.env.EMBEDDING_HTTP_DISABLE_KEEP_ALIVES=false \
             --set hub.embeddings.background.persistence.storageClass=gp3 \
             --set hub.embeddings.background.autoscaling.enabled=true \
             --show-only templates/hub-deployment.yaml \
@@ -148,6 +152,8 @@ jobs:
           test "$(grep -c 'http://formbricks-hub-embeddings-background:8080/v1' "$render_dir/hub-embeddings-background.yaml")" -eq 1
           grep -A1 'name: EMBEDDING_MAX_CONCURRENT' "$render_dir/hub-embeddings-background.yaml" | grep -q 'value: "24"'
           grep -A1 'name: EMBEDDING_BATCH_SIZE' "$render_dir/hub-embeddings-background.yaml" | grep -q 'value: "8"'
+          test "$(grep -c 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-background.yaml")" -eq 1
+          grep -A1 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-background.yaml" | grep -q 'value: "true"'
           grep -q '^kind: StatefulSet$' "$render_dir/hub-embeddings-background.yaml"
           grep -q 'podManagementPolicy: Parallel' "$render_dir/hub-embeddings-background.yaml"
           test "$(grep -c 'whenScaled: Retain' "$render_dir/hub-embeddings-background.yaml")" -eq 1

--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -227,6 +227,7 @@ jobs:
             --set formbricks.webappUrl=https://qa.example.com \
             --set hub.embeddings.enabled=true \
             --set hub.embeddings.background.enabled=true \
+            --set-string hub.embeddings.background.httpDisableKeepAlives=true \
             --set hub.embeddingBackfill.enabled=true \
             --set hub.embeddingBackfill.runId=eu-canary-001 \
             --set hub.embeddingBackfill.taxonomy=true \
@@ -239,6 +240,8 @@ jobs:
           grep -q -- '- --taxonomy' "$render_dir/hub-embedding-backfill.yaml"
           grep -A1 -- '- --tenant-id' "$render_dir/hub-embedding-backfill.yaml" | grep -q -- '- "tenant-a"'
           grep -A1 -- '- --max-records' "$render_dir/hub-embedding-backfill.yaml" | grep -q -- '- "500"'
+          test "$(grep -c 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embedding-backfill.yaml")" -eq 1
+          grep -A1 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embedding-backfill.yaml" | grep -q 'value: "true"'
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \

--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -128,8 +128,18 @@ jobs:
           ! grep -q 'hub-embeddings-background:8080/v1' "$render_dir/hub-embeddings-legacy.yaml"
           grep -A1 'name: EMBEDDING_BATCH_SIZE' "$render_dir/hub-embeddings-legacy.yaml" | grep -q 'value: "1"'
           grep -A1 'name: EMBEDDING_BATCH_MAX_WAIT_MS' "$render_dir/hub-embeddings-legacy.yaml" | grep -q 'value: "25"'
-          test "$(grep -c 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-legacy.yaml")" -eq 1
-          grep -A1 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-legacy.yaml" | grep -q 'value: "false"'
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --show-only templates/hub-deployment.yaml > "$render_dir/hub-embeddings-legacy-api.yaml"
+          ! grep -q 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-legacy-api.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-embeddings-legacy-worker.yaml"
+          grep -A1 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-legacy-worker.yaml" | grep -q 'value: "false"'
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \
@@ -140,7 +150,6 @@ jobs:
             --set-string hub.embeddings.background.batchMaxWaitMs=25 \
             --set-string hub.embeddings.background.batchMaxInFlight=3 \
             --set-string hub.embeddings.background.httpDisableKeepAlives=true \
-            --set-string hub.worker.env.EMBEDDING_HTTP_DISABLE_KEEP_ALIVES=false \
             --set hub.embeddings.background.persistence.storageClass=gp3 \
             --set hub.embeddings.background.autoscaling.enabled=true \
             --show-only templates/hub-deployment.yaml \
@@ -152,8 +161,6 @@ jobs:
           test "$(grep -c 'http://formbricks-hub-embeddings-background:8080/v1' "$render_dir/hub-embeddings-background.yaml")" -eq 1
           grep -A1 'name: EMBEDDING_MAX_CONCURRENT' "$render_dir/hub-embeddings-background.yaml" | grep -q 'value: "24"'
           grep -A1 'name: EMBEDDING_BATCH_SIZE' "$render_dir/hub-embeddings-background.yaml" | grep -q 'value: "8"'
-          test "$(grep -c 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-background.yaml")" -eq 1
-          grep -A1 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-background.yaml" | grep -q 'value: "true"'
           grep -q '^kind: StatefulSet$' "$render_dir/hub-embeddings-background.yaml"
           grep -q 'podManagementPolicy: Parallel' "$render_dir/hub-embeddings-background.yaml"
           test "$(grep -c 'whenScaled: Retain' "$render_dir/hub-embeddings-background.yaml")" -eq 1
@@ -163,6 +170,32 @@ jobs:
           grep -q '^  minReplicas: 1$' "$render_dir/hub-embeddings-background.yaml"
           grep -q '^  maxReplicas: 6$' "$render_dir/hub-embeddings-background.yaml"
           grep -q 'stabilizationWindowSeconds: 900' "$render_dir/hub-embeddings-background.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --set hub.embeddings.background.enabled=true \
+            --set-string hub.embeddings.background.httpDisableKeepAlives=true \
+            --show-only templates/hub-deployment.yaml > "$render_dir/hub-embeddings-background-api.yaml"
+          ! grep -q 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-background-api.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --set hub.embeddings.background.enabled=true \
+            --set-string hub.embeddings.background.httpDisableKeepAlives=true \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-embeddings-background-worker.yaml"
+          grep -A1 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-background-worker.yaml" | grep -q 'value: "true"'
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --set hub.embeddings.background.enabled=true \
+            --set-string hub.embeddings.background.httpDisableKeepAlives=true \
+            --set-string hub.worker.env.EMBEDDING_HTTP_DISABLE_KEEP_ALIVES=false \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-embeddings-background-worker-override.yaml"
+          test "$(grep -c 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-background-worker-override.yaml")" -eq 1
+          grep -A1 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-background-worker-override.yaml" | grep -q 'value: "false"'
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \

--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -192,6 +192,7 @@ jobs:
             --set hub.embeddings.enabled=true \
             --set hub.embeddings.background.enabled=true \
             --set-string hub.embeddings.background.httpDisableKeepAlives=true \
+            --set-string hub.env.EMBEDDING_HTTP_DISABLE_KEEP_ALIVES=true \
             --set-string hub.worker.env.EMBEDDING_HTTP_DISABLE_KEEP_ALIVES=false \
             --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-embeddings-background-worker-override.yaml"
           test "$(grep -c 'name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES' "$render_dir/hub-embeddings-background-worker-override.yaml")" -eq 1

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -123,10 +123,11 @@ hub:
     enabled: true
     background:
       enabled: true
-      maxConcurrent: "24"
+      maxConcurrent: "48"
       batchSize: "8"
-      batchMaxWaitMs: "25"
-      batchMaxInFlight: "3"
+      batchMaxWaitMs: "100"
+      batchMaxInFlight: "12"
+      httpDisableKeepAlives: "true"
       persistence:
         storageClass: gp3
       resources:
@@ -467,6 +468,7 @@ tokens, provider response bodies, and collector URLs are never telemetry fields.
 | hub.embeddings.background.batchMaxWaitMs                           | string | `"25"`                                                                      |                                                           |
 | hub.embeddings.background.batchSize                                | string | `"1"`                                                                       |                                                           |
 | hub.embeddings.background.enabled                                  | bool   | `false`                                                                     |                                                           |
+| hub.embeddings.background.httpDisableKeepAlives                    | string | `"false"`                                                                 | Opens a new worker provider connection per request.       |
 | hub.embeddings.background.maxConcurrent                            | string | `"5"`                                                                       |                                                           |
 | hub.embeddings.background.persistence.enabled                      | bool   | `true`                                                                      |                                                           |
 | hub.embeddings.background.persistence.size                         | string | `"10Gi"`                                                                    | One retained cache volume per StatefulSet replica.        |

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -143,6 +143,8 @@ hub:
 The background pool is a StatefulSet with one retained RWO cache PVC per replica. Before a planned
 backfill, temporarily set both autoscaling replica bounds to the desired pre-warmed count and wait
 for every pod to become Ready. Restore the steady-state bounds after the backlog drains.
+An existing `hub.worker.env.EMBEDDING_HTTP_DISABLE_KEEP_ALIVES` override remains supported and takes
+precedence over `hub.embeddings.background.httpDisableKeepAlives` during chart upgrades.
 
 Embedding backfills are opt-in and never render a Job unless `hub.embeddingBackfill.enabled=true`.
 Each deliberate run requires a new `runId`; start with `countOnly: true`, then use `tenantId` or
@@ -468,7 +470,7 @@ tokens, provider response bodies, and collector URLs are never telemetry fields.
 | hub.embeddings.background.batchMaxWaitMs                           | string | `"25"`                                                                      |                                                           |
 | hub.embeddings.background.batchSize                                | string | `"1"`                                                                       |                                                           |
 | hub.embeddings.background.enabled                                  | bool   | `false`                                                                     |                                                           |
-| hub.embeddings.background.httpDisableKeepAlives                    | string | `"false"`                                                                 | Opens a new worker provider connection per request.       |
+| hub.embeddings.background.httpDisableKeepAlives                    | string | `"false"`                                                                 | Opens a new worker provider connection per request. Existing `hub.worker.env` override wins. |
 | hub.embeddings.background.maxConcurrent                            | string | `"5"`                                                                       |                                                           |
 | hub.embeddings.background.persistence.enabled                      | bool   | `true`                                                                      |                                                           |
 | hub.embeddings.background.persistence.size                         | string | `"10Gi"`                                                                    | One retained cache volume per StatefulSet replica.        |

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -487,6 +487,7 @@ self-hosted runtime is enabled so Hub API and Hub worker cannot drift.
 {{- define "formbricks.hubEmbeddingEnv" -}}
 {{- $root := .root -}}
 {{- $worker := .worker | default false -}}
+{{- $env := .env | default (dict) -}}
 {{- if $root.Values.hub.embeddings.enabled }}
 - name: EMBEDDING_PROVIDER
   value: "openai"
@@ -519,7 +520,11 @@ self-hosted runtime is enabled so Hub API and Hub worker cannot drift.
 - name: EMBEDDING_BATCH_MAX_IN_FLIGHT
   value: {{ ternary $root.Values.hub.embeddings.background.batchMaxInFlight "1" $root.Values.hub.embeddings.background.enabled | quote }}
 - name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES
+  {{- if hasKey $env "EMBEDDING_HTTP_DISABLE_KEEP_ALIVES" }}
+  value: {{ index $env "EMBEDDING_HTTP_DISABLE_KEEP_ALIVES" | quote }}
+  {{- else }}
   value: {{ ternary $root.Values.hub.embeddings.background.httpDisableKeepAlives "false" $root.Values.hub.embeddings.background.enabled | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -518,6 +518,8 @@ self-hosted runtime is enabled so Hub API and Hub worker cannot drift.
   value: {{ ternary $root.Values.hub.embeddings.background.batchMaxWaitMs "25" $root.Values.hub.embeddings.background.enabled | quote }}
 - name: EMBEDDING_BATCH_MAX_IN_FLIGHT
   value: {{ ternary $root.Values.hub.embeddings.background.batchMaxInFlight "1" $root.Values.hub.embeddings.background.enabled | quote }}
+- name: EMBEDDING_HTTP_DISABLE_KEEP_ALIVES
+  value: {{ ternary $root.Values.hub.embeddings.background.httpDisableKeepAlives "false" $root.Values.hub.embeddings.background.enabled | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -527,7 +529,7 @@ Returns true when an env var is managed by hub.embeddings and should not be rend
 */}}
 {{- define "formbricks.hubEmbeddingEnvManaged" -}}
 {{- $key := .key -}}
-{{- if has $key (list "EMBEDDING_PROVIDER" "EMBEDDING_MODEL" "EMBEDDING_BASE_URL" "EMBEDDING_PROVIDER_API_KEY" "EMBEDDING_MAX_CONCURRENT" "EMBEDDING_NORMALIZE" "EMBEDDING_BATCH_SIZE" "EMBEDDING_BATCH_MAX_WAIT_MS" "EMBEDDING_BATCH_MAX_IN_FLIGHT") -}}
+{{- if has $key (list "EMBEDDING_PROVIDER" "EMBEDDING_MODEL" "EMBEDDING_BASE_URL" "EMBEDDING_PROVIDER_API_KEY" "EMBEDDING_MAX_CONCURRENT" "EMBEDDING_NORMALIZE" "EMBEDDING_BATCH_SIZE" "EMBEDDING_BATCH_MAX_WAIT_MS" "EMBEDDING_BATCH_MAX_IN_FLIGHT" "EMBEDDING_HTTP_DISABLE_KEEP_ALIVES") -}}
 true
 {{- end -}}
 {{- end }}

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -86,8 +86,9 @@ spec:
                 name: {{ include "formbricks.hubSecretName" . }}
           {{- if or .Values.hub.embeddings.enabled (gt (len .Values.hub.env) 0) (gt (len .Values.hub.worker.env) 0) }}
           env:
-            {{- $workerEnv := mergeOverwrite (dict) .Values.hub.env .Values.hub.worker.env }}
-            {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" $workerEnv "worker" true) | nindent 12 }}
+            {{- $keepAliveKey := "EMBEDDING_HTTP_DISABLE_KEEP_ALIVES" }}
+            {{- $embeddingWorkerEnv := mergeOverwrite (dict) (pick .Values.hub.env $keepAliveKey) (pick .Values.hub.worker.env $keepAliveKey) }}
+            {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" $embeddingWorkerEnv "worker" true) | nindent 12 }}
             {{- range $key, $value := .Values.hub.env }}
             {{- if and (not (hasKey $.Values.hub.worker.env $key)) (not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key)))) }}
             {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -86,7 +86,7 @@ spec:
                 name: {{ include "formbricks.hubSecretName" . }}
           {{- if or .Values.hub.embeddings.enabled (gt (len .Values.hub.env) 0) (gt (len .Values.hub.worker.env) 0) }}
           env:
-            {{- $workerEnv := merge (dict) .Values.hub.env .Values.hub.worker.env }}
+            {{- $workerEnv := mergeOverwrite (dict) .Values.hub.env .Values.hub.worker.env }}
             {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" $workerEnv "worker" true) | nindent 12 }}
             {{- range $key, $value := .Values.hub.env }}
             {{- if and (not (hasKey $.Values.hub.worker.env $key)) (not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key)))) }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -1131,6 +1131,7 @@ hub:
       batchSize: "1"
       batchMaxWaitMs: "25"
       batchMaxInFlight: "1"
+      httpDisableKeepAlives: "false"
       replicas: 1
 
       service:


### PR DESCRIPTION
No ticket; this is the follow-up to the staging EU embedding throughput gate.

## What & why

- Hub worker HTTP keep-alive currently pins long-lived connections to a subset of the worker-only TEI endpoints.
- Add `hub.embeddings.background.httpDisableKeepAlives`, defaulting to `"false"`, and render it only for background worker paths.
- Preserve an existing `hub.worker.env.EMBEDDING_HTTP_DISABLE_KEEP_ALIVES` override during chart upgrades.
- Document the measured staging tuning target: `48 / 8 / 100 / 12` with per-request connection balancing enabled.

## Breaking changes

- [ ] This PR contains breaking changes

None. The chart value is additive and defaults off, so existing installs render the current connection-reuse behavior.

## Migrations & env

- Adds optional chart value `hub.embeddings.background.httpDisableKeepAlives`.
- When the background pool is enabled, it renders worker env `EMBEDDING_HTTP_DISABLE_KEEP_ALIVES`; the default is `"false"`.
- No database migration.

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Existing embeddings installs keep connection reuse and the Hub API receives no worker transport setting | unit (mutation): `.github/workflows/helm-chart-validation.yml:121-142` | Separate API and worker renders prove API absence and worker `"false"` |
| Background tuning enables connection balancing only on the worker | unit (mutation): `.github/workflows/helm-chart-validation.yml:144-188` | Separate API and worker renders prove API absence and worker `"true"` |
| Worker-specific raw env wins a conflicting global Hub env value after upgrade | unit (mutation): `.github/workflows/helm-chart-validation.yml:190-199` | With global `true` and worker `false`, the worker renders exactly one managed entry with value `"false"` |
| Guarded embedding backfill Jobs use the background transport setting | unit (mutation): `.github/workflows/helm-chart-validation.yml:226-244`; renders `charts/formbricks/templates/hub-embedding-backfill-job.yaml` | Enabled backfill Job renders exactly one keep-alive setting with value `"true"` |
| Chart remains valid with defaults | manual: `helm lint charts/formbricks --set formbricks.webappUrl=https://qa.example.com` | 1 chart linted, 0 failures |

**Open gaps**

- Runtime throughput and six-pod request distribution are intentionally verified by the guarded 500-record staging canary after the matching Hub release is deployed.

**Risks**

- Enabling the value trades HTTP connection reuse for Kubernetes endpoint distribution; it is background-only and remains opt-in. An existing raw worker override takes precedence for upgrade compatibility.

---

> [!NOTE]
> **AI model used** — `gpt-5`, reasoning effort `unknown`.
