### PR TITLE
docs: correct UI references that no longer match the product

### DIFF
--- a/docs/platform/features/integrations/overview.mdx
+++ b/docs/platform/features/integrations/overview.mdx
@@ -29,6 +29,8 @@ At Formbricks, we understand the importance of integrating with third-party appl
 
 * [Slack](/platform/features/integrations/slack): Automatically send responses to a Slack channel of your choice on response events.
 
+* [Webhooks](/platform/features/integrations/webhooks): Send real-time HTTP notifications to any endpoint of your choice when responses come in.
+
 * [Wordpress](/platform/features/integrations/wordpress)(Open Source): Automatically integrate your Formbricks surveys with your Wordpress website.
 
 * [Zapier](/platform/features/integrations/zapier): Connect Formbricks with 2000+ apps on Zapier.

--- a/docs/platform/introduction.mdx
+++ b/docs/platform/introduction.mdx
@@ -15,18 +15,27 @@ This guide covers everything you need to set up, use, and develop with Formbrick
 
 <CardGroup cols={2}>
 
-  <Card title="XM & Surveys" icon="square-poll-vertical" href="/surveys/overview">
-    Learn how to use Formbricks' XM & Surveys to collect feedback from your customers, users, and employees.
+  <Card title="Surveys (Ask)" icon="square-poll-vertical" href="/surveys/overview">
+    Collect feedback from customers, users, and employees with link, website, and in-app surveys.
   </Card>
-  <Card href="/self-hosting/overview" title="Self Host" icon="server">
-  Learn how to self-host Formbricks on your infrastructure.
-</Card>
 
-<Card href="/api-reference/rest-api" title="API" icon="code">
-  Learn how to use Formbricks' API to CRUD various resources programmatically.
-</Card>
+  <Card title="Unify Feedback (Analyze)" icon="layer-group" href="/unify-feedback/overview">
+    Bring feedback from every source into one store and turn it into insights.
+  </Card>
 
-  <Card title="Start developing" icon="rocket" href="/development/overview">
+  <Card title="Workflows (Act)" icon="diagram-project" href="/workflows/overview">
+    Automate what happens next with triggers, filters, actions, and observable runs.
+  </Card>
+
+  <Card title="Self Hosting" icon="server" href="/self-hosting/overview">
+    Learn how to self-host Formbricks on your infrastructure.
+  </Card>
+
+  <Card title="API Reference" icon="code" href="/api-reference/rest-api">
+    Learn how to use Formbricks' API to CRUD various resources programmatically.
+  </Card>
+
+  <Card title="Development" icon="rocket" href="/development/overview">
     Warm up with the Formbricks code base to make changes to the platform.
   </Card>
 

--- a/docs/surveys/link-surveys/pretty-url.mdx
+++ b/docs/surveys/link-surveys/pretty-url.mdx
@@ -54,7 +54,7 @@ All surveys that have a pretty URL assigned are listed in one place:
 1. Go to **Settings → Organization → Domain**.
 2. Open the **Pretty URLs** section.
 
-The table shows each survey's name, workspace, slug, and environment type (production / development).
+The table has three columns — **Survey Name**, **Workspace**, and **Pretty URL** — with one row per survey that has a slug.
 
 ## Slug Rules
 

--- a/docs/unify-feedback/feedback-datasets.mdx
+++ b/docs/unify-feedback/feedback-datasets.mdx
@@ -39,7 +39,7 @@ Archiving a dataset hides it from default views but does not delete its records.
   This cannot be undone, and it is not limited to your workspace. It permanently deletes every feedback record in the dataset — including its AI enrichment and the topics generated from it — for **every workspace the dataset is shared with**.
 </Warning>
 
-The dataset and its sources are kept, so new feedback keeps arriving. Topics are generated again once it does, and charts built on the dataset are empty until then.
+The dataset and its sources are kept, so new feedback keeps arriving. Topics are generated again once new feedback comes in, and charts built on the dataset are empty until then.
 
 To confirm, type the dataset's exact name. Only **Owners** and **Managers** can do this; everyone else sees the button disabled.
 

--- a/docs/unify-feedback/feedback-datasets.mdx
+++ b/docs/unify-feedback/feedback-datasets.mdx
@@ -18,14 +18,31 @@ Create one dataset per logically separate group of feedback. Common patterns:
 
 Datasets live at the **organization** level but are exposed to **workspaces** through an access list. Each workspace can **only access one dataset.**
 
