### PR TITLE
docs(surveys): document the strict declared-field naming rule and pin it [ENG-2539]

### DIFF
--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -3463,9 +3463,11 @@ components:
     SurveyHiddenFields:
       type: object
       description: |
-        Hidden fields, sometimes called embedded data in other survey products. Field ids are stable
-        public identifiers and may be referenced by logic, recall, quotas, integrations, and response data.
-        Use only letters, numbers, underscores, and hyphens; avoid spaces and reserved ids.
+        Hidden fields, sometimes called embedded data in other survey products. Field ids are stable public identifiers and may be referenced by logic, recall, quotas, integrations, and response data.
+
+        **Naming rule for new field ids** — the same rule the survey editor applies (ENG-2539): a new id must start with a lowercase letter and then contain only lowercase letters, numbers and underscores (`^[a-z][a-z0-9_]*$`), and must not take a reserved name. Reserved are the link-survey system params and internal ids — `userId`, `source`, `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport` (matched case-insensitively) — and the names of auto-captured system fields such as `url`, `country`, `language`, `timezone` or `utmSource`, which every survey can already read without declaring them.
+
+        **Ids a survey already declares are grandfathered**: they always load, and re-sending the survey unchanged never fails validation — only *adding* such a name as a new field is refused. Note this means re-creating a survey from an exported document can fail with a 400 when the export declares a name the rule refuses; rename the field in the payload before importing. The `pattern` below describes what stored surveys may hold (the pre-existing lenient charset), not what a new id may look like.
       required:
         - enabled
       properties:

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -3465,9 +3465,9 @@ components:
       description: |
         Hidden fields, sometimes called embedded data in other survey products. Field ids are stable public identifiers and may be referenced by logic, recall, quotas, integrations, and response data.
 
-        **Naming rule for new field ids** — the same rule the survey editor applies (ENG-2539): a new id must start with a lowercase letter and then contain only lowercase letters, numbers and underscores (`^[a-z][a-z0-9_]*$`), and must not take a reserved name. Reserved are the link-survey system params and internal ids — `userId`, `source`, `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport` (matched case-insensitively) — and the names of auto-captured system fields such as `url`, `country`, `language`, `timezone` or `utmSource`, which every survey can already read without declaring them.
+        **Naming rule for new field ids** — the same rule the survey editor applies (ENG-2539): a new id must start with a lowercase letter and then contain only lowercase letters, numbers and underscores (`^[a-z][a-z0-9_]*$`), and must not take a reserved name. Reserved are the link-survey system params and internal ids — `userId`, `source`, `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport` (matched case-insensitively) — and the names of auto-captured system fields, which every survey can already read without declaring them: `source`, `url`, `country`, `action`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`, `locale`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`, `pagePath`, `pageReferrer`, `utmSource`, `utmMedium`, `utmCampaign`, `utmTerm`, `utmContent`, `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`.
 
-        **Ids a survey already declares are grandfathered**: they always load, and re-sending the survey unchanged never fails validation — only *adding* such a name as a new field is refused. Note this means re-creating a survey from an exported document can fail with a 400 when the export declares a name the rule refuses; rename the field in the payload before importing. The `pattern` below describes what stored surveys may hold (the pre-existing lenient charset), not what a new id may look like.
+        **Ids a survey already declares are grandfathered**: they always load, and re-sending the survey unchanged never fails validation — only *adding* such a name as a new field is refused. Deleting a grandfathered field spends the reprieve: once it is gone from the saved survey, the name can no longer be re-added. Note this means re-creating a survey from an exported document can fail with a 400 when the export declares a name the rule refuses; rename the field in the payload before importing. The `pattern` below describes what stored surveys may hold (the pre-existing lenient charset), not what a new id may look like.
       required:
         - enabled
       properties:
@@ -3493,8 +3493,9 @@ components:
           description: Optional stable variable id. Generated when omitted.
         name:
           type: string
