### PR TITLE
fix(js-core): prefetch the surveys bundle instead of preloading it (ENG-2350)

### DIFF
--- a/packages/js-core/src/lib/common/setup.ts
+++ b/packages/js-core/src/lib/common/setup.ts
@@ -4,7 +4,7 @@ import { addCleanupEventListeners, addEventListeners } from "@/lib/common/event-
 import { Logger } from "@/lib/common/logger";
 import { getIsSetup, setIsSetup } from "@/lib/common/status";
 import { filterSurveys, getIsDebug, isNowExpired, wrapThrows } from "@/lib/common/utils";
-import { addLiveRegionContainer, closeSurvey, preloadSurveysScript } from "@/lib/survey/widget";
+import { addLiveRegionContainer, closeSurvey, prefetchSurveysScript } from "@/lib/survey/widget";
 import { DEFAULT_USER_STATE_NO_USER_ID } from "@/lib/user/state";
 import { sendUpdatesToBackend } from "@/lib/user/update";
 import { fetchWorkspaceState } from "@/lib/workspace/state";
@@ -344,8 +344,8 @@ export const setup = async (
   // first survey announces its opening into it.
   addLiveRegionContainer();
 
-  // Preload surveys script so it's ready when a survey triggers
-  preloadSurveysScript(configInput.appUrl);
+  // Prefetch surveys script so it's warm in the cache when a survey triggers
+  prefetchSurveysScript(configInput.appUrl);
 
   setIsSetup(true);
   logger.debug("Set up complete");

--- a/packages/js-core/src/lib/common/tests/setup.test.ts
+++ b/packages/js-core/src/lib/common/tests/setup.test.ts
@@ -73,7 +73,7 @@ vi.mock("@/lib/survey/no-code-action", () => ({
 // 9) Mock survey widget
 vi.mock("@/lib/survey/widget", () => ({
   closeSurvey: vi.fn(),
-  preloadSurveysScript: vi.fn(),
+  prefetchSurveysScript: vi.fn(),
   addLiveRegionContainer: vi.fn(),
 }));
 

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -705,7 +705,7 @@ describe("widget-file", () => {
 
     const linkEl = createElementSpy.mock.results[0].value as Record<string, string>;
     expect(linkEl.rel).toBe("prefetch");
-    expect(linkEl.as).toBe("script");
+    expect(linkEl.as).toBeUndefined();
     expect(linkEl.href).toBe("https://fake.app/js/surveys.umd.cjs");
 
     // Second call should be a no-op (deduplication)

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -694,22 +694,22 @@ describe("widget-file", () => {
     });
   });
 
-  test("preloadSurveysScript adds a preload link and deduplicates subsequent calls", () => {
+  test("prefetchSurveysScript adds a prefetch link and deduplicates subsequent calls", () => {
     const createElementSpy = vi.spyOn(document, "createElement");
     const appendChildSpy = vi.spyOn(document.head, "appendChild");
 
-    widget.preloadSurveysScript("https://fake.app");
+    widget.prefetchSurveysScript("https://fake.app");
 
     expect(createElementSpy).toHaveBeenCalledWith("link");
     expect(appendChildSpy).toHaveBeenCalledTimes(1);
 
     const linkEl = createElementSpy.mock.results[0].value as Record<string, string>;
-    expect(linkEl.rel).toBe("preload");
+    expect(linkEl.rel).toBe("prefetch");
     expect(linkEl.as).toBe("script");
     expect(linkEl.href).toBe("https://fake.app/js/surveys.umd.cjs");
 
     // Second call should be a no-op (deduplication)
-    widget.preloadSurveysScript("https://fake.app");
+    widget.prefetchSurveysScript("https://fake.app");
     expect(appendChildSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -376,9 +376,9 @@ let isPrefetched = false;
  *
  * `prefetch`, not `preload`: preload claims the page needs the file now, so Chrome fetches it at high
  * priority and warns when it goes unused. Most page views never trigger a survey, so we were outbidding
- * the host page's own critical resources for a ~260 KB bundle we usually never run. Keep `as="script"` —
- * it puts the hint and the later <script> on the same cache entry, which is what makes the reuse work.
- * Safari ignores prefetch entirely; there the fetch just happens when a survey triggers.
+ * the host page's own critical resources for a ~260 KB bundle we usually never run. The later <script>
+ * reuses this fetch out of the plain HTTP cache — `/js/*` is served `public, max-age=3600` — so no `as`
+ * is needed; Chrome ignores it on prefetch. Safari ignores prefetch itself, and fetches on trigger.
  */
 export const prefetchSurveysScript = (appUrl: string): void => {
   // Don't prefetch if already loaded or already prefetching
@@ -388,7 +388,6 @@ export const prefetchSurveysScript = (appUrl: string): void => {
   isPrefetched = true;
   const link = document.createElement("link");
   link.rel = "prefetch";
-  link.as = "script";
   link.href = `${appUrl}/js/surveys.umd.cjs`;
   document.head.appendChild(link);
 };

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -369,16 +369,25 @@ const loadFormbricksSurveysExternally = (): Promise<TFormbricksSurveys> => {
   return surveysLoadPromise;
 };
 
-let isPreloaded = false;
+let isPrefetched = false;
 
-export const preloadSurveysScript = (appUrl: string): void => {
-  // Don't preload if already loaded or already preloading
+/**
+ * Warms the browser cache with the surveys bundle so a triggered survey renders without a cold fetch.
+ *
+ * `prefetch`, not `preload`: preload claims the page needs the file now, so Chrome fetches it at high
+ * priority and warns when it goes unused. Most page views never trigger a survey, so we were outbidding
+ * the host page's own critical resources for a ~260 KB bundle we usually never run. Keep `as="script"` —
+ * it puts the hint and the later <script> on the same cache entry, which is what makes the reuse work.
+ * Safari ignores prefetch entirely; there the fetch just happens when a survey triggers.
+ */
+export const prefetchSurveysScript = (appUrl: string): void => {
+  // Don't prefetch if already loaded or already prefetching
   if (globalThis.window.formbricksSurveys) return;
-  if (isPreloaded) return;
+  if (isPrefetched) return;
 
-  isPreloaded = true;
+  isPrefetched = true;
   const link = document.createElement("link");
-  link.rel = "preload";
+  link.rel = "prefetch";
   link.as = "script";
   link.href = `${appUrl}/js/surveys.umd.cjs`;
   document.head.appendChild(link);


### PR DESCRIPTION
Fixes ENG-2350

## What & why

**Was:** The SDK hinted the surveys bundle with `<link rel="preload">` at setup, so Chrome fetched ~260 KB gzipped at high priority and then warned in the console when nothing used it.

**Now:** The hint is `rel="prefetch"` — Chrome drops the request from `High` to `VeryLow` and fetches it while idle. The warning is gone and we no longer outbid the host page's own critical resources.

Most page views never trigger a survey, so preload's "this page needs it now" claim was wrong on the common path. The later `<script>` still reuses the fetch, out of the plain HTTP cache — `/js/*` is served `public, max-age=3600`.

Before:
<img width="624" height="318" alt="Screenshot 2026-08-27 at 15 01 54" src="https://github.com/user-attachments/assets/54b66e0e-f3d2-4f63-a661-3afd3c74952f" />


After:
<img width="623" height="310" alt="Screenshot 2026-08-27 at 15 00 02" src="https://github.com/user-attachments/assets/5c75587f-8c8e-444d-b931-55104a9f6e61" />


## Where to look

- [widget.ts:372-393](https://github.com/formbricks/formbricks/blob/anshuman/eng-2350-investigate-chrome-preload-warning-for-surveys-bundle/packages/js-core/src/lib/survey/widget.ts#L372-L393) — the hint itself
- [setup.ts:348](https://github.com/formbricks/formbricks/blob/anshuman/eng-2350-investigate-chrome-preload-warning-for-surveys-bundle/packages/js-core/src/lib/common/setup.ts#L348) — the one call site

## Breaking changes

- [ ] This PR contains breaking changes

None. `prefetchSurveysScript` is internal to js-core — the SDK's exported surface is the `formbricks` object in `src/index.ts`, which never carried it, so the rename reaches no consumer.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/js-core test`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Hint is `rel="prefetch"` and carries no `as` | unit (red on main) | `widget.test.ts` → "prefetchSurveysScript adds a prefetch link and deduplicates subsequent calls" |
| Request priority drops | manual | Chrome via CDP: `High` → `VeryLow` |
| Chrome stops warning after the load event | manual | Warning reproduced verbatim on `preload`, absent on `prefetch` |
| A triggered survey still loads from cache | manual | Cross-origin: the `<script>` reports `fromPrefetchCache`, 0 bytes over the wire, and sets `window.formbricksSurveys` |

<details>
<summary>Measured in Chrome — the three variants</summary>

Driven through `Network.requestWillBeSent` against the dev server, one uncached URL per row.

| Hint | Priority | Chrome resource type | `<script>` | Console |
| --- | --- | --- | --- | --- |
| `preload` + `as="script"` | `High` | `Script` | reused | **warns** |
| `prefetch` + `as="script"` | `VeryLow` | `Other` | `transferSize: 0` | clean |
| `prefetch`, no `as` | `VeryLow` | `Other` | `transferSize: 0` | clean |

The middle row is why `as` was dropped: Chrome still reports the request as `Other`, so the attribute is not read on a prefetch. Reuse comes from the HTTP cache either way.

Repeated cross-origin — page on `127.0.0.1:8099`, bundle on `localhost:3000`, which is what a customer page actually does. Identical with and without `as`:

| Request | Priority | `fromPrefetchCache` | Bytes over the wire |
| --- | --- | --- | --- |
| prefetch hint | `VeryLow` | — | full body |
| later `<script>` | `Low` | `true` | `0` |

</details>

<details>
<summary>red-on-main command</summary>

Revert `link.rel` to `"preload"` in `packages/js-core/src/lib/survey/widget.ts:390`, then:

```
pnpm --filter @formbricks/js-core test -- --run -t "prefetchSurveysScript adds a prefetch link"
```

Fails on `expect(linkEl.rel).toBe("prefetch")`.
</details>

**Open gaps**

- Safari ignores `rel=prefetch`, so there is no warm-up there — the fetch happens when a survey triggers. Checked in Chrome only.

**Risks**

- Reuse depends on `/js/*` staying `public, max-age=3600`. If those headers ever go `no-store`, the prefetch becomes a wasted download.
- Separately: `/js/*.cjs` returns `cf-cache-status: DYNAMIC` in production, so Cloudflare is not edge-caching the bundle at all. Out of scope here, worth its own ticket.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `xhigh`.
