### PR TITLE
fix(api): clamp workspace-team writes to the API key creator's role (ENG-2329)

### DIFF
--- a/apps/web/modules/api/v2/organizations/[organizationId]/workspace-teams/lib/tests/utils.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/workspace-teams/lib/tests/utils.test.ts
@@ -1,0 +1,127 @@
+import { type Mock, beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { OrganizationRole } from "@formbricks/database/prisma";
+import { TAuthenticationApiKey } from "@formbricks/types/auth";
+import { checkAuthenticationAndAccess } from "../utils";
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual("react");
+  return { ...actual, cache: vi.fn((fn: unknown) => fn) };
+});
+
+vi.mock("@/lib/constants", () => ({
+  USER_MANAGEMENT_MINIMUM_ROLE: "manager",
+}));
+
+vi.mock("@/modules/api/v2/management/lib/utils", () => ({
+  pickCommonFilter: vi.fn(),
+  buildCommonFilterQuery: vi.fn(),
+}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    apiKey: { findUnique: vi.fn() },
+    membership: { findUnique: vi.fn() },
+    organization: { findFirst: vi.fn() },
+  },
+}));
+
+const apiKeyFindUnique = prisma.apiKey.findUnique as unknown as Mock;
+const membershipFindUnique = prisma.membership.findUnique as unknown as Mock;
+const organizationFindFirst = prisma.organization.findFirst as unknown as Mock;
+
+// An org-scoped key that already clears every check the write routes made before this guard existed:
+// the organization id matches and `accessControl.write` is granted. So every case below turns on the
+// creator's current role alone, which is the whole point of the clamp.
+const authentication: TAuthenticationApiKey = {
+  type: "apiKey",
+  apiKeyId: "apiKey123",
+  organizationId: "org123",
+  workspacePermissions: [],
+  organizationAccess: { accessControl: { read: true, write: true } },
+};
+
+const mockCreatorRole = (role: OrganizationRole | null) => {
+  apiKeyFindUnique.mockResolvedValue({ createdBy: "user123" });
+  membershipFindUnique.mockResolvedValue(role ? { role } : null);
+};
+
+describe("checkAuthenticationAndAccess", () => {
+  beforeEach(() => {
+    apiKeyFindUnique.mockReset();
+    membershipFindUnique.mockReset();
+    organizationFindFirst.mockReset();
+    organizationFindFirst.mockResolvedValue({ id: "org123" });
+  });
+
+  test.each([OrganizationRole.owner, OrganizationRole.manager])(
+    "allows the write when the key creator is still an %s",
+    async (role) => {
+      mockCreatorRole(role);
+
+      const result = await checkAuthenticationAndAccess("team123", "workspace123", authentication);
+
+      expect(result.ok).toBe(true);
+      expect(organizationFindFirst).toHaveBeenCalled();
+    }
+  );
+
+  test.each([OrganizationRole.member, OrganizationRole.billing])(
+    "refuses the write when the key creator has been demoted to %s",
+    async (role) => {
+      mockCreatorRole(role);
+
+      const result = await checkAuthenticationAndAccess("team123", "workspace123", authentication);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("forbidden");
+        expect(result.error.details?.[0].field).toBe("apiKey");
+      }
+    }
+  );
+
+  test("refuses the write when the key creator is no longer a member of the organization", async () => {
+    mockCreatorRole(null);
+
+    const result = await checkAuthenticationAndAccess("team123", "workspace123", authentication);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("forbidden");
+    }
+  });
+
+  test("refuses the write for a legacy key that records no creator", async () => {
+    apiKeyFindUnique.mockResolvedValue({ createdBy: null });
+
+    const result = await checkAuthenticationAndAccess("team123", "workspace123", authentication);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("forbidden");
+    }
+  });
+
+  // A refused caller must not learn which ids exist: running the lookup first would answer with
+  // not_found for a made-up team and forbidden for a real one, turning the error into an id oracle.
+  test("does not look up the team or workspace when the creator role check fails", async () => {
+    mockCreatorRole(OrganizationRole.member);
+
+    await checkAuthenticationAndAccess("team123", "workspace123", authentication);
+
+    expect(organizationFindFirst).not.toHaveBeenCalled();
+  });
+
+  test("still refuses a team or workspace outside the organization once the role check passes", async () => {
+    mockCreatorRole(OrganizationRole.owner);
+    organizationFindFirst.mockResolvedValue(null);
+
+    const result = await checkAuthenticationAndAccess("team123", "workspace123", authentication);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("not_found");
+    }
+  });
+});