-          pattern: ^[a-z0-9_]+$
-          description: Unique variable name. Lowercase letters, numbers, and underscores only.
+          pattern: ^[a-z][a-z0-9_]*$
+          description: |
+            Unique variable name. Must start with a lowercase letter, then lowercase letters, numbers and underscores only — the same rule as new hidden-field ids (this schema is create-only, so no grandfathered name validates against it). Reserved names are refused: `userId`, `source`, `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport`, and the auto-captured system field names `source`, `url`, `country`, `action`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`, `locale`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`, `pagePath`, `pageReferrer`, `utmSource`, `utmMedium`, `utmCampaign`, `utmTerm`, `utmContent`, `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`.
         type:
           type: string
           enum:
@@ -3516,8 +3517,9 @@ components:
           description: Optional stable variable id. Generated when omitted.
         name:
           type: string
-          pattern: ^[a-z0-9_]+$
-          description: Unique variable name. Lowercase letters, numbers, and underscores only.
+          pattern: ^[a-z][a-z0-9_]*$
+          description: |
+            Unique variable name. Must start with a lowercase letter, then lowercase letters, numbers and underscores only — the same rule as new hidden-field ids (this schema is create-only, so no grandfathered name validates against it). Reserved names are refused: `userId`, `source`, `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport`, and the auto-captured system field names `source`, `url`, `country`, `action`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`, `locale`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`, `pagePath`, `pageReferrer`, `utmSource`, `utmMedium`, `utmCampaign`, `utmTerm`, `utmContent`, `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`.
         type:
           type: string
           enum:

--- a/docs/api-v3-reference/src/components/schemas/CreateSurveyNumberVariable.yml
+++ b/docs/api-v3-reference/src/components/schemas/CreateSurveyNumberVariable.yml
@@ -10,8 +10,14 @@ properties:
     description: Optional stable variable id. Generated when omitted.
   name:
     type: string
-    pattern: ^[a-z0-9_]+$
-    description: Unique variable name. Lowercase letters, numbers, and underscores only.
+    pattern: ^[a-z][a-z0-9_]*$
+    description: >
+      Unique variable name. Must start with a lowercase letter, then lowercase letters, numbers and
+      underscores only — the same rule as new hidden-field ids (this schema is create-only, so no
+      grandfathered name validates against it). Reserved names are refused: `userId`, `source`,
+      `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`,
+      `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport`, and the
+      auto-captured system field names `source`, `url`, `country`, `action`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`, `locale`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`, `pagePath`, `pageReferrer`, `utmSource`, `utmMedium`, `utmCampaign`, `utmTerm`, `utmContent`, `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`.
   type:
     type: string
     enum:

--- a/docs/api-v3-reference/src/components/schemas/CreateSurveyTextVariable.yml
+++ b/docs/api-v3-reference/src/components/schemas/CreateSurveyTextVariable.yml
@@ -10,8 +10,14 @@ properties:
     description: Optional stable variable id. Generated when omitted.
   name:
     type: string
-    pattern: ^[a-z0-9_]+$
-    description: Unique variable name. Lowercase letters, numbers, and underscores only.
+    pattern: ^[a-z][a-z0-9_]*$
+    description: >
+      Unique variable name. Must start with a lowercase letter, then lowercase letters, numbers and
+      underscores only — the same rule as new hidden-field ids (this schema is create-only, so no
+      grandfathered name validates against it). Reserved names are refused: `userId`, `source`,
+      `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`,
+      `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport`, and the
+      auto-captured system field names `source`, `url`, `country`, `action`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`, `locale`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`, `pagePath`, `pageReferrer`, `utmSource`, `utmMedium`, `utmCampaign`, `utmTerm`, `utmContent`, `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`.
   type:
     type: string
     enum:

--- a/docs/api-v3-reference/src/components/schemas/SurveyHiddenFields.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyHiddenFields.yml
@@ -11,12 +11,14 @@ description: >
   link-survey system params and internal ids — `userId`, `source`, `suid`, `end`, `start`,
   `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`,
   `preview`, `startAt`, `skipPrefilled`, `offlineSupport` (matched case-insensitively) — and the
