### PR TITLE
feat: lower unlicensed self-hosted workspace cap to 1

### DIFF
--- a/apps/web/app/api/v1/management/responses/lib/response.test.ts
+++ b/apps/web/app/api/v1/management/responses/lib/response.test.ts
@@ -105,7 +105,7 @@ vi.mock("@/lib/constants", () => ({
   IS_PRODUCTION: false,
   SENTRY_DSN: "mock-sentry-dsn",
   COMMUNITY_WORKSPACE_LIMIT: 1,
-  CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT: 3,
+  CLOUD_HOBBY_WORKSPACE_LIMIT: 1,
 }));
 vi.mock("@/lib/utils/helper");
 vi.mock("@/lib/response/service");

--- a/apps/web/app/api/v1/management/responses/lib/response.test.ts
+++ b/apps/web/app/api/v1/management/responses/lib/response.test.ts
@@ -104,6 +104,8 @@ vi.mock("@/lib/constants", () => ({
   STRIPE_API_VERSION: "2026-01-28.clover",
   IS_PRODUCTION: false,
   SENTRY_DSN: "mock-sentry-dsn",
+  COMMUNITY_WORKSPACE_LIMIT: 1,
+  CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT: 3,
 }));
 vi.mock("@/lib/utils/helper");
 vi.mock("@/lib/response/service");

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
@@ -48,6 +48,8 @@ vi.mock("@/lib/constants", () => ({
   SMTP_HOST: "mock-smtp-host",
   SMTP_PORT: "mock-smtp-port",
   STRIPE_API_VERSION: "2026-01-28.clover",
+  COMMUNITY_WORKSPACE_LIMIT: 1,
+  CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT: 3,
 }));
 
 vi.mock("@/lib/organization/service");

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/lib/constants", () => ({
   SMTP_PORT: "mock-smtp-port",
   STRIPE_API_VERSION: "2026-01-28.clover",
   COMMUNITY_WORKSPACE_LIMIT: 1,
-  CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT: 3,
+  CLOUD_HOBBY_WORKSPACE_LIMIT: 1,
 }));
 
 vi.mock("@/lib/organization/service");

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -550,7 +550,7 @@ checksums:
     common/yes: ec580fd11a45779b039466f1e35eed2a
     common/you_are_downgraded_to_the_community_edition: e3ae56502ff787109cae0997519f628e
     common/you_are_not_authorized_to_perform_this_action: 1b3255ab740582ddff016a399f8bf302
-    common/you_have_reached_your_limit_of_workspace_limit: 506a6ee315d9754da7ea26929bc40f52
+    common/you_have_reached_your_limit_of_workspace_limit: 444293496a4029ea608ec12266bb2e94
     common/you_have_reached_your_monthly_response_limit_of_count: d1e427dbc5ce704bd6b9e188d8407e07
     common/you_will_be_downgraded_to_the_community_edition_on_date: bff35b54c13e2c205dc4c19056261cc0
     common/your_license_has_expired_please_renew: 3f21ae4a7deab351b143b407ece58254

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -116,11 +116,13 @@ export const MAX_OTHER_OPTION_LENGTH = 250;
 export const COMMUNITY_WORKSPACE_LIMIT = 1;
 
 /**
- * Cloud fallback when the license server cannot confirm the instance license (expired,
- * invalid_license, instance_mismatch, unreachable). Deliberately NOT the community limit: cutting
- * paying cloud customers down to one workspace during a license-server outage would be an incident.
+ * Workspaces a cloud organization falls back to when the license server cannot confirm the instance
+ * license (expired, invalid_license, instance_mismatch, unreachable). Deliberately the Hobby (free
+ * tier) allowance: an entitlement we cannot verify is treated as no entitlement. The create gate is
+ * `count >= limit`, so an org already above it keeps every workspace it has and only pauses creating
+ * new ones until the license resolves.
  */
-export const CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT = 3;
+export const CLOUD_HOBBY_WORKSPACE_LIMIT = 1;
 
 export const SKIP_INVITE_FOR_SSO = env.AUTH_SKIP_INVITE_FOR_SSO === "1";
 export const DEFAULT_TEAM_ID = env.AUTH_DEFAULT_TEAM_ID;

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -109,6 +109,19 @@ export const TEXT_RESPONSES_PER_PAGE = 5;
 export const MAX_RESPONSES_FOR_INSIGHT_GENERATION = 500;
 export const MAX_OTHER_OPTION_LENGTH = 250;
 
