### PR TITLE
docs: mark Analyze and Act as Beta, and fix their nav paths (ENG-2742)

### DIFF
--- a/docs/unify-feedback/dashboards-charts.mdx
+++ b/docs/unify-feedback/dashboards-charts.mdx
@@ -8,7 +8,7 @@ Dashboards & Charts let you turn Feedback Records into visual analytics. A **Cha
 
 ## Charts
 
-Charts live under **Workspace → Charts**. Each chart is a query plus a visualization config.
+Charts live under **Analyze → Analysis**. Each chart is a query plus a visualization config.
 
 ### Available chart types
 
@@ -34,7 +34,7 @@ The AI builder requires **Smart functionality (AI)** to be enabled at the organi
 
 ## Dashboards
 
-Dashboards live under **Workspace → Dashboards**. Each dashboard is a grid you can resize and arrange.
+Dashboards live under **Analyze → Analysis**, alongside charts. Each dashboard is a grid you can resize and arrange.
 
 From a dashboard you can:
 

--- a/docs/unify-feedback/feedback-datasets.mdx
+++ b/docs/unify-feedback/feedback-datasets.mdx
@@ -24,7 +24,7 @@ Manage dataset access from **Settings → Organization → Feedback Datasets**:
 - Rename or archive datasets
 - Add or remove workspace access
 
-Only **Owners** and **Managers** can manage datasets. Workspace members see the datasets their workspace has access to inside the Unify section.
+Only **Owners** and **Managers** can manage datasets. Workspace members see the datasets their workspace has access to under **Analyze**.
 
 ## Archiving
 

--- a/docs/unify-feedback/overview.mdx
+++ b/docs/unify-feedback/overview.mdx
@@ -37,6 +37,11 @@ Most companies collect feedback in many places: surveys, support tickets, app st
   </Card>
 </CardGroup>
 
+<Info>
+  Unify Feedback is in **Beta**. It appears under **Analyze** in the app, badged Beta. Expect the
+  feature set to keep moving; we will note breaking changes here.
+</Info>
+
 <Note>
   Unify Feedback is an enterprise feature. Enable it on Formbricks Cloud with a paid plan, or self-host with a license.
 </Note>

--- a/docs/workflows/overview.mdx
+++ b/docs/workflows/overview.mdx
@@ -8,6 +8,11 @@ icon: "https://d3gk2c5xim1je2.cloudfront.net/lucide/v1.16.0/workflow.svg"
 Workflows automate tasks in response to events in Formbricks. You define the event that starts the workflow,
 narrow down which events qualify, and choose the action Formbricks should perform.
 
+<Info>
+  Workflows are in **Beta**. They appear under **Act** in the app, badged Beta. Expect the feature set
+  to keep moving; we will note breaking changes here.
+</Info>
+
 <Note>Workflows are part of the Formbricks [Enterprise Edition](/self-hosting/advanced/license).</Note>
 
 ## How Workflows work


### PR DESCRIPTION
Ref ENG-2742

## What & why

**Was:** Two areas are badged Beta in the app and no page said so, and the charts page sent readers to two menu items that do not exist.

**Now:** Both say Beta, and the nav paths name real menu items.

- "Workspace → Charts" and "Workspace → Dashboards" become **Analyze → Analysis**. Neither original ever existed — `grep -c "common.charts\|common.dashboards"` on `MainNavigation.tsx` returns 0.
- "inside the Unify section" becomes "under **Analyze**".

Pairs with #9020, which moves the sidebar from Ask/Unify/Act to Ask/Analyze/Act. **Merge #9020 first**, or these paths describe a name the app has not adopted yet.

## Where to look

- [dashboards-charts.mdx](https://github.com/formbricks/formbricks/blob/docs/mark-analyze-and-act-beta/docs/unify-feedback/dashboards-charts.mdx) — the two nav paths that pointed at nothing

## Breaking changes

- [ ] This PR contains breaking changes

None. Prose-only edits to four `.mdx` files.

## Migrations & env

- none

## How this was tested

Rerun: `grep -rn "Unify section\|Workspace → Charts\|Workspace → Dashboards" docs --include="*.mdx"` — expects no matches.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Beta stated for Unify Feedback and Workflows | manual | `<Info>` note on both overview pages, above the existing Enterprise note |
| Nav paths name real menu items | manual | Sidebar reads `ANALYZE → Feedback Data / Analysis`; confirmed on a running instance with #9020 applied |
| No nav-section drift left in docs | manual | Swept for all three stale phrasings; 0 matches |

**Open gaps**

- The Beta wording is mine, not product copy. If there is a house sentence for Beta features, this should use it instead.
- "Analyze → Analysis" reads oddly, and the docs call that page "Dashboards & Charts". Renaming the nav item is a separate call, tracked on ENG-2742; the docs follow whatever the app says.

**Risks**

- If #9020 does not merge, these paths are wrong in the other direction. They are a pair.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).
