### PR TITLE
fix(settings): title each workspace settings tab with its own heading (ENG-2749)

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/(setup)/app-connection/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/(setup)/app-connection/page.tsx
@@ -1,3 +1,6 @@
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { AppConnectionPage } from "@/modules/workspaces/settings/(setup)/app-connection/page";
+
+export const generateMetadata = () => getSettingsPageMetadata("common.connect_your_app");
 
 export default AppConnectionPage;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/(setup)/user-actions/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/(setup)/user-actions/page.tsx
@@ -1,1 +1,5 @@
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
+
+export const generateMetadata = () => getSettingsPageMetadata("common.user_actions");
+
 export { UserActionsPage as default } from "@/modules/workspaces/settings/(setup)/user-actions/page";

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/general/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/general/page.tsx
@@ -1,3 +1,6 @@
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { GeneralSettingsPage } from "@/modules/workspaces/settings/general/page";
+
+export const generateMetadata = () => getSettingsPageMetadata("common.workspace_settings");
 
 export default GeneralSettingsPage;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/page.tsx
@@ -10,10 +10,14 @@ import { redactIntegrationCredentials } from "@/lib/integration/redact-credentia
 import { getIntegrations } from "@/lib/integration/service";
 import { getUserLocale } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { GoBackButton } from "@/modules/ui/components/go-back-button";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+
+export const generateMetadata = () =>
+  getSettingsPageMetadata("workspace.integrations.airtable.airtable_integration");
 
 const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
   const params = await props.params;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/page.tsx
@@ -13,10 +13,14 @@ import { redactIntegrationCredentials } from "@/lib/integration/redact-credentia
 import { getIntegrations } from "@/lib/integration/service";
 import { getUserLocale } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { GoBackButton } from "@/modules/ui/components/go-back-button";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+
+export const generateMetadata = () =>
+  getSettingsPageMetadata("workspace.integrations.google_sheets.google_sheets_integration");
 
 const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
   const params = await props.params;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/page.tsx
@@ -16,10 +16,14 @@ import { getNotionDatabases } from "@/lib/notion/service";
 import { getUserLocale } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
 import { getContactAttributeKeys } from "@/modules/ee/contacts/lib/contact-attribute-keys";
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { GoBackButton } from "@/modules/ui/components/go-back-button";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+
+export const generateMetadata = () =>
+  getSettingsPageMetadata("workspace.integrations.notion.notion_integration");
 
 const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
   const params = await props.params;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/page.tsx
