### PR TITLE
fix(sso): stop generic OIDC failing when pointed at a Microsoft multi-tenant authority

### DIFF
--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -499,6 +499,80 @@ describe("better-auth SSO providers", () => {
       });
     });
 
+    /**
+     * ENG-2754: the generic OIDC provider shares ENG-2750's failure mode, because it too resolves its
+     * endpoints from a discovery document. Pointed at a Microsoft multi-tenant authority it would
+     * verify id_tokens against a `{tenantid}` placeholder and fail every sign-in, so those authorities
+     * skip discovery here too — and the operator is told to prefer the dedicated azuread provider.
+     */
+    const oidcBase = {
+      ENTERPRISE_LICENSE_KEY: "lic",
+      OIDC_OAUTH_ENABLED: true,
+      OIDC_CLIENT_ID: "oidc-id",
+      OIDC_CLIENT_SECRET: "oidc-secret",
+    };
+
+    test.each([
+      ["https://login.microsoftonline.com/common/v2.0", "common"],
+      ["https://login.microsoftonline.com/organizations/v2.0", "organizations"],
+      // Case and a trailing slash are operator typing, not a different provider.
+      ["https://LOGIN.microsoftonline.com/Common/", "common"],
+      // No /v2.0 suffix: the authority is the first path segment either way.
+      ["https://login.microsoftonline.com/common", "common"],
+    ])("OIDC pointed at %s skips discovery and uses Microsoft's endpoints", async (issuer, authority) => {
+      const m = await loadProviders({ ...oidcBase, OIDC_ISSUER: issuer });
+      const oidc = m.ssoGenericOAuthConfig.find((c) => c.providerId === "openid");
+
+      expect(oidc?.discoveryUrl).toBeUndefined();
+      expect(oidc?.authorizationUrl).toBe(
+        `https://login.microsoftonline.com/${authority}/oauth2/v2.0/authorize`
+      );
+      expect(oidc?.tokenUrl).toBe(`https://login.microsoftonline.com/${authority}/oauth2/v2.0/token`);
+      expect(oidc?.userInfoUrl).toBe("https://graph.microsoft.com/oidc/userinfo");
+      // Account keying must not move, or existing linked accounts stop matching.
+      expect(oidc?.accountIssuer).toBe("local:oauth:openid");
+      expect(loggerWarn).toHaveBeenCalledTimes(1);
+      // Recommends the dedicated provider, and — like the azuread warning — does not imply the
+      // configured authority has been discarded, since `organizations` keeps restricting sign-in.
+      const message = loggerWarn.mock.calls[0][0] as string;
+      expect(message).toContain("AZUREAD_CLIENT_ID");
+      expect(message).toContain("still applies");
+      expect(message).not.toMatch(/like unset|treated as unset/i);
+    });
+
+    /**
+     * Everything else keeps discovery. `consumers` is included deliberately: it is a Microsoft
+     * authority but advertises a real issuer, so it must not be swept up with the other two — the same
+     * distinction ENG-2750 turns on. The lookalike host guards against matching on a substring.
+     */
+    test.each([
+      ["a normal IdP", "https://idp.test"],
+      ["Microsoft's personal-accounts authority", "https://login.microsoftonline.com/consumers/v2.0"],
+      [
+        "a concrete Microsoft tenant",
+        "https://login.microsoftonline.com/00000000-1111-2222-3333-444444444444/v2.0",
+      ],
+      ["a lookalike host", "https://login.microsoftonline.com.evil.test/common/v2.0"],
+    ])("OIDC keeps discovery for %s", async (_label, issuer) => {
+      const m = await loadProviders({ ...oidcBase, OIDC_ISSUER: issuer });
+      const oidc = m.ssoGenericOAuthConfig.find((c) => c.providerId === "openid");
+
+      expect(oidc?.discoveryUrl).toBe(`${issuer}/.well-known/openid-configuration`);
+      expect(oidc?.authorizationUrl).toBeUndefined();
+      expect(loggerWarn).not.toHaveBeenCalled();
+    });
+
+    test("OIDC does not warn about a Microsoft authority when the instance is unlicensed", async () => {
+      const m = await loadProviders({
+        ...oidcBase,
+        ENTERPRISE_LICENSE_KEY: undefined,
+        OIDC_ISSUER: "https://login.microsoftonline.com/common/v2.0",
+      });
+
+      expect(m.ssoGenericOAuthConfig.find((c) => c.providerId === "openid")).toBeUndefined();
+      expect(loggerWarn).not.toHaveBeenCalled();
+    });
+
     test("SAML bridges to the local Jackson endpoints and resolves first/last name", async () => {
       const m = await loadProviders({
         ENTERPRISE_LICENSE_KEY: "lic",
@@ -658,5 +732,102 @@ describe("Azure identity comes from Graph, not an unverified id_token (#9017 rev
 
     expect(azure?.getUserInfo).toBeUndefined();
     expect(azure?.discoveryUrl).toBeDefined();
+  });
+});
+
+/**
+ * Raised in review on #9023: the generic OIDC provider reaches the same explicit-endpoint branch when
+ * `OIDC_ISSUER` points at a Microsoft multi-tenant authority, so it inherited the same unverified
+ * id_token shortcut. Driven through the initialised provider, for the same reason as the azuread
+ * suite above: the config object cannot show which of the two paths actually runs.
+ *
+ * Also pins the sweep result — `saml` reaches an explicit-endpoint branch too but is NOT affected,
+ * because it requests no `openid` scope, so BoxyHQ never mints an id_token for the shortcut to read.
+ */
+describe("OIDC identity comes from Graph when pointed at Microsoft (#9023 review)", () => {
+  const forgedIdToken = `${Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")}.${Buffer.from(
+    JSON.stringify({ sub: "forged-subject", email: "attacker@evil.test" })
+  ).toString("base64url")}.`;
+
+  const initializedProvider = async (providerId: string, overrides: Partial<MockConstants>) => {
+    const m = await loadProviders({ ENTERPRISE_LICENSE_KEY: "lic", ...overrides });
+    const { betterAuth } = await import("better-auth");
+    const { memoryAdapter } = await import("better-auth/adapters/memory");
+    const { genericOAuth } = await import("better-auth/plugins");
+    const auth = betterAuth({
+      baseURL: "https://app.formbricks.test",
+      secret: "sso-oidc-contract-secret-0123456789ab",
+      database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+      plugins: [genericOAuth({ config: m.ssoGenericOAuthConfig })],
+    });
+    return (await auth.$context).socialProviders.find((p) => p.id === providerId);
+  };
+
+  const oidcAtMicrosoft = {
+    OIDC_OAUTH_ENABLED: true,
+    OIDC_CLIENT_ID: "oidc-id",
+    OIDC_CLIENT_SECRET: "oidc-secret",
+    OIDC_ISSUER: "https://login.microsoftonline.com/common/v2.0",
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("a forged id_token is never accepted as the identity", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("graph unreachable");
+      })
+    );
+
+    const provider = await initializedProvider("openid", oidcAtMicrosoft);
+    expect(await provider?.getUserInfo?.({ accessToken: "t", idToken: forgedIdToken } as never)).toBeNull();
+  });
+
+  test("the identity is the Graph response, and Graph is actually called", async () => {
+    const graph = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ sub: "graph-subject", email: "real@corp.test", name: "Real User" }),
+    }));
+    vi.stubGlobal("fetch", graph);
+
+    const provider = await initializedProvider("openid", oidcAtMicrosoft);
+    const result = await provider?.getUserInfo?.({
+      accessToken: "access-token",
+      idToken: forgedIdToken,
+    } as never);
+
+    expect(graph).toHaveBeenCalledWith("https://graph.microsoft.com/oidc/userinfo", expect.anything());
+    expect(JSON.stringify(result)).not.toContain("forged-subject");
+    expect(JSON.stringify(result)).not.toContain("attacker@evil.test");
+  });
+
+  test("a normal OIDC issuer keeps discovery and the default profile path", async () => {
+    const m = await loadProviders({
+      ENTERPRISE_LICENSE_KEY: "lic",
+      ...oidcAtMicrosoft,
+      OIDC_ISSUER: "https://idp.test",
+    });
+    const oidc = m.ssoGenericOAuthConfig.find((c) => c.providerId === "openid");
+
+    expect(oidc?.getUserInfo).toBeUndefined();
+    expect(oidc?.discoveryUrl).toBe("https://idp.test/.well-known/openid-configuration");
+  });
+
+  /**
+   * The sweep result, pinned. `saml` also configures explicit endpoints with no discovery, which is
+   * the shape that exposed the other two — but BoxyHQ only mints an id_token for an OIDC-flow request
+   * (`requestedOIDCFlow` in Jackson's oauth controller), and this provider requests no scopes at all.
+   * No id_token means the shortcut cannot fire, so no override is needed. If someone ever adds
+   * `openid` to these scopes, this test fails and says why.
+   */
+  test("saml requests no openid scope, so no id_token exists for the shortcut to read", async () => {
+    const m = await loadProviders({ ENTERPRISE_LICENSE_KEY: "lic", SAML_OAUTH_ENABLED: true });
+    const saml = m.ssoGenericOAuthConfig.find((c) => c.providerId === "saml");
+
+    expect(saml?.scopes ?? []).not.toContain("openid");
+    expect(saml?.discoveryUrl).toBeUndefined();
   });
 });

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -831,7 +831,12 @@ describe("OIDC identity comes from Graph when pointed at Microsoft (#9023 review
     const m = await loadProviders({ ENTERPRISE_LICENSE_KEY: "lic", SAML_OAUTH_ENABLED: true });
     const saml = m.ssoGenericOAuthConfig.find((c) => c.providerId === "saml");
 
-    expect(saml?.scopes ?? []).not.toContain("openid");
-    expect(saml?.discoveryUrl).toBeUndefined();
+    // Anchor the negatives: without this, an unregistered `saml` makes `saml?.scopes ?? []` an empty
+    // array and `saml?.discoveryUrl` undefined, so both assertions below would hold while proving
+    // nothing about the provider they are supposed to be describing.
+    if (!saml) throw new Error("saml provider not registered");
+
+    expect(saml.scopes ?? []).not.toContain("openid");
+    expect(saml.discoveryUrl).toBeUndefined();
   });
 });

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -800,6 +800,10 @@ describe("OIDC identity comes from Graph when pointed at Microsoft (#9023 review
     } as never);
 
     expect(graph).toHaveBeenCalledWith("https://graph.microsoft.com/oidc/userinfo", expect.anything());
