### PR TITLE
docs: document the setEmail and setNonce SDK methods

### DIFF
--- a/docs/surveys/website-app-surveys/framework-guides.mdx
+++ b/docs/surveys/website-app-surveys/framework-guides.mdx
@@ -657,7 +657,16 @@ formbricks.setup({
 });
 ```
 
-Pass the raw value only — not the `nonce-` prefix that appears in the header. If your policy also sets `style-src-elem`, list the nonce there too: that directive takes precedence over `style-src` for `<style>` elements. Passing `undefined` stops the SDK nonce-ing style elements it creates from then on; elements already in the page keep the attribute they were given.
+The matching header side, with the nonce in both style directives:
+
+```text
+style-src 'self' 'nonce-<your-request-nonce>';
+style-src-elem 'self' 'nonce-<your-request-nonce>';
+```
+
+`style-src-elem` is what the browser consults for `<style>` elements whenever it is present, and it does not fall back to `style-src` — so a nonce listed only under `style-src` leaves surveys unstyled on any policy that sets both. If your policy has no `style-src-elem`, the first line alone is enough.
+
+Pass the raw value only — not the `nonce-` prefix that appears in the header. Passing `undefined` stops the SDK nonce-ing style elements it creates from then on; elements already in the page keep the attribute they were given.
 
 <Note>
   **Note**: call `setNonce` before `setup`. The SDK stores the nonce and applies it when the survey

--- a/docs/surveys/website-app-surveys/framework-guides.mdx
+++ b/docs/surveys/website-app-surveys/framework-guides.mdx
@@ -622,6 +622,50 @@ To this:
 
 ![second validate](https://res.cloudinary.com/dwdb9tvii/image/upload/v1738122750/image_ymaenn.jpg)
 
+## Content Security Policy
+
+If your app serves a strict `Content-Security-Policy` header, the browser can block the Formbricks widget before anything renders. Three directives are involved.
+
+<Note>
+  This applies to the JavaScript SDK only. Link surveys are served by Formbricks itself, and the mobile
+  SDKs render surveys in a WebView, so neither is affected by your app's CSP.
+</Note>
+
+### Allowing scripts and API calls
+
+The SDK loads two scripts from your Formbricks instance: `formbricks.umd.cjs` (the SDK) and `surveys.umd.cjs` (the survey renderer, fetched the first time a survey is shown). It then talks to the client API on the same host. Both directives need to point at your `appUrl`:
+
+```text
+script-src 'self' https://app.formbricks.com;
+connect-src 'self' https://app.formbricks.com;
+```
+
+The SDK does not put a nonce on the script tags it creates, so allowlisting the host is what makes them load. If you use `'strict-dynamic'` instead of a host allowlist, both scripts are inserted programmatically by already-trusted code, so they inherit trust from the script that loaded the SDK.
+
+### Passing a nonce for survey styles
+
+Surveys are styled by two `<style>` elements the renderer appends to `<head>`: `formbricks__css` for the base stylesheet and `formbricks__css__custom` for your workspace and survey theme. `style-src` treats an injected `<style>` element as inline CSS, so a policy without `'unsafe-inline'` blocks both and surveys appear unstyled.
+
+Instead of loosening the policy, hand the SDK the nonce your server already generated for the request. `setNonce` stamps it onto both style elements, which satisfies `style-src 'nonce-...'`:
+
+```javascript Setting the CSP nonce
+formbricks.setNonce("<your-request-nonce>");
+
+formbricks.setup({
+  workspaceId: "<workspace-id>",
+  appUrl: "<app-url>",
+});
+```
+
+Pass the raw value only — not the `nonce-` prefix that appears in the header. Passing `undefined` clears it.
+
+<Note>
+  **Note**: call `setNonce` before `setup`. The SDK stores the nonce and applies it when the survey
+  renderer loads, so setting it early covers every survey in the page's lifetime. A nonce must be
+  regenerated per response and match the one in the header, so read it from wherever your framework
+  exposes it rather than hardcoding a value.
+</Note>
+
 ## Debugging Formbricks Integration
 
 <Note>

--- a/docs/surveys/website-app-surveys/framework-guides.mdx
+++ b/docs/surveys/website-app-surveys/framework-guides.mdx
@@ -640,7 +640,7 @@ script-src 'self' https://app.formbricks.com;
 connect-src 'self' https://app.formbricks.com;
 ```
 
-The SDK does not put a nonce on the script tags it creates, so allowlisting the host is what makes them load. If you use `'strict-dynamic'` instead of a host allowlist, both scripts are inserted programmatically by already-trusted code, so they inherit trust from the script that loaded the SDK.
+The SDK does not put a nonce on the script tags it creates, so allowlisting the host is what makes them load. `'strict-dynamic'` works instead of a host allowlist, but only if the script that loads the SDK carries a matching nonce or hash of its own — both bundles are inserted programmatically, so they inherit trust from that root. Without a trusted root, `'strict-dynamic'` blocks the SDK before it ever reaches `surveys.umd.cjs`.
 
 ### Passing a nonce for survey styles
 
