### PR TITLE
fix(ci): complete Linear releases independently of the Helm appVersion PR

### DIFF
--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -269,12 +269,14 @@ jobs:
     name: Mark Linear release as complete
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Shipped artifacts only. update-helm-app-version opens a follow-up PR against main
+    # rather than publishing anything for this tag, so gating completion on it left Linear
+    # stuck on every stable release the appVersion PR job failed.
     needs:
       - docker-build-community
       - docker-build-cloud
       - helm-chart-release
       - move-stable-tag
-      - update-helm-app-version
     if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Harden the runner
@@ -287,18 +289,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Stamp the in-progress release with the tag version before completing it.
-      # complete only looks up a release by version, it never assigns one, so a
-      # versioned sync must run first (Linear's recommended scheduled-pipeline flow).
+      # A versioned sync targets the release carrying this exact version, or creates it when
+      # none exists - which is what makes patch releases work, since 5.3.4 never had a
+      # planned train of its own. complete then looks that exact version up; it never
+      # assigns one, so the sync has to run first.
+      #
+      # VERSION is this release's tag with any v-prefix stripped and validated as SemVer by
+      # release-docker-github.yml. Using the raw tag_name instead would silently create a
+      # second, v-prefixed Linear release the first time somebody tags v5.6.0.
       - name: Stamp Linear release version
-        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b # v0.7.0
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
-          version: ${{ github.event.release.tag_name }}
+          version: ${{ needs.docker-build-community.outputs.VERSION }}
 
       - name: Complete Linear release
-        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b # v0.7.0
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: complete
-          version: ${{ github.event.release.tag_name }}
+          version: ${{ needs.docker-build-community.outputs.VERSION }}

--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -269,14 +269,20 @@ jobs:
     name: Mark Linear release as complete
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Shipped artifacts only. update-helm-app-version opens a follow-up PR against main
-    # rather than publishing anything for this tag, so gating completion on it left Linear
-    # stuck on every stable release the appVersion PR job failed.
+    # Published artifacts only, and only jobs that always run for a stable release.
+    #
+    # update-helm-app-version opens a follow-up PR against main rather than publishing
+    # anything for this tag, so gating completion on it left Linear stuck on every stable
+    # release its appVersion PR job failed.
+    #
+    # move-stable-tag is excluded for a subtler reason: its called job is gated on
+    # `!is_prerelease && make_latest`, so it is legitimately skipped for any stable release
+    # that is not the latest - every patch on an older line. A skipped dependency skips this
+    # job too, so depending on it would keep Linear stuck on exactly those releases.
     needs:
       - docker-build-community
       - docker-build-cloud
       - helm-chart-release
-      - move-stable-tag
     if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Harden the runner

--- a/.github/workflows/linear-release-smoke.yml
+++ b/.github/workflows/linear-release-smoke.yml
@@ -13,9 +13,10 @@ name: Linear Release Smoke
 # only exercised by a real published release.
 #
 # TRIGGERS ARE DELIBERATELY TRUSTED-ONLY. This job holds a Linear key that can mutate the
-# pipeline, so it must never run code from a pull request branch: `pull_request` runs the PR's
-# own copy of this file, so anyone who can push a branch could drop dry_run or add an
-# exfiltration step. main and manual dispatch are the only events allowed to hold the key.
+# pipeline, so it must never run code from outside main. `pull_request` would run the PR's own
+# copy of this file, and `workflow_dispatch` runs the copy on whichever ref the caller picks,
+# so either would let a pushed branch drop dry_run or add an exfiltration step. Hence: no
+# pull_request trigger, push restricted to main, and the ref check on the job below.
 on:
   workflow_dispatch:
     inputs:
@@ -39,6 +40,9 @@ jobs:
     name: Dry-run the Linear release flow
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Belt to the trigger's braces: a workflow_dispatch runs the file as it exists on the ref
+    # the caller chose, so the key must not be handed to a branch's copy of these steps.
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/linear-release-smoke.yml
+++ b/.github/workflows/linear-release-smoke.yml
@@ -1,14 +1,21 @@
 name: Linear Release Smoke
 
-# Dry-run of the Linear release flow. Nothing here mutates the pipeline: dry_run makes the
-# action scan commits and call read-only Linear APIs, then log the action it would have taken.
+# Dry-run canary for the Linear release flow. dry_run makes the action scan commits and call
+# read-only Linear APIs, then log the action it would have taken; it never mutates the pipeline.
 #