-Manage dataset access from **Settings → Organization → Feedback Datasets**:
+Manage dataset access from **Settings → Organization → Datasets**:
 
 - Create new datasets
 - Rename or archive datasets
 - Add or remove workspace access
+- Delete all records in a dataset
 
 Only **Owners** and **Managers** can manage datasets. Workspace members see the datasets their workspace has access to inside the Unify section.
 
 ## Archiving
 
 Archiving a dataset hides it from default views but does not delete its records. Use it for one-off programs that have ended.
+
+## Delete all records
+
+**Delete all records** empties a dataset while keeping the dataset itself. Open **Settings → Organization → Datasets**, click **Manage** on the dataset, then click **Delete all records**.
+
+<Warning>
+  This cannot be undone, and it is not limited to your workspace. It permanently deletes every feedback record in the dataset — including its AI enrichment and the topics generated from it — for **every workspace the dataset is shared with**.
+</Warning>
+
+The dataset and its sources are kept, so new feedback keeps arriving. Topics are generated again once it does, and charts built on the dataset are empty until then.
+
+To confirm, type the dataset's exact name. Only **Owners** and **Managers** can do this; everyone else sees the button disabled.
+
+Deletion runs in the background, so records may still show up for a few minutes after you confirm.
+
+This is what separates it from archiving: archiving keeps the records and hides the dataset, deleting keeps the dataset and removes the records.


### PR DESCRIPTION
Fixes ENG-2638, ENG-2640, ENG-2641, ENG-2642, ENG-2643

## What & why

**Was:** Five docs claims did not match the product — a Pretty URLs table described with four columns including a production/development flag that no longer exists, a nav path naming a menu item that isn't there, an undocumented irreversible delete, a Webhooks page reachable from the sidebar but absent from the integrations overview, and a docs-home card grid promising Ask / Analyze / Act while offering "XM & Surveys".

**Now:** Each page describes what the running app and the current `docs.json` actually show. Unify Feedback and Workflows finally have a route in from the docs home.

- Every claim was checked against a local instance, not against source alone.
- `docs/unify-feedback/dashboards-charts.mdx` deliberately untouched (ENG-2742 pending).

## Where to look

- [`feedback-datasets.mdx` — new "Delete all records" section](https://github.com/formbricks/formbricks/blob/2afa978eef/docs/unify-feedback/feedback-datasets.mdx#L33-L47) — the one destructive claim
- [`introduction.mdx` — rebuilt card grid](https://github.com/formbricks/formbricks/blob/2afa978eef/docs/platform/introduction.mdx#L16-L41) — six hrefs to check against `docs.json`

## Breaking changes

- [ ] This PR contains breaking changes

None — prose-only `.mdx` edits, touching no API shape, env var, route or SDK signature.

## Migrations & env

- none

## How this was tested

Rerun: `open http://localhost:3000 signed in as admin@formbricks.com, then visit each page named below`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Pretty URLs table columns | manual | Settings → Organization → Domain: headers read `Survey Name`, `Workspace`, `Pretty URL`. Three, no environment column. |
| Datasets nav label | manual | Settings sidebar, ORGANIZATION group, reads `Datasets` (route `…/settings/feedback-directories`). |
| Delete all records exists | manual | Dataset → `Manage` modal footer: `Archive dataset` and `Delete all records`. |
| Delete all records is guarded | manual | Dialog says "This action cannot be undone", names every shared workspace, and demands the exact dataset name typed. |
| Webhooks link target | manual | `docs/platform/features/integrations/webhooks.mdx` exists and is the last page of the Integrations sidebar group. |
| Intro card hrefs | manual | All six point at the first page of a current `navigation.tabs` entry in `docs.json`. |

**Open gaps**

- I did not eyeball the rendered pages. The `<Warning>` block and the `layer-group` / `diagram-project` card icons rest on their use elsewhere in `docs/`.
- The Pretty URLs table was empty on the seeded instance; headers were observed, a populated row was not.
- The delete was observed up to the confirmation dialog. I did not execute it, so the async toast copy rests on `en-US.json`.

**Risks**

- The new card grid overlaps the Ask / Analyze / Act grid on `what-is-formbricks.mdx`. Intentional — different entry point, different card set.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.