+    // Assert the Graph identity positively first: on its own, `not.toContain` passes for a `null`
+    // result, so the two negatives below would hold even if the provider resolved nothing at all.
+    expect(result?.user).toMatchObject({ email: "real@corp.test" });
+    expect(result?.data).toMatchObject({ sub: "graph-subject", email: "real@corp.test" });
     expect(JSON.stringify(result)).not.toContain("forged-subject");
     expect(JSON.stringify(result)).not.toContain("attacker@evil.test");
   });

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.ts
@@ -267,6 +267,53 @@ const microsoftGraphUserInfo = async (tokens: {
     return null;
   }
 };
+
+/**
+ * The endpoints Microsoft publishes for a given authority, configured explicitly so Better Auth never
+ * builds an id_token verification config for it (ENG-2750). Shared with the `openid` provider, which
+ * can be pointed at the same authorities and breaks identically when it is (ENG-2754).
+ *
+ * These are the values Microsoft's own discovery document returns for a multi-tenant authority, so
+ * configuring them by hand changes nothing about where the flow goes — only that we skip discovery.
+ * Skipping it is the sole lever for turning verification off: `GenericOAuthConfig` offers no way to
+ * opt out once a discovery document has supplied both `jwks_uri` and `issuer`.
+ *
+ * Skipping discovery is NOT sufficient on its own, though, and that half is easy to miss — it was
+ * missed here until review. Removing the verification config also removes the guard that would
+ * otherwise stop Better Auth reading identity straight out of the unverified id_token, which is why
+ * `getUserInfo` below is part of this shape rather than an optimisation.
+ */
+const microsoftExplicitEndpoints = (authority: string) => ({
+  authorizationUrl: `https://login.microsoftonline.com/${authority}/oauth2/v2.0/authorize`,
+  tokenUrl: `https://login.microsoftonline.com/${authority}/oauth2/v2.0/token`,
+  userInfoUrl: MICROSOFT_GRAPH_USERINFO_URL,
+  // Not redundant with `userInfoUrl` — see microsoftGraphUserInfo. The URL alone leaves Better Auth's
+  // unverified-id_token shortcut in play; this override is what actually forces the Graph call, and it
+  // applies to every provider that reaches this branch (azuread and openid alike).
+  getUserInfo: microsoftGraphUserInfo,
+});
+
+/**
+ * The Microsoft multi-tenant authority a URL names, if it names one — e.g. an `OIDC_ISSUER` of
+ * `https://login.microsoftonline.com/common/v2.0` resolves to `common` (ENG-2754).
+ *
+ * Matched on the parsed host rather than a substring, so a lookalike host cannot be mistaken for
+ * Microsoft, and returns undefined for a concrete tenant (a GUID or verified domain) since those
+ * advertise a real issuer and must keep discovery.
+ */
+const microsoftTemplateIssuerAuthority = (issuerUrl: string | undefined): string | undefined => {
+  if (!issuerUrl?.trim()) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(issuerUrl.trim());
+  } catch {
+    return undefined;
+  }
+  if (parsed.host.toLowerCase() !== "login.microsoftonline.com") return undefined;
+  const authority = parsed.pathname.split("/").find(Boolean)?.toLowerCase();
+  return authority && AZURE_TEMPLATE_ISSUER_TENANTS.has(authority) ? authority : undefined;
+};
+
 // Unset behaves exactly like `common`: Microsoft's multi-tenant authority, and the documented default.
 const azureTenant = AZUREAD_TENANT_ID?.trim() || "common";
 const isAzureTemplateIssuerTenant = AZURE_TEMPLATE_ISSUER_TENANTS.has(azureTenant.toLowerCase());