@@ -17,10 +17,13 @@ import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getIntegrations } from "@/lib/integration/service";
 import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getTranslate } from "@/lingodotdev/server";
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { Card } from "@/modules/ui/components/integration-card";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+
+export const generateMetadata = () => getSettingsPageMetadata("common.integrations");
 
 const getStatusText = (count: number, t: TFunction, type: string) => {
   if (count === 1) return `1 ${type}`;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/slack/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/slack/page.tsx
@@ -7,10 +7,14 @@ import { redactIntegrationCredentials } from "@/lib/integration/redact-credentia
 import { getIntegrationByType } from "@/lib/integration/service";
 import { getUserLocale } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { GoBackButton } from "@/modules/ui/components/go-back-button";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+
+export const generateMetadata = () =>
+  getSettingsPageMetadata("workspace.integrations.slack.slack_integration");
 
 const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
   const params = await props.params;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/webhooks/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/webhooks/page.tsx
@@ -1,3 +1,6 @@
 import { WebhooksPage } from "@/modules/integrations/webhooks/page";
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
+
+export const generateMetadata = () => getSettingsPageMetadata("common.webhooks");
 
 export default WebhooksPage;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/languages/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/languages/page.tsx
@@ -1,3 +1,6 @@
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { LanguagesPage } from "@/modules/workspaces/settings/languages/page";
+
+export const generateMetadata = () => getSettingsPageMetadata("common.survey_languages");
 
 export default LanguagesPage;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/layout.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/layout.tsx
@@ -1,4 +1,3 @@
-import { WorkspaceSettingsLayout, metadata } from "@/modules/workspaces/settings/layout";
+import { WorkspaceSettingsLayout } from "@/modules/workspaces/settings/layout";
 
-export { metadata };
 export default WorkspaceSettingsLayout;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/look/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/look/page.tsx
@@ -1,3 +1,6 @@
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { WorkspaceLookSettingsPage } from "@/modules/workspaces/settings/look/page";
+
+export const generateMetadata = () => getSettingsPageMetadata("common.appearance");
 
 export default WorkspaceLookSettingsPage;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/tags/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/tags/page.tsx
@@ -1,3 +1,6 @@
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
 import { TagsPage } from "@/modules/workspaces/settings/tags/page";
+
+export const generateMetadata = () => getSettingsPageMetadata("common.tags");
 
 export default TagsPage;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/teams/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/teams/page.tsx
@@ -1,3 +1,6 @@
 import { WorkspaceTeams } from "@/modules/ee/teams/workspace-teams/page";
+import { getSettingsPageMetadata } from "@/modules/settings/lib/metadata";
+
+export const generateMetadata = () => getSettingsPageMetadata("common.team_access");
 
 export default WorkspaceTeams;

--- a/apps/web/modules/settings/lib/metadata.test.ts
+++ b/apps/web/modules/settings/lib/metadata.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getSettingsPageMetadata } from "./metadata";
+
+const translate = vi.fn();
+
+vi.mock("@/lingodotdev/server", () => ({
+  getTranslate: () => Promise.resolve(translate),
+}));
+
+describe("getSettingsPageMetadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("titles the tab with the translated heading", async () => {
+    translate.mockReturnValue("Tags");
+
+    const metadata = await getSettingsPageMetadata("common.tags");
+
+    expect(translate).toHaveBeenCalledWith("common.tags");
+    expect(metadata).toEqual({ title: "Tags" });
+  });
+
+  test("uses the translation as-is, so the tab matches what the page shows", async () => {
+    translate.mockReturnValue("Survey Languages");
+
+    const metadata = await getSettingsPageMetadata("common.survey_languages");
+
+    expect(metadata.title).toBe("Survey Languages");
+  });
+});

--- a/apps/web/modules/settings/lib/metadata.ts
+++ b/apps/web/modules/settings/lib/metadata.ts
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+import { getTranslate } from "@/lingodotdev/server";
+
+/**
+ * Browser tab title for a settings page: pass the same translation key the page renders as its
+ * heading, so the tab and the sidebar always say the same thing. Titles have to resolve per request
+ * because they are translated, which a static `metadata` object cannot do.
+ *
+ * Each settings page names itself rather than inheriting one title for the whole section. The
+ * section-wide title this replaced still said "Configuration" long after the UI stopped using that
+ * word anywhere — and it reached the product docs from there.
+ */
+export const getSettingsPageMetadata = async (headingKey: string): Promise<Metadata> => {
+  const t = await getTranslate();
+  return { title: t(headingKey) };
+};