-# It exists because the real flow only runs on a published release, so a broken job graph or
-# a stale action pin stayed invisible until release day - which is how stable-release
-# completion silently skipped three releases in a row.
+# It exists because the real flow only runs on a published release, so a stale action pin or a
+# broken install stayed invisible until release day.
 #
-# So it runs on any pull request that touches the release flow, giving that PR a dry run of
-# the change it is making. Dispatch it by hand to check the pipeline at any other time.
+# WHAT THIS DOES NOT PROVE. The pinned CLI returns from its complete command before resolving a
+# release when dry_run is set, so a green run here says nothing about whether an exact version
+# resolves or completes - a nonexistent version passes too. Treat it as "the action installs,
+# authenticates and scans", not as validation of the release flow. Exact-version completion is
+# only exercised by a real published release.
+#
+# TRIGGERS ARE DELIBERATELY TRUSTED-ONLY. This job holds a Linear key that can mutate the
+# pipeline, so it must never run code from a pull request branch: `pull_request` runs the PR's
+# own copy of this file, so anyone who can push a branch could drop dry_run or add an
+# exfiltration step. main and manual dispatch are the only events allowed to hold the key.
 on:
   workflow_dispatch:
     inputs:
@@ -16,7 +23,9 @@ on:
         description: "Version to target (blank targets the active started release)"
         required: false
         type: string
-  pull_request:
+  push:
+    branches:
+      - main
     paths:
       - .github/workflows/linear-release.yml
       - .github/workflows/formbricks-release.yml
@@ -30,11 +39,6 @@ jobs:
     name: Dry-run the Linear release flow
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Fork pull requests get no access to LINEAR_ACCESS_KEY, so the dry run would fail on an
-    # empty key rather than tell anyone anything.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/linear-release-smoke.yml
+++ b/.github/workflows/linear-release-smoke.yml
@@ -7,9 +7,8 @@ name: Linear Release Smoke
 # a stale action pin stayed invisible until release day - which is how stable-release
 # completion silently skipped three releases in a row.
 #
-# The paths trigger is deliberate: workflow_dispatch only becomes available once a workflow is
-# on the default branch, so the push filter is what lets the commit introducing a change here
-# prove itself on a PR branch. After merge, dispatch it by hand whenever the flow changes.
+# So it runs on any pull request that touches the release flow, giving that PR a dry run of
+# the change it is making. Dispatch it by hand to check the pipeline at any other time.
 on:
   workflow_dispatch:
     inputs:
@@ -17,8 +16,10 @@ on:
         description: "Version to target (blank targets the active started release)"
         required: false
         type: string
-  push:
+  pull_request:
     paths:
+      - .github/workflows/linear-release.yml
+      - .github/workflows/formbricks-release.yml
       - .github/workflows/linear-release-smoke.yml
 
 permissions:
@@ -29,6 +30,11 @@ jobs:
     name: Dry-run the Linear release flow
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Fork pull requests get no access to LINEAR_ACCESS_KEY, so the dry run would fail on an
+    # empty key rather than tell anyone anything.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/linear-release-smoke.yml
+++ b/.github/workflows/linear-release-smoke.yml
@@ -1,0 +1,58 @@
+name: Linear Release Smoke
+
+# Dry-run of the Linear release flow. Nothing here mutates the pipeline: dry_run makes the
+# action scan commits and call read-only Linear APIs, then log the action it would have taken.
+#
+# It exists because the real flow only runs on a published release, so a broken job graph or
+# a stale action pin stayed invisible until release day - which is how stable-release
+# completion silently skipped three releases in a row.
+#
+# The paths trigger is deliberate: workflow_dispatch only becomes available once a workflow is
+# on the default branch, so the push filter is what lets the commit introducing a change here
+# prove itself on a PR branch. After merge, dispatch it by hand whenever the flow changes.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to target (blank targets the active started release)"
+        required: false
+        type: string
+  push:
+    paths:
+      - .github/workflows/linear-release-smoke.yml
+
+permissions:
+  contents: read
+
+jobs:
+  linear-release-smoke:
+    name: Dry-run the Linear release flow
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Dry-run the release sync
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ inputs.version }}
+          dry_run: "true"
+          log_level: verbose
+
+      - name: Dry-run the release completion
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: complete
+          version: ${{ inputs.version }}
+          dry_run: "true"
+          log_level: verbose

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -25,6 +25,6 @@ jobs:
           fetch-depth: 0
 
       - name: Sync Linear release
-        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b # v0.7.0
+        uses: linear/linear-release-action@17b8c24f8ceb2b98cabaf1965ff83c55dd596fac # v0.15.1
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}