@@ -657,7 +657,7 @@ formbricks.setup({
 });
 ```
 
-Pass the raw value only — not the `nonce-` prefix that appears in the header. Passing `undefined` clears it.
+Pass the raw value only — not the `nonce-` prefix that appears in the header. If your policy also sets `style-src-elem`, list the nonce there too: that directive takes precedence over `style-src` for `<style>` elements. Passing `undefined` stops the SDK nonce-ing style elements it creates from then on; elements already in the page keep the attribute they were given.
 
 <Note>
   **Note**: call `setNonce` before `setup`. The SDK stores the nonce and applies it when the survey

--- a/docs/surveys/website-app-surveys/user-identification.mdx
+++ b/docs/surveys/website-app-surveys/user-identification.mdx
@@ -37,6 +37,35 @@ To enable user identification, call the `setUserId` function of Formbricks and p
 formbricks.setUserId("<user-id>");
 ```
 
+### Setting User Email
+
+Use the `setEmail` function to store the user's email address on the contact. Email is one of the built-in contact attributes, so it gets its own column in the Contacts table and is never removed by an attribute update that omits it.
+
+```javascript Setting User Email
+formbricks.setEmail("hola@formbricks.com");
+```
+
+`setEmail` is a shorthand, not a separate identity mechanism. It writes the `email` attribute exactly as `setAttributes` would, so these two calls are equivalent:
+
+```javascript setEmail vs setAttributes
+formbricks.setEmail("hola@formbricks.com");
+formbricks.setAttributes({ email: "hola@formbricks.com" });
+```
+
+Order matters: call `setUserId` before `setEmail`. Attributes are only stored for identified users, so if no user ID has been set yet, Formbricks drops the email and logs an error to the console:
+
+```text
+🧱 Formbricks - <timestamp> [ERROR] - Formbricks can't set attributes without a userId! Please set a userId first with the setUserId function
+```
+
+<Note>
+  **Note**: an email address can belong to only one contact per workspace. If another contact already
+  has the address you pass, Formbricks keeps that contact's email and silently skips the update. The SDK
+  reports this only in [debug mode](/surveys/website-app-surveys/framework-guides#activate-debug-mode),
+  as _"The email already exists for this environment and was not updated."_ The value must be a valid
+  email address of at most 255 characters.
+</Note>
+
 ## Setting Custom User Attributes
 
 Use the `setAttribute` function to set custom attributes for the user (e.g., name, plan).


### PR DESCRIPTION
Fixes ENG-2724

## What & why

**Was:** `formbricks.setEmail` and `formbricks.setNonce` are public methods on the JS SDK's exported object, but `grep -rn "setEmail\|setNonce" docs/` returned nothing — the other eight were documented.

**Now:** Both are documented on the pages a reader already goes to, with the behaviour traced from the implementations rather than the names.

- `setEmail` → **User Identification**, next to `setUserId`/`setAttribute`. It is shorthand for the built-in `email` attribute, so ordering and the workspace-uniqueness rule matter.
- `setNonce` → **Framework Guides**, in a new Content Security Policy section. It only affects the two `<style>` elements the renderer injects, so it answers `style-src`, not `script-src`.

## Where to look

- [Content Security Policy section](https://github.com/formbricks/formbricks/blob/83848a84108e084a7c8310cbc8204b4225c2f737/docs/surveys/website-app-surveys/framework-guides.mdx#L625-L668) — the directive claims
- [Setting User Email section](https://github.com/formbricks/formbricks/blob/83848a84108e084a7c8310cbc8204b4225c2f737/docs/surveys/website-app-surveys/user-identification.mdx#L40-L69) — ordering and duplicate-email behaviour

## Breaking changes

- [ ] This PR contains breaking changes

None — documenting methods that already ship changes no signature, default or payload.

## Migrations & env

- none

## How this was tested

Rerun: `grep -rn "setEmail\|setNonce" docs/`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `setEmail` is shorthand for the `email` attribute | manual | `packages/js-core/src/index.ts:52` forwards to `Attribute.setAttributes({ email })` — identical path to `setAttributes` |
| Email is dropped without a prior `setUserId` | manual | `packages/js-core/src/lib/user/update-queue.ts:143` logs the quoted error, then clears the queued update |
| A duplicate email is skipped, not surfaced | manual | `apps/web/modules/ee/contacts/lib/attributes.ts:215` strips it; the `email_already_exists` message (`:41`) reaches the SDK as `logger.debug` |
| `setNonce` satisfies `style-src` only | manual | `packages/surveys/src/lib/styles.ts:17` stamps `formbricks__css` and `formbricks__css__custom`; nothing else is nonced |
| Nonce set before `setup` still applies | manual | `packages/js-core/src/lib/survey/widget.ts:318` replays `window.__formbricksNonce` when the renderer global appears |
| `script-src`/`connect-src` must allow `appUrl` | manual | Renderer at `widget.ts:350`, client API at `packages/js-core/src/lib/common/api.ts:78,91` |

**Open gaps**

- Not rendered in Mintlify — no local preview command in this repo, so component and anchor syntax were checked against neighbouring pages only.
- The `'strict-dynamic'` note is reasoned from how both script tags are inserted, not observed against a live policy.

**Risks**

- The duplicate-email message says "environment" while the check is workspace-scoped (`attributes.ts:41` vs `hasEmailAttribute`). The docs describe the real scoping and quote the string as-is; if that message is corrected, the quote goes stale.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.