-  names of auto-captured system fields such as `url`, `country`, `language`, `timezone` or
-  `utmSource`, which every survey can already read without declaring them.
+  names of auto-captured system fields, which every survey can already read without declaring
+  them: `source`, `url`, `country`, `action`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`, `locale`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`, `pagePath`, `pageReferrer`, `utmSource`, `utmMedium`, `utmCampaign`, `utmTerm`, `utmContent`, `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`.
 
 
   **Ids a survey already declares are grandfathered**: they always load, and re-sending the survey
-  unchanged never fails validation — only *adding* such a name as a new field is refused. Note this
+  unchanged never fails validation — only *adding* such a name as a new field is refused. Deleting a
+  grandfathered field spends the reprieve: once it is gone from the saved survey, the name can no
+  longer be re-added. Note this
   means re-creating a survey from an exported document can fail with a 400 when the export declares
   a name the rule refuses; rename the field in the payload before importing. The `pattern` below
   describes what stored surveys may hold (the pre-existing lenient charset), not what a new id may

--- a/docs/api-v3-reference/src/components/schemas/SurveyHiddenFields.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyHiddenFields.yml
@@ -1,13 +1,26 @@
 type: object
 description: >
-  Hidden fields, sometimes called embedded data in other survey products. Field
-  ids are stable
+  Hidden fields, sometimes called embedded data in other survey products. Field ids are stable
+  public identifiers and may be referenced by logic, recall, quotas, integrations, and response
+  data.
 
-  public identifiers and may be referenced by logic, recall, quotas,
-  integrations, and response data.
 
-  Use only letters, numbers, underscores, and hyphens; avoid spaces and reserved
-  ids.
+  **Naming rule for new field ids** — the same rule the survey editor applies (ENG-2539): a new id
+  must start with a lowercase letter and then contain only lowercase letters, numbers and
+  underscores (`^[a-z][a-z0-9_]*$`), and must not take a reserved name. Reserved are the
+  link-survey system params and internal ids — `userId`, `source`, `suid`, `end`, `start`,
+  `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`,
+  `preview`, `startAt`, `skipPrefilled`, `offlineSupport` (matched case-insensitively) — and the
+  names of auto-captured system fields such as `url`, `country`, `language`, `timezone` or
+  `utmSource`, which every survey can already read without declaring them.
+
+
+  **Ids a survey already declares are grandfathered**: they always load, and re-sending the survey
+  unchanged never fails validation — only *adding* such a name as a new field is refused. Note this
+  means re-creating a survey from an exported document can fail with a 400 when the export declares
+  a name the rule refuses; rename the field in the payload before importing. The `pattern` below
+  describes what stored surveys may hold (the pre-existing lenient charset), not what a new id may
+  look like.
 required:
   - enabled
 properties:

--- a/docs/surveys/general-features/hidden-fields.mdx
+++ b/docs/surveys/general-features/hidden-fields.mdx
@@ -20,6 +20,21 @@ icon: "eye-slash"
 
 ![Filled Hidden Fields](/images/surveys/general-features/hidden-fields/filled-hidden-fields.webp)
 
+## Naming
+
+Field ids follow one rule everywhere — the editor and the management API refuse the same names (ENG-2539):
+
+- A **new** field id must start with a lowercase letter and then contain only lowercase letters, numbers and underscores: `^[a-z][a-z0-9_]*$`. So `page_type`, not `pageType` or `Page Type`.
+- **Reserved names are refused in any casing.** These are the link-survey system params and internal ids: `userId`, `source`, `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport`. A field with one of these names could never be filled from a survey URL.
+- **Auto-captured field names are refused too** (`url`, `country`, `language`, `timezone`, `utmSource`, …): every survey can already read those by name without declaring them, and a second field under the same name would be ambiguous in recall and logic.
+
+<Note>
+  Ids a survey **already declares keep working**: they load, collect values and can be re-saved unchanged —
+  only adding such a name as a *new* field is refused. One consequence: re-creating a survey from an exported
+  document fails with a 400 when the export declares a refused name. Rename that field in the payload before
+  importing.
+</Note>
+
 ## Set Hidden Field via URL
 
 Single Hidden Field:
