### PR TITLE
feat(navigation): rename Unify to Analyze and badge Act as Beta (ENG-2742)

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -72,6 +72,25 @@ interface NavigationProps {
   isFormbricksSurveysConfigured: boolean;
 }
 
+/**
+ * A nav section header carrying a Beta badge.
+ *
+ * Analyze and Act are both pre-1.0 surfaces, and the badge is what tells someone the difference
+ * between "this is finished" and "this is early". Extracted rather than duplicated so the two
+ * sections cannot drift into looking subtly different from each other.
+ */
+const sectionLabelWithBeta = (label: React.ReactNode) => (
+  <span className="inline-flex items-center gap-2">
+    <span>{label}</span>
+    <Badge
+      text="Beta"
+      type="gray"
+      size="tiny"
+      className="text-[10px] font-semibold tracking-normal normal-case"
+    />
+  </span>
+);
+
 export const MainNavigation = ({
   organization,
   user,
@@ -151,18 +170,9 @@ export const MainNavigation = ({
       },
       {
         id: "unify-feedback",
-        name: (
-          <span className="inline-flex items-center gap-2">
-            {/* Product section (IA) label — intentionally not localized (kept in English across all locales) */}
-            <span>Unify</span>
-            <Badge
-              text="Beta"
-              type="gray"
-              size="tiny"
-              className="text-[10px] font-semibold tracking-normal normal-case"
-            />
-          </span>
-        ),
+        // Same policy as "Ask" above: product section labels stay English in every locale.
+        // Was "Unify" until ENG-2742 settled on Ask / Analyze / Act as the three pillars.
+        name: sectionLabelWithBeta("Analyze"),
         items: [
           {
             name: t("workspace.unify.feedback_data"),
@@ -184,7 +194,11 @@ export const MainNavigation = ({
       },
       {
         id: "act",
-        name: t("common.act"),
+        // Kept translated, unlike "Ask" and "Analyze" above. Those two are deliberately English in
+        // every locale; this one has been going through t() since it was added. Making the three
+        // consistent means dropping a string 15 locales already translate, which is a naming
+        // decision rather than a side effect of adding a badge — see ENG-2742.
+        name: sectionLabelWithBeta(t("common.act")),
         items: [
           {
             name: t("common.workflows"),


### PR DESCRIPTION
Ref ENG-2742

## What & why

**Was:** The sidebar read **Ask / Unify / Act**, with the Beta badge on Unify alone.

**Now:** **Ask / Analyze / Act**, with Beta on both Analyze and Act.

- The product's three pillars are Ask, Analyze and Act. The middle third was called something else on screen, so docs saying "go to Analyze" sent readers looking for a section named Unify.
- Analyze and Act are both pre-1.0; only one of them said so.

| Before | After |
| --- | --- |
| `ASK` · `UNIFY [Beta]` · `ACT` | `ASK` · `ANALYZE [Beta]` · `ACT [Beta]` |

Verified in a running instance — the sidebar reads `ASK / Surveys / Contacts / ANALYZE / Beta / Feedback Data / Analysis / ACT / Beta / Workflows`.

## Where to look

- [MainNavigation.tsx](https://github.com/formbricks/formbricks/blob/feat/nav-analyze-and-beta-badges/apps/web/app/\(app\)/workspaces/%5BworkspaceId%5D/components/MainNavigation.tsx) — the three section headers and the extracted badge helper

## Breaking changes

- [ ] This PR contains breaking changes

None. A visible label changes, but nothing outside this repo depends on it: no route, API shape, env var or SDK signature moves. The section id stays `unify-feedback`, so nothing keyed on it breaks.

## Migrations & env

- none

## How this was tested

Rerun: drive a local instance and read the sidebar — `ASK / Surveys / Contacts / ANALYZE / Beta / Feedback Data / Analysis / ACT / Beta / Workflows / Settings`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Sidebar reads Ask / Analyze / Act | manual | Confirmed against a running instance, not just the diff |
| Both Analyze and Act carry a Beta badge | manual | Both render the badge; screenshot below |
| The Ask section is unchanged | manual | Still `Ask`, still hardcoded, still no badge |

<details>
<summary>Sidebar after this change</summary>

<img src="https://raw.githubusercontent.com/formbricks/formbricks/assets/eng-2742-nav-rename/nav-after.webp" width="260" alt="Sidebar showing ASK, ANALYZE with a Beta badge, and ACT with a Beta badge">

</details>

**Open gaps**

- The Analyze section still contains an item called **Analysis**, which reads oddly one line under its own parent. The docs call that page "Dashboards & Charts" and its route is `/dashboards`, so `Dashboards` may be the better label — but that is a separate naming call and is deliberately not made here.
- `Act` stays translated (`t("common.act")`) while `Ask` and `Analyze` are deliberately English in every locale. That inconsistency predates this PR; resolving it drops a string 15 locales already translate, so it is a naming decision rather than a side effect of adding a badge.

**Risks**

- Anyone with a bookmark or a screenshot referring to "Unify" as a nav section will find it renamed. The route (`/unify/sources`) and the section id are untouched.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).