@@ -291,17 +338,33 @@ if (
   );
 }
 const azureEndpoints = isAzureTemplateIssuerTenant
-  ? {
-      authorizationUrl: `https://login.microsoftonline.com/${azureAuthority}/oauth2/v2.0/authorize`,
-      tokenUrl: `https://login.microsoftonline.com/${azureAuthority}/oauth2/v2.0/token`,
-      userInfoUrl: MICROSOFT_GRAPH_USERINFO_URL,
-      // Not redundant with `userInfoUrl` — see microsoftGraphUserInfo. The URL alone leaves Better
-      // Auth's unverified-id_token shortcut in play; this is what actually forces the Graph call.
-      getUserInfo: microsoftGraphUserInfo,
-    }
+  ? microsoftExplicitEndpoints(azureAuthority)
   : {
       discoveryUrl: `https://login.microsoftonline.com/${azureAuthority}/v2.0/.well-known/openid-configuration`,
     };
+
+/**
+ * The generic OIDC provider hits the same wall when it is pointed at Microsoft (ENG-2754).
+ *
+ * `OIDC_ISSUER` is arbitrary operator input, so unlike azuread there is no set of values to enumerate
+ * — but the one issuer known to advertise a placeholder is Microsoft's, and we already know its
+ * endpoints. Anything else keeps discovery: OpenID Discovery §4.3 requires the advertised issuer to be
+ * identical to the one in the tokens, so a conforming provider cannot land here at all.
+ *
+ * Falls back rather than failing at init, matching how azuread treats the identical root cause: this
+ * configuration worked on 5.3 (1.6 never parsed the id_token), so refusing to start would be a harsher
+ * regression than the one being fixed. The warning names the better answer instead — the dedicated
+ * `AZUREAD_*` provider, which maps Entra's profile properly.
+ */
+const oidcTemplateIssuerAuthority = microsoftTemplateIssuerAuthority(OIDC_ISSUER);
+if (ENTERPRISE_LICENSE_KEY && OIDC_OAUTH_ENABLED && oidcTemplateIssuerAuthority) {
+  logger.warn(
+    `OIDC_ISSUER points at Microsoft's "${oidcTemplateIssuerAuthority}" authority, whose discovery document advertises a placeholder issuer, so id_tokens cannot be verified against it. Skipping discovery for this provider and taking identity from the userinfo endpoint; the authority you configured still applies at sign-in. Prefer the dedicated AZUREAD_CLIENT_ID / AZUREAD_CLIENT_SECRET provider for Microsoft Entra ID.`
+  );
+}
+const oidcEndpoints = oidcTemplateIssuerAuthority
+  ? microsoftExplicitEndpoints(oidcTemplateIssuerAuthority)
+  : { discoveryUrl: `${OIDC_ISSUER}/.well-known/openid-configuration` };
 
 export const ssoGenericOAuthConfig: GenericOAuthConfig[] = ENTERPRISE_LICENSE_KEY
   ? [
@@ -345,7 +408,7 @@ export const ssoGenericOAuthConfig: GenericOAuthConfig[] = ENTERPRISE_LICENSE_KE
               providerId: "openid",
               clientId: OIDC_CLIENT_ID ?? "",
               clientSecret: OIDC_CLIENT_SECRET ?? "",
-              discoveryUrl: `${OIDC_ISSUER}/.well-known/openid-configuration`,
+              ...oidcEndpoints,
               scopes: ["openid", "email", "profile"],
               // Redundant since 1.7 defaults it to true, kept explicit (see azuread above).
               pkce: true,

--- a/docs/self-hosting/configuration/auth-sso/open-id-connect.mdx
+++ b/docs/self-hosting/configuration/auth-sso/open-id-connect.mdx
@@ -23,6 +23,15 @@ Integrating your own OIDC (OpenID Connect) instance with your Formbricks instanc
   `{WEBAPP_URL}/api/auth/oauth2/callback/openid`.
 </Note>
 
+<Note>
+  **Using Microsoft Entra ID?** Configure it through the dedicated [Azure AD
+  provider](/self-hosting/configuration/auth-sso/azure-ad-oauth) rather than here — it maps Entra's
+  profile correctly. If you do point `OIDC_ISSUER` at a multi-tenant authority
+  (`login.microsoftonline.com/common` or `/organizations`), Formbricks skips OpenID discovery for it
+  and logs a warning at startup: those authorities advertise a placeholder issuer instead of a real
+  one, so id_tokens cannot be verified against it and sign-in would otherwise fail.
+</Note>
+
 <Warning>
   **Upgrading from v5.1 or earlier?** This path changed once, at v5.2:
 


### PR DESCRIPTION
Fixes ENG-2754

> [!NOTE]
> Stacked on #9017 (ENG-2750) — review that one first. Kept as a draft until it merges; the base will then switch to `main`.

## What & why

**Was:** Pointing `OIDC_ISSUER` at a Microsoft multi-tenant authority (`login.microsoftonline.com/common` or `/organizations`) failed every sign-in with `?error=unable_to_get_user_info` — the same root cause as #9017, reached through the generic OIDC provider instead of azuread. Those authorities advertise a `{tenantid}` placeholder as their issuer, and Better Auth 1.7 compares `iss` literally.

**Now:** Those two authorities skip OpenID discovery and use Microsoft's endpoints directly, so no id_token verification config is built and identity comes from the userinfo endpoint — the 5.3 behaviour. A startup warning points the operator at the dedicated `AZUREAD_*` provider, which maps Entra's profile properly. Every other issuer keeps discovery untouched.

Skipping discovery is the only lever for turning verification *off*: `GenericOAuthConfig` exposes no way to opt out (only `requireIdTokenVerification`, which forces it on).

Skipping it is not sufficient on its own, though. Better Auth's `fetchUserInfo` opens by decoding — not verifying — `tokens.idToken` and returns those claims whenever they carry `sub` and `email`, so identity would come from an unverified JWT despite `userInfoUrl` being set. A custom `getUserInfo` **is** the lever there: with no `idToken` config the verification guard never runs and Better Auth delegates straight to it. Raised by Bhagya in review; the shared `microsoftExplicitEndpoints` helper now supplies one that always calls Graph.

Falls back rather than failing at init, matching #9017's treatment of the identical root cause — this configuration worked on 5.3, so refusing to boot would be a harsher regression than the bug.

## Where to look

- [better-auth-providers.ts](https://github.com/formbricks/formbricks/blob/fix/ENG-2754_oidc-placeholder-issuer/apps/web/modules/ee/sso/lib/better-auth-providers.ts) — `microsoftTemplateIssuerAuthority` (host-parsed, not substring-matched) and `oidcEndpoints`
- Account keying is deliberately untouched: `accountIssuer` (`local:oauth:openid`) and `accountSubject` (`sub`) sit outside the endpoint block, and Microsoft's discovery document points userinfo at the same `graph.microsoft.com/oidc/userinfo` the explicit branch uses — so existing linked accounts keep matching.

## Breaking changes

- [ ] This PR contains breaking changes

None. The only behaviour that changes belongs to configurations that cannot sign in at all today; every other `OIDC_ISSUER` keeps discovery and full id_token verification.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && pnpm test modules/ee/sso/lib/better-auth-providers.test.ts` (42/42)

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The two Microsoft authorities skip discovery and use its endpoints, case and trailing slash included | unit (mutation) | 4 cases; neutralising the detection (`microsoftTemplateIssuerAuthority`) fails 4 |
| A lookalike host is not mistaken for Microsoft | unit (mutation) | Relaxing the host check to `includes()` fails this case |
| `consumers`, a concrete tenant and a normal IdP keep discovery | unit (guard) | `consumers` is the trap — it is a Microsoft authority but advertises a real issuer |
| The warning is gated on the provider actually being registered | unit (guard) | Unlicensed instance: no provider, no warning |
| **Before/after, end to end against a real OpenID Provider** | manual | Same IdP advertising a placeholder issuer: pre-fix config → `error=unable_to_get_user_info`; fixed config → signs in with a session. 5/5 |
| **Nothing else changed, proven mechanically** | manual | Resolved provider config dumped for 26 env permutations on both branches and diffed: **22/26 byte-identical**, the 4 differing ones are exactly the Microsoft-authority openid cases. All 11 azuread permutations identical, so #9017's fix is untouched |
| **Live stack: SSO login, logout, credential login, deletion** | manual | Real app + Postgres + Valkey + a real OP. SSO sign-in through the pinned legacy callback → session; sign-out → `get-session` null and the DB session row gone; credential sign-up/sign-in; wrong password → 401; `delete-user` → user row gone. 9/9 |
| **The fix on the real app against real Microsoft metadata** | manual | `OIDC_ISSUER=…/common/v2.0`: base branch arms id_token verification (nonce present, discovery ran against Microsoft); this branch emits Microsoft's endpoints with **no** nonce and logs the warning |

<details>
<summary>Smoke harness</summary>

`oauth2-mock-server` as a real OP (real JWKS, code exchange, userinfo, discovery) behind a facade that reproduces Microsoft's quirk — an advertised issuer that does not match the `iss` of the tokens it mints. Also covers a provider that returns no id_token (identity still resolves from userinfo) and asserts structurally that `saml` builds no verification config, so it cannot reach this failure mode.

</details>

**Open gaps**

- Not verified against real Microsoft Entra through the generic provider; evidence is the live discovery documents plus the mock-OP reproduction.
- Only Microsoft's authorities are recognised. A general fix — detect any placeholder issuer — needs a boot-time discovery fetch and its own decision about what to do when the IdP is unreachable at boot. Deliberately deferred; ENG-2753 covers the investigation.
- No E2E: the suite drives no SSO sign-in at all (ENG-2445).

**Risks**

- Affected instances lose id_token verification for that provider. Identical to what #9017 does for azuread, and strictly better than being unable to sign in — but it is a weaker posture than a conforming IdP gets.
- **No RP-initiated logout on the explicit path.** `end_session_endpoint` only ever arrives via discovery, so signing out ends the Formbricks session but not the session at Microsoft. Not a regression (that configuration could not sign in at all before, and the default azuread config has always behaved this way), but worth knowing: it was visible in the live test, where the compliant-IdP path *did* return an end-session URL and this path does not.
- The warning is a module-level side effect, so it prints once per boot on an instance in that configuration.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code), reasoning effort `unknown`.

