### PR TITLE
fix(sso): stop Microsoft SSO failing when AZUREAD_TENANT_ID is a multi-tenant authority

### DIFF
--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -369,6 +369,26 @@ describe("better-auth SSO providers", () => {
     );
 
     /**
+     * The warning must not describe this as "treating it like unset". Unset resolves to `common`,
+     * which accepts personal accounts, so an operator who chose `organizations` to allow only
+     * work/school accounts would read that as having silently lost the restriction — while in fact
+     * only id_token verification is given up and the authority still applies at the authorize
+     * endpoint. Pinned because it is a deliberate wording decision, not incidental phrasing.
+     */
+    test("the tenant warning says the configured authority still applies, not that it is ignored", async () => {
+      await loadProviders({
+        ENTERPRISE_LICENSE_KEY: "lic",
+        AZURE_OAUTH_ENABLED: true,
+        AZUREAD_TENANT_ID: "organizations",
+      });
+
+      expect(loggerWarn).toHaveBeenCalledTimes(1);
+      const message = loggerWarn.mock.calls[0][0] as string;
+      expect(message).toContain("still applies");
+      expect(message).not.toMatch(/like unset|treated as unset/i);
+    });
+
+    /**
      * Every tenant whose discovery document carries a real issuer keeps the stronger discovery path.
      * `consumers` is the one that is easy to get wrong: it looks like a sibling of `common` and
      * `organizations`, but all personal Microsoft accounts live in one well-known MSA tenant, so its

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -329,22 +329,25 @@ describe("better-auth SSO providers", () => {
     });
 
     /**
-     * ENG-2750: the multi-tenant pseudo-tenants must NOT take the discovery branch. Their discovery
-     * documents advertise the literal `{tenantid}` template as `issuer`, which 1.7's literal `iss`
+     * ENG-2750: `common` and `organizations` must NOT take the discovery branch. Their discovery
+     * documents advertise the literal `{tenantid}` placeholder as `issuer`, which 1.7's literal `iss`
      * comparison can never match — with `AZUREAD_TENANT_ID=common` in the env (Cloud prod's config),
      * every Microsoft sign-in failed verification and landed on `?error=unable_to_get_user_info`.
-     * The pseudo-tenant is preserved in the endpoint URLs: `organizations`/`consumers` still restrict
-     * which account types Microsoft accepts at the authorize endpoint.
+     * The authority is preserved in the endpoint URLs: `organizations` still restricts which account
+     * types Microsoft accepts at the authorize endpoint.
+     *
+     * `consumers` is deliberately absent — it advertises a real issuer, so it belongs with the
+     * discovery cases below.
      */
     test.each([
       ["common", "common"],
       ["organizations", "organizations"],
-      ["consumers", "consumers"],
-      // Case-insensitive and trimmed: the value is an operator-typed env var.
-      ["Common", "Common"],
+      // Case-insensitive and trimmed (an operator-typed env var), and emitted in canonical lower case.
+      ["Common", "common"],
       [" common ", "common"],
+      ["ORGANIZATIONS", "organizations"],
     ])(
-      "Azure treats the pseudo-tenant %j like unset: explicit endpoints, no discovery",
+      "Azure treats the template-issuer authority %j like unset: explicit endpoints, no discovery",
       async (value, inUrl) => {
         const m = await loadProviders({
           ENTERPRISE_LICENSE_KEY: "lic",
@@ -361,29 +364,41 @@ describe("better-auth SSO providers", () => {
         expect(azure?.userInfoUrl).toBe("https://graph.microsoft.com/oidc/userinfo");
         // The operator set a value and is getting the weaker multi-tenant mode — that must be visible.
         expect(loggerWarn).toHaveBeenCalledTimes(1);
-        expect(loggerWarn.mock.calls[0][0]).toContain("pseudo-tenant");
+        expect(loggerWarn.mock.calls[0][0]).toContain("placeholder issuer");
       }
     );
 
-    // A verified-domain tenant is concrete: its discovery document carries a real issuer, so it keeps
-    // the stronger discovery path exactly like a GUID.
-    test("Azure uses discovery for a domain-style tenant", async () => {
+    /**
+     * Every tenant whose discovery document carries a real issuer keeps the stronger discovery path.
+     * `consumers` is the one that is easy to get wrong: it looks like a sibling of `common` and
+     * `organizations`, but all personal Microsoft accounts live in one well-known MSA tenant, so its
+     * discovery document names that tenant as the issuer and its id_tokens verify. Treating it as a
+     * placeholder authority would silently drop a check that works today.
+     */
+    test.each([
+      ["a verified domain", "contoso.onmicrosoft.com", "contoso.onmicrosoft.com"],
+      ["the personal-accounts authority", "consumers", "consumers"],
+      ["a mixed-case value, passed through unchanged", "Contoso.OnMicrosoft.com", "Contoso.OnMicrosoft.com"],
+    ])("Azure uses discovery for %s", async (_label, value, inUrl) => {
       const m = await loadProviders({
         ENTERPRISE_LICENSE_KEY: "lic",
         AZURE_OAUTH_ENABLED: true,
-        AZUREAD_TENANT_ID: "contoso.onmicrosoft.com",
+        AZUREAD_TENANT_ID: value,
       });
       const azure = m.ssoGenericOAuthConfig.find((c) => c.providerId === "azuread");
 
       expect(azure?.discoveryUrl).toBe(
-        "https://login.microsoftonline.com/contoso.onmicrosoft.com/v2.0/.well-known/openid-configuration"
+        `https://login.microsoftonline.com/${inUrl}/v2.0/.well-known/openid-configuration`
       );
       expect(azure?.authorizationUrl).toBeUndefined();
+      expect(azure?.tokenUrl).toBeUndefined();
     });
 
     test.each([
       ["unset", undefined],
+      ["whitespace only", "   "],
       ["a concrete tenant", "00000000-1111-2222-3333-444444444444"],
+      ["the personal-accounts authority", "consumers"],
     ])("Azure does not warn when the tenant is %s", async (_label, value) => {
       await loadProviders({
         ENTERPRISE_LICENSE_KEY: "lic",
@@ -391,6 +406,19 @@ describe("better-auth SSO providers", () => {
         AZUREAD_TENANT_ID: value,
       });
 
+      expect(loggerWarn).not.toHaveBeenCalled();
+    });
+
+    // The warning describes how Azure sign-in will behave, so it is pointless — and misleading — on an
+    // instance that registers no Azure provider at all. A leftover env value must stay quiet.
+    test("Azure does not warn about a template-issuer authority when Azure SSO is disabled", async () => {
+      const m = await loadProviders({
+        ENTERPRISE_LICENSE_KEY: "lic",
+        AZURE_OAUTH_ENABLED: false,
+        AZUREAD_TENANT_ID: "common",
+      });
+
+      expect(m.ssoGenericOAuthConfig.find((c) => c.providerId === "azuread")).toBeUndefined();
       expect(loggerWarn).not.toHaveBeenCalled();
     });
 

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -409,14 +409,17 @@ describe("better-auth SSO providers", () => {
       expect(loggerWarn).not.toHaveBeenCalled();
     });
 
-    // The warning describes how Azure sign-in will behave, so it is pointless — and misleading — on an
-    // instance that registers no Azure provider at all. A leftover env value must stay quiet.
-    test("Azure does not warn about a template-issuer authority when Azure SSO is disabled", async () => {
-      const m = await loadProviders({
-        ENTERPRISE_LICENSE_KEY: "lic",
-        AZURE_OAUTH_ENABLED: false,
-        AZUREAD_TENANT_ID: "common",
-      });
+    /**
+     * The warning describes how Azure sign-in will behave, so it is pointless — and misleading — on an
+     * instance that registers no Azure provider. Both cases below reach that state, and registration
+     * needs BOTH gates, so the warning has to check both too: an unlicensed instance with Azure
+     * credentials configured is just as provider-less as a licensed one with none.
+     */
+    test.each([
+      ["Azure SSO is disabled", { ENTERPRISE_LICENSE_KEY: "lic", AZURE_OAUTH_ENABLED: false }],
+      ["the instance is unlicensed", { ENTERPRISE_LICENSE_KEY: undefined, AZURE_OAUTH_ENABLED: true }],
+    ])("Azure does not warn about a template-issuer authority when %s", async (_label, overrides) => {
+      const m = await loadProviders({ ...overrides, AZUREAD_TENANT_ID: "common" });
 
       expect(m.ssoGenericOAuthConfig.find((c) => c.providerId === "azuread")).toBeUndefined();
       expect(loggerWarn).not.toHaveBeenCalled();

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -546,3 +546,117 @@ describe("better-auth SSO providers", () => {
     });
   });
 });
+
+/**
+ * Raised in review on #9017: setting `userInfoUrl` does not guarantee Better Auth calls it.
+ *
+ * `fetchUserInfo` opens with `decodeJwt(tokens.idToken)` — decode, not verify — and returns those
+ * claims whenever the token carries `sub` and `email`, never touching the userinfo endpoint. The
+ * explicit-endpoint branch deliberately has no `idToken` config, so nothing validates that token's
+ * signature, issuer or nonce, and we request the `email` scope, so a real Microsoft token takes the
+ * shortcut every time.
+ *
+ * These tests drive the provider Better Auth actually initialises rather than the config object,
+ * because the config object cannot show which of the two paths runs — asserting `userInfoUrl` is
+ * exactly the check that passed while the shortcut was live.
+ */
+describe("Azure identity comes from Graph, not an unverified id_token (#9017 review)", () => {
+  // An UNSIGNED token carrying the claims the shortcut looks for. If it is ever accepted, an
+  // attacker-supplied token would be too.
+  const forgedIdToken = `${Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")}.${Buffer.from(
+    JSON.stringify({ sub: "forged-subject", email: "attacker@evil.test", name: "Forged" })
+  ).toString("base64url")}.`;
+
+  const initializedAzureProvider = async (tenant?: string) => {
+    const m = await loadProviders({
+      ENTERPRISE_LICENSE_KEY: "lic",
+      AZURE_OAUTH_ENABLED: true,
+      AZUREAD_CLIENT_ID: "az-id",
+      AZUREAD_CLIENT_SECRET: "az-secret",
+      AZUREAD_TENANT_ID: tenant,
+    });
+    const { betterAuth } = await import("better-auth");
+    const { memoryAdapter } = await import("better-auth/adapters/memory");
+    const { genericOAuth } = await import("better-auth/plugins");
+    const auth = betterAuth({
+      baseURL: "https://app.formbricks.test",
+      secret: "sso-provider-contract-secret-0123456789",
+      database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+      plugins: [genericOAuth({ config: m.ssoGenericOAuthConfig })],
+    });
+    const ctx = await auth.$context;
+    return ctx.socialProviders.find((p) => p.id === "azuread");
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test.each([["common"], ["organizations"], [undefined]])(
+    "tenant %s: a forged id_token is never accepted as the identity",
+    async (tenant) => {
+      // Graph is unreachable, so the ONLY way to produce a profile is the unverified shortcut.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          throw new Error("graph unreachable");
+        })
+      );
+
+      const provider = await initializedAzureProvider(tenant);
+      const result = await provider?.getUserInfo?.({
+        accessToken: "access-token",
+        idToken: forgedIdToken,
+      } as never);
+
+      expect(result).toBeNull();
+    }
+  );
+
+  test("the identity is the Graph response, and Graph is actually called", async () => {
+    const graph = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ sub: "graph-subject", email: "real@corp.test", name: "Real User" }),
+    }));
+    vi.stubGlobal("fetch", graph);
+
+    const provider = await initializedAzureProvider("common");
+    const result = await provider?.getUserInfo?.({
+      accessToken: "access-token",
+      idToken: forgedIdToken,
+    } as never);
+
+    expect(graph).toHaveBeenCalledWith(
+      "https://graph.microsoft.com/oidc/userinfo",
+      expect.objectContaining({ headers: { Authorization: "Bearer access-token" } })
+    );
+    // The forged subject must not appear anywhere in the resolved identity.
+    expect(result?.user).toMatchObject({ email: "real@corp.test" });
+    expect(JSON.stringify(result)).not.toContain("forged-subject");
+    expect(JSON.stringify(result)).not.toContain("attacker@evil.test");
+  });
+
+  test("a Graph error fails the sign-in closed rather than falling back to the token", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 401, json: async () => ({}) }))
+    );
+
+    const provider = await initializedAzureProvider("common");
+    expect(await provider?.getUserInfo?.({ accessToken: "t", idToken: forgedIdToken } as never)).toBeNull();
+  });
+
+  // The concrete-tenant branch keeps discovery, where Better Auth verifies the id_token before any
+  // profile is resolved — so it is intentionally left on the default path.
+  test("a concrete tenant still uses discovery, not the Graph override", async () => {
+    const m = await loadProviders({
+      ENTERPRISE_LICENSE_KEY: "lic",
+      AZURE_OAUTH_ENABLED: true,
+      AZUREAD_TENANT_ID: "00000000-1111-2222-3333-444444444444",
+    });
+    const azure = m.ssoGenericOAuthConfig.find((c) => c.providerId === "azuread");
+
+    expect(azure?.getUserInfo).toBeUndefined();
+    expect(azure?.discoveryUrl).toBeDefined();
+  });
+});

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -6,6 +6,10 @@ import { PINNED_SSO_PROVIDER_IDS } from "@/modules/auth/lib/legacy-sso-callback"
 const { captureSsoIdentity } = vi.hoisted(() => ({ captureSsoIdentity: vi.fn() }));
 vi.mock("./sso-request-context", () => ({ captureSsoIdentity }));
 