+/**
+ * Workspaces an organization gets on a self-hosted instance with no active enterprise license
+ * (Community Edition). Mirrors docs/self-hosting/advanced/license.mdx.
+ */
+export const COMMUNITY_WORKSPACE_LIMIT = 1;
+
+/**
+ * Cloud fallback when the license server cannot confirm the instance license (expired,
+ * invalid_license, instance_mismatch, unreachable). Deliberately NOT the community limit: cutting
+ * paying cloud customers down to one workspace during a license-server outage would be an incident.
+ */
+export const CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT = 3;
+
 export const SKIP_INVITE_FOR_SSO = env.AUTH_SKIP_INVITE_FOR_SSO === "1";
 export const DEFAULT_TEAM_ID = env.AUTH_DEFAULT_TEAM_ID;
 

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -579,7 +579,7 @@
     "yes": "Ja",
     "you_are_downgraded_to_the_community_edition": "Du wurdest auf die Community Edition herabgestuft.",
     "you_are_not_authorized_to_perform_this_action": "Du bist nicht berechtigt, diese Aktion durchzuführen.",
-    "you_have_reached_your_limit_of_workspace_limit": "Du hast dein Limit von {workspaceLimit} Workspaces erreicht.",
+    "you_have_reached_your_limit_of_workspace_limit": "Du hast dein Workspace-Limit ({workspaceLimit}) erreicht.",
     "you_have_reached_your_monthly_response_limit_of_count": "Du hast dein monatliches Antwortlimit von {count} erreicht.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Du wirst am {date} auf die Community Edition herabgestuft.",
     "your_license_has_expired_please_renew": "Deine Enterprise-Lizenz ist abgelaufen. Bitte erneuere sie, um weiterhin Enterprise-Funktionen nutzen zu können.",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -579,7 +579,7 @@
     "yes": "Yes",
     "you_are_downgraded_to_the_community_edition": "You are downgraded to the Community Edition.",
     "you_are_not_authorized_to_perform_this_action": "You are not authorized to perform this action.",
-    "you_have_reached_your_limit_of_workspace_limit": "You have reached your limit of {workspaceLimit} workspaces.",
+    "you_have_reached_your_limit_of_workspace_limit": "You have reached your workspace limit ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "You have reached your monthly response limit of {count}.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "You will be downgraded to the Community Edition on {date}.",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -579,7 +579,7 @@
     "yes": "Sí",
     "you_are_downgraded_to_the_community_edition": "Has sido degradado a la edición Community.",
     "you_are_not_authorized_to_perform_this_action": "No tienes autorización para realizar esta acción.",
-    "you_have_reached_your_limit_of_workspace_limit": "Has alcanzado tu límite de {workspaceLimit} espacios de trabajo.",
+    "you_have_reached_your_limit_of_workspace_limit": "Has alcanzado el límite de tu espacio de trabajo ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Has alcanzado tu límite mensual de respuestas de {count}.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Serás degradado a la edición Community el {date}.",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -579,7 +579,7 @@
     "yes": "Oui",
     "you_are_downgraded_to_the_community_edition": "Vous êtes rétrogradé à l'édition communautaire.",
     "you_are_not_authorized_to_perform_this_action": "Vous n'êtes pas autorisé à effectuer cette action.",
-    "you_have_reached_your_limit_of_workspace_limit": "Vous avez atteint votre limite de {workspaceLimit} espaces de travail.",
+    "you_have_reached_your_limit_of_workspace_limit": "Tu as atteint la limite de ton espace de travail ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Vous avez atteint votre limite mensuelle de {count} réponses.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Vous serez rétrogradé à l'édition communautaire le {date}.",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -579,7 +579,7 @@
     "yes": "Igen",
     "you_are_downgraded_to_the_community_edition": "Visszaváltott a közösségi kiadásra.",
     "you_are_not_authorized_to_perform_this_action": "Nincs felhatalmazva ennek a műveletnek a végrehajtásához.",
-    "you_have_reached_your_limit_of_workspace_limit": "Elérte a(z) {workspaceLimit} munkaterületből álló korlátját.",
+    "you_have_reached_your_limit_of_workspace_limit": "Elérte a munkaterület korlátját ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Elérte a havi {count} értékű válaszkorlátját.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Vissza lesz állítva a közösségi kiadásra ekkor: {date}.",
     "your_license_has_expired_please_renew": "A vállalati licence lejárt. Újítsa meg, hogy továbbra is használhassa a vállalati funkciókat.",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -579,7 +579,7 @@
     "yes": "はい",
     "you_are_downgraded_to_the_community_edition": "コミュニティ版にダウングレードされました。",
     "you_are_not_authorized_to_perform_this_action": "このアクションを実行する権限がありません。",
-    "you_have_reached_your_limit_of_workspace_limit": "ワークスペースの上限である{workspaceLimit}件に達しました。",
+    "you_have_reached_your_limit_of_workspace_limit": "ワークスペースの上限（{workspaceLimit}）に達しました。",
     "you_have_reached_your_monthly_response_limit_of_count": "月間の回答制限{count}件に達しました。",
     "you_will_be_downgraded_to_the_community_edition_on_date": "コミュニティ版へのダウングレードは {date} に行われます。",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -579,7 +579,7 @@
     "yes": "Ja",
     "you_are_downgraded_to_the_community_edition": "Je bent gedowngraded naar de Community-editie.",
     "you_are_not_authorized_to_perform_this_action": "U bent niet geautoriseerd om deze actie uit te voeren.",
