### PR TITLE
feat(analytics): add person-level last_survey_created_at to PostHog

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@formbricks/logger";
 import { FormbricksProvider } from "@/app/formbricks/components/formbricks-provider";
 import { PlainChat } from "@/app/plain/components/plain-chat";
 import { getIsActiveCustomer } from "@/app/plain/lib/customer";
@@ -12,6 +13,7 @@ import {
   PLAIN_APP_ID,
   POSTHOG_KEY,
 } from "@/lib/constants";
+import { getLastSurveyCreatedAtPersonProperty } from "@/lib/posthog/last-survey-created";
 import { getUser } from "@/lib/user/service";
 import { getSession } from "@/modules/auth/lib/session";
 import { ClientLogout } from "@/modules/ui/components/client-logout";
@@ -37,11 +39,31 @@ const AppLayout = async ({ children }: Readonly<{ children: React.ReactNode }>) 
       ? PLAIN_ACTIVE_CUSTOMER_LABEL_TYPE_ID
       : null;
 
+  // Most recent survey creation timestamp across every organization this person belongs to — see
+  // lib/posthog/last-survey-created.ts. Recomputed on every app page load (not just at the moment a
+  // survey is created) so a teammate creating a survey in a shared organization also moves this
+  // forward for this person. Best-effort: read-only analytics enrichment and must never fail the app
+  // shell render if the lookup errors.
+  let lastSurveyCreatedAt: string | null = null;
+  if (POSTHOG_KEY && user) {
+    try {
+      ({ last_survey_created_at: lastSurveyCreatedAt } = await getLastSurveyCreatedAtPersonProperty(user.id));
+    } catch (error) {
+      logger.warn({ error }, "Failed to load last survey created at for PostHog");
+    }
+  }
+
   return (
     <>
       <NoMobileOverlay />
       {POSTHOG_KEY && user && (
-        <PostHogIdentify posthogKey={POSTHOG_KEY} userId={user.id} email={user.email} name={user.name} />
+        <PostHogIdentify
+          posthogKey={POSTHOG_KEY}
+          userId={user.id}
+          email={user.email}
+          name={user.name}
+          lastSurveyCreatedAt={lastSurveyCreatedAt}
+        />
       )}
       {IS_PLAIN_CHAT_CONFIGURED && PLAIN_APP_ID && (
         <PlainChat

--- a/apps/web/app/posthog/PostHogIdentify.tsx
+++ b/apps/web/app/posthog/PostHogIdentify.tsx
@@ -9,9 +9,21 @@ interface PostHogIdentifyProps {
   userId: string;
   email: string;
   name: string | null;
+  // Most recent survey creation timestamp (ISO 8601) across every organization this person belongs
+  // to, not just the org/workspace open right now — see lib/posthog/last-survey-created.ts. Recomputed
+  // server-side on every app page load, so a teammate creating a survey in a shared organization
+  // still moves this forward for this person the next time they load a page, without this person
+  // having created anything themselves.
+  lastSurveyCreatedAt: string | null;
 }
 
-export const PostHogIdentify = ({ posthogKey, userId, email, name }: PostHogIdentifyProps) => {
+export const PostHogIdentify = ({
+  posthogKey,
+  userId,
+  email,
+  name,
+  lastSurveyCreatedAt,
+}: Readonly<PostHogIdentifyProps>) => {
   const lastIdentifiedUserId = useRef<string | null>(null);
 
   useEffect(() => {
@@ -32,9 +44,9 @@ export const PostHogIdentify = ({ posthogKey, userId, email, name }: PostHogIden
       posthog.reset();
     }
 
-    posthog.identify(userId, { email, name });
+    posthog.identify(userId, { email, name, last_survey_created_at: lastSurveyCreatedAt });
     lastIdentifiedUserId.current = userId;
-  }, [posthogKey, userId, email, name]);
+  }, [posthogKey, userId, email, name, lastSurveyCreatedAt]);
 
   return null;
 };

--- a/apps/web/lib/posthog/last-survey-created.test.ts
+++ b/apps/web/lib/posthog/last-survey-created.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test, vi } from "vitest";
+import { DatabaseError, UnknownError } from "@formbricks/types/errors";
+import { getLastSurveyCreatedAtPersonProperty } from "./last-survey-created";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  findManyMembership: vi.fn(),
+  findFirstSurvey: vi.fn(),
+}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    membership: { findMany: mocks.findManyMembership },
+    survey: { findFirst: mocks.findFirstSurvey },
+  },
+}));
+
+describe("getLastSurveyCreatedAtPersonProperty", () => {
+  test("returns null when the user has no memberships", async () => {
+    mocks.findManyMembership.mockResolvedValueOnce([]);
+
+    const result = await getLastSurveyCreatedAtPersonProperty("user-1");
+
+    expect(result).toEqual({ last_survey_created_at: null });
+    expect(mocks.findFirstSurvey).not.toHaveBeenCalled();
+  });
+
+  test("returns null when none of the user's organizations have created a survey", async () => {
+    mocks.findManyMembership.mockResolvedValueOnce([{ organizationId: "org-1" }]);
+    mocks.findFirstSurvey.mockResolvedValueOnce(null);
+
+    const result = await getLastSurveyCreatedAtPersonProperty("user-1");
+
+    expect(result).toEqual({ last_survey_created_at: null });
+  });
+
+  test("returns the latest survey createdAt across every organization the user belongs to, not just one", async () => {
+    mocks.findManyMembership.mockResolvedValueOnce([
+      { organizationId: "org-1" },
+      { organizationId: "org-2" },
+    ]);
+    const createdAt = new Date("2026-08-20T12:00:00.000Z");
+    mocks.findFirstSurvey.mockResolvedValueOnce({ createdAt });
+
+    const result = await getLastSurveyCreatedAtPersonProperty("user-1");
+
+    expect(result).toEqual({ last_survey_created_at: createdAt.toISOString() });
+    expect(mocks.findFirstSurvey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { workspace: { organizationId: { in: ["org-1", "org-2"] } } },
+        orderBy: { createdAt: "desc" },
+      })
+    );
+  });
+
+  test("wraps a Prisma error in DatabaseError", async () => {
+    const { Prisma } = await import("@formbricks/database/prisma");
+    mocks.findManyMembership.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("boom", { code: "P2002", clientVersion: "0.0.0" })
+    );
+
+    await expect(getLastSurveyCreatedAtPersonProperty("user-1")).rejects.toThrow(DatabaseError);
+  });
+
+  test("wraps a non-Prisma error in UnknownError", async () => {
+    mocks.findManyMembership.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(getLastSurveyCreatedAtPersonProperty("user-1")).rejects.toThrow(UnknownError);
+  });
+});