+// The module warns at import time when a pseudo-tenant is configured (ENG-2750); capture it.
+const { loggerWarn } = vi.hoisted(() => ({ loggerWarn: vi.fn() }));
+vi.mock("@formbricks/logger", () => ({ logger: { warn: loggerWarn } }));
+
 // The pinned SSO callback URL is built from `getAuthIssuerUrl()`, which reads `@/lib/env` directly rather
 // than the constants mocked below — it has to, because that helper encodes Better Auth's own base-URL
 // precedence (`BETTER_AUTH_URL ?? NEXTAUTH_URL ?? WEBAPP_URL`). Spread the real env so `@/lib/constants`
@@ -85,6 +89,7 @@ const callMapper = (mapper: unknown, profile: Record<string, unknown>): { email?
 
 beforeEach(() => {
   captureSsoIdentity.mockClear();
+  loggerWarn.mockClear();
 });
 
 afterEach(() => {
@@ -321,6 +326,72 @@ describe("better-auth SSO providers", () => {
       );
       expect(azure?.authorizationUrl).toBeUndefined();
       expect(azure?.tokenUrl).toBeUndefined();
+    });
+
+    /**
+     * ENG-2750: the multi-tenant pseudo-tenants must NOT take the discovery branch. Their discovery
+     * documents advertise the literal `{tenantid}` template as `issuer`, which 1.7's literal `iss`
+     * comparison can never match — with `AZUREAD_TENANT_ID=common` in the env (Cloud prod's config),
+     * every Microsoft sign-in failed verification and landed on `?error=unable_to_get_user_info`.
+     * The pseudo-tenant is preserved in the endpoint URLs: `organizations`/`consumers` still restrict
+     * which account types Microsoft accepts at the authorize endpoint.
+     */
+    test.each([
+      ["common", "common"],
+      ["organizations", "organizations"],
+      ["consumers", "consumers"],
+      // Case-insensitive and trimmed: the value is an operator-typed env var.
+      ["Common", "Common"],
+      [" common ", "common"],
+    ])(
+      "Azure treats the pseudo-tenant %j like unset: explicit endpoints, no discovery",
+      async (value, inUrl) => {
+        const m = await loadProviders({
+          ENTERPRISE_LICENSE_KEY: "lic",
+          AZURE_OAUTH_ENABLED: true,
+          AZUREAD_TENANT_ID: value,
+        });
+        const azure = m.ssoGenericOAuthConfig.find((c) => c.providerId === "azuread");
+
+        expect(azure?.discoveryUrl).toBeUndefined();
+        expect(azure?.authorizationUrl).toBe(
+          `https://login.microsoftonline.com/${inUrl}/oauth2/v2.0/authorize`
+        );
+        expect(azure?.tokenUrl).toBe(`https://login.microsoftonline.com/${inUrl}/oauth2/v2.0/token`);
+        expect(azure?.userInfoUrl).toBe("https://graph.microsoft.com/oidc/userinfo");
+        // The operator set a value and is getting the weaker multi-tenant mode — that must be visible.
+        expect(loggerWarn).toHaveBeenCalledTimes(1);
+        expect(loggerWarn.mock.calls[0][0]).toContain("pseudo-tenant");
+      }
+    );
+
+    // A verified-domain tenant is concrete: its discovery document carries a real issuer, so it keeps
+    // the stronger discovery path exactly like a GUID.
+    test("Azure uses discovery for a domain-style tenant", async () => {
+      const m = await loadProviders({
+        ENTERPRISE_LICENSE_KEY: "lic",
+        AZURE_OAUTH_ENABLED: true,
+        AZUREAD_TENANT_ID: "contoso.onmicrosoft.com",
+      });
+      const azure = m.ssoGenericOAuthConfig.find((c) => c.providerId === "azuread");
+
+      expect(azure?.discoveryUrl).toBe(
+        "https://login.microsoftonline.com/contoso.onmicrosoft.com/v2.0/.well-known/openid-configuration"
+      );
+      expect(azure?.authorizationUrl).toBeUndefined();
+    });
+
+    test.each([
+      ["unset", undefined],
+      ["a concrete tenant", "00000000-1111-2222-3333-444444444444"],
+    ])("Azure does not warn when the tenant is %s", async (_label, value) => {
+      await loadProviders({
+        ENTERPRISE_LICENSE_KEY: "lic",
+        AZURE_OAUTH_ENABLED: true,
+        AZUREAD_TENANT_ID: value,
+      });
+
+      expect(loggerWarn).not.toHaveBeenCalled();
     });
 
     test("Azure mapProfileToUser resolves the display name through its fallback chain", async () => {

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.ts
@@ -211,6 +211,62 @@ const ssoAccountSubject =
  * and take Azure sign-in down, which is the outcome this split exists to avoid.
  */
 const AZURE_TEMPLATE_ISSUER_TENANTS = new Set(["common", "organizations"]);
+
+const MICROSOFT_GRAPH_USERINFO_URL = "https://graph.microsoft.com/oidc/userinfo";
+
+/**
+ * Resolve the signed-in identity from Microsoft Graph, always (raised in review on #9017).
+ *
+ * Setting `userInfoUrl` is NOT enough to guarantee Graph is called. Better Auth's default
+ * `fetchUserInfo` opens with an unverified shortcut
+ * (`better-auth/dist/plugins/generic-oauth/index.mjs`):
+ *
+ * ```js
+ * if (tokens.idToken) try {
+ *   const decoded = decodeJwt(tokens.idToken);          // decode, NOT verify
+ *   if (decoded?.sub && decoded?.email) return { id: decoded.sub, ...decoded };
+ * } catch {}
+ * if (!userInfoUrl) return null;                        // only reached when the shortcut misses
+ * ```
+ *
+ * On the explicit-endpoint branch no `idToken` config exists — that is the whole point of skipping
+ * discovery — so the verification step in `getUserInfo` is a no-op and nothing checks that token's
+ * signature, issuer or nonce. We request the `email` scope, so a real Microsoft id_token carries both
+ * `sub` and `email` and takes the shortcut every time. Identity would come from an unverified JWT
+ * while the comments, the startup warning and the docs all promised it came from Graph.
+ *
+ * `c.getUserInfo` takes precedence over `fetchUserInfo` in that same file, so supplying it is how the
+ * promise is kept. The access token authenticates the call, and it reached us over the
+ * client-authenticated token exchange.
+ *
+ * Fails CLOSED: a non-OK response, an unparseable body, or a missing `sub` returns null, which Better
+ * Auth turns into a failed sign-in rather than a partially-trusted identity. `sub` specifically,
+ * because `accountSubject` pins the account key to it — inventing a fallback is how the wrong account
+ * gets linked.
+ */
+const microsoftGraphUserInfo = async (tokens: {
+  accessToken?: string;
+}): Promise<GenericOAuthUserInfo | null> => {
+  if (!tokens.accessToken) return null;
+  try {
+    const response = await fetch(MICROSOFT_GRAPH_USERINFO_URL, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${tokens.accessToken}` },
+    });
+    if (!response.ok) return null;
+    const profile = (await response.json()) as GenericOAuthUserInfo;
+    if (!profile?.sub) return null;
+    return {
+      ...profile,
+      // Strictly `=== true`, not Better Auth's `?? false`: this flag is a claim from the provider that
+      // feeds provisioning, so anything that is not an explicit boolean true is treated as unverified.
+      emailVerified: profile.email_verified === true,
+      image: typeof profile.picture === "string" ? profile.picture : undefined,
+    };
+  } catch {
+    return null;
+  }
+};
 // Unset behaves exactly like `common`: Microsoft's multi-tenant authority, and the documented default.
 const azureTenant = AZUREAD_TENANT_ID?.trim() || "common";
 const isAzureTemplateIssuerTenant = AZURE_TEMPLATE_ISSUER_TENANTS.has(azureTenant.toLowerCase());
@@ -238,7 +294,10 @@ const azureEndpoints = isAzureTemplateIssuerTenant
   ? {
       authorizationUrl: `https://login.microsoftonline.com/${azureAuthority}/oauth2/v2.0/authorize`,
       tokenUrl: `https://login.microsoftonline.com/${azureAuthority}/oauth2/v2.0/token`,
-      userInfoUrl: "https://graph.microsoft.com/oidc/userinfo",
+      userInfoUrl: MICROSOFT_GRAPH_USERINFO_URL,
+      // Not redundant with `userInfoUrl` — see microsoftGraphUserInfo. The URL alone leaves Better
+      // Auth's unverified-id_token shortcut in play; this is what actually forces the Graph call.
+      getUserInfo: microsoftGraphUserInfo,
     }
   : {
       discoveryUrl: `https://login.microsoftonline.com/${azureAuthority}/v2.0/.well-known/openid-configuration`,

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type { BetterAuthOptions } from "better-auth";
 import type { GenericOAuthConfig, GenericOAuthUserInfo } from "better-auth/plugins";
+import { logger } from "@formbricks/logger";
 import {
   AZUREAD_CLIENT_ID,
   AZUREAD_CLIENT_SECRET,
@@ -174,20 +175,37 @@ const ssoAccountSubject =
  * has not set it, and drop support for genuinely multi-tenant app registrations, which have no single
  * issuer by construction — the tenant decides the mechanism:
  *
- * - **Concrete tenant**: keep `discoveryUrl`. The discovered issuer is a real value, so the id_token is
- *   fully verified. Strictly stronger than 1.6.
- * - **`common`**: configure the endpoints explicitly and skip discovery, so no `idTokenConfig` is built
+ * - **Concrete tenant** (a directory GUID, or a verified domain like `contoso.onmicrosoft.com`): keep
+ *   `discoveryUrl`. The discovered issuer is a real value, so the id_token is fully verified. Strictly
+ *   stronger than 1.6.
+ * - **Unset, or a multi-tenant pseudo-tenant (`common` / `organizations` / `consumers`, ENG-2750)**:
+ *   configure the endpoints explicitly and skip discovery, so no `idTokenConfig` is built
  *   (`generic-oauth/index.mjs` only constructs it inside the discovery branch) and identity comes from
  *   UserInfo — the 1.6 behaviour, over a client-authenticated back-channel call to Microsoft. Note this
  *   is not where the code flow's security lives: that is `state` + PKCE and the authenticated code
  *   exchange, and RFC 9207 mix-up defence still applies via `iss` on the authorization response when a
  *   provider sends one.
  *
- * Deliberately NOT setting `requireIdTokenVerification`: on the `common` path it would throw at init and
- * take Azure sign-in down, which is the outcome this split exists to avoid.
+ * The pseudo-tenants must not take the discovery branch because their discovery documents advertise the
+ * literal `{tenantid}` template as `issuer` — Microsoft's guidance is to substitute the token's `tid`,
+ * which a literal comparison can never satisfy — so every sign-in would fail verification and land on
+ * `?error=unable_to_get_user_info`. That is exactly how ENG-2750 took Microsoft SSO down on Cloud: prod
+ * had `AZUREAD_TENANT_ID=common`, harmless on 1.6, a full outage on 1.7. The pseudo-tenant is still kept
+ * in the endpoint URLs, because `organizations` / `consumers` meaningfully restrict which account types
+ * Microsoft accepts at the authorize endpoint.
+ *
+ * Deliberately NOT setting `requireIdTokenVerification`: on the multi-tenant path it would throw at init
+ * and take Azure sign-in down, which is the outcome this split exists to avoid.
  */
-const azureTenant = AZUREAD_TENANT_ID || "common";
-const azureEndpoints = AZUREAD_TENANT_ID
+const AZURE_PSEUDO_TENANTS = new Set(["common", "organizations", "consumers"]);
+const azureTenant = AZUREAD_TENANT_ID?.trim() || "common";
+const isConcreteAzureTenant = !AZURE_PSEUDO_TENANTS.has(azureTenant.toLowerCase());
+if (AZUREAD_TENANT_ID?.trim() && !isConcreteAzureTenant) {
+  logger.warn(
+    `AZUREAD_TENANT_ID="${azureTenant}" is a multi-tenant pseudo-tenant; treating it like unset — identity comes from the userinfo endpoint and id_tokens are not verified. Set a Directory (tenant) ID for full id_token verification.`
+  );
+}
+const azureEndpoints = isConcreteAzureTenant
   ? {
       discoveryUrl: `https://login.microsoftonline.com/${azureTenant}/v2.0/.well-known/openid-configuration`,
     }

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.ts
@@ -220,6 +220,10 @@ const azureAuthority = isAzureTemplateIssuerTenant ? azureTenant.toLowerCase() :
 // Only worth saying when Azure SSO is actually registered — which needs BOTH gates below, mirroring
 // `ssoGenericOAuthConfig`'s own conditions — and only when the operator set the value themselves, since
 // an unset var takes this same path by design and needs no warning.
+//
+// The wording deliberately avoids "treating it like unset": an operator who set `organizations` would
+// read that as having lost their work/school-only restriction, which still applies at the authorize
+// endpoint. Only id_token verification is given up.
 if (
   ENTERPRISE_LICENSE_KEY &&
   AZURE_OAUTH_ENABLED &&
@@ -227,7 +231,7 @@ if (
   isAzureTemplateIssuerTenant
 ) {
   logger.warn(
-    `AZUREAD_TENANT_ID="${azureTenant}" names a Microsoft multi-tenant authority whose discovery document advertises a placeholder issuer, so id_tokens cannot be verified against it. Treating it like unset: sign-in identity comes from the userinfo endpoint. Set a Directory (tenant) ID for full id_token verification.`
+    `AZUREAD_TENANT_ID="${azureTenant}" names a Microsoft multi-tenant authority whose discovery document advertises a placeholder issuer, so id_tokens cannot be verified against it. Skipping discovery for this provider and taking identity from the userinfo endpoint; the authority you configured still applies at sign-in. Set a Directory (tenant) ID for full id_token verification.`
   );
 }
 const azureEndpoints = isAzureTemplateIssuerTenant

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.ts
@@ -217,9 +217,15 @@ const isAzureTemplateIssuerTenant = AZURE_TEMPLATE_ISSUER_TENANTS.has(azureTenan
 // A template-issuer authority is one of two known literals, so emit its canonical lower-case form; a
 // concrete tenant is passed through exactly as the operator configured it.
 const azureAuthority = isAzureTemplateIssuerTenant ? azureTenant.toLowerCase() : azureTenant;
-// Only worth saying when Azure SSO is actually registered, and only when the operator set the value
-// themselves — an unset var takes this same path by design and needs no warning.
-if (AZURE_OAUTH_ENABLED && AZUREAD_TENANT_ID?.trim() && isAzureTemplateIssuerTenant) {
+// Only worth saying when Azure SSO is actually registered — which needs BOTH gates below, mirroring
+// `ssoGenericOAuthConfig`'s own conditions — and only when the operator set the value themselves, since
+// an unset var takes this same path by design and needs no warning.
+if (
+  ENTERPRISE_LICENSE_KEY &&
+  AZURE_OAUTH_ENABLED &&
+  AZUREAD_TENANT_ID?.trim() &&
+  isAzureTemplateIssuerTenant
+) {
   logger.warn(
     `AZUREAD_TENANT_ID="${azureTenant}" names a Microsoft multi-tenant authority whose discovery document advertises a placeholder issuer, so id_tokens cannot be verified against it. Treating it like unset: sign-in identity comes from the userinfo endpoint. Set a Directory (tenant) ID for full id_token verification.`
   );

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.ts
@@ -175,44 +175,63 @@ const ssoAccountSubject =
  * has not set it, and drop support for genuinely multi-tenant app registrations, which have no single
  * issuer by construction — the tenant decides the mechanism:
  *
- * - **Concrete tenant** (a directory GUID, or a verified domain like `contoso.onmicrosoft.com`): keep
- *   `discoveryUrl`. The discovered issuer is a real value, so the id_token is fully verified. Strictly
- *   stronger than 1.6.
- * - **Unset, or a multi-tenant pseudo-tenant (`common` / `organizations` / `consumers`, ENG-2750)**:
- *   configure the endpoints explicitly and skip discovery, so no `idTokenConfig` is built
+ * - **A tenant whose discovery document carries a real issuer** — a directory GUID, a verified domain
+ *   like `contoso.onmicrosoft.com`, **or `consumers`** (see the table below): keep `discoveryUrl`. The
+ *   discovered issuer is a real value, so the id_token is fully verified. Strictly stronger than 1.6.
+ * - **Unset, or a template-issuer authority (`common` / `organizations`, ENG-2750)**: configure the
+ *   endpoints explicitly and skip discovery, so no `idTokenConfig` is built
  *   (`generic-oauth/index.mjs` only constructs it inside the discovery branch) and identity comes from
  *   UserInfo — the 1.6 behaviour, over a client-authenticated back-channel call to Microsoft. Note this
  *   is not where the code flow's security lives: that is `state` + PKCE and the authenticated code
  *   exchange, and RFC 9207 mix-up defence still applies via `iss` on the authorization response when a
  *   provider sends one.
  *
- * The pseudo-tenants must not take the discovery branch because their discovery documents advertise the
- * literal `{tenantid}` template as `issuer` — Microsoft's guidance is to substitute the token's `tid`,
- * which a literal comparison can never satisfy — so every sign-in would fail verification and land on
- * `?error=unable_to_get_user_info`. That is exactly how ENG-2750 took Microsoft SSO down on Cloud: prod
- * had `AZUREAD_TENANT_ID=common`, harmless on 1.6, a full outage on 1.7. The pseudo-tenant is still kept
- * in the endpoint URLs, because `organizations` / `consumers` meaningfully restrict which account types
- * Microsoft accepts at the authorize endpoint.
+ * Which of Microsoft's three multi-tenant authorities can be verified is NOT uniform, and guessing it
+ * wrong costs either an outage or a silently weakened check. Read live from each
+ * `/{authority}/v2.0/.well-known/openid-configuration`:
+ *
+ * | authority | advertised `issuer` | verifiable? |
+ * | --- | --- | --- |
+ * | `common` | `https://login.microsoftonline.com/{tenantid}/v2.0` | no — placeholder |
+ * | `organizations` | `https://login.microsoftonline.com/{tenantid}/v2.0` | no — placeholder |
+ * | `consumers` | `https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0` | **yes** |
+ *
+ * `consumers` is the odd one out: personal Microsoft accounts all live in that one well-known MSA tenant,
+ * so its discovery document names a real issuer and every id_token it mints matches. It therefore stays
+ * on the discovery branch and keeps full verification — moving it here would drop a check that works.
+ *
+ * `common` and `organizations` must not take the discovery branch: Microsoft's guidance is to substitute
+ * the token's `tid` into that placeholder, which a literal `iss` comparison can never satisfy, so every
+ * sign-in fails verification and lands on `?error=unable_to_get_user_info`. That is exactly how ENG-2750
+ * took Microsoft SSO down on Cloud — prod had `AZUREAD_TENANT_ID=common`, harmless on 1.6, a full outage
+ * on 1.7. The authority is still kept in the endpoint URLs, because `organizations` meaningfully
+ * restricts which account types Microsoft accepts at the authorize endpoint.
  *
  * Deliberately NOT setting `requireIdTokenVerification`: on the multi-tenant path it would throw at init
  * and take Azure sign-in down, which is the outcome this split exists to avoid.
  */
-const AZURE_PSEUDO_TENANTS = new Set(["common", "organizations", "consumers"]);
+const AZURE_TEMPLATE_ISSUER_TENANTS = new Set(["common", "organizations"]);
+// Unset behaves exactly like `common`: Microsoft's multi-tenant authority, and the documented default.
 const azureTenant = AZUREAD_TENANT_ID?.trim() || "common";
-const isConcreteAzureTenant = !AZURE_PSEUDO_TENANTS.has(azureTenant.toLowerCase());
-if (AZUREAD_TENANT_ID?.trim() && !isConcreteAzureTenant) {
+const isAzureTemplateIssuerTenant = AZURE_TEMPLATE_ISSUER_TENANTS.has(azureTenant.toLowerCase());
+// A template-issuer authority is one of two known literals, so emit its canonical lower-case form; a
+// concrete tenant is passed through exactly as the operator configured it.
+const azureAuthority = isAzureTemplateIssuerTenant ? azureTenant.toLowerCase() : azureTenant;
+// Only worth saying when Azure SSO is actually registered, and only when the operator set the value
+// themselves — an unset var takes this same path by design and needs no warning.
+if (AZURE_OAUTH_ENABLED && AZUREAD_TENANT_ID?.trim() && isAzureTemplateIssuerTenant) {
   logger.warn(
-    `AZUREAD_TENANT_ID="${azureTenant}" is a multi-tenant pseudo-tenant; treating it like unset — identity comes from the userinfo endpoint and id_tokens are not verified. Set a Directory (tenant) ID for full id_token verification.`
+    `AZUREAD_TENANT_ID="${azureTenant}" names a Microsoft multi-tenant authority whose discovery document advertises a placeholder issuer, so id_tokens cannot be verified against it. Treating it like unset: sign-in identity comes from the userinfo endpoint. Set a Directory (tenant) ID for full id_token verification.`
   );
 }
-const azureEndpoints = isConcreteAzureTenant
+const azureEndpoints = isAzureTemplateIssuerTenant
   ? {
-      discoveryUrl: `https://login.microsoftonline.com/${azureTenant}/v2.0/.well-known/openid-configuration`,
+      authorizationUrl: `https://login.microsoftonline.com/${azureAuthority}/oauth2/v2.0/authorize`,
+      tokenUrl: `https://login.microsoftonline.com/${azureAuthority}/oauth2/v2.0/token`,
+      userInfoUrl: "https://graph.microsoft.com/oidc/userinfo",
     }
   : {
-      authorizationUrl: `https://login.microsoftonline.com/${azureTenant}/oauth2/v2.0/authorize`,
-      tokenUrl: `https://login.microsoftonline.com/${azureTenant}/oauth2/v2.0/token`,
-      userInfoUrl: "https://graph.microsoft.com/oidc/userinfo",
+      discoveryUrl: `https://login.microsoftonline.com/${azureAuthority}/v2.0/.well-known/openid-configuration`,
     };
 
 export const ssoGenericOAuthConfig: GenericOAuthConfig[] = ENTERPRISE_LICENSE_KEY

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -242,14 +242,17 @@ Better Auth 1.7 verifies Microsoft id_tokens against the issuer advertised by th
 discovery document whenever `AZUREAD_TENANT_ID` names a concrete tenant — a Directory (tenant) ID GUID or
 a verified domain. That is strictly stronger than v5.3 and needs no action.
 
-Microsoft's multi-tenant pseudo-tenants — `common`, `organizations`, `consumers` — are different: their
-discovery documents advertise the literal placeholder `https://login.microsoftonline.com/{tenantid}/v2.0`
-as the issuer, so verifying real tokens against it fails every Microsoft sign-in with
-`?error=unable_to_get_user_info`. Formbricks therefore treats these three values exactly like an unset
-`AZUREAD_TENANT_ID`: sign-in identity comes from Microsoft's userinfo endpoint over a
-client-authenticated call (the v5.3 behavior) and id_tokens are not verified, while the configured value
-still restricts which account types Microsoft accepts. A warning is logged at startup when one of these
-values is set. To get full id_token verification, set your Directory (tenant) ID instead.
+Two of Microsoft's multi-tenant authorities are different. `common` and `organizations` advertise the
+literal placeholder `https://login.microsoftonline.com/{tenantid}/v2.0` as their issuer, so verifying
+real tokens against it fails every Microsoft sign-in with `?error=unable_to_get_user_info`. Formbricks
+therefore treats those two values exactly like an unset `AZUREAD_TENANT_ID`: sign-in identity comes from
+Microsoft's userinfo endpoint over a client-authenticated call (the v5.3 behavior) and id_tokens are not
+verified, while the configured value still restricts which account types Microsoft accepts. Formbricks
+logs a warning at startup when either is set. To get full id_token verification, set your Directory
+(tenant) ID instead.
+
+`consumers` needs no action and is not affected: every personal Microsoft account lives in one
+well-known tenant, so that authority advertises a real issuer and keeps full id_token verification.
 
 #### SSO callback URLs are unchanged
 

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -236,7 +236,7 @@ instance's JWT signing keys. Keys created before the upgrade keep working untouc
 null `alg` as the default algorithm — so there is nothing to backfill, but the columns must exist before
 the new version mints its next key.
 
-#### AZUREAD_TENANT_ID must be a concrete tenant, or unset
+#### AZUREAD_TENANT_ID: set a concrete tenant for full id_token verification
 
 Better Auth 1.7 verifies Microsoft id_tokens against the issuer advertised by the tenant's OpenID
 discovery document whenever `AZUREAD_TENANT_ID` names a concrete tenant — a Directory (tenant) ID GUID or
@@ -245,9 +245,10 @@ a verified domain. That is strictly stronger than v5.3 and needs no action.
 Two of Microsoft's multi-tenant authorities are different. `common` and `organizations` advertise the
 literal placeholder `https://login.microsoftonline.com/{tenantid}/v2.0` as their issuer, so verifying
 real tokens against it fails every Microsoft sign-in with `?error=unable_to_get_user_info`. Formbricks
-therefore treats those two values exactly like an unset `AZUREAD_TENANT_ID`: sign-in identity comes from
-Microsoft's userinfo endpoint over a client-authenticated call (the v5.3 behavior) and id_tokens are not
-verified, while the configured value still restricts which account types Microsoft accepts. Formbricks
+therefore handles those two the way it already handles an unset `AZUREAD_TENANT_ID`: sign-in identity
+comes from Microsoft's userinfo endpoint over a client-authenticated call (the v5.3 behavior) and
+id_tokens are not verified. The authority you configure still applies at sign-in, so `organizations`
+keeps restricting sign-in to work/school accounts, and an unset value behaves as `common`. Formbricks
 logs a warning at startup when either is set and Microsoft SSO is enabled. To get full id_token
 verification, set your Directory (tenant) ID instead.
 

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -248,8 +248,8 @@ real tokens against it fails every Microsoft sign-in with `?error=unable_to_get_
 therefore treats those two values exactly like an unset `AZUREAD_TENANT_ID`: sign-in identity comes from
 Microsoft's userinfo endpoint over a client-authenticated call (the v5.3 behavior) and id_tokens are not
 verified, while the configured value still restricts which account types Microsoft accepts. Formbricks
-logs a warning at startup when either is set. To get full id_token verification, set your Directory
-(tenant) ID instead.
+logs a warning at startup when either is set and Microsoft SSO is enabled. To get full id_token
+verification, set your Directory (tenant) ID instead.
 
 `consumers` needs no action and is not affected: every personal Microsoft account lives in one
 well-known tenant, so that authority advertises a real issuer and keeps full id_token verification.

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -236,6 +236,21 @@ instance's JWT signing keys. Keys created before the upgrade keep working untouc
 null `alg` as the default algorithm — so there is nothing to backfill, but the columns must exist before
 the new version mints its next key.
 
+#### AZUREAD_TENANT_ID must be a concrete tenant, or unset
+
+Better Auth 1.7 verifies Microsoft id_tokens against the issuer advertised by the tenant's OpenID
+discovery document whenever `AZUREAD_TENANT_ID` names a concrete tenant — a Directory (tenant) ID GUID or
+a verified domain. That is strictly stronger than v5.3 and needs no action.
+
+Microsoft's multi-tenant pseudo-tenants — `common`, `organizations`, `consumers` — are different: their
+discovery documents advertise the literal placeholder `https://login.microsoftonline.com/{tenantid}/v2.0`
+as the issuer, so verifying real tokens against it fails every Microsoft sign-in with
+`?error=unable_to_get_user_info`. Formbricks therefore treats these three values exactly like an unset
+`AZUREAD_TENANT_ID`: sign-in identity comes from Microsoft's userinfo endpoint over a
+client-authenticated call (the v5.3 behavior) and id_tokens are not verified, while the configured value
+still restricts which account types Microsoft accepts. A warning is logged at startup when one of these
+values is set. To get full id_token verification, set your Directory (tenant) ID instead.
+
 #### SSO callback URLs are unchanged
 
 Your SSO callback URLs stay exactly as they are:

--- a/docs/self-hosting/configuration/auth-sso/azure-ad-oauth.mdx
+++ b/docs/self-hosting/configuration/auth-sso/azure-ad-oauth.mdx
@@ -70,11 +70,16 @@ Do you have a Microsoft Entra ID Tenant? Integrate it with your Formbricks insta
 
     <Note>
       Use the **Directory (tenant) ID** GUID (or a verified domain) — with it set, Formbricks fully
-      verifies Microsoft id_tokens against your tenant's issuer. For a multi-tenant app registration,
-      leave `AZUREAD_TENANT_ID` unset instead: `common` and `organizations` advertise a placeholder
-      issuer rather than a real one, so Formbricks treats those two values like unset and reads the
-      signed-in identity from Microsoft's userinfo endpoint. `consumers` is unaffected — personal
-      Microsoft accounts share one well-known tenant, so its id_tokens are verified normally.
+      verifies Microsoft id_tokens against your tenant's issuer.
+
+      For a multi-tenant app registration, either leave `AZUREAD_TENANT_ID` unset, which is equivalent
+      to `common` and accepts both work/school and personal accounts, or set it to `organizations` to
+      accept work/school accounts only. Those two authorities advertise a placeholder issuer rather
+      than a real one, so Formbricks skips id_token verification for them and takes the signed-in
+      identity from Microsoft's userinfo endpoint — the authority you configure still applies at
+      sign-in, so `organizations` keeps restricting which accounts Microsoft will accept. `consumers`
+      is unaffected: personal Microsoft accounts share one well-known tenant, so its id_tokens are
+      verified normally.
     </Note>
 
     ![sixth](https://res.cloudinary.com/dwdb9tvii/image/upload/v1738250876/image_dj2vi5.jpg)

--- a/docs/self-hosting/configuration/auth-sso/azure-ad-oauth.mdx
+++ b/docs/self-hosting/configuration/auth-sso/azure-ad-oauth.mdx
@@ -68,6 +68,14 @@ Do you have a Microsoft Entra ID Tenant? Integrate it with your Formbricks insta
       - Copy the entry for **Application (client) ID** to populate the `AZUREAD_CLIENT_ID` variable.
       - Copy the entry for **Directory (tenant) ID** to populate the `AZUREAD_TENANT_ID` variable.
 
+    <Note>
+      Use the **Directory (tenant) ID** GUID (or a verified domain) — with it set, Formbricks fully
+      verifies Microsoft id_tokens against your tenant's issuer. For a multi-tenant app registration,
+      leave `AZUREAD_TENANT_ID` unset instead: the pseudo-tenants `common`, `organizations` and
+      `consumers` have no single issuer, so Formbricks treats those values like unset and reads the
+      signed-in identity from Microsoft's userinfo endpoint.
+    </Note>
+
     ![sixth](https://res.cloudinary.com/dwdb9tvii/image/upload/v1738250876/image_dj2vi5.jpg)
   </Step>
 

--- a/docs/self-hosting/configuration/auth-sso/azure-ad-oauth.mdx
+++ b/docs/self-hosting/configuration/auth-sso/azure-ad-oauth.mdx
@@ -71,9 +71,10 @@ Do you have a Microsoft Entra ID Tenant? Integrate it with your Formbricks insta
     <Note>
       Use the **Directory (tenant) ID** GUID (or a verified domain) — with it set, Formbricks fully
       verifies Microsoft id_tokens against your tenant's issuer. For a multi-tenant app registration,
-      leave `AZUREAD_TENANT_ID` unset instead: the pseudo-tenants `common`, `organizations` and
-      `consumers` have no single issuer, so Formbricks treats those values like unset and reads the
-      signed-in identity from Microsoft's userinfo endpoint.
+      leave `AZUREAD_TENANT_ID` unset instead: `common` and `organizations` advertise a placeholder
+      issuer rather than a real one, so Formbricks treats those two values like unset and reads the
+      signed-in identity from Microsoft's userinfo endpoint. `consumers` is unaffected — personal
+      Microsoft accounts share one well-known tenant, so its id_tokens are verified normally.
     </Note>
 
     ![sixth](https://res.cloudinary.com/dwdb9tvii/image/upload/v1738250876/image_dj2vi5.jpg)


### PR DESCRIPTION
Fixes ENG-2750

## What & why

**Was:** `AZUREAD_TENANT_ID=common` put the azuread provider on the Better Auth 1.7 discovery branch, whose discovered issuer is the literal `{tenantid}` placeholder — every id_token failed the literal `iss` comparison, so every Microsoft sign-in ended in `?error=unable_to_get_user_info`. That is what took Microsoft SSO down on Cloud after 5.4.0 (prod's env had `common`; harmless on 1.6, which never parsed the id_token).

**Now:** `common` and `organizations` are treated like unset — explicit endpoints, identity from Microsoft's userinfo endpoint over the client-authenticated back-channel, which is what unset already did on 5.3. Everything else keeps discovery and full id_token verification.

Which authority can be verified is **not** uniform, and it decides the whole fix, so it is read from Microsoft rather than assumed:

| authority | advertised `issuer` | verifiable? |
| --- | --- | --- |
| `common`, `organizations` | `…/{tenantid}/v2.0` | no — placeholder |
| `consumers` | `…/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0` | **yes** — the well-known MSA tenant |

So `consumers` stays on discovery. Grouping it with the other two by name would have silently dropped a verification that works today.

## Where to look

- [better-auth-providers.ts:213-234](https://github.com/formbricks/formbricks/blob/fix/ENG-2750_azuread-pseudo-tenant/apps/web/modules/ee/sso/lib/better-auth-providers.ts#L213-L234) — the classification, the warning, and the branch
- [migration.mdx](https://github.com/formbricks/formbricks/blob/fix/ENG-2750_azuread-pseudo-tenant/docs/self-hosting/advanced/migration.mdx) — new v5.4 note under Better Auth 1.7

## Breaking changes

- [ ] This PR contains breaking changes

None — no API, schema, env or config surface changes. `common`/`organizations` go from 100% sign-in failure to working; unset, `consumers` and concrete tenants behave exactly as before.

## Migrations & env

- none (no new vars, no migrations; the guide gains a note about existing `AZUREAD_TENANT_ID` values)

## How this was tested

Rerun: `cd apps/web && pnpm test modules/ee/sso/lib/better-auth-providers.test.ts` (32/32)

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `common`/`organizations` (+ case and whitespace variants) get explicit endpoints, no `discoveryUrl`, canonical lower-case authority | unit (red on main) | 5 cases; all fail against main's truthiness branch |
| `consumers`, a GUID and a verified domain keep discovery | unit (mutation) | Adding `consumers` to `AZURE_TEMPLATE_ISSUER_TENANTS` (`better-auth-providers.ts:213`) fails 2 |
| Startup warning fires only for a placeholder authority, and only when Azure SSO is registered | unit (mutation) | Dropping the `AZURE_OAUTH_ENABLED` gate (`:222`) fails 1; unset / whitespace / GUID / `consumers` assert no warning |
| **Sign-in, end to end, against a real OpenID Provider** | manual | 8 authority values × main vs this PR. main: `common`/`organizations`/`Common` → `unable_to_get_user_info`, `' common '` → provider unusable. This PR: all sign in. `consumers`/GUID/domain keep verification wired up under both |
| The classification matches live Microsoft | manual | Fetches all three real discovery documents and asserts placeholder ⟺ membership of the shipped set, parsed from the source file so it cannot drift |

<details>
<summary>Smoke-test harness (evidence for the last two rows)</summary>

`oauth2-mock-server` as a real OP (real JWKS, code exchange, userinfo, discovery), fronted by a facade reproducing Microsoft's actual quirk — a discovery document whose advertised `issuer` does not match the `iss` of the tokens it mints — with an undici dispatcher rewriting `login.microsoftonline.com` and `graph.microsoft.com` onto it, so the production URL strings are exercised verbatim. 21/21 checks. It reproduces the reported failure through the real library: `Provider "azuread": id_token failed verification against the discovery JWKS or expected nonce` → `Unable to get user info` → `302 …?error=unable_to_get_user_info`.

Two harness bugs were found and fixed while building it, both of which had been manufacturing false passes: the callback was posted to the pinned legacy path rather than the one Better Auth 1.7 mounts (`route.ts` maps between them), so every callback 404'd; and "no `error=` in the destination" was scored as success, so those 404s read as clean sign-ins. Success now requires a redirect to the callbackURL *and* a session cookie.

</details>

**Open gaps**

- Not exercised against real Microsoft with `common` configured — the evidence is the live discovery documents, the mock-OP reproduction, and Cloud prod's own failure.
- The generic `openid` provider can hit the same placeholder-issuer trap if pointed at a non-compliant IdP. Out of scope; only Microsoft is known to do this.
- No E2E: the suite drives no SSO sign-in at all (ENG-2445), so there is no spec to extend.

**Risks**

- Needs a backport to `release/5.4` for 5.4.1 — Cloud prod and any self-hoster carrying `common` are broken on 5.4.0.
- The warning is a module-level side effect, so it prints once per boot on an instance with Azure SSO enabled and a placeholder authority set.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code), reasoning effort `unknown`.