-    "you_have_reached_your_limit_of_workspace_limit": "Je hebt je limiet van {workspaceLimit} workspaces bereikt.",
+    "you_have_reached_your_limit_of_workspace_limit": "Je hebt je limiet van werkruimtes bereikt ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Je hebt je maandelijkse responslimiet van {count} bereikt.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Je wordt gedowngraded naar de Community-editie op {date}.",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -579,7 +579,7 @@
     "yes": "Sim",
     "you_are_downgraded_to_the_community_edition": "Você foi rebaixado para a Edição Comunitária.",
     "you_are_not_authorized_to_perform_this_action": "Você não tem autorização para realizar essa ação.",
-    "you_have_reached_your_limit_of_workspace_limit": "Você atingiu o limite de {workspaceLimit} espaços de trabalho.",
+    "you_have_reached_your_limit_of_workspace_limit": "Você atingiu o limite do seu workspace ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Você atingiu seu limite mensal de respostas de {count}.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Você será rebaixado para a Edição Comunitária em {date}.",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -579,7 +579,7 @@
     "yes": "Sim",
     "you_are_downgraded_to_the_community_edition": "Foi rebaixado para a Edição Comunitária.",
     "you_are_not_authorized_to_perform_this_action": "Não está autorizado a realizar esta ação.",
-    "you_have_reached_your_limit_of_workspace_limit": "Atingiste o teu limite de {workspaceLimit} espaços de trabalho.",
+    "you_have_reached_your_limit_of_workspace_limit": "Atingiste o teu limite de espaço de trabalho ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Atingiste o teu limite mensal de respostas de {count}.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Será rebaixado para a Edição Comunitária em {date}.",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -579,7 +579,7 @@
     "yes": "Da",
     "you_are_downgraded_to_the_community_edition": "Ai fost retrogradat la ediția Community.",
     "you_are_not_authorized_to_perform_this_action": "Nu sunteți autorizat să efectuați această acțiune.",
-    "you_have_reached_your_limit_of_workspace_limit": "Ai atins limita de {workspaceLimit} spații de lucru.",
+    "you_have_reached_your_limit_of_workspace_limit": "Ai atins limita spațiului de lucru ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Ai atins limita lunară de răspunsuri de {count}.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Vei fi retrogradat la ediția Community pe {date}.",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -579,7 +579,7 @@
     "yes": "Да",
     "you_are_downgraded_to_the_community_edition": "Ваша версия понижена до Community Edition.",
     "you_are_not_authorized_to_perform_this_action": "У вас нет прав для выполнения этого действия.",
-    "you_have_reached_your_limit_of_workspace_limit": "Вы достигли лимита в {workspaceLimit} рабочих пространств.",
+    "you_have_reached_your_limit_of_workspace_limit": "Вы достигли лимита рабочих пространств ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Вы достигли месячного лимита ответов: {count}.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Ваша версия будет понижена до Community Edition {date}.",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -579,7 +579,7 @@
     "yes": "Ja",
     "you_are_downgraded_to_the_community_edition": "Du har nedgraderats till Community Edition.",
     "you_are_not_authorized_to_perform_this_action": "Du har inte behörighet att utföra denna åtgärd.",
-    "you_have_reached_your_limit_of_workspace_limit": "Du har nått din gräns på {workspaceLimit} arbetsytor.",
+    "you_have_reached_your_limit_of_workspace_limit": "Du har nått din gräns för arbetsytor ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Du har nått din månatliga svarsgräns på {count}.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "Du kommer att nedgraderas till Community Edition den {date}.",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -579,7 +579,7 @@
     "yes": "Evet",
     "you_are_downgraded_to_the_community_edition": "Topluluk Sürümüne düşürüldünüz.",
     "you_are_not_authorized_to_perform_this_action": "Bu işlemi gerçekleştirme yetkiniz yok.",
-    "you_have_reached_your_limit_of_workspace_limit": "{workspaceLimit} çalışma alanı limitine ulaştınız.",
+    "you_have_reached_your_limit_of_workspace_limit": "Çalışma alanı limitine ulaştın ({workspaceLimit}).",
     "you_have_reached_your_monthly_response_limit_of_count": "Aylık {count} yanıt limitinize ulaştınız.",
     "you_will_be_downgraded_to_the_community_edition_on_date": "{date} tarihinde Topluluk Sürümüne düşürüleceksiniz.",
     "your_license_has_expired_please_renew": "Kurumsal lisansınızın süresi doldu. Kurumsal özellikleri kullanmaya devam etmek için lütfen yenileyin.",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -579,7 +579,7 @@
     "yes": "是",
     "you_are_downgraded_to_the_community_edition": "您已降级到社区版。",
     "you_are_not_authorized_to_perform_this_action": "您无权执行此操作。",