--- a/apps/web/lib/posthog/last-survey-created.ts
+++ b/apps/web/lib/posthog/last-survey-created.ts
@@ -1,0 +1,58 @@
+import "server-only";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { logger } from "@formbricks/logger";
+import { ZString } from "@formbricks/types/common";
+import { DatabaseError, UnknownError } from "@formbricks/types/errors";
+import { validateInputs } from "@/lib/utils/validate";
+
+export type TPostHogLastSurveyCreatedProperty = {
+  // ISO 8601, or null when none of the person's organizations have created a survey yet. Not scoped
+  // to "the organization I'm currently looking at" or "surveys I personally created" — a person can
+  // belong to several organizations, and a teammate creating a survey in any of them should still
+  // move this forward, since PostHog person properties are a single flat value per key rather than
+  // something scoped per organization/relationship.
+  last_survey_created_at: string | null;
+};
+
+/**
+ * The most recent survey creation timestamp across every organization this person is a member of.
+ * Recomputed from the database on every call rather than patched at the moment of creation, so it
+ * self-heals regardless of who created the survey or which organization/workspace they were in —
+ * the same reasoning as the multi-org role snapshot in lib/posthog/organization-roles.ts.
+ */
+export const getLastSurveyCreatedAtPersonProperty = async (
+  userId: string
+): Promise<TPostHogLastSurveyCreatedProperty> => {
+  validateInputs([userId, ZString]);
+
+  try {
+    const memberships = await prisma.membership.findMany({
+      where: { userId },
+      select: { organizationId: true },
+    });
+
+    if (memberships.length === 0) {
+      return { last_survey_created_at: null };
+    }
+
+    const latestSurvey = await prisma.survey.findFirst({
+      where: {
+        workspace: {
+          organizationId: { in: memberships.map((membership) => membership.organizationId) },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      select: { createdAt: true },
+    });
+
+    return { last_survey_created_at: latestSurvey?.createdAt.toISOString() ?? null };
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      logger.error(error, "Error getting last survey created at for PostHog person property");
+      throw new DatabaseError(error.message);
+    }
+
+    throw new UnknownError("Error while fetching last survey created at");
+  }
+};


### PR DESCRIPTION
No ticket — ad hoc analytics improvement raised in conversation, not tracked in Linear.

## What & why

**Was:** PostHog had no person-level signal for when a person's organizations last created a survey — only group-scoped and event data, nothing on the person profile.

**Now:** `last_survey_created_at` is a person property holding the newest survey `createdAt` across every organization the person belongs to (not just the one currently open), recomputed from the database on every app page load. A teammate creating a survey in a shared organization moves this forward for everyone in that org too, without them creating anything themselves.

## Where to look

- `apps/web/lib/posthog/last-survey-created.ts:24` — the recompute query (memberships → orgs → newest survey)
- `apps/web/app/(app)/layout.tsx:47` — best-effort wiring; a lookup failure is logged and swallowed, never breaks the app shell render

## Breaking changes

- [ ] This PR contains breaking changes

None — purely additive: one new internal helper, one new optional prop threaded through an internal client component, both gated behind the existing `POSTHOG_KEY` check.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter=web test -- lib/posthog/last-survey-created.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Computes the newest `survey.createdAt` across every org a user belongs to, scoped via membership → workspace → organization | unit (guard) — `last-survey-created.test.ts` | 5/5 passing |
| Returns `null` with no memberships, and `null` when no org has a survey (without querying surveys) | unit (guard) — same file | 2/5 tests |
| Prisma vs. unknown errors classified into `DatabaseError`/`UnknownError` | unit (guard) — same file | 2/5 tests |
| Scoped typecheck (`tsc --noEmit`) and lint (`eslint`) over every touched file | guard | 0 errors |

**Open gaps**

- The client-side wiring (`PostHogIdentify`, the app layout) wasn't exercised by an e2e test or a live PostHog check — `.tsx` files aren't unit-tested per repo convention, and no e2e covers this identify call.
- No live PostHog project was queried to confirm the property lands with the expected shape end-to-end.

**Risks**

- The recompute query orders by `createdAt` across every survey in every workspace under all of a user's organizations on each app page load; no dedicated index backs this shape specifically, same profile as comparable existing queries in this codebase.

---

> [!NOTE]
> **AI model used** — `claude-sonnet-5`, reasoning effort `unknown`.
