### PR TITLE
fix(contacts): say workspace, not environment, in duplicate-attribute messages

### DIFF
--- a/apps/web/modules/ee/contacts/lib/attributes.test.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.test.ts
@@ -7,7 +7,7 @@ import {
   hasEmailAttribute,
   hasUserIdAttribute,
 } from "@/modules/ee/contacts/lib/contact-attributes";
-import { updateAttributes } from "./attributes";
+import { formatAttributeMessage, updateAttributes } from "./attributes";
 
 vi.mock("@/lib/constants", () => ({
   MAX_ATTRIBUTE_CLASSES_PER_ENVIRONMENT: 2,
@@ -489,5 +489,32 @@ describe("updateAttributes", () => {
     const transactionCall = vi.mocked(prisma.$transaction).mock.calls[0][0];
     // Both name (coerced from boolean) and email should be upserted
     expect(transactionCall).toHaveLength(2);
+  });
+});
+
+describe("formatAttributeMessage", () => {
+  test("describes the duplicate email/userId checks as workspace-scoped", () => {
+    // The checks behind these two codes call hasEmailAttribute/hasUserIdAttribute with workspaceId,
+    // and the UI renders the same conditions via workspace.contacts.attributes_msg_* — so the
+    // English templates must not describe the scope as an environment.
+    expect(formatAttributeMessage({ code: "email_already_exists", params: {} })).toBe(
+      "The email already exists for this workspace and was not updated."
+    );
+    expect(formatAttributeMessage({ code: "userid_already_exists", params: {} })).toBe(
+      "The userId already exists for this workspace and was not updated."
+    );
+  });
+
+  test("interpolates every occurrence of a param", () => {
+    expect(
+      formatAttributeMessage({
+        code: "attribute_type_validation_error",
+        params: { error: "Not a number", key: "age", dataType: "number" },
+      })
+    ).toBe("Not a number (attribute 'age' has dataType: number)");
+  });
+
+  test("falls back to the raw code when no template exists", () => {
+    expect(formatAttributeMessage({ code: "some_unmapped_code", params: {} })).toBe("some_unmapped_code");
   });
 });

--- a/apps/web/modules/ee/contacts/lib/attributes.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.ts
@@ -38,8 +38,8 @@ export interface TAttributeUpdateMessage {
 const MESSAGE_TEMPLATES: Record<string, string> = {
   email_or_userid_required: "Either email or userId is required. The existing values were preserved.",
   attribute_type_validation_error: "{error} (attribute '{key}' has dataType: {dataType})",
-  email_already_exists: "The email already exists for this environment and was not updated.",
-  userid_already_exists: "The userId already exists for this environment and was not updated.",
+  email_already_exists: "The email already exists for this workspace and was not updated.",
+  userid_already_exists: "The userId already exists for this workspace and was not updated.",
   invalid_attribute_keys:
     "Skipped creating attribute(s) with invalid key(s): {keys}. Keys must only contain lowercase letters, numbers, and underscores, and must start with a letter.",
   reserved_attribute_keys: "{issue}",


### PR DESCRIPTION
<!-- No ticket: #9012 covers the docs half of this drift; these two code strings had none. -->

## What & why

**Was:** The English templates for `email_already_exists` and `userid_already_exists` said the duplicate "already exists for this environment".

**Now:** Both say workspace, matching what the check does and what the UI already shows.

- The check is workspace-scoped — `hasEmailAttribute(emailValue, workspaceId, contactId)` — and Formbricks 5 replaced the `Environment` model with `Workspace`.
- The UI renders these two conditions from `workspace.contacts.attributes_msg_*`, which already say workspace. Only the API-facing templates drifted.
- Kept as hardcoded English, not `t()`: the v2 response envelope is literal throughout, and the one `getTranslate` under an API route localizes survey content it creates, not responses.

## Where to look

- [attributes.ts:41](https://github.com/formbricks/formbricks/blob/claude/unruffled-joliot-810eed/apps/web/modules/ee/contacts/lib/attributes.ts#L41) — the two templates
- [update-user.ts:246](https://github.com/formbricks/formbricks/blob/claude/unruffled-joliot-810eed/apps/web/modules/ee/contacts/api/v1/client/%5BworkspaceId%5D/user/lib/update-user.ts#L246) — the only consumer; it filters both codes

## Breaking changes

- [ ] This PR contains breaking changes

None. `formatAttributeMessage` has one consumer, the public client route, and it drops both codes as enumeration protection — so no response any external consumer receives changes.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && npx vitest run modules/ee/contacts/lib/attributes.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Both messages name the workspace | unit (red on main) | Restoring "environment" on `attributes.ts:41-42` fails the new test |
| Interpolation replaces every placeholder | unit (guard) | `attribute_type_validation_error` renders all three params |
| Unmapped code falls back to the code | unit (guard) | Returns `some_unmapped_code` |

**Open gaps**

- No end-to-end check exists: the only consumer filters both codes, so these strings are unreachable at runtime and the unit test is the sole guard.
- `attribute_limit_exceeded` still says "attribute classes"; `MAX_ATTRIBUTE_CLASSES_PER_ENVIRONMENT` keeps its name. Both are gaps #9012 lists too.
- `en-US.json` capitalises "this Workspace" in these two keys alone, against 14 lowercase elsewhere. Templates use lowercase; locales untouched.

**Risks**

- none — no rendered surface reads these strings.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).