-    "you_have_reached_your_limit_of_workspace_limit": "您已达到 {workspaceLimit} 个工作区的上限。",
+    "you_have_reached_your_limit_of_workspace_limit": "你已达到工作区限制 ({workspaceLimit})。",
     "you_have_reached_your_monthly_response_limit_of_count": "您已达到每月响应限制 {count} 次。",
     "you_will_be_downgraded_to_the_community_edition_on_date": "您将在 {date} 降级到社区版。",
     "your_license_has_expired_please_renew": "Your enterprise license has expired. Please renew it to continue using enterprise features.",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -579,7 +579,7 @@
     "yes": "是",
     "you_are_downgraded_to_the_community_edition": "您已降級至社群版。",
     "you_are_not_authorized_to_perform_this_action": "您沒有執行此操作的權限。",
-    "you_have_reached_your_limit_of_workspace_limit": "您已達到 {workspaceLimit} 個工作區的上限。",
+    "you_have_reached_your_limit_of_workspace_limit": "你已達到工作區上限（{workspaceLimit}）。",
     "you_have_reached_your_monthly_response_limit_of_count": "您已達到每月回應上限 {count} 次。",
     "you_will_be_downgraded_to_the_community_edition_on_date": "您將於 {date} 降級至社群版。",
     "your_license_has_expired_please_renew": "您的企業授權已過期。請續約以繼續使用企業功能。",