--- a/apps/web/modules/api/v2/organizations/[organizationId]/workspace-teams/lib/tests/utils.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/workspace-teams/lib/tests/utils.test.ts
@@ -103,6 +103,17 @@ describe("checkAuthenticationAndAccess", () => {
     }
   });
 
+  test("returns internal_server_error when the creator role lookup fails", async () => {
+    apiKeyFindUnique.mockRejectedValue(new Error("DB error"));
+
+    const result = await checkAuthenticationAndAccess("team123", "workspace123", authentication);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("internal_server_error");
+    }
+  });
+
   // A refused caller must not learn which ids exist: running the lookup first would answer with
   // not_found for a made-up team and forbidden for a real one, turning the error into an id oracle.
   test("does not look up the team or workspace when the creator role check fails", async () => {

--- a/apps/web/modules/api/v2/organizations/[organizationId]/workspace-teams/lib/utils.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/workspace-teams/lib/utils.ts
@@ -4,6 +4,10 @@ import { Prisma } from "@formbricks/database/prisma";
 import { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
 import { buildCommonFilterQuery, pickCommonFilter } from "@/modules/api/v2/management/lib/utils";
+import {
+  canManageOrganizationUsers,
+  getApiKeyCreatorRole,
+} from "@/modules/api/v2/organizations/[organizationId]/users/lib/utils";
 import { TGetWorkspaceTeamsFilter } from "@/modules/api/v2/organizations/[organizationId]/workspace-teams/types/workspace-teams";
 import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
 
@@ -88,11 +92,33 @@ export const validateTeamIdAndWorkspaceId = reactCache(
   }
 );
 
+/**
+ * Guards every workspace-team write (POST/PUT/DELETE).
+ *
+ * Org API keys carry read/write/manage flags but no role of their own, so authorization is anchored
+ * to the key creator's current role, mirroring the owner/manager clamp `updateTeamDetailsAction`
+ * applies to workspace access changes on the settings path. Without it a key whose creator was
+ * demoted, removed or deleted keeps granting, raising and revoking a team's workspace access.
+ *
+ * The role check runs before the team/workspace lookup on purpose: a caller that fails it must not
+ * be able to tell a real team or workspace id from a made-up one by the 404 it would get back.
+ */
 export const checkAuthenticationAndAccess = async (
   teamId: string,
   workspaceId: string,
   authentication: TAuthenticationApiKey
 ): Promise<Result<boolean, ApiErrorResponseV2>> => {
+  const assignerRole = await getApiKeyCreatorRole(authentication.apiKeyId, authentication.organizationId);
+
+  if (!canManageOrganizationUsers(assignerRole)) {
+    return err({
+      type: "forbidden",
+      details: [
+        { field: "apiKey", issue: "You are not allowed to manage workspace teams in this organization" },
+      ],
+    });
+  }
+
   const hasAccess = await validateTeamIdAndWorkspaceId(authentication.organizationId, teamId, workspaceId);
 
   if (!hasAccess.ok) {

--- a/apps/web/modules/api/v2/organizations/[organizationId]/workspace-teams/lib/utils.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/workspace-teams/lib/utils.ts
@@ -3,6 +3,7 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
+import { TOrganizationRole } from "@formbricks/types/memberships";
 import { buildCommonFilterQuery, pickCommonFilter } from "@/modules/api/v2/management/lib/utils";
 import {
   canManageOrganizationUsers,
@@ -108,7 +109,19 @@ export const checkAuthenticationAndAccess = async (
   workspaceId: string,
   authentication: TAuthenticationApiKey
 ): Promise<Result<boolean, ApiErrorResponseV2>> => {
-  const assignerRole = await getApiKeyCreatorRole(authentication.apiKeyId, authentication.organizationId);
+  // The route wrapper would turn a rejected read into a 500 on its own, but it discards the audit
+  // log doing so. Returning a Result keeps a failed lookup on this guard's audit trail.
+  let assignerRole: TOrganizationRole | null;
+  try {
+    assignerRole = await getApiKeyCreatorRole(authentication.apiKeyId, authentication.organizationId);
+  } catch (error) {
+    return err({
+      type: "internal_server_error",
+      details: [
+        { field: "apiKey", issue: error instanceof Error ? error.message : "Unknown error occurred" },
+      ],
+    });
+  }
 
   if (!canManageOrganizationUsers(assignerRole)) {
     return err({


### PR DESCRIPTION
Fixes ENG-2329

## What & why

**Was:** any organization API key with write access could create, update and delete workspace-team permission grants, whatever its creator was allowed to do — so a key whose creator was later demoted, removed or deleted kept granting a team `manage` on any workspace, and kept revoking it.

**Now:** those writes resolve the creator's current role and return `403` unless it clears the user-management floor, matching the owner/manager clamp the settings path applies to workspace access changes.

- The v2 `users` and `teams` routes have carried this check since #8634; `workspace-teams` was the last organization route without it.
- `GET` is untouched — it needs read access only.

Reported by Yash Shendge (GitHub: `ashrexon`).

## Where to look

- [`utils.ts:107`](https://github.com/formbricks/formbricks/blob/f3ec8e2f/apps/web/modules/api/v2/organizations/%5BorganizationId%5D/workspace-teams/lib/utils.ts#L107) — the clamp, and why it precedes the id lookup
- [`utils.test.ts:119`](https://github.com/formbricks/formbricks/blob/f3ec8e2f/apps/web/modules/api/v2/organizations/%5BorganizationId%5D/workspace-teams/lib/tests/utils.test.ts#L119) — the 403-before-404 ordering case

## Breaking changes

- [x] This PR contains breaking changes

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| `POST`/`PUT`/`DELETE /api/v2/organizations/{organizationId}/workspace-teams` | `200` for any organization key with write access | `403` unless the creator can manage organization users | Installs automating grants with a key whose creator was demoted, removed, or predates `createdBy` | Re-issue the key from an owner or manager account |

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter=@formbricks/web test "workspace-teams/lib/tests"`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Demoted, removed or `createdBy`-less creator refused | unit (red on main) | `forbidden` with field `apiKey` |
| `403` decided before the team/workspace lookup | unit (red on main) | `organization.findFirst` never called — no id oracle |
| Failed role lookup returns a `Result`, not a throw | unit (mutation) | `internal_server_error`; red with the catch at `utils.ts:115` removed |
| Owner and manager creators still allowed | unit (guard) | grant proceeds, lookup still runs |
| Team or workspace outside the organization still `404` | unit (guard) | unchanged by the clamp |

<details>
<summary>Revert check</summary>

Against `main`'s `lib/utils.ts` with the new spec kept, 6 of its 9 cases fail; the 3 that stay green are the two guard rows above.

```
× refuses the write when the key creator has been demoted to member
× refuses the write when the key creator has been demoted to billing
× refuses the write when the key creator is no longer a member of the organization
× refuses the write for a legacy key that records no creator
× returns internal_server_error when the creator role lookup fails
× does not look up the team or workspace when the creator role check fails
Tests  6 failed | 3 passed (9)
```

Removing only the `try`/`catch` reds exactly one case — the `unit (mutation)` row.

</details>

**Open gaps**

- Not exercised against a live instance: these endpoints have no Playwright or Schemathesis coverage to extend.

**Risks**

- `checkAuthenticationAndAccess` is shared by all three writes; a future read path calling it would inherit the manage-users requirement.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code), reasoning effort `xhigh`.