--- a/apps/web/modules/workspaces/settings/layout.tsx
+++ b/apps/web/modules/workspaces/settings/layout.tsx
@@ -1,12 +1,7 @@
-import { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
-
-export const metadata: Metadata = {
-  title: "Configuration",
-};
 
 export const WorkspaceSettingsLayout = async (props: {
   params: Promise<{ workspaceId: string }>;

--- a/apps/web/playwright/settings-tags.spec.ts
+++ b/apps/web/playwright/settings-tags.spec.ts
@@ -45,6 +45,11 @@ test.describe("Workspace tags settings @slow", () => {
       waitUntil: "domcontentloaded",
     });
 
+    // The tab title used to come from one section-wide `metadata` that still said "Configuration" — a
+    // word the UI shows nowhere, and the phrase the product docs picked up from it. Each settings page
+    // now titles itself with the heading it renders, so assert the two agree on the way past.
+    await expect(page).toHaveTitle("Tags | Formbricks");
+
     // Rows are addressed by the id the API returned, and names are read with `toHaveValue`, which reads
     // the live value. An `input[value="…"]` selector would match the *attribute* instead — `fill()` never
     // updates that, so such a locator passes before a rename and fails after one for the wrong reason.


### PR DESCRIPTION
Fixes ENG-2749

## What & why

**Was:** every page under Settings → Workspace set the browser tab to `Configuration | Formbricks` — a word the UI shows nowhere, and where the docs got "Workspace Configuration" (ENG-2748 fixed those).

**Now:** each of the 13 pages titles its tab with the heading it renders — `Tags | Formbricks`, `Survey Languages | Formbricks`, and so on.

- One section-wide static `metadata` gives way to per-page `generateMetadata`, keyed to the same `t()` string as the page's `PageHeader`.
- No new i18n keys, so no locale file changes.

<details>
<summary>All 13 routes and their tab titles</summary>

| Route under `/workspaces/{id}/settings/workspace/` | Tab title | Key |
| --- | --- | --- |
| `general` | Workspace Settings | `common.workspace_settings` |
| `teams` | Team Access | `common.team_access` |
| `languages` | Survey Languages | `common.survey_languages` |
| `app-connection` | Connect Your App | `common.connect_your_app` |
| `integrations` | Integrations | `common.integrations` |
| `integrations/airtable` | Airtable Integration | `workspace.integrations.airtable.airtable_integration` |
| `integrations/google-sheets` | Google Sheets Integration | `workspace.integrations.google_sheets.google_sheets_integration` |
| `integrations/notion` | Notion Integration | `workspace.integrations.notion.notion_integration` |
| `integrations/slack` | Slack Integration | `workspace.integrations.slack.slack_integration` |
| `integrations/webhooks` | Webhooks | `common.webhooks` |
| `look` | Appearance | `common.appearance` |
| `user-actions` | User Actions | `common.user_actions` |
| `tags` | Tags | `common.tags` |

The two redirect-only segments (`settings`, `settings/workspace`) stay untitled — they never render.

</details>

## Where to look

- [modules/settings/lib/metadata.ts](https://github.com/formbricks/formbricks/blob/claude/xenodochial-davinci-104b49/apps/web/modules/settings/lib/metadata.ts) — the shared helper
- [modules/workspaces/settings/layout.tsx](https://github.com/formbricks/formbricks/blob/claude/xenodochial-davinci-104b49/apps/web/modules/workspaces/settings/layout.tsx) — stale section-wide title deleted
- [general/page.tsx](https://github.com/formbricks/formbricks/blob/claude/xenodochial-davinci-104b49/apps/web/app/%28app%29/workspaces/%5BworkspaceId%5D/settings/workspace/general/page.tsx) — titles its own heading, not the sidebar's "General"

## Breaking changes

- [ ] This PR contains breaking changes

None — a document `<title>` only: no API or SDK shape, route, env var, default or payload changes.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && node ../../node_modules/.bin/vitest run modules/settings/lib/metadata.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Tags tab title is the page's heading | e2e | `settings-tags.spec.ts` asserts `Tags \| Formbricks` on its existing navigation — green in CI |
| Helper titles the tab with the translated heading | unit (mutation) | `metadata.test.ts`; drop `t()` at `modules/settings/lib/metadata.ts:14` to turn it red |
| Next accepts all 13 `generateMetadata` exports | manual | compiled Next's generated `.next/types/validator.ts` — no errors |
| Every title key is its page's heading key | manual | read off each `PageHeader pageTitle`; mapping in the fold |

**Open gaps**

- Only the tags route is asserted end to end; the other 12 rest on the key reading.
- No screenshot: the changed surface is the tab string itself, which the e2e row asserts exactly.
- Org and account settings pages still title a bare "Formbricks" — recorded on ENG-2749.

**Risks**

- A future page under `/settings/workspace/` with no `generateMetadata` falls back to "Formbricks".

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code 2.1.246), reasoning effort `xhigh`.