@@ -37,13 +52,14 @@ https://formbricks.com/s/clin34bjy?screen=landing_page&job=Founder
 ## Set Hidden Fields via SDK
 
 <Note>
-  We are reworking how to add Hidden Fields via SDK moving away from binding them to Actions over to Context. Until then, we will **continue to support the current approach for the JS SDK**. However, we don't support Hidden Fields for the Android and iOS SDKs.
+  We are reworking how to add Hidden Fields via SDK moving away from binding them to Actions over to Context.
+  Until then, we will **continue to support the current approach for the JS SDK**. However, we don't support
+  Hidden Fields for the Android and iOS SDKs.
 </Note>
 
 ```js
-formbricks.track("action_name", {hiddenFields: {myField: "value"}})
+formbricks.track("action_name", { hiddenFields: { myField: "value" } });
 ```
-
 
 ## View Hidden Fields in Responses
 

--- a/docs/surveys/general-features/hidden-fields.mdx
+++ b/docs/surveys/general-features/hidden-fields.mdx
@@ -26,13 +26,14 @@ Field ids follow one rule everywhere — the editor and the management API refus
 
 - A **new** field id must start with a lowercase letter and then contain only lowercase letters, numbers and underscores: `^[a-z][a-z0-9_]*$`. So `page_type`, not `pageType` or `Page Type`.
 - **Reserved names are refused in any casing.** These are the link-survey system params and internal ids: `userId`, `source`, `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport`. A field with one of these names could never be filled from a survey URL.
-- **Auto-captured field names are refused too** (`url`, `country`, `language`, `timezone`, `utmSource`, …): every survey can already read those by name without declaring them, and a second field under the same name would be ambiguous in recall and logic.
+- **Auto-captured field names are refused too**: every survey can already read those by name without declaring them, and a second field under the same name would be ambiguous in recall and logic. The full list: `source`, `url`, `country`, `action`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`, `locale`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`, `pagePath`, `pageReferrer`, `utmSource`, `utmMedium`, `utmCampaign`, `utmTerm`, `utmContent`, `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`.
 
 <Note>
   Ids a survey **already declares keep working**: they load, collect values and can be re-saved unchanged —
-  only adding such a name as a *new* field is refused. One consequence: re-creating a survey from an exported
-  document fails with a 400 when the export declares a refused name. Rename that field in the payload before
-  importing.
+  only adding such a name as a *new* field is refused. Deleting a grandfathered field spends the reprieve:
+  once it is gone from the saved survey, the name can no longer be re-added. One consequence: re-creating a
+  survey from an exported document fails with a 400 when the export declares a refused name. Rename that field
+  in the payload before importing.
 </Note>
 
 ## Set Hidden Field via URL
@@ -58,7 +59,7 @@ https://formbricks.com/s/clin34bjy?screen=landing_page&job=Founder
 </Note>
 
 ```js
-formbricks.track("action_name", { hiddenFields: { myField: "value" } });
+formbricks.track("action_name", { hiddenFields: { my_field: "value" } });
 ```
 
 ## View Hidden Fields in Responses