--- a/apps/web/modules/ee/license-check/lib/license.test.ts
+++ b/apps/web/modules/ee/license-check/lib/license.test.ts
@@ -332,7 +332,7 @@ describe("License Core Logic", () => {
           active: false,
           features: {
             isMultiOrgEnabled: false,
-            workspaces: 3,
+            workspaces: 1,
             twoFactorAuth: false,
             sso: false,
             whitelabel: false,
@@ -356,7 +356,7 @@ describe("License Core Logic", () => {
         active: false,
         features: {
           isMultiOrgEnabled: false,
-          workspaces: 3,
+          workspaces: 1,
           twoFactorAuth: false,
           sso: false,
           whitelabel: false,
@@ -389,7 +389,7 @@ describe("License Core Logic", () => {
       const license = await getEnterpriseLicense();
       const expectedFeatures: TEnterpriseLicenseFeatures = {
         isMultiOrgEnabled: false,
-        workspaces: 3,
+        workspaces: 1,
         twoFactorAuth: false,
         sso: false,
         whitelabel: false,
@@ -489,7 +489,7 @@ describe("License Core Logic", () => {
         active: false,
         features: expect.objectContaining({
           isMultiOrgEnabled: false,
-          workspaces: 3,
+          workspaces: 1,
           removeBranding: false,
         }),
         lastChecked: expect.any(Date),
@@ -522,7 +522,7 @@ describe("License Core Logic", () => {
 
       expect(license).toEqual({
         active: false,
-        features: expect.objectContaining({ workspaces: 3 }),
+        features: expect.objectContaining({ workspaces: 1 }),
         lastChecked: expect.any(Date),
         isPendingDowngrade: false,
         fallbackLevel: "default" as const,
@@ -553,7 +553,7 @@ describe("License Core Logic", () => {
 
       expect(license).toEqual({
         active: false,
-        features: expect.objectContaining({ workspaces: 3 }),
+        features: expect.objectContaining({ workspaces: 1 }),
         lastChecked: expect.any(Date),
         isPendingDowngrade: false,
         fallbackLevel: "default" as const,
@@ -1304,7 +1304,7 @@ describe("License Core Logic", () => {
         active: false,
         features: expect.objectContaining({
           isMultiOrgEnabled: false,
-          workspaces: 3,
+          workspaces: 1,
         }),
         lastChecked: expect.any(Date),
         isPendingDowngrade: false,
@@ -1328,7 +1328,7 @@ describe("License Core Logic", () => {
         active: false,
         features: expect.objectContaining({
           isMultiOrgEnabled: false,
-          workspaces: 3,
+          workspaces: 1,
         }),
         lastChecked: expect.any(Date),
         isPendingDowngrade: false,

--- a/apps/web/modules/ee/license-check/lib/license.ts
+++ b/apps/web/modules/ee/license-check/lib/license.ts
@@ -6,7 +6,7 @@ import { createCacheKey } from "@formbricks/cache";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import { cache } from "@/lib/cache";
-import { E2E_TESTING } from "@/lib/constants";
+import { COMMUNITY_WORKSPACE_LIMIT, E2E_TESTING } from "@/lib/constants";
 import { env } from "@/lib/env";
 import { hashString } from "@/lib/hash-string";
 import { getInstanceId } from "@/lib/instance";
@@ -146,7 +146,7 @@ export const getCacheKeys = () => {
 // Default features
 const DEFAULT_FEATURES: TEnterpriseLicenseFeatures = {
   isMultiOrgEnabled: false,
-  workspaces: 3,
+  workspaces: COMMUNITY_WORKSPACE_LIMIT,
   twoFactorAuth: false,
   sso: false,
   whitelabel: false,

--- a/apps/web/modules/ee/license-check/lib/utils.test.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.test.ts
@@ -552,7 +552,7 @@ describe("License Utils", () => {
       expect(result).toBe(Infinity);
     });
 
-    test("returns the cloud license-server fallback when cloud license status does not allow usage", async () => {
+    test("falls back to the cloud Hobby limit when the license status does not allow usage", async () => {
       vi.mocked(constants).IS_FORMBRICKS_CLOUD = true;
       vi.mocked(getOrganizationEntitlementsContext).mockResolvedValue({
         ...defaultEntitlementsContext,
@@ -562,7 +562,9 @@ describe("License Utils", () => {
 
       const result = await getOrganizationWorkspacesLimit("org_1");
 
-      expect(result).toBe(3);
+      // The org's own entitlement (10) is deliberately ignored: an entitlement we cannot verify is
+      // treated as no entitlement, so the free-tier allowance applies until the license resolves.
+      expect(result).toBe(1);
     });
 
     test("returns self-hosted workspace limit from active license feature", async () => {

--- a/apps/web/modules/ee/license-check/lib/utils.test.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.test.ts
@@ -552,7 +552,7 @@ describe("License Utils", () => {
       expect(result).toBe(Infinity);
     });
 
-    test("returns 3 when cloud license status does not allow usage", async () => {
+    test("returns the cloud license-server fallback when cloud license status does not allow usage", async () => {
       vi.mocked(constants).IS_FORMBRICKS_CLOUD = true;
       vi.mocked(getOrganizationEntitlementsContext).mockResolvedValue({
         ...defaultEntitlementsContext,
@@ -593,7 +593,7 @@ describe("License Utils", () => {
       expect(result).toBe(Infinity);
     });
 
-    test("returns 3 for self-hosted when the license is not active", async () => {
+    test("returns the community limit for self-hosted when the license is not active", async () => {
       vi.mocked(constants).IS_FORMBRICKS_CLOUD = false;
       vi.mocked(getOrganizationEntitlementsContext).mockResolvedValue({
         ...defaultEntitlementsContext,
@@ -604,10 +604,10 @@ describe("License Utils", () => {
 
       const result = await getOrganizationWorkspacesLimit("org_1");
 
-      expect(result).toBe(3);
+      expect(result).toBe(1);
     });
 
-    test("returns 3 for self-hosted when there are no license features", async () => {
+    test("returns the community limit for self-hosted when there are no license features", async () => {
       vi.mocked(constants).IS_FORMBRICKS_CLOUD = false;
       vi.mocked(getOrganizationEntitlementsContext).mockResolvedValue({
         ...defaultEntitlementsContext,
@@ -618,7 +618,21 @@ describe("License Utils", () => {
 
       const result = await getOrganizationWorkspacesLimit("org_1");
 
-      expect(result).toBe(3);
+      expect(result).toBe(1);
+    });
+
+    test("returns the community limit for self-hosted with no license key at all", async () => {
+      vi.mocked(constants).IS_FORMBRICKS_CLOUD = false;
+      vi.mocked(getOrganizationEntitlementsContext).mockResolvedValue({
+        ...defaultEntitlementsContext,
+        source: "self_hosted_license",
+        licenseStatus: "no-license",
+        licenseFeatures: null,
+      });
+
+      const result = await getOrganizationWorkspacesLimit("org_1");
+
+      expect(result).toBe(1);
     });
   });
 

--- a/apps/web/modules/ee/license-check/lib/utils.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import {
   AUDIT_LOG_ENABLED,
-  CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT,
+  CLOUD_HOBBY_WORKSPACE_LIMIT,
   COMMUNITY_WORKSPACE_LIMIT,
   IS_FORMBRICKS_CLOUD,
   IS_RECAPTCHA_CONFIGURED,
@@ -195,7 +195,7 @@ export const getOrganizationWorkspacesLimit = async (organizationId: string): Pr
   if (IS_FORMBRICKS_CLOUD) {
     const cloudLicenseAllowsLimits =
       entitlementsContext.licenseStatus === "active" || entitlementsContext.licenseStatus === "no-license";
-    if (!cloudLicenseAllowsLimits) return CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT;
+    if (!cloudLicenseAllowsLimits) return CLOUD_HOBBY_WORKSPACE_LIMIT;
     return entitlementsContext.limits.workspaces ?? Infinity;
   }
 

--- a/apps/web/modules/ee/license-check/lib/utils.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.ts
@@ -1,5 +1,11 @@
 import "server-only";
-import { AUDIT_LOG_ENABLED, IS_FORMBRICKS_CLOUD, IS_RECAPTCHA_CONFIGURED } from "@/lib/constants";
+import {
+  AUDIT_LOG_ENABLED,
+  CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT,
+  COMMUNITY_WORKSPACE_LIMIT,
+  IS_FORMBRICKS_CLOUD,
+  IS_RECAPTCHA_CONFIGURED,
+} from "@/lib/constants";
 import { CLOUD_STRIPE_FEATURE_LOOKUP_KEYS } from "@/modules/billing/lib/stripe-catalog";
 import type { TEnterpriseLicenseFeatures } from "@/modules/ee/license-check/types/enterprise-license";
 import { hasOrganizationEntitlementWithLicenseGuard } from "@/modules/entitlements/lib/checks";
@@ -189,7 +195,7 @@ export const getOrganizationWorkspacesLimit = async (organizationId: string): Pr
   if (IS_FORMBRICKS_CLOUD) {
     const cloudLicenseAllowsLimits =
       entitlementsContext.licenseStatus === "active" || entitlementsContext.licenseStatus === "no-license";
-    if (!cloudLicenseAllowsLimits) return 3;
+    if (!cloudLicenseAllowsLimits) return CLOUD_LICENSE_FALLBACK_WORKSPACE_LIMIT;
     return entitlementsContext.limits.workspaces ?? Infinity;
   }
 
@@ -198,5 +204,6 @@ export const getOrganizationWorkspacesLimit = async (organizationId: string): Pr
     return entitlementsContext.licenseFeatures.workspaces ?? Infinity;
   }
 
-  return 3;
+  // No active license (no-license / expired / invalid / unreachable) — Community Edition.
+  return COMMUNITY_WORKSPACE_LIMIT;
 };

--- a/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
+++ b/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
@@ -114,7 +114,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
       organizationId: "org1",
       source: "self_hosted_license",
       features: [],
-      limits: { workspaces: 3, monthlyResponses: null, monthlyWorkflowRuns: null },
+      limits: { workspaces: 1, monthlyResponses: null, monthlyWorkflowRuns: null },
       licenseStatus: "no-license",
       licenseFeatures: null,
       stripeCustomerId: null,
@@ -155,7 +155,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
     expect(result.limits.workspaces).toBeNull();
   });
 
-  test("defaults workspaces to 3 when license is inactive", async () => {
+  test("defaults workspaces to the community limit when license is inactive", async () => {
     mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(
       expiredLicense({ workspaces: 10, contacts: true, spamProtection: true })
@@ -164,7 +164,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
     expect(result.features).toEqual([]);
-    expect(result.limits.workspaces).toBe(3);
+    expect(result.limits.workspaces).toBe(1);
   });
 
   test("maps whitelabel feature to hide-branding", async () => {

--- a/apps/web/modules/entitlements/lib/self-hosted-provider.ts
+++ b/apps/web/modules/entitlements/lib/self-hosted-provider.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
+import { COMMUNITY_WORKSPACE_LIMIT } from "@/lib/constants";
 import { getOrganization } from "@/lib/organization/service";
 import { CLOUD_STRIPE_FEATURE_LOOKUP_KEYS } from "@/modules/billing/lib/stripe-catalog";
 import { getEnterpriseLicense } from "@/modules/ee/license-check/lib/license";
@@ -61,7 +62,8 @@ export const getSelfHostedOrganizationEntitlementsContext = async (
     features: license.active ? mapLicenseFeaturesToEntitlements(license.features) : [],
     limits: {
       // null = unlimited; only an inactive or feature-less license falls back to the community default.
-      workspaces: license.active && license.features ? license.features.workspaces : 3,
+      workspaces:
+        license.active && license.features ? license.features.workspaces : COMMUNITY_WORKSPACE_LIMIT,
       // Self-hosted response limits are not license-server-managed today.
       monthlyResponses: null,
       // Self-hosted workflows are gated by the boolean license feature, not metered (ENG-1936).


### PR DESCRIPTION
Fixes ENG-2400

## What & why

Two workspace caps were wrong, in opposite directions.

**Self-hosted without a license** could create 3 workspaces, while `docs/self-hosting/advanced/license.mdx:29` already documents the Community Edition cap as `Workspaces | 1`. The docs were right and the code was wrong; this aligns them, so no docs change is needed.

The cap was hard-coded as **two unlinked literals** encoding the same policy, which is how they were able to drift in the first place:

- `getOrganizationWorkspacesLimit` (`modules/ee/license-check/lib/utils.ts`) — the value the create gate actually reads
- `modules/entitlements/lib/self-hosted-provider.ts` — populates `entitlementsContext.limits.workspaces`, which the first function never consults

Both now read `COMMUNITY_WORKSPACE_LIMIT` from `lib/constants.ts`, alongside the other policy limits (`ITEMS_PER_PAGE`, `MAX_ATTRIBUTE_CLASSES_PER_ENVIRONMENT`). `DEFAULT_FEATURES.workspaces` in `license.ts` follows the same constant — it is unreachable today (only ever returned alongside `active: false`, and both readers gate on `active`), but leaving a stale `3` there would mean "no license ⇒ 1 workspace" holds only by accident of a guard elsewhere, which is exactly how this bug was planted.

**Cloud with an unverifiable license** had the opposite problem: the cloud branch returned a flat `3` when the license server could not confirm the instance license (expired, invalid, instance mismatch, unreachable). That is *more* generous than the free tier it stands in for — [formbricks.com/pricing](https://formbricks.com/pricing) and the in-app table both list **Hobby at 1 workspace** — so an org whose entitlement could not be verified ended up with more capacity than any free plan grants. Renamed to `CLOUD_HOBBY_WORKSPACE_LIMIT` and **lowered from 3 to 1**: an entitlement we cannot verify is treated as no entitlement.

Nothing is taken away in either case. The gate is `count >= limit` and fires only inside `createWorkspaceAction`, so an org already above its limit keeps every workspace it has and only pauses *creating* new ones.

Deliberately **not** touched: `getDefaultOrganizationBilling` (both copies) already yields `1` on cloud and is never read by self-hosted enforcement; the `ZOrganizationBilling` zod defaults; and the DB seed.

Also rewords the limit-modal copy, which would otherwise render the ungrammatical **"You have reached your limit of 1 workspaces."** on every community instance — the new default state. The repo has no i18next plural convention (`_one`/`_other` appear nowhere in `en-US.json`), so the string was reworded rather than pluralised: no key rename, no call-site change, grammatical at 1, 3 and 10.

The companion PR in `formbricks/ee` (formbricks/ee#133) lowers the license server's own `DEFAULT_LICENSE_FEATURES` baseline to match, with a guard migration so existing licensees are not silently downgraded. The two are only correct together.

## Breaking changes

- [x] This PR contains breaking changes

Both rows below match the template's *changing a default* bullet. Neither breaks anything *at* upgrade — no install stops functioning, the gate is creation-only, and no existing workspace is deleted or hidden.

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| Workspaces per organization without an enterprise license (`COMMUNITY_WORKSPACE_LIMIT`) | 3 | 1 | Self-hosted Community Edition instances | Existing workspaces stay accessible and editable; only creating an additional one is blocked. Creating a 2nd workspace now requires an Enterprise License. |
| Workspaces per organization when the license server cannot confirm the instance license — expired, invalid, instance mismatch or unreachable (`CLOUD_HOBBY_WORKSPACE_LIMIT`, was an unnamed literal) | 3 | 1 | Formbricks Cloud organizations, only while the license is unconfirmed | None. Existing workspaces are unaffected and creation resumes at the org's own entitlement as soon as the license resolves. The previous `3` exceeded the Hobby tier's documented 1, so an unverified org could out-provision every paid-plan boundary below Pro. |

The self-hosted row is the one that reaches the self-hoster migration guide; the cloud row is recorded here for the release notes and because the diff changes a default, not because a self-hoster or an API/SDK consumer must act on it.

## Migrations & env

- none

## How this was tested

**Rerun the red-on-main rows:** mutate a constant, then run the suites. Each row names the test it rests on and which mutation makes it fail.

```bash
# self-hosted rows
sed -i 's/COMMUNITY_WORKSPACE_LIMIT = 1/COMMUNITY_WORKSPACE_LIMIT = 3/' apps/web/lib/constants.ts
# cloud row
sed -i 's/CLOUD_HOBBY_WORKSPACE_LIMIT = 1/CLOUD_HOBBY_WORKSPACE_LIMIT = 3/' apps/web/lib/constants.ts

pnpm --filter @formbricks/web exec vitest run \
  modules/ee/license-check/lib/utils.test.ts \
  modules/entitlements/lib/self-hosted-provider.test.ts \
  modules/ee/license-check/lib/license.test.ts
```

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Self-hosted with **no license key at all** (`status: "no-license"` — the actual Community Edition path) returns 1 | unit (red on main) | `utils.test.ts` › `getOrganizationWorkspacesLimit` › **"returns the community limit for self-hosted with no license key at all"**. New; no test covered this path before, only `expired` and `active + null features`. Fails with `3` under the `COMMUNITY_WORKSPACE_LIMIT` mutation. |
| Self-hosted with an inactive/expired license returns 1 | unit (red on main) | `utils.test.ts` › **"returns the community limit for self-hosted when the license is not active"**. Fails under the same mutation. |
| Self-hosted with an active license but no features returns 1 | unit (red on main) | `utils.test.ts` › **"returns the community limit for self-hosted when there are no license features"**. Fails under the same mutation. |
| `self-hosted-provider` reports `limits.workspaces: 1` for no-license and for an inactive license | unit (red on main) | `self-hosted-provider.test.ts` › **"returns context with no license features"** and **"defaults workspaces to the community limit when license is inactive"**. Both fail under the same mutation. |
| **Cloud** fallback on an unverifiable license changed **3 → 1**, and overrides the org's own entitlement | unit (red on main) | `utils.test.ts` › **"falls back to the cloud Hobby limit when the license status does not allow usage"**. Seeds `limits.workspaces: 10` and asserts `1`, so it pins the *override*, not just the number. Fails under the `CLOUD_HOBBY_WORKSPACE_LIMIT` mutation (1 failed, 40 passed). |
| `DEFAULT_FEATURES.workspaces` changed 3 → 1 on every inactive-license result | unit (guard) | `license.test.ts` — 8 assertions across **"should return inactive default when freshLicense is null and no previous result"**, **"should return expired state when freshLicense has expired status"**, **"should return invalid_license when API returns 400 (bad license key)"**, **"should return instance_mismatch when API returns 403"**, **"should return inactive with default features if fetch fails and no previous result (initial fail)"**, **"should handle fetch throwing an error and use grace period or return inactive"**, **"should return inactive and set new previousResult if fetch fails and previous result is outside grace period"**. Guard, not red-on-main: this value is unreachable at runtime (see Open gaps). |
| A usable license is still honoured — self-hosted active value, self-hosted `null` (unlimited), and cloud reading its own entitlement | unit (guard) | `utils.test.ts` › **"returns self-hosted workspace limit from active license feature"** (`5`), **"returns Infinity for self-hosted when an active license grants unlimited workspaces"**, **"returns cloud workspaces limit when cloud license status allows usage"**, **"returns Infinity when cloud workspaces limit is unbounded"**. Unchanged by this PR. |
| Billing defaults, entitlement checks, nav data and Stripe sync unaffected | unit (guard) | No behaviour of theirs changed; verified by the whole suite staying green — **643 files / 8539 tests**, also under `--coverage` (what the SonarQube job runs). |
| Community-edition user at the cap sees the reworded modal | manual | Captured against a real local instance with **no** `ENTERPRISE_LICENSE_KEY`, driving the real switcher → "Add new workspace" flow at the cap. Pair below. |
| First-workspace creation still works at a cap of 1 | manual (code trace) | Gate is `count >= limit` in `app/(app)/workspaces/[workspaceId]/actions.ts:59-62`; the three bypassing callers (signup, org creation, setup) create an org's *first* workspace, where `0 >= 1` is false. **The one path that would be catastrophic to break — worth a second pair of eyes.** |

**Screenshots — workspace limit modal**

| Before | After |
| --- | --- |
| ![Modal reading "You have reached your limit of 3 workspaces."](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9008/workspace-limit-modal-before.png) | ![Modal reading "You have reached your workspace limit (1)."](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9008/workspace-limit-modal-after.png) |

Same route, viewport (1280×820 @2x), colour scheme and interaction; the org is seeded to its cap in each case (3 before, 1 after), which is the change. Captured with a Playwright fixture user, so no real data is in frame.

No E2E added. The cap is business logic, not a journey (AGENTS.md testing table), and no Playwright spec exercises the gate: every spec seeds workspaces through `prisma.workspace.create`, which bypasses `createWorkspaceAction`. The two `/workspaces/new/` navigations in `workspace-delete.spec.ts` run at 0 workspaces, so the new cap does not affect them.

**Open gaps**

- `DEFAULT_FEATURES.workspaces` is changed but **unreachable at runtime**, so it has guard coverage only and no red-on-main proof. All seven sites return it alongside `active: false`, and both readers gate on `active`; the genuinely unlicensed path (`no-license`) returns `features: null`. It is changed for consistency, so the invariant does not survive only by accident of a guard elsewhere.
- The `ZOrganizationBilling` zod `.default({ workspaces: 3 })` in `packages/types/organizations.ts` and the matching `.prefault()` in `packages/database/zod/organizations.ts` are left at `3`. They are reachable on paper — `ZOrganization` embeds `ZOrganizationBilling`, and two modules import `ZOrganization` — but only inside `ZOrganizationAuth` / `ZWorkspaceAuth`, which are consumed solely through `z.infer` and never `.parse()`d, so the defaults do not execute at runtime. Left alone rather than changed blind; worth a follow-up to delete them as dead configuration.

**Risks**

- Self-hosted orgs already holding 2–3 workspaces are frozen at their current count. They can still delete down, and deleting to 1 does not re-enable creation — correct, but it will generate support questions.
- During a license-server degradation, cloud orgs are now held to 1 workspace rather than 3 until it resolves. Existing workspaces are unaffected; only creation pauses. If that window is ever long enough to matter, the better fix is to honour `billing.limits.workspaces` (which lives in our own DB and stays available) instead of any flat fallback — deliberately not done here, since it would remove the existing "don't trust entitlements we can't verify" guard.
- Two suites mock `@/lib/constants` with an **exhaustive factory** rather than spreading `importOriginal`, so a new export is `undefined` there and vitest fails the module link. Both were updated. 43 such factories exist repo-wide; only these two pull in the module chain that reads the new constants, so the rest were left alone. Anything adding a constant that reaches those code paths will hit the same thing.
- If a community instance reports an unexpected workspace count, check the `ee` guard migration first: it pins the previous default onto legacy license rows, and the two changes are only correct together.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.