--- a/docker/__tests__/release-workflows.test.ts
+++ b/docker/__tests__/release-workflows.test.ts
@@ -8,6 +8,8 @@ const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
 const workflowsDirectory = ".github/workflows";
 const linearSyncWorkflow = `${workflowsDirectory}/linear-release.yml`;
 const formbricksReleaseWorkflow = `${workflowsDirectory}/formbricks-release.yml`;
+const linearSmokeWorkflow = `${workflowsDirectory}/linear-release-smoke.yml`;
+const releaseWorkflows = [linearSyncWorkflow, formbricksReleaseWorkflow, linearSmokeWorkflow];
 
 const linearAction = "linear/linear-release-action";
 const linearActionSha = "17b8c24f8ceb2b98cabaf1965ff83c55dd596fac";
@@ -42,19 +44,20 @@ const linearSteps = (workflow: Workflow, jobId: string): WorkflowStep[] =>
   (workflow.jobs?.[jobId]?.steps ?? []).filter((step) => step.uses?.startsWith(`${linearAction}@`));
 
 describe("release workflows", () => {
-  test.each([linearSyncWorkflow, formbricksReleaseWorkflow])(
-    "%s parses as YAML and declares jobs",
-    (path) => {
-      expect(Object.keys(readWorkflow(path).jobs ?? {})).not.toHaveLength(0);
-    }
-  );
+  test.each(releaseWorkflows)("%s parses as YAML and declares jobs", (path) => {
+    expect(Object.keys(readWorkflow(path).jobs ?? {})).not.toHaveLength(0);
+  });
 
-  test.each([linearSyncWorkflow, formbricksReleaseWorkflow])(
-    "pins the Linear release action by commit SHA in %s",
-    (path) => {
-      expect(readText(path)).toContain(`${linearAction}@${linearActionSha} # ${linearActionVersion}`);
-    }
-  );
+  test.each(releaseWorkflows)("pins the Linear release action by commit SHA in %s", (path) => {
+    expect(readText(path)).toContain(`${linearAction}@${linearActionSha}`);
+  });
+
+  // Separate from the pin above so a drifted annotation and a drifted pin fail distinguishably.
+  // The annotation is worth asserting: this repo shipped a comment describing v0.15.1 behaviour
+  // next to a v0.7.0 pin for months, which is what hid the bug this test guards.
+  test.each(releaseWorkflows)("annotates that pin with its release tag in %s", (path) => {
+    expect(readText(path)).toContain(`${linearAction}@${linearActionSha} # ${linearActionVersion}`);
+  });
 
   test("uses no other ref of the Linear release action across the workflows", () => {
     const directory = join(repositoryRoot, workflowsDirectory);

--- a/docker/__tests__/release-workflows.test.ts
+++ b/docker/__tests__/release-workflows.test.ts
@@ -1,0 +1,109 @@
+import { load } from "js-yaml";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
+const workflowsDirectory = ".github/workflows";
+const linearSyncWorkflow = `${workflowsDirectory}/linear-release.yml`;
+const formbricksReleaseWorkflow = `${workflowsDirectory}/formbricks-release.yml`;
+
+const linearAction = "linear/linear-release-action";
+const linearActionSha = "17b8c24f8ceb2b98cabaf1965ff83c55dd596fac";
+const linearActionVersion = "v0.15.1";
+const releasedVersion = "${{ needs.docker-build-community.outputs.VERSION }}";
+
+type WorkflowStep = {
+  uses?: string;
+  with?: {
+    "fetch-depth"?: number;
+    access_key?: string;
+    command?: string;
+    dry_run?: string;
+    version?: string;
+  };
+};
+
+type WorkflowTriggers = { push?: { branches?: string[] } };
+
+type Workflow = {
+  jobs?: Record<string, { if?: string; needs?: string[]; steps?: WorkflowStep[] } | undefined>;
+  on?: WorkflowTriggers;
+  // js-yaml 3 resolved the YAML 1.1 truthy key `on:` to boolean `true`; 4.x keeps it a string.
+  true?: WorkflowTriggers;
+};
+
+const readText = (relativePath: string): string => readFileSync(join(repositoryRoot, relativePath), "utf8");
+
+const readWorkflow = (relativePath: string): Workflow => load(readText(relativePath)) as Workflow;
+
+const linearSteps = (workflow: Workflow, jobId: string): WorkflowStep[] =>
+  (workflow.jobs?.[jobId]?.steps ?? []).filter((step) => step.uses?.startsWith(`${linearAction}@`));
+
+describe("release workflows", () => {
+  test.each([linearSyncWorkflow, formbricksReleaseWorkflow])(
+    "%s parses as YAML and declares jobs",
+    (path) => {
+      expect(Object.keys(readWorkflow(path).jobs ?? {})).not.toHaveLength(0);
+    }
+  );
+
+  test.each([linearSyncWorkflow, formbricksReleaseWorkflow])(
+    "pins the Linear release action by commit SHA in %s",
+    (path) => {
+      expect(readText(path)).toContain(`${linearAction}@${linearActionSha} # ${linearActionVersion}`);
+    }
+  );
+
+  test("uses no other ref of the Linear release action across the workflows", () => {
+    const directory = join(repositoryRoot, workflowsDirectory);
+    const pattern = new RegExp(`${linearAction}@(\\S+)`, "g");
+    const refs = readdirSync(directory)
+      .filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml"))
+      .flatMap((entry) => [...readFileSync(join(directory, entry), "utf8").matchAll(pattern)])
+      .map((match) => match[1]);
+
+    expect([...new Set(refs)]).toEqual([linearActionSha]);
+  });
+
+  test("completes the Linear release once the shipped artifacts are published", () => {
+    const needs = readWorkflow(formbricksReleaseWorkflow).jobs?.["linear-release-complete"]?.needs;
+
+    expect(needs).toEqual(
+      expect.arrayContaining([
+        "docker-build-community",
+        "docker-build-cloud",
+        "helm-chart-release",
+        "move-stable-tag",
+      ])
+    );
+    // The Helm appVersion PR targets main, not the released tag, so it must not gate Linear completion.
+    expect(needs).not.toContain("update-helm-app-version");
+  });
+
+  test("stamps the released version on Linear before completing the release", () => {
+    const steps = linearSteps(readWorkflow(formbricksReleaseWorkflow), "linear-release-complete");
+
+    expect(steps.map((step) => step.with?.version)).toEqual([releasedVersion, releasedVersion]);
+    expect(steps.map((step) => step.with?.command)).toEqual([undefined, "complete"]);
+  });
+
+  test("skips the Linear completion for prereleases", () => {
+    expect(readWorkflow(formbricksReleaseWorkflow).jobs?.["linear-release-complete"]?.if).toBe(
+      "${{ !github.event.release.prerelease }}"
+    );
+  });
+
+  test("keeps the unversioned Linear sync on pushes to main", () => {
+    const workflow = readWorkflow(linearSyncWorkflow);
+    const checkout = workflow.jobs?.["linear-release"]?.steps?.find((step) =>
+      step.uses?.startsWith("actions/checkout@")
+    );
+
+    expect((workflow.on ?? workflow.true)?.push?.branches).toContain("main");
+    expect(checkout?.with?.["fetch-depth"]).toBe(0);
+    // No version input: this train is the started release that `command: complete` later looks up.
+    expect(linearSteps(workflow, "linear-release").map((step) => step.with?.version)).toEqual([undefined]);
+  });
+});

--- a/docker/__tests__/release-workflows.test.ts
+++ b/docker/__tests__/release-workflows.test.ts
@@ -94,6 +94,9 @@ describe("release workflows", () => {
     expect(needs).toEqual(
       expect.arrayContaining(["docker-build-community", "docker-build-cloud", "helm-chart-release"])
     );
+    // Exactly three, so a future non-publishing dependency cannot slip in and reintroduce the
+    // bug from a direction the named exclusions below do not anticipate.
+    expect(needs).toHaveLength(3);
     // Neither of these publishes anything for the released tag, and a skipped or failed
     // dependency skips this job, so either one gates Linear completion on unrelated work:
     // update-helm-app-version opens a follow-up PR against main and fails without its
@@ -103,16 +106,19 @@ describe("release workflows", () => {
     expect(needs).not.toContain("move-stable-tag");
   });
 
-  // The smoke job holds a pipeline-mutating Linear key, so it must not run a pull request
-  // branch's own copy of itself: that would let anyone who can push a branch drop dry_run or
-  // add an exfiltration step. Only main and manual dispatch may carry the key.
-  test("keeps the credentialed smoke dry-run off pull request branches", () => {
+  // The smoke job holds a pipeline-mutating Linear key, so it must only ever run main's copy of
+  // itself. Any path that executes a branch's copy - a pull request, or a dispatch aimed at that
+  // ref - would let whoever pushed it drop dry_run or add an exfiltration step.
+  test("only ever runs the credentialed smoke dry-run from main", () => {
     const workflow = readWorkflow(linearSmokeWorkflow);
     const triggers = workflow.on ?? workflow.true;
 
     expect(triggers).not.toHaveProperty("pull_request");
     expect(triggers).not.toHaveProperty("pull_request_target");
     expect(triggers?.push?.branches).toEqual(["main"]);
+    // workflow_dispatch runs the file as it exists on the caller's chosen ref, so the trigger
+    // list alone is not enough - the job itself has to refuse any ref but main.
+    expect(workflow.jobs?.["linear-release-smoke"]?.if).toBe("github.ref == 'refs/heads/main'");
   });
 
   test("stamps the released version on Linear before completing the release", () => {

--- a/docker/__tests__/release-workflows.test.ts
+++ b/docker/__tests__/release-workflows.test.ts
@@ -29,6 +29,7 @@ type WorkflowStep = {
 
 type WorkflowTriggers = {
   push?: { branches?: string[] };
+  workflow_dispatch?: unknown;
   pull_request?: unknown;
   pull_request_target?: unknown;
 };
@@ -116,6 +117,9 @@ describe("release workflows", () => {
     expect(triggers).not.toHaveProperty("pull_request");
     expect(triggers).not.toHaveProperty("pull_request_target");
     expect(triggers?.push?.branches).toEqual(["main"]);
+    // Required, not incidental: dispatch is the only way to check the pipeline between release
+    // flow changes, and dropping it would quietly remove that without failing anything else.
+    expect(triggers).toHaveProperty("workflow_dispatch");
     // workflow_dispatch runs the file as it exists on the caller's chosen ref, so the trigger
     // list alone is not enough - the job itself has to refuse any ref but main.
     expect(workflow.jobs?.["linear-release-smoke"]?.if).toBe("github.ref == 'refs/heads/main'");

--- a/docker/__tests__/release-workflows.test.ts
+++ b/docker/__tests__/release-workflows.test.ts
@@ -27,7 +27,11 @@ type WorkflowStep = {
   };
 };
 
-type WorkflowTriggers = { push?: { branches?: string[] } };
+type WorkflowTriggers = {
+  push?: { branches?: string[] };
+  pull_request?: unknown;
+  pull_request_target?: unknown;
+};
 
 type Workflow = {
   jobs?: Record<string, { if?: string; needs?: string[]; steps?: WorkflowStep[] } | undefined>;
@@ -84,19 +88,31 @@ describe("release workflows", () => {
     expect([...new Set(refs)]).toEqual([linearActionSha]);
   });
 
-  test("completes the Linear release once the shipped artifacts are published", () => {
+  test("completes the Linear release once the published artifacts are out", () => {
     const needs = readWorkflow(formbricksReleaseWorkflow).jobs?.["linear-release-complete"]?.needs;
 
     expect(needs).toEqual(
-      expect.arrayContaining([
-        "docker-build-community",
-        "docker-build-cloud",
-        "helm-chart-release",
-        "move-stable-tag",
-      ])
+      expect.arrayContaining(["docker-build-community", "docker-build-cloud", "helm-chart-release"])
     );
-    // The Helm appVersion PR targets main, not the released tag, so it must not gate Linear completion.
+    // Neither of these publishes anything for the released tag, and a skipped or failed
+    // dependency skips this job, so either one gates Linear completion on unrelated work:
+    // update-helm-app-version opens a follow-up PR against main and fails without its
+    // credentials, and move-stable-tag is skipped by design for any stable release that is
+    // not the latest - i.e. every patch on an older line.
     expect(needs).not.toContain("update-helm-app-version");
+    expect(needs).not.toContain("move-stable-tag");
+  });
+
+  // The smoke job holds a pipeline-mutating Linear key, so it must not run a pull request
+  // branch's own copy of itself: that would let anyone who can push a branch drop dry_run or
+  // add an exfiltration step. Only main and manual dispatch may carry the key.
+  test("keeps the credentialed smoke dry-run off pull request branches", () => {
+    const workflow = readWorkflow(linearSmokeWorkflow);
+    const triggers = workflow.on ?? workflow.true;
+
+    expect(triggers).not.toHaveProperty("pull_request");
+    expect(triggers).not.toHaveProperty("pull_request_target");
+    expect(triggers?.push?.branches).toEqual(["main"]);
   });
 
   test("stamps the released version on Linear before completing the release", () => {

--- a/docker/__tests__/release-workflows.test.ts
+++ b/docker/__tests__/release-workflows.test.ts
@@ -43,20 +43,34 @@ const readWorkflow = (relativePath: string): Workflow => load(readText(relativeP
 const linearSteps = (workflow: Workflow, jobId: string): WorkflowStep[] =>
   (workflow.jobs?.[jobId]?.steps ?? []).filter((step) => step.uses?.startsWith(`${linearAction}@`));
 
+const linearUses = (workflow: Workflow): string[] =>
+  Object.values(workflow.jobs ?? {})
+    .flatMap((job) => job?.steps ?? [])
+    .map((step) => step.uses)
+    .filter((uses): uses is string => uses?.startsWith(`${linearAction}@`) ?? false);
+
 describe("release workflows", () => {
   test.each(releaseWorkflows)("%s parses as YAML and declares jobs", (path) => {
     expect(Object.keys(readWorkflow(path).jobs ?? {})).not.toHaveLength(0);
   });
 
-  test.each(releaseWorkflows)("pins the Linear release action by commit SHA in %s", (path) => {
-    expect(readText(path)).toContain(`${linearAction}@${linearActionSha}`);
+  // Every use is checked, not just the first: formbricks-release.yml calls the action twice, so a
+  // `toContain` on the file text would let one correct use mask a second that had drifted.
+  test.each(releaseWorkflows)("pins every Linear release action use by commit SHA in %s", (path) => {
+    const uses = linearUses(readWorkflow(path));
+
+    expect(uses).not.toHaveLength(0);
+    expect(uses).toEqual(uses.map(() => `${linearAction}@${linearActionSha}`));
   });
 
-  // Separate from the pin above so a drifted annotation and a drifted pin fail distinguishably.
-  // The annotation is worth asserting: this repo shipped a comment describing v0.15.1 behaviour
-  // next to a v0.7.0 pin for months, which is what hid the bug this test guards.
-  test.each(releaseWorkflows)("annotates that pin with its release tag in %s", (path) => {
-    expect(readText(path)).toContain(`${linearAction}@${linearActionSha} # ${linearActionVersion}`);
+  // Separate from the pin above so a drifted annotation and a drifted pin fail distinguishably, and
+  // counted so one annotated line cannot vouch for an unannotated sibling. The annotation is worth
+  // asserting at all because this repo ran a v0.7.0 pin under a comment describing v0.15.1
+  // behaviour for months, which is the drift that hid the bug these tests guard.
+  test.each(releaseWorkflows)("annotates every pin with its release tag in %s", (path) => {
+    const annotated = readText(path).split(`${linearAction}@${linearActionSha} # ${linearActionVersion}`);
+
+    expect(annotated).toHaveLength(linearUses(readWorkflow(path)).length + 1);
   });
 
   test("uses no other ref of the Linear release action across the workflows", () => {


### PR DESCRIPTION
Fixes ENG-2475

## What & why

Stable releases shipped their Docker and Helm artifacts, then left the Linear release open. `linear-release-complete` gated itself on jobs that do not publish anything for the tag being released, and a failed *or skipped* dependency skips the dependent job. Two separate dependencies each did it:

- `update-helm-app-version` **fails** on every stable release, because `vars.HELM_APP_VERSION_PR_APP_CLIENT_ID` / `secrets.HELM_APP_VERSION_PR_APP_PRIVATE_KEY` are unset.
- `move-stable-tag`'s called job is **skipped by design** for any stable release that is not the latest — every patch on an older line — since it is gated on `!is_prerelease && make_latest`.

Observed, all with every artifact job green:

| Run | Version | `update-helm-app-version` | `move-stable-tag` | `linear-release-complete` |
| --- | --- | --- | --- | --- |
| [29918121071](https://github.com/formbricks/formbricks/actions/runs/29918121071) | 5.1.5 (stable, not latest) | failure | **skipped** | **skipped** |
| [31378131643](https://github.com/formbricks/formbricks/actions/runs/31378131643) | 5.3.3 | failure | — | **skipped** |
| [31487401618](https://github.com/formbricks/formbricks/actions/runs/31487401618) | 5.3.4 | failure | — | **skipped** |
| [32969368595](https://github.com/formbricks/formbricks/actions/runs/32969368595) | 5.4.0 | failure | — | **skipped** |

RC runs looked fine only because that job is gated on `!prerelease`.

**Where to look**

- `.github/workflows/formbricks-release.yml:275-286` — **Was:** `needs:` carried `update-helm-app-version` and `move-stable-tag`. **Now:** the three jobs that publish artifacts for this tag (`docker-build-community`, `docker-build-cloud`, `helm-chart-release`), all still required to succeed. Removal over a status override: an `always()`-style condition would have to keep distinguishing a by-design skip from a real failure, for the same outcome.
- `.github/workflows/formbricks-release.yml:310`, `:317` — **Was:** `version: ${{ github.event.release.tag_name }}`. **Now:** `version: ${{ needs.docker-build-community.outputs.VERSION }}`. Same tag, `v`-stripped and SemVer-validated by `release-docker-github.yml`, whose job is already in `needs:`, so the value cannot be empty or malformed. The raw tag would silently create a second, `v`-prefixed Linear release the first time someone tags `v5.6.0`.
- `.github/workflows/formbricks-release.yml:307`, `:314`, `.github/workflows/linear-release.yml:28` — **Was:** `@0353b5fa…  # v0.7.0`. **Now:** `@17b8c24f…  # v0.15.1`. The inline comment already described v0.15.1 semantics ("`complete` only looks up a release by version, it never assigns one") while the workflow ran v0.7.0. Under v0.15.1 a versioned sync targets that version *or creates it*, which is what makes patch releases work — `5.3.4` never had a planned train of its own.
- `.github/workflows/linear-release-smoke.yml` — new dry-run canary on `workflow_dispatch` and `push` to `main`. Deliberately **not** on `pull_request`: that event runs the PR branch's own copy of the workflow, so anyone able to push a branch could drop `dry_run` or add an exfiltration step and reach a pipeline-mutating Linear key. Its header states plainly what a green run does and does not prove.
- `docker/__tests__/release-workflows.test.ts` — new. Asserts the wiring, including both `needs` exclusions and the no-`pull_request` rule, so neither regression returns quietly.

### Linear state, reconciled separately

Already reconciled: the legacy catch-all (399 issues across several shipped versions) and the planned `5.2` / `5.3`, all canceled with descriptions preserved, no history deleted. `5.4.0` is now Released against tag commit `286958e`.

Its issue count is **not** clean 5.4.0 scope. The pipeline had no frozen stage when `release/5.4` was cut, so `main` commits landing after the cut kept syncing into the train — the count went 451 → 457 while this PR was being written. The GitHub release body is the accurate changelog for 5.4.0, not that issue list.

<details>
<summary>Branch-cut runbook — for the Notion Release QA handbook (@Dhruwang)</summary>

The pipeline needs a frozen stage, which cannot be created through the Linear API — release CRUD is exposed, release *stages* are not:

1. Linear → Settings → Release pipelines → **Formbricks** → add a stage named `Code Freeze`, type *started*, marked **frozen**.
2. At each `release/x.y` cut, move the current release to `Code Freeze` **before** starting the next train on `main`.

Skipping step 2 is what produced 5.4.0's inflated issue list: the train stayed open on `main` while the release branch was being prepared, so post-cut commits leaked into it.

</details>

## Breaking changes

- [ ] This PR contains breaking changes

None — CI wiring plus a test. No API, SDK, route, env var, config key or default changes; nothing outside this repo reaches any of it, and self-hosters consume none of these workflows. The new smoke-workflow input is optional, and `LINEAR_ACCESS_KEY` was already used by these workflows before this PR.

## Migrations & env

- none

Worth flagging but **not fixed here**: `HELM_APP_VERSION_PR_APP_CLIENT_ID` (repo variable) and `HELM_APP_VERSION_PR_APP_PRIVATE_KEY` (repo secret) are unset, which is why `update-helm-app-version` fails. After this PR that no longer blocks Linear completion, but the Helm appVersion PR still won't be opened until someone configures them.

## How this was tested

**Rerun:** `pnpm --filter @formbricks/docker test` — every row below is a test in `docker/__tests__/release-workflows.test.ts` and runs under that one command. Red-on-main rows were observed by running it with the workflow files at `origin/main`; mutation rows by editing the named `file:line`, rerunning, then `git checkout -- .github/workflows/`.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Completion not gated on the appVersion PR job | unit (red on main) | `completes the Linear release once the published artifacts are out` — on `main`: `expected [ 'docker-build-community', …(4) ] to not include 'update-helm-app-version'`. Green on this head. |
| Completion not gated on the conditionally-skipped stable-tag job | unit (mutation) | Same test. Re-adding `- move-stable-tag` to the `needs` list at `formbricks-release.yml:286` fails it: `expected [ 'docker-build-community', …(3) ] to not include 'move-stable-tag'`. Observed. |
| The credentialed dry-run never runs a PR branch's code | unit (mutation) | `keeps the credentialed smoke dry-run off pull request branches` — replacing `push:`/`branches: [main]` at `linear-release-smoke.yml:25-27` with `pull_request:` fails it: `expected { workflow_dispatch: …, …(1) } to not have property "pull_request"`. Observed. |
| Every Linear action use pinned to v0.15.1 by SHA | unit (red on main) | `pins every Linear release action use by commit SHA in %s`, 3 cases — on `main`: `expected … to contain 'linear/linear-release-action@17b8c24f…'`. Green on this head. |
| Each pin's `# v0.15.1` annotation matches its SHA | unit (mutation) | `annotates every pin with its release tag in %s` — changing the comment at `formbricks-release.yml:314` to `# v0.7.0` with the SHA untouched fails **only** this test, not the pin test. Observed. |
| One correct use cannot mask a second drifted one | unit (mutation) | Changing **only** the second use at `formbricks-release.yml:314` to the v0.7.0 SHA fails `pins every…`, `annotates every…` and `uses no other ref…`. Before this fix that mutation left both per-file assertions green — the hole it closes. Observed. |
| No stale ref of the action anywhere in `.github/workflows/` | unit (red on main) | `uses no other ref of the Linear release action across the workflows` — on `main`: `expected [ "0353b5fa…" ] to deeply equal [ "17b8c24f…" ]`. Set-equality over a directory scan, so it cannot pass vacuously. Green on this head. |
| Both steps target the released version; second is `command: complete` | unit (red on main) | `stamps the released version on Linear before completing the release` — on `main`: `expected [ "${{ github.event.release.tag_name }}", … ] to deeply equal [ "${{ needs.docker-build-community.outputs.VERSION }}", … ]`. Green on this head. |
| Prereleases still skip completion | unit (mutation) | `skips the Linear completion for prereleases` — guard; passes before and after the diff. Deleting the `if:` at `formbricks-release.yml:287` fails it. Observed. |
| Main-push train keeps syncing unversioned, full history | unit (mutation) | `keeps the unversioned Linear sync on pushes to main` — guard. Adding a `version:` under `linear-release.yml:28`'s step fails it; so does deleting `linear-release.yml:25` (`fetch-depth: 0`). Both observed. |
| The three workflows are valid YAML | unit (mutation) | `%s parses as YAML and declares jobs`, 3 cases — appending `\n  \tbroken: [` to `linear-release.yml` fails it. Observed. |

Full run on this head: 36 tests passed in the `@formbricks/docker` suite. Root `pnpm test` passed (26 turbo tasks, 8589 web tests); `pnpm lint` 0 errors; `pnpm format:check` clean.

**Open gaps**

- **Exact-version resolution and completion are not exercised anywhere before a real release.** The earlier PR-triggered dry run is gone (it reached a mutation-capable credential from any pushable branch), and it could not have proven this regardless: the pinned CLI returns from its complete command before resolving a release when `dry_run` is set, so even a nonexistent version passes. A controlled integration path would need its own non-production pipeline and credential plus teardown — a separate change, not improvised here. First real proof is the next published stable release.
- **The remaining dry-run canary proves only that the action installs, authenticates and scans.** It runs post-merge and on demand.
- **The real `main`-push sync is exercised by this PR's own merge**, not by the PR.
- **The frozen `Code Freeze` stage does not exist yet** and cannot be created through the Linear API — it needs the manual step in the fold above. Until it exists, the next branch cut will leak `main` commits into the release being prepared, exactly as 5.4.0 did.
- **The sync scan base is broken independently of this PR.** From the dry run, verbatim: *"None of the last 4 synced releases' commit SHAs exist in this repository's history. Syncing only the current commit until a scan base can be established… otherwise pass `--base-ref` to pin the scan range."* Stable releases are cut from `release/x.y`, so the tag commit stored as the baseline is never an ancestor of `main`, and each `main` push syncs only its own commit. That still feeds the train commit-by-commit, so it is not a regression here, but a `base_ref` follow-up is warranted.

**Risks**

- Linear completion can now run while `update-helm-app-version` is still failing, and while `move-stable-tag` was skipped. That is the intent — neither publishes anything for the released tag — and both remain independently visible in the run.
- The three artifact jobs are still hard dependencies, so a genuine publish failure still blocks completion.
- The smoke workflow holds `LINEAR_ACCESS_KEY` but runs only on `main` and manual dispatch, and is `dry_run` only.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.