--- a/packages/types/surveys/declared-field-docs.test.ts
+++ b/packages/types/surveys/declared-field-docs.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { RESERVED_DECLARED_FIELD_NAMES } from "./validation";
+
+/**
+ * Anti-drift check for ENG-2539's decision docs: both public surfaces enumerate the refused
+ * declared-field names concretely, and the lists are hand-maintained — a name added to
+ * `FORBIDDEN_IDS` or `LINK_SURVEY_SYSTEM_PARAMS` fails no other check (the review round on the
+ * ticket found exactly that: 17 names in the set, 16 in the docs — `embed` was missing).
+ *
+ * Deliberately couples this test to the docs' location and to the backtick convention: names appear
+ * as `` `name` `` in both files, and matching on the delimited form is what keeps short names like
+ * `end` or `start` from passing vacuously off ordinary prose. If a doc moves, this failing IS the
+ * signal that its enumeration needs to move with it.
+ */
+describe("the refused-name enumeration in the docs matches RESERVED_DECLARED_FIELD_NAMES", () => {
+  const read = (relativeToRepoRoot: string): string =>
+    readFileSync(path.resolve(process.cwd(), "../..", relativeToRepoRoot), "utf8").toLowerCase();
+
+  const surfaces = [
+    "docs/api-v3-reference/src/components/schemas/SurveyHiddenFields.yml",
+    "docs/surveys/general-features/hidden-fields.mdx",
+  ];
+
+  test.each(surfaces)("%s names every refused id", (surface) => {
+    const content = read(surface);
+    const missing = [...RESERVED_DECLARED_FIELD_NAMES].filter((name) => !content.includes(`\`${name}\``));
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/types/surveys/declared-field-docs.test.ts
+++ b/packages/types/surveys/declared-field-docs.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
+import { RESERVED_FIELD_NAMES } from "../reserved-field-names";
 import { RESERVED_DECLARED_FIELD_NAMES } from "./validation";
 
 /**
@@ -14,18 +15,27 @@ import { RESERVED_DECLARED_FIELD_NAMES } from "./validation";
  * `end` or `start` from passing vacuously off ordinary prose. If a doc moves, this failing IS the
  * signal that its enumeration needs to move with it.
  */
-describe("the refused-name enumeration in the docs matches RESERVED_DECLARED_FIELD_NAMES", () => {
+describe("the refused-name enumeration in the docs matches the two reserved sets", () => {
   const read = (relativeToRepoRoot: string): string =>
     readFileSync(path.resolve(process.cwd(), "../..", relativeToRepoRoot), "utf8").toLowerCase();
+
+  // Both halves of the refusal surface: the 17 link-contract names AND the auto-captured catalog.
+  // The catalog is the larger half and grows (ENG-1858, `locale` via ENG-2472) — pinning only the 17
+  // left 26+ names as prose no test could hold to, which is how `embed` went missing the first time.
+  const refusedNames = [...RESERVED_DECLARED_FIELD_NAMES, ...RESERVED_FIELD_NAMES];
 
   const surfaces = [
     "docs/api-v3-reference/src/components/schemas/SurveyHiddenFields.yml",
     "docs/surveys/general-features/hidden-fields.mdx",
+    // Create-only variable schemas carry the same rule: `collectDeclaredFieldNames` maps variables
+    // too, so a new variable named `country` or `1foo` gets the identical 400.
+    "docs/api-v3-reference/src/components/schemas/CreateSurveyTextVariable.yml",
+    "docs/api-v3-reference/src/components/schemas/CreateSurveyNumberVariable.yml",
   ];
 
-  test.each(surfaces)("%s names every refused id", (surface) => {
+  test.each(surfaces)("%s names every refused id from both sets", (surface) => {
     const content = read(surface);
-    const missing = [...RESERVED_DECLARED_FIELD_NAMES].filter((name) => !content.includes(`\`${name}\``));
+    const missing = refusedNames.filter((name) => !content.includes(`\`${name}\``));
 
     expect(missing).toEqual([]);
   });

--- a/packages/types/surveys/declared-field-guard.test.ts
+++ b/packages/types/surveys/declared-field-guard.test.ts
@@ -184,10 +184,40 @@ describe("describeDeclaredFieldNameError", () => {
   });
 
   test("a name that is merely not a safe identifier keeps the naming-rule reason", () => {
-    const reason = reasonFor("Team Size");
+    // `UserRegion`, not `Team Size`: a space is refused by the shared `HasSpaces` check BEFORE
+    // `isSafeIdentifier` is consulted, so the old spelling never exercised this reason — it passed
+    // only while every non-reserved code returned the same sentence (the drift ENG-2539's review
+    // caught). `UserRegion` genuinely produces `NotSafeIdentifier`.
+    const reason = reasonFor("UserRegion");
 
     expect(reason).toContain("lowercase letter");
     expect(reason).not.toContain("reserved");
+  });
+
+  // ENG-2539: the reason follows the check that fired. One sentence for everything non-reserved sent
+  // a caller in circles — told about lowercase letters when the space was the whole problem, and ""
+  // read identically to a charset violation.
+  describe("the reason names the check that actually fired", () => {
+    test("a space names the space, not the charset", () => {
+      const reason = reasonFor("team size");
+
+      expect(reason).toContain("spaces");
+      expect(reason).not.toContain("lowercase letter");
+    });
+
+    test("an illegal character names the legacy charset, not the strict one", () => {
+      const reason = reasonFor("user:name");
+
+      expect(reason).toContain("letters, numbers, underscores and hyphens");
+      expect(reason).not.toContain("lowercase letter");
+    });
+
+    test("an empty name says so", () => {
+      const reason = reasonFor("");
+
+      expect(reason).toContain("must not be empty");
+      expect(reason).not.toContain("lowercase letter");
+    });
   });
 });
 

--- a/packages/types/surveys/declared-field-guard.ts
+++ b/packages/types/surveys/declared-field-guard.ts
@@ -148,11 +148,34 @@ const describeReservedReason = (field: string): string => {
   return "it is a reserved name";
 };
 
+/**
+ * Why a name refused for a reason other than {@link TValidateIdErrorCode.Reserved} was refused, one
+ * clause per code.
+ *
+ * Per code rather than one sentence for "not reserved": the old fallback returned the
+ * `NotSafeIdentifier` sentence for every non-reserved code, so a caller sending `Team Size` was told
+ * about lowercase letters when the space was the whole problem, and `""` produced the same sentence
+ * as a charset violation. Each code now states the check that actually fired — so following the
+ * message always moves the caller forward one check instead of around in a circle.
+ */
+const DECLARED_FIELD_NAME_REASONS: Record<Exclude<TValidateIdErrorCode, "reserved">, string> = {
+  [TValidateIdErrorCode.Empty]: "it must not be empty",
+  [TValidateIdErrorCode.HasSpaces]: "it must not contain spaces",
+  [TValidateIdErrorCode.InvalidChars]: "it may contain only letters, numbers, underscores and hyphens",
+  [TValidateIdErrorCode.NotSafeIdentifier]:
+    "it must start with a lowercase letter and contain only lowercase letters, numbers and underscores",
+  // Unreachable from `validateNewDeclaredFieldNames`, which passes empty id lists so a collision is
+  // never reported here. Spelled out anyway: the map is exhaustive over the enum, so a caller that
+  // does pass id lists gets a true sentence instead of falling through to a wrong one.
+  [TValidateIdErrorCode.Duplicate]: "another field in this survey already uses that name",
+};
+
+/** The client-facing sentence for one refused name: `Field name "x" cannot be used: <reason>.` */
 export const describeDeclaredFieldNameError = (error: TValidateIdError): string => {
   const reason =
     error.code === TValidateIdErrorCode.Reserved
       ? describeReservedReason(error.field)
-      : "it must start with a lowercase letter and contain only lowercase letters, numbers and underscores";
+      : DECLARED_FIELD_NAME_REASONS[error.code];
 
   return `Field name "${error.field}" cannot be used: ${reason}.`;
 };


### PR DESCRIPTION
## What & why

ENG-2539 asked for a decision on how strict the management API should be about declared field names, and the decision (with Johannes) is: **strict for new names, all three groups — back-compat via grandfathering only.** That is what the guard on this branch already enforces, so #8949 (which relaxed the API) was closed and this PR ships the part of the ticket that remained: write the decision down, pin it, and take the two review findings from #8949 that survive the reversal.

**1. Docs now state the real rule.** `SurveyHiddenFields.yml` advertised the lenient legacy charset with a vague "avoid reserved ids"; the API actually refuses `UserRegion`, `country` and `lang` alike for new names. The description now spells out the strict rule, enumerates all **17** refused link-contract names (the #8949 review found the docs listing 16 — `embed` was missing), names the auto-captured group, and explains grandfathering — including that re-creating a survey from an exported document 400s on a refused name (accepted; rename on import). The `pattern` stays lenient on purpose: it describes what *stored* surveys may hold, which grandfathered ids must keep satisfying on re-send. `hidden-fields.mdx` gets the same content as a **Naming** section in prose. `openapi.yml` regenerated with `bundle.mjs`.

**2. The 400 now names the check that fired** (carried over from #8949's `206011e`, reworked for the strict rule). Every non-reserved refusal returned `isSafeIdentifier`'s sentence — so `""`, `team size` and `user:name` all read as charset violations, and following the message sent a caller in circles. The reason now follows the error code: empty, spaces, legacy charset, strict charset, duplicate.

**3. The docs enumeration is pinned against drift.** The refused lists are hand-maintained and a name added to `FORBIDDEN_IDS` fails no other check — exactly how `embed` went missing. A new test asserts every name in `RESERVED_DECLARED_FIELD_NAMES` appears (backtick-delimited, so short names like `end` can't pass off prose) in both docs surfaces. It deliberately couples to the docs' location — if a doc moves, the failure IS the signal its enumeration must move too. (This was flagged as an open gap on #8949; taking it here since it guards this PR's own content.)

**No behavior change** beyond the error-message wording: the strict rule itself has been enforced on this branch since ENG-1839 (#8897). The decision-pinning tests for that already exist and stay untouched — the guard suite covers all three groups + grandfathering + casing, and `service.test.ts` / `patch.test.ts` cover create, update and the v3 patch seam including grandfathered re-sends.

## Linear ticket

Fixes ENG-2539 — https://linear.app/formbricks/issue/ENG-2539/decide-how-strict-the-management-api-should-be-about-declared-field

## How this was tested

- `@formbricks/types` ✅ 370 tests (30 in the two touched suites) · `turbo run typecheck lint --filter=@formbricks/types` ✅ · prettier ✅
- `bundle.mjs` regenerate + `--lint` + `--check` all green (the bundle is what CI's api-v3-spec check verifies)
- New tests checked to **fail without their change**:
  - the three reason-follows-the-code tests go red with the per-code map reverted to the old single sentence
  - the anti-drift test goes red with `embed` removed from the YML enumeration (the exact historical gap)
- The pre-existing "Team Size → lowercase letter" test was re-pointed at `UserRegion`: a space is refused by `HasSpaces` *before* `isSafeIdentifier` is consulted, so the old spelling never exercised the reason it asserted — it passed only while every non-reserved code returned the same sentence.

## Breaking changes

None — docs, tests, and 400-message wording only. No accepted or refused payload changes.

## QA / Test Plan

**How to test**

- [ ] `POST /api/v1/management/surveys` with `hiddenFields.fieldIds: [""]` → 400 whose message says the name *must not be empty* (previously: a sentence about lowercase letters).
- [ ] Same with `["team size"]` → 400 saying it *must not contain spaces*.
- [ ] Same with `["user:name"]` → 400 saying *letters, numbers, underscores and hyphens*.
- [ ] Same with `["UserRegion"]` → 400 saying it *must start with a lowercase letter…*.
- [ ] Same with `["lang"]` → 400 saying the name is *never filled from the URL* (unchanged).
- [ ] A survey that already declares `country`: `PUT` it back unchanged → 200 (grandfathering, unchanged behavior).
- [ ] Docs: the v3 reference for `SurveyHiddenFields` lists all 17 refused names (including `embed`) and describes grandfathering; `hidden-fields.mdx` has the same under **Naming**.

**Preconditions / test data**

- A v1 management API key. The grandfathered step needs a survey stored with a reserved name (create the rows via DB/API — the editor refuses the name).

**Risks & regressions**

- The 400 message wording changed for empty/space/charset refusals — anything parsing those strings (nothing known) would notice. Error *codes* and status are untouched.
- The anti-drift test couples `packages/types` to two docs paths; moving either file breaks it deliberately.

**Migrations / env / cutover**

- none
