### PR TITLE
fix(auth): stop paging on client-caused OAuth state rejections (ENG-2471) [backport 5.4]

### DIFF
--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -1,4 +1,7 @@
+import { BetterAuthError } from "@better-auth/core/error";
 import * as Sentry from "@sentry/nextjs";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
 import { APIError } from "better-auth/api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
@@ -377,6 +380,213 @@ describe("betterAuthLogger (Sentry capture gating, ENG-2037)", () => {
 
     expect(Sentry.captureException).not.toHaveBeenCalled();
     expect(contextLoggerMock.info).toHaveBeenCalledWith("some info");
+  });
+});
+
+/**
+ * ENG-2471: `BetterAuthError: State mismatch: verification not found` cleared the ENG-2037 gate and
+ * paged — 52 events in 14 days. It is a third shape ENG-2037 never enumerated: not a bare string code,
+ * not an `APIError`, but a `StateError extends BetterAuthError` carrying a stable `code`.
+ *
+ * Mirrors the real shape rather than importing it: `StateError` is internal to
+ * `better-auth/dist/state.mjs`, and it extends `BetterAuthError` adding only `code`/`details`/`errorURL`
+ * — so a subclass carrying `code` is exactly what the gate sees. The codes below are the five that
+ * module throws, read from its throw sites.
+ */
+class StateErrorLike extends BetterAuthError {
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
+  const log = betterAuthLogger.log!;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Client- or timing-caused: the verification record was purged or already consumed, or the parsed
+  // state is past its `expiresAt`. Nothing to act on, so these must not page.
+  test.each([
+    ["state_mismatch", "State mismatch: verification not found"],
+    // Cookie-branch message, kept as a label only: the code is what the gate reads, and this variant
+    // is unreachable on our database strategy.
+    ["state_mismatch", "State mismatch: auth state cookie not found"],
+    ["state_mismatch", "Invalid state: request expired"],
+  ])("does not capture the client-caused %s (%s)", (code, message) => {
+    const stateError = new StateErrorLike(message, code);
+
+    log("error", message, stateError);
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    // Still visible in the application log — suppression is Sentry-only. A burst of these is how a
+    // Redis eviction would present, since verification records live in Redis only.
+    expect(contextLoggerMock.error).toHaveBeenCalledWith(message);
+  });
+
+  /**
+   * The other four codes stay captured, and each for its own reason:
+   * - `state_generation_error` — the adapter could not write the verification row: a real fault.
+   * - `state_security_mismatch` — the state does not match the stored one, OR the signed state cookie
+   *   fails verification. That second half is where a cross-replica `BETTER_AUTH_SECRET` divergence
+   *   surfaces (a real outage) and also where the benign 5–10 minute cookie-expiry case lands, so it is
+   *   mixed and ENG-2471 defers judging it until the ENG-2259 `auth.path` tag has sized the split.
+   * - `state_invalid` — cookie-branch only, so unreachable on this configuration. Kept because
+   *   suppressing a code that never fires buys nothing.
+   * - `state_not_found` — a defensive entry rather than a live one. Verified against 1.7.0 that the
+   *   callback route short-circuits a missing `state` before any `StateError` is thrown, and logs it
+   *   with the OAuth `error` query param rather than an `Error` — so it reaches neither this gate nor
+   *   Sentry, and the assertion below is a contract for a shape the callback route does not currently
+   *   produce. Kept captured so that if upstream ever does route it through as a real `StateError`, it
+   *   pages instead of being dropped by a stale allow-list.
+   */
+  test.each([
+    ["state_generation_error", "Unable to create verification"],
+    ["state_invalid", "State invalid: Failed to decrypt or parse auth state"],
+    ["state_security_mismatch", "State mismatch: OAuth state parameter does not match stored state"],
+    ["state_not_found", "State not found in OAuth callback"],
+  ])("still captures %s", (code, message) => {
+    const stateError = new StateErrorLike(message, code);
+
+    log("error", message, stateError);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(stateError, {
+      tags: { component: "better-auth" },
+    });
+  });
+
+  /**
+   * The log field is the whole justification for suppressing anything: a suppressed event survives only
+   * in the application log, so it has to be queryable by the same value that suppressed it. Without this
+   * test the field can be deleted and the suite stays green — verified, it did.
+   *
+   * Recorded for captured codes too, so one query covers the class rather than only its quiet half.
+   */
+  test.each([
+    ["state_mismatch", "suppressed"],
+    ["state_security_mismatch", "captured"],
+  ])("records %s on the log context (%s)", (code) => {
+    log("error", "State mismatch", new StateErrorLike("State mismatch", code));
+
+    expect(logger.withContext).toHaveBeenCalledWith({
+      source: "better-auth",
+      stateErrorCode: code,
+    });
+  });
+
+  // The raw `state` is a single-use credential for the in-flight flow and lives on the error's
+  // `details`. Only the code is ever read, so it cannot reach the log through this path.
+  test("never puts the raw state value on the log context", () => {
+    const stateError = new StateErrorLike("State mismatch: verification not found", "state_mismatch");
+    Object.assign(stateError, { details: { state: "super-secret-state-value" } });
+
+    log("error", "State mismatch: verification not found", stateError);
+
+    expect(JSON.stringify(vi.mocked(logger.withContext).mock.calls)).not.toContain(
+      "super-secret-state-value"
+    );
+  });
+
+  // The gate fails CLOSED: anything it cannot positively identify as THE one suppressed code
+  // (`state_mismatch`) is still captured. A wrong answer should add noise, never silence a fault.
+  test("captures a BetterAuthError carrying no code", () => {
+    const bare = new BetterAuthError("something upstream broke");
+
+    log("error", "something upstream broke", bare);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(bare, {
+      tags: { component: "better-auth" },
+    });
+  });
+
+  test("captures a look-alike that is not a BetterAuthError, even with a suppressed code", () => {
+    const impostor = Object.assign(new Error("State mismatch: verification not found"), {
+      name: "BetterAuthError",
+      code: "state_mismatch",
+    });
+
+    log("error", "State mismatch: verification not found", impostor);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(impostor, {
+      tags: { component: "better-auth" },
+    });
+  });
+});
+
+/**
+ * The contract test for the gate above, and the reason the `StateErrorLike` tests are not enough on
+ * their own: they assert against a stand-in we define here, so they would keep passing if the REAL
+ * `StateError` stopped satisfying the gate. `StateError` is internal to `better-auth/dist/state.mjs`
+ * and cannot be imported, so the only way to bind the real shape is to make Better Auth throw one.
+ *
+ * This drives a real `betterAuth` instance — configured with `betterAuthLogger` itself, so the whole
+ * production path runs — at an OAuth callback carrying a `state` with no verification record. That is
+ * exactly the reported failure (`State mismatch: verification not found`, FORMBRICKS-16G). If a future
+ * upgrade renames the code, changes the class, or stops routing it through the logger, this fails.
+ */
+describe("betterAuthLogger — the real Better Auth StateError (ENG-2471 contract)", () => {
+  const BASE_URL = "http://localhost:3000";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const provokeStateMismatch = async (): Promise<void> => {
+    const auth = betterAuth({
+      baseURL: BASE_URL,
+      secret: "eng-2471-contract-test-secret-0123456789abcdef",
+      // memoryAdapter declares its models up front; an empty `verification` table is the point — the
+      // state below resolves to no record, which is what throws.
+      database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+      logger: betterAuthLogger,
+      socialProviders: { google: { clientId: "contract-test", clientSecret: "contract-test" } },
+    });
+
+    await auth.handler(
+      new Request(`${BASE_URL}/api/auth/callback/google?state=no-such-state&code=irrelevant`)
+    );
+  };
+
+  test("is logged, so this suite is exercising the path at all", async () => {
+    await provokeStateMismatch();
+
+    // Anti-vacuity: if Better Auth stopped routing this through our logger, the assertion below would
+    // pass for the wrong reason — nothing captured because nothing happened.
+    expect(contextLoggerMock.error).toHaveBeenCalled();
+  });
+
+  // Pins the exact shape the gate depends on, so an upstream rename fails here loudly instead of
+  // quietly restoring the noise. Uses a capturing logger rather than `betterAuthLogger`, because the
+  // production logger deliberately forwards only the message to our logger, not the Error.
+  test("is a BetterAuthError carrying code state_mismatch", async () => {
+    const seen: unknown[] = [];
+    const auth = betterAuth({
+      baseURL: BASE_URL,
+      secret: "eng-2471-contract-test-secret-0123456789abcdef",
+      database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+      logger: { level: "error", log: (_level, _message, ...args) => seen.push(...args) },
+      socialProviders: { google: { clientId: "contract-test", clientSecret: "contract-test" } },
+    });
+
+    await auth.handler(
+      new Request(`${BASE_URL}/api/auth/callback/google?state=no-such-state&code=irrelevant`)
+    );
+
+    const stateError = seen.find((arg): arg is Error & { code?: unknown } => arg instanceof BetterAuthError);
+    expect(stateError).toBeDefined();
+    expect(stateError?.name).toBe("BetterAuthError");
+    expect(stateError?.code).toBe("state_mismatch");
+  });
+
+  test("is NOT captured to Sentry", async () => {
+    await provokeStateMismatch();
+
+    expect(contextLoggerMock.error).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { BetterAuthError } from "@better-auth/core/error";
 import * as Sentry from "@sentry/nextjs";
 import type { BetterAuthOptions } from "better-auth";
 import { isAPIError } from "better-auth/api";
@@ -130,6 +131,117 @@ export const redactEmailsInLogMessage = (message: unknown): unknown =>
   typeof message === "string" ? message.replace(EMAIL_IN_MESSAGE, "[redacted]@$1") : message;
 
 /**
+ * `StateError` codes whose events are client- or timing-caused, and so are not actionable in Sentry
+ * (ENG-2471). `StateError extends BetterAuthError` and carries a stable `code`, which is what we match
+ * on — never the message, which is not a contract.
+ *
+ * Read from the throw sites in `better-auth/dist/state.mjs`, **for the strategy we actually run**. That
+ * matters more than it sounds: the file has two branches that throw different codes for the same
+ * underlying cause, and reading the wrong one inverts the conclusions. Better Auth picks the strategy
+ * from `!!options.database || !!options.secondaryStorage`, and `auth.ts` sets BOTH — so it resolves to
+ * `"database"` and the cookie branch never executes here. Noted as both deliberately: dropping Redis
+ * alone would not flip it back.
+ *
+ * | code | thrown when (database strategy) | actionable? |
+ * | --- | --- | --- |
+ * | `state_mismatch` | no verification record for this `state` — purged after its 10-minute TTL, already consumed, or never issued — or the parsed state is past `expiresAt` | no — **suppressed** |
+ * | `state_not_found` | the callback carried no `state` — **never reaches this gate on 1.7**, see below | kept |
+ * | `state_security_mismatch` | the state does not match the stored one, or the signed `state` cookie fails verification ("State not persisted correctly") | **yes**, kept |
+ * | `state_generation_error` | the adapter could not write the verification row | **yes**, kept — a real fault |
+ * | `state_invalid` | undecryptable state — **cookie branch only, unreachable on this config** | kept; suppressing a code that never fires buys nothing |
+ *
+ * `state_not_found` is kept out of the set, but on 1.7 that choice is **inert**, and the honest reason
+ * is worth recording because an earlier draft of this comment got it wrong in both directions.
+ *
+ * Verified live against 1.7.0: an OAuth callback with no `state` never produces a `StateError` at all.
+ * The callback route short-circuits before `parseGenericState` is reached
+ * (`better-auth/dist/api/routes/callback.mjs:72-76`):
+ *
+ * ```js
+ * if (!state) { c.context.logger.error("State not found", error); throw c.redirect(`…error=state_not_found`); }
+ * ```
+ *
+ * That second argument is the OAuth `error` *query parameter*, not an `Error`, so our `cause` lookup
+ * finds nothing, the Sentry gate's `cause &&` is already false, and the event is logged without a
+ * `stateErrorCode`. It was therefore never captured — this code is not part of the over-capture problem,
+ * and the `StateError` carrying it (`state.mjs:90`) is unreachable from this route. Listing it here or
+ * omitting it changes nothing today; it stays omitted so that if upstream ever routes it through the
+ * logger as a real `StateError`, it pages rather than being silently dropped by a stale allow-list.
+ *
+ * Worth knowing separately, because it is a gap this PR does not close: that makes an IdP which stops
+ * echoing `state` — a provider-wide sign-in outage — produce **no Sentry event whatsoever**, only that
+ * log line. Independent of this change, and not fixable from this gate.
+ *
+ * `state_security_mismatch` carries the load this gate deliberately does not take on, and it is mixed:
+ *
+ * - The state cookie's `maxAge` is 300s while the verification record lives 10 minutes, so a user who
+ *   spends 5–10 minutes at the identity provider loses the cookie first and lands here. Benign, and
+ *   probably common — **so this change likely leaves residual noise behind**; it closes the reported
+ *   `verification not found` shape (FORMBRICKS-16G), not the whole class.
+ * - It is also where a `BETTER_AUTH_SECRET` divergence across replicas surfaces, because the signed
+ *   cookie cannot be verified with a different secret. That is a genuine outage and must keep paging.
+ * - And it is the shape a forged or mixed-up callback takes.
+ *
+ * Code cannot separate those three, which is exactly why ENG-2471 defers the decision to the `auth.path`
+ * tag from ENG-2259 rather than guessing. Suppressing a signal before measuring it is how ENG-2037 left
+ * this shape behind in the first place.
+ *
+ * One security-visible consequence, stated rather than left implicit: a *replayed* callback — the same
+ * `state` presented again after the legitimate flow consumed it — also lands on `state_mismatch`, so
+ * replay attempts stop being visible in Sentry. That is judged acceptable because the replay fails
+ * closed (the record is single-use, and the authorization code is single-use at the IdP too), so this is
+ * a loss of visibility into a *failed* attempt, not of a control. The events remain in the application
+ * log with their `stateErrorCode`, which is where a campaign would show up as volume.
+ *
+ * What suppression costs, stated narrowly. Two shapes produce `state_mismatch` for *real* login
+ * failures, and this gate hides both from Sentry:
+ *
+ * 1. **Runtime:** a Redis eviction, flush, or failover to an empty replica drops in-flight verification
+ *    records. Arrives as a trickle or a burst, mid-operation.
+ * 2. **Deploy-time, and the worse of the two:** replicas that do not share one Redis. The record is
+ *    written by the pod that started the flow and looked up by whichever pod serves the callback, and
+ *    that lookup is the *first* check in the database branch — before the signed-cookie check. So a
+ *    split-Redis deployment fails 100% of SSO sign-ins while the state cookie still verifies perfectly
+ *    (the secret is shared even when the store is not), which keeps it off `state_security_mismatch` and
+ *    squarely on the code we suppress. It also lands exactly when someone is watching Sentry rather than
+ *    the logs.
+ *
+ * A *hard* Redis outage is not in this class — `secondary-storage.ts` rethrows on connect failure, which
+ * is not a `StateError`, so it still pages.
+ *
+ * The suppressed events stay at `error` in the application log with `stateErrorCode` and the request's
+ * `authPath`, so they are greppable — and `stateErrorCode` is load-bearing rather than convenient here,
+ * because upstream logs every state error under the same "Failed to parse state" message. What is
+ * missing is the alert: there is no log-based rule on that field today, so a burst is discoverable
+ * rather than announced, which for shape 2 means a total outage nobody is paged for. Tracked separately;
+ * this gate cannot fix it.
+ */
+const UNACTIONABLE_STATE_ERROR_CODES: ReadonlySet<string> = new Set(["state_mismatch"]);
+
+/**
+ * The `StateError` code carried by a logged cause, or undefined when it is not one.
+ *
+ * Extracted once and used for BOTH the log context and the Sentry gate, so a suppressed event stays
+ * queryable by the same value that suppressed it — the log is the only place these survive, and an
+ * upstream message string is not something to build an alert on.
+ *
+ * Deliberately reads only `code`, never the error's `details`, which holds the raw `state` value: that
+ * is a single-use credential for the in-flight OAuth flow and has no business in a log line.
+ */
+const getStateErrorCode = (cause: Error | undefined): string | undefined => {
+  if (!(cause instanceof BetterAuthError)) return undefined;
+  const { code } = cause as { code?: unknown };
+  return typeof code === "string" ? code : undefined;
+};
+
+/**
+ * Fails CLOSED on purpose: anything not positively identified as an unactionable code is still
+ * captured. A wrong answer here should add noise, never silence a genuine fault.
+ */
+const isUnactionableStateError = (code: string | undefined): boolean =>
+  code !== undefined && UNACTIONABLE_STATE_ERROR_CODES.has(code);
+
+/**
  * Route Better Auth's logger to @formbricks/logger and capture GENUINE internal faults to Sentry in
  * production — replaces auth.ts's placeholder logger (and the route's Sentry.captureException on auth
  * failures).
@@ -158,21 +270,26 @@ export const betterAuthLogger: NonNullable<BetterAuthOptions["logger"]> = {
     // construction, a server-side `auth.api.*` call). Already reduced to a safe label — never a raw
     // path, which on `/reset-password/:token` would be a live credential (better-auth-path-label.ts).
     const request = getBetterAuthRequestContext();
+    // BA usually passes the Error as a trailing arg, but a couple of sites pass it as `message`.
+    const cause = [...args, message].find((arg): arg is Error => arg instanceof Error);
+    const stateErrorCode = getStateErrorCode(cause);
     const contextLogger = logger.withContext({
       source: "better-auth",
       // Self-hosters have no Sentry, so the label has to reach the application log too — otherwise
       // their copy of this fault stays as untriageable as FORMBRICKS-183 was.
       ...(request && { authPath: request.path, httpMethod: request.method }),
+      // The suppressed state rejections survive only in the log, so the code has to be queryable there
+      // (ENG-2471). Recorded for every state error, not only the suppressed ones.
+      ...(stateErrorCode && { stateErrorCode }),
     });
     const safeMessage = redactEmailsInLogMessage(message);
     if (level === "error") {
       contextLogger.error(safeMessage);
       if (SENTRY_DSN && IS_PRODUCTION) {
-        // BA usually passes the Error as a trailing arg, but a couple of sites pass it as `message`.
-        const cause = [...args, message].find((arg): arg is Error => arg instanceof Error);
-        // Skip handled rejections: a bare string code (no Error) or a client-facing APIError. Capture
-        // only genuine internal faults so Sentry stays actionable (see the reason-split above).
-        if (cause && !isAPIError(cause)) {
+        // Skip handled rejections: a bare string code (no Error), a client-facing APIError, or a
+        // client/timing-caused OAuth `StateError` (ENG-2471). Capture only genuine internal faults so
+        // Sentry stays actionable (see the reason-split above and UNACTIONABLE_STATE_ERROR_CODES).
+        if (cause && !isAPIError(cause) && !isUnactionableStateError(stateErrorCode)) {
           // ENG-2259: Better Auth's router logs a non-APIError as `(e.name, e)` and discards the
           // endpoint (`better-auth/dist/api/index.mjs:210`), so a bare capture arrives with no
           // transaction, URL or route — which is why FORMBRICKS-183 sat at ~242 events untriageable.


### PR DESCRIPTION
Fixes ENG-2471

## What & why

The 5.3.4 → 5.4.0 cutover shipped Better Auth 1.7 (#8835) with a single production-code gap on
`release/5.4`: the ENG-2471 Sentry-noise fix was merged to `main` but never backported. This PR
cherry-picks it so 5.4.1 carries the same auth behaviour as `main`.

Backport audit of every auth/SSO fix merged to `main` after the `5.4.0` tag:

| PR | Fix | Backport state |
| --- | --- | --- |
| #8962 (ENG-2557) | strip live local auth factors on SSO recovery | already on `release/5.4` via #8998 |
| #8951 (ENG-2555) | write canonical `Account.issuer` (incl. `repair_account_issuer` migration) | production code already on `release/5.4` |
| **#8933 (ENG-2471)** | stop paging on client-caused OAuth state rejections | **missing — backported by this PR** |

Only #8933 has production code absent from the release branch. Its change
(`better-auth-observability.ts`) adds a third shape to the ENG-2037 Sentry capture gate: a
`StateError extends BetterAuthError` whose `code` is client- or timing-caused (`state_mismatch`,
i.e. a purged/already-consumed `state` verification record) previously cleared the gate and paged
(52 events in 14 days). Suppression keys on the stable `code`, not the message, and the code is
recorded on the log context so one query covers the class.

## Breaking changes

- [ ] This PR contains breaking changes

None — observability-only; no API, route, env var or payload changes.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `state_mismatch` (verification not found / cookie not found / expired) does not reach Sentry | unit (guard), `better-auth-observability.test.ts` — the existing 12-case suite already covers the two ENG-2037 shapes; these three cases pin the new one | passed (`pnpm test modules/auth/lib/better-auth-observability.test.ts`) |
| `state_generation_error`, `state_invalid`, `state_security_mismatch`, `state_not_found` stay captured | unit (guard), same file | passed |
| suppression is queryable (code logged on context) and raw `state` never reaches logs | unit (guard), same file | passed |

The 5.4 tree's own auth+SSO suites were also run against this branch before the cherry-pick
(54 files / 629 tests green); this PR only adds the two ENG-2471 files and their new assertions.

**Open gaps**

- The `state_security_mismatch` code keeps paging (mixed benign cookie-expiry vs. real
  cross-replica `BETTER_AUTH_SECRET` divergence) — deferred by ENG-2471 itself pending the
  ENG-2259 `auth.path` tag sizing that split.

**Risks**

- None beyond the deferred `state_security_mismatch` paging noted above. No behaviour change for
  captured codes or for non-Sentry logging paths.
