### PR TITLE
docs: correct workspace scoping and settings paths (ENG-2637)

### DIFF
--- a/docs/platform/features/integrations/hubspot.mdx
+++ b/docs/platform/features/integrations/hubspot.mdx
@@ -138,7 +138,7 @@ For maximum flexibility, you can use Formbricks webhooks with a custom endpoint 
 
 <Steps>
   <Step title="Create a Formbricks Webhook">
-    Go to **Configuration** → **Integrations** in Formbricks, click **Manage Webhooks** → **Add Webhook**, enter your endpoint URL, select **Response Finished** as the trigger, and choose the surveys to monitor.
+    Go to **Settings → Workspace → Integrations** in Formbricks, click **Manage Webhooks** → **Add Webhook**, enter your endpoint URL, select **Response Finished** as the trigger, and choose the surveys to monitor.
 
     ![Integrations Tab](/images/platform/features/integrations/webhooks/integrations-tab.webp)
   </Step>

--- a/docs/platform/features/integrations/n8n.mdx
+++ b/docs/platform/features/integrations/n8n.mdx
@@ -64,7 +64,7 @@ Here, we are adding `Response Finished` as an event, which will trigger when the
 
 ## Step 5: Select Survey
 
-Next, you can choose from all the surveys you have created in this environment. You can select multiple surveys:
+Next, you can choose from all the surveys you have created in this workspace. You can select multiple surveys:
 
 ![Select Survey](/images/platform/features/integrations/n8n/select-survey.webp)
 

--- a/docs/platform/features/integrations/zapier.mdx
+++ b/docs/platform/features/integrations/zapier.mdx
@@ -54,7 +54,7 @@ Once you copied it in the newly opened Zapier window, you will be connected:
 
 ## Step 5: Select Survey
 
-Next, you can choose from all the surveys you have created in this environment:
+Next, you can choose from all the surveys you have created in this workspace:
 
 ![Select Survey](/images/platform/features/integrations/zapier/select-survey.webp)
 

--- a/docs/self-hosting/configuration/integrations/n8n.mdx
+++ b/docs/self-hosting/configuration/integrations/n8n.mdx
@@ -40,7 +40,7 @@ Once you copied it in the API Key field, hit Save button to test the connection 
 
 Here, we are adding `Response Finished` as an event, which will trigger when the survey has been filled out.
 
-* Select Survey: Next, you can choose from all the surveys you have created in this environment. You can select multiple surveys:
+* Select Survey: Next, you can choose from all the surveys you have created in this workspace. You can select multiple surveys:
 
 ![select survey](https://res.cloudinary.com/dwdb9tvii/image/upload/v1738253219/image_hbubu7.jpg)
 

--- a/docs/surveys/general-features/tags.mdx
+++ b/docs/surveys/general-features/tags.mdx
@@ -13,7 +13,7 @@ Tags are labels that you can apply to individual survey responses. They allow yo
 - Track and organize feedback across multiple surveys
 - Simplify analysis and reporting workflows
 
-Tags are environment-specific, meaning each environment maintains its own set of tags.
+Tags are workspace-specific, meaning each workspace maintains its own set of tags.
 
 ## Add tags to responses
 
@@ -49,15 +49,15 @@ The tag will be removed from the response immediately.
 
 ## Manage tags
 
-Access the tag management page to view and organize all tags in your environment.
+Access the tag management page to view and organize all tags in your workspace.
 
 <Steps>
-  <Step title="Navigate to Configuration">
-    Click on **Workspace Configuration** > **Tags**.
+  <Step title="Open Tag settings">
+    Go to **Settings → Workspace → Tags**.
   </Step>
   
   <Step title="View all tags">
-    You'll see a list of all tags in your environment with their usage count showing how many responses have each tag applied.
+    You'll see a list of all tags in your workspace with their usage count showing how many responses have each tag applied.
   </Step>
 </Steps>
 
@@ -68,7 +68,7 @@ Access the tag management page to view and organize all tags in your environment
 3. Click outside the field or press Enter to save
 
 <Note>
-Tag names must be unique within an environment. If you try to use an existing tag name, you'll receive an error.
+Tag names must be unique within a workspace. If you try to use an existing tag name, you'll receive an error.
 </Note>
 
 ### Merge tags

--- a/docs/surveys/website-app-surveys/user-identification.mdx
+++ b/docs/surveys/website-app-surveys/user-identification.mdx
@@ -62,7 +62,7 @@ formbricks.setAttributes({
 
 <Note>
   **Note**: the number of different attribute classes (e.g., "Plan," "First Name," etc.) is currently limited
-  to 150 attributes per environment.
+  to 150 attributes per workspace.
 </Note>
 
 ### Setting User Language


### PR DESCRIPTION
Fixes ENG-2637, ENG-2639, ENG-2748

## What & why

**Was:** Four pages described tags, contact attributes and survey pickers as scoped to an *environment*, and sent readers to a **Workspace Configuration** menu.

**Now:** They say workspace, and point at **Settings → Workspace → Tags / Integrations**.

- Formbricks 5 replaced the Environment model with Workspace. `model Environment` no longer exists.
- No nav item is called Configuration — no `en-US.json` string even equals it.

## Where to look

- [tags.mdx](https://github.com/formbricks/formbricks/blob/docs/environment-to-workspace-wording/docs/surveys/general-features/tags.mdx) — scoping claim plus the settings path
- [user-identification.mdx:65](https://github.com/formbricks/formbricks/blob/docs/environment-to-workspace-wording/docs/surveys/website-app-surveys/user-identification.mdx#L65) — the 150-attribute limit

## Breaking changes

- [ ] This PR contains breaking changes

None — prose-only edits to five `.mdx` files. No API shape, env var, route or SDK signature is touched.

## Migrations & env

- none

## How this was tested

Rerun: `grep -rn "environment\|Workspace Configuration" docs/surveys/general-features/tags.mdx docs/surveys/website-app-surveys/user-identification.mdx docs/platform/features/integrations/zapier.mdx docs/platform/features/integrations/n8n.mdx docs/platform/features/integrations/hubspot.mdx` — expects no matches.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Tags are workspace-scoped | manual | `model Tag` keys on `workspaceId`, `@@unique([workspaceId, name])`; no `Environment` model |
| 150-attribute limit is per workspace | manual | Enforcing query in `modules/ee/contacts/lib/attributes.ts:351` is workspaceId-scoped |
| Tags live at Settings → Workspace → Tags | manual | Opened the page on a local instance of `main`: sidebar group WORKSPACE, item and heading both "Tags" |
| Integrations live under Settings → Workspace | manual | Same sidebar, item "Integrations" (`workspaceSettingsPath`) |

**Open gaps**

- `MAX_ATTRIBUTE_CLASSES_PER_ENVIRONMENT` still carries the old name in `lib/constants.ts`. Its behaviour is workspace-scoped; renaming it is a code change, out of scope here.
- The product calls these "attribute classes" in one error string and "attribute keys" in the Contacts UI. Docs kept the existing term rather than picking a side.

**Risks**

- none

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).
