### PR TITLE
chore(docs): add the screenshot capture harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ stats.html
 docs/api-v3-reference/contract-tests/fixtures.json
 .schemathesis/
 __pycache__/
+
+# Playwright storage state written by the docs capture script — contains live session cookies
+scripts/docs-capture/.auth.json

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -55,6 +55,7 @@
     "db:push": "prisma db push --accept-data-loss --config ./prisma.config.ts",
     "db:seed": "dotenv -e ../../.env -- tsx src/seed.ts",
     "db:seed:clear": "dotenv -e ../../.env -- tsx src/seed.ts --clear",
+    "db:seed:docs": "dotenv -e ../../.env -- tsx src/scripts/seed-docs-fixtures.ts",
     "db:seed:contract": "dotenv -e ../../.env -- tsx src/scripts/seed-contract-fixtures.ts",
     "db:setup": "pnpm db:migrate:dev && pnpm db:create-saml-database:dev",
     "db:start": "pnpm db:setup",

--- a/packages/database/src/scripts/seed-docs-fixtures.ts
+++ b/packages/database/src/scripts/seed-docs-fixtures.ts
@@ -1,0 +1,282 @@
+/**
+ * Seeds the ACME Inc. workspace that every screenshot in `docs/` is captured from.
+ *
+ * Why a separate script rather than an addition to `seed.ts`: `db:seed` is what every developer runs
+ * to get a workable local instance, and its content shows up in nobody's published output. This
+ * fixture's content ships — it is visible in ~200 public documentation images — so it is versioned,
+ * reviewed and changed on its own terms. Editing `seed.ts` to brand it ACME would push a docs concern
+ * into every developer's database.
+ *
+ * The demo company is a financial services firm because that matches our ICP: a prospect reading the
+ * docs should recognise the survey they are looking at. Everything is fictional, and no email address
+ * in it resolves to a real inbox.
+ *
+ * Requires `db:seed` to have run first — the admin user comes from there, so one login
+ * (SEED_CREDENTIALS.ADMIN) reaches both the seed workspace and this one.
+ *
+ * Run: pnpm --filter @formbricks/database db:seed:docs
+ */
+import { createId } from "@paralleldrive/cuid2";
+import { logger } from "@formbricks/logger";
+import { type TSurveyBlocks } from "@formbricks/types/surveys/blocks";
+import { PrismaClient } from "../prisma";
+import { createPrismaPgAdapter } from "../prisma-adapter";
+import { SEED_IDS } from "../seed/constants";
+
+const prisma = new PrismaClient({ adapter: createPrismaPgAdapter().adapter });
+
+if (process.env.NODE_ENV === "production" && process.env.ALLOW_SEED !== "true") {
+  logger.error("ERROR: Seeding blocked in production. Set ALLOW_SEED=true to override.");
+  process.exit(1);
+}
+
+/**
+ * Fixed ids so the capture script can address a survey without querying for it, and so re-running
+ * this script updates the same rows instead of accumulating duplicates.
+ */
+export const DOCS_IDS = {
+  ORGANIZATION: "cldocsacmeorg00000000001",
+  WORKSPACE: "cldocsacmeworkspace000001",
+  SURVEY_ALL_ELEMENTS: "cldocsallelements00000001",
+} as const;
+
+/** Shown in the breadcrumb of nearly every screenshot, so it is part of the docs' visual identity. */
+const ORGANIZATION_NAME = "ACME Inc.";
+const WORKSPACE_NAME = "Retail Banking";
+
+/**
+ * One survey carrying all 17 element types, in the order the Question Types nav lists them.
+ *
+ * This exists so the 15 question-type pages can be captured in a single pass: seed once, open the
+ * editor once, expand each card in turn. Copy is ACME's, not Formbricks' — a reader on
+ * `question-type/nps` should see a bank asking a bank's question.
+ *
+ * `pictureSelection` is deliberately absent: its choices are `ZStorageUrl` values, so it needs real
+ * uploaded files to render thumbnails rather than broken images. The capture script uploads those and
+ * appends the element, keeping this file free of storage paths that only exist on one machine.
+ */
+const ACME_ELEMENTS = [
+  {
+    id: "acme-openText",
+    type: "openText",
+    headline: { default: "What made you open an account with us?" },
+    subheader: { default: "A sentence or two is plenty." },
+    required: true,
+    placeholder: { default: "Type your answer here..." },
+    longAnswer: true,
+  },
+  {
+    id: "acme-multipleChoiceSingle",
+    type: "multipleChoiceSingle",
+    headline: { default: "Which account did you open?" },
+    required: true,
+    choices: [
+      { id: createId(), label: { default: "Everyday Checking" } },
+      { id: createId(), label: { default: "High-Yield Savings" } },
+      { id: createId(), label: { default: "Joint Account" } },
+      { id: createId(), label: { default: "Business Account" } },
+    ],
+  },
+  {
+    id: "acme-multipleChoiceMulti",
+    type: "multipleChoiceMulti",
+    headline: { default: "Which of these do you use at least monthly?" },
+    required: false,
+    choices: [
+      { id: createId(), label: { default: "Mobile app" } },
+      { id: createId(), label: { default: "Online banking" } },
+      { id: createId(), label: { default: "Branch visit" } },
+      { id: createId(), label: { default: "Telephone banking" } },
+    ],
+  },
+  {
+    id: "acme-nps",
+    type: "nps",
+    headline: { default: "How likely are you to recommend ACME to a friend or colleague?" },
+    required: true,
+    lowerLabel: { default: "Not at all likely" },
+    upperLabel: { default: "Extremely likely" },
+  },
+  {
+    id: "acme-csat",
+    type: "csat",
+    headline: { default: "How satisfied are you with your account opening experience?" },
+    required: true,
+    scale: "smiley",
+    range: 5,
+    lowerLabel: { default: "Very unsatisfied" },
+    upperLabel: { default: "Very satisfied" },
+    isColorCodingEnabled: true,
+  },
+  {
+    id: "acme-ces",
+    type: "ces",
+    headline: { default: "Opening my account was easy." },
+    required: true,
+    scale: "number",
+    range: 7,
+    lowerLabel: { default: "Strongly disagree" },
+    upperLabel: { default: "Strongly agree" },
+  },
+  {
+    id: "acme-rating",
+    type: "rating",
+    headline: { default: "How would you rate our mobile app?" },
+    required: true,
+    scale: "star",
+    range: 5,
+    lowerLabel: { default: "Poor" },
+    upperLabel: { default: "Excellent" },
+  },
+  {
+    id: "acme-ranking",
+    type: "ranking",
+    headline: { default: "Rank these by how much they matter to you." },
+    required: true,
+    choices: [
+      { id: createId(), label: { default: "No monthly fees" } },
+      { id: createId(), label: { default: "Higher interest rate" } },
+      { id: createId(), label: { default: "Faster support" } },
+      { id: createId(), label: { default: "Better mobile app" } },
+    ],
+  },
+  {
+    id: "acme-matrix",
+    type: "matrix",
+    headline: { default: "How do you feel about each of these?" },
+    required: true,
+    rows: [
+      { id: createId(), label: { default: "Opening an account" } },
+      { id: createId(), label: { default: "Making a transfer" } },
+      { id: createId(), label: { default: "Reaching support" } },
+    ],
+    columns: [
+      { id: createId(), label: { default: "Difficult" } },
+      { id: createId(), label: { default: "Neutral" } },
+      { id: createId(), label: { default: "Easy" } },
+    ],
+  },
+  {
+    id: "acme-date",
+    type: "date",
+    headline: { default: "When did you open your account?" },
+    required: false,
+    format: "M-d-y",
+  },
+  {
+    id: "acme-fileUpload",
+    type: "fileUpload",
+    headline: { default: "Upload a document to verify your address" },
+    subheader: { default: "A utility bill or bank statement from the last three months." },
+    required: false,
+    allowMultipleFiles: false,
+    maxSizeInMB: 10,
+  },
+  {
+    id: "acme-cal",
+    type: "cal",
+    headline: { default: "Book a call with an advisor" },
+    subheader: { default: "Pick a time that suits you." },
+    required: false,
+    calUserName: "acme-advisors",
+  },
+  {
+    id: "acme-consent",
+    type: "consent",
+    headline: { default: "Marketing preferences" },
+    required: false,
+    label: { default: "ACME may contact me about products and offers" },
+  },
+  {
+    id: "acme-contactInfo",
+    type: "contactInfo",
+    headline: { default: "How can we reach you?" },
+    required: false,
+    firstName: { show: true, required: true, placeholder: { default: "First name" } },
+    lastName: { show: true, required: true, placeholder: { default: "Last name" } },
+    email: { show: true, required: true, placeholder: { default: "Email" } },
+    phone: { show: true, required: false, placeholder: { default: "Phone" } },
+    company: { show: false, required: false, placeholder: { default: "Company" } },
+  },
+  {
+    id: "acme-address",
+    type: "address",
+    headline: { default: "What is your current address?" },
+    required: false,
+    addressLine1: { show: true, required: true, placeholder: { default: "Address line 1" } },
+    addressLine2: { show: true, required: false, placeholder: { default: "Address line 2" } },
+    city: { show: true, required: true, placeholder: { default: "City" } },
+    state: { show: true, required: true, placeholder: { default: "State" } },
+    zip: { show: true, required: true, placeholder: { default: "ZIP" } },
+    country: { show: true, required: true, placeholder: { default: "Country" } },
+  },
+  {
+    id: "acme-cta",
+    type: "cta",
+    headline: { default: "See how your savings could grow" },
+    required: false,
+    ctaButtonLabel: { default: "Open the calculator" },
+    buttonUrl: "https://example.com/acme/savings-calculator",
+    buttonExternal: true,
+  },
+];
+
+async function main(): Promise<void> {
+  const organization = await prisma.organization.upsert({
+    where: { id: DOCS_IDS.ORGANIZATION },
+    update: { name: ORGANIZATION_NAME },
+    create: { id: DOCS_IDS.ORGANIZATION, name: ORGANIZATION_NAME },
+  });
+
+  // The admin from `db:seed` owns this org too, so one login reaches both workspaces and no
+  // screenshot session needs a second set of credentials.
+  await prisma.membership.upsert({
+    where: { userId_organizationId: { userId: SEED_IDS.USER_ADMIN, organizationId: organization.id } },
+    update: { role: "owner" },
+    create: { userId: SEED_IDS.USER_ADMIN, organizationId: organization.id, role: "owner", accepted: true },
+  });
+
+  const workspace = await prisma.workspace.upsert({
+    where: { id: DOCS_IDS.WORKSPACE },
+    update: { name: WORKSPACE_NAME },
+    create: { id: DOCS_IDS.WORKSPACE, name: WORKSPACE_NAME, organizationId: organization.id },
+  });
+
+  const blocks = [
+    {
+      id: createId(),
+      name: "Account opening feedback",
+      elements: ACME_ELEMENTS,
+    },
+  ] as unknown as TSurveyBlocks;
+
+  await prisma.survey.upsert({
+    where: { id: DOCS_IDS.SURVEY_ALL_ELEMENTS },
+    update: { workspaceId: workspace.id, blocks },
+    create: {
+      id: DOCS_IDS.SURVEY_ALL_ELEMENTS,
+      name: "Account opening feedback",
+      workspaceId: workspace.id,
+      status: "inProgress",
+      type: "link",
+      blocks,
+    },
+  });
+
+  logger.info(
+    {
+      organization: ORGANIZATION_NAME,
+      workspace: WORKSPACE_NAME,
+      workspaceId: workspace.id,
+      elements: ACME_ELEMENTS.length,
+    },
+    "Docs fixtures seeded"
+  );
+}
+
+main()
+  .catch((error: unknown) => {
+    logger.error(error, "Failed to seed docs fixtures");
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/docs-capture/capture.ts
+++ b/scripts/docs-capture/capture.ts
@@ -1,0 +1,231 @@
+/**
+ * Captures the screenshots that ship in `docs/`.
+ *
+ * Not a test: nothing here asserts, and it must stay out of the PR gate. It lives in `scripts/`
+ * rather than under `apps/web/playwright/` for a second reason — `apps/web/tsconfig.json` includes
+ * `**\/*.ts`, so anything under the app is typechecked by the Next build, and a dev script that
+ * fails to compile takes the whole build down with it. Run it by hand against a local instance when
+ * a release changes what the product looks like.
+ *
+ * Why a script rather than driving a browser by hand: 200-odd images only read as one set if every
+ * one shares a viewport, a theme and a workspace, and the set is worth nothing in eighteen months
+ * unless it can be regenerated. Both of those are properties of a script, not of a person clicking.
+ *
+ *   1. `pnpm --filter @formbricks/database db:seed`       (admin user)
+ *   2. `pnpm --filter @formbricks/database db:seed:docs`  (the ACME Inc. workspace)
+ *   3. `pnpm dev`
+ *   4. `pnpm tsx scripts/docs-capture/capture.ts [name ...]`
+ *
+ * With no arguments it captures everything registered in `shots`. With arguments it captures only
+ * the named shots, which is the loop you want while iterating on one page.
+ */
+import { type Browser, type Page, chromium } from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "../..");
+const DOCS_IMAGES = resolve(REPO_ROOT, "docs/images");
+
+const BASE_URL = process.env.DOCS_CAPTURE_URL ?? "http://localhost:3000";
+
+/** Must match `SEED_CREDENTIALS.ADMIN` in `packages/database/src/seed/constants.ts`. */
+const LOGIN = { email: "admin@formbricks.com", password: "Password#123" };
+
+/** Must match `DOCS_IDS` in `packages/database/src/scripts/seed-docs-fixtures.ts`. */
+const ACME = {
+  workspaceId: "cldocsacmeworkspace000001",
+  surveyAllElements: "cldocsallelements00000001",
+};
+
+/**
+ * One viewport for every shot. The three current screenshots in the docs are 1920x1200, 1027x666 and
+ * 2420x1400 — three sizes for three images, which is part of why the set never looked like a set.
+ *
+ * deviceScaleFactor 2 because these are read on retina displays; at 1x the UI text in a downscaled
+ * screenshot goes soft, which is the single most common way a docs image looks amateurish.
+ */
+const VIEWPORT = { width: 1920, height: 1200 };
+const DEVICE_SCALE_FACTOR = 2;
+
+interface Shot {
+  /** Selects this shot on the command line, and names nothing else. */
+  name: string;
+  /** Path under `docs/images/`, extension included. */
+  out: string;
+  /** Drives the app to the moment worth photographing, then returns the region to capture. */
+  take: (page: Page) => Promise<{ clip?: { x: number; y: number; width: number; height: number } } | void>;
+}
+
+/** The element the editor expands on load — see `openElementCard`. First in the fixture's order. */
+const AUTO_EXPANDED_ELEMENT_ID = "acme-openText";
+
+const editorUrl = (surveyId: string): string =>
+  `${BASE_URL}/workspaces/${ACME.workspaceId}/surveys/${surveyId}/edit`;
+
+/**
+ * Waits for the editor to stop moving. The block list mounts, then re-renders once the survey
+ * resolves; screenshotting between the two catches a half-drawn card.
+ */
+const settleEditor = async (page: Page): Promise<void> => {
+  await page.waitForSelector("text=Questions", { timeout: 30_000 });
+  // Wait on a concrete node rather than `networkidle`. The preview pane renders the survey, and a
+  // CTA element pointing at an external URL keeps requests in flight indefinitely, so networkidle
+  // never arrives and the whole shot times out — which is exactly how `statement-cta` failed.
+  await page.locator(`[id="${AUTO_EXPANDED_ELEMENT_ID}"].scroll-mt-16`).waitFor({
+    state: "visible",
+    timeout: 30_000,
+  });
+};
+
+/**
+ * Opens one element's card in the editor and returns it, with every other card collapsed.
+ *
+ * The editor auto-expands the first element on load, so a card shot taken without collapsing it
+ * catches two cards open — which reads as a mistake rather than a choice. Elements are addressed by
+ * the fixed ids the fixture assigns (`acme-<type>`), so this never depends on question order or on
+ * matching headline text that the copy might later change.
+ */
+const openElementCard = async (page: Page, elementId: string) => {
+  // The element id is NOT unique on this page: the live preview pane renders the same survey, so
+  // every element id appears twice — once on the editor card, once inside the preview. `.scroll-mt-16`
+  // is the editor card wrapper and is what disambiguates them. Matching the bare id would sometimes
+  // photograph the preview instead of the card, which is the wrong picture for a question-type page.
+  //
+  // Attribute selector rather than `#id` because `CSS.escape` is a browser API, unavailable here.
+  const cardOf = (id: string) => page.locator(`[id="${id}"].scroll-mt-16`);
+  // `.cursor-pointer` picks the clickable summary row out of the other Radix nodes in a card that
+  // also carry `data-state`.
+  const headerOf = (id: string) => cardOf(id).locator("[data-state].cursor-pointer").first();
+
+  // The editor always mounts with the first element expanded. Collapse that one by id rather than
+  // sweeping every `[data-state="open"]` node: clicking mutates the set mid-iteration, so a sweep
+  // races itself and the later indices go stale.
+  if (elementId !== AUTO_EXPANDED_ELEMENT_ID) {
+    const first = headerOf(AUTO_EXPANDED_ELEMENT_ID);
+    if ((await first.getAttribute("data-state")) === "open") {
+      await first.click();
+      await page.waitForTimeout(200);
+    }
+  }
+
+  const card = cardOf(elementId);
+  await card.waitFor({ state: "visible", timeout: 30_000 });
+
+  const header = headerOf(elementId);
+  if ((await header.getAttribute("data-state")) === "closed") {
+    await header.click();
+  }
+
+  await card.scrollIntoViewIfNeeded();
+  // The card grows as it expands; screenshotting mid-transition clips it short.
+  await page.waitForTimeout(400);
+  return card;
+};
+
+/**
+ * The 15 question-type pages, keyed to the element ids in the fixture.
+ *
+ * `thank-you-card` is not here — it was re-shot on 2026-08-12 and is already current.
+ * `select-picture` is not here either; it needs uploaded images before it can be captured (ENG-2650).
+ */
+const QUESTION_TYPE_PAGES: { page: string; elementId: string }[] = [
+  { page: "free-text", elementId: "acme-openText" },
+  { page: "select-single", elementId: "acme-multipleChoiceSingle" },
+  { page: "select-multiple", elementId: "acme-multipleChoiceMulti" },
+  { page: "net-promoter-score", elementId: "acme-nps" },
+  { page: "rating", elementId: "acme-rating" },
+  { page: "ranking", elementId: "acme-ranking" },
+  { page: "matrix", elementId: "acme-matrix" },
+  { page: "date", elementId: "acme-date" },
+  { page: "file-upload", elementId: "acme-fileUpload" },
+  { page: "schedule-a-meeting", elementId: "acme-cal" },
+  { page: "consent", elementId: "acme-consent" },
+  { page: "contact-info", elementId: "acme-contactInfo" },
+  { page: "address", elementId: "acme-address" },
+  { page: "statement-cta", elementId: "acme-cta" },
+];
+
+const shots: Shot[] = [
+  ...QUESTION_TYPE_PAGES.map(({ page: docsPage, elementId }) => ({
+    name: `question-type/${docsPage}`,
+    // New home for these images. The originals live under the legacy
+    // `images/xm-and-surveys/core-features/question-type/` tree, which ENG-2662 retires.
+    out: `surveys/question-type/${docsPage}/editor.webp`,
+    take: async (page: Page) => {
+      await page.goto(editorUrl(ACME.surveyAllElements));
+      await settleEditor(page);
+      const card = await openElementCard(page, elementId);
+      const box = await card.boundingBox();
+      return box ? { clip: box } : undefined;
+    },
+  })),
+];
+
+const login = async (browser: Browser): Promise<string> => {
+  const page = await browser.newPage({ viewport: VIEWPORT });
+  await page.goto(`${BASE_URL}/auth/login`);
+  await page.getByRole("button", { name: /log in with email/i }).click();
+  await page.getByPlaceholder("work@email.com").fill(LOGIN.email);
+  await page.locator('input[type="password"]').fill(LOGIN.password);
+  await page.getByRole("button", { name: /log in with email/i }).click();
+  await page.waitForURL(/\/workspaces\//, { timeout: 60_000 });
+
+  const statePath = resolve(HERE, ".auth.json");
+  await page.context().storageState({ path: statePath });
+  await page.close();
+  return statePath;
+};
+
+const main = async (): Promise<void> => {
+  const wanted = process.argv.slice(2);
+  const selected = wanted.length > 0 ? shots.filter((s) => wanted.includes(s.name)) : shots;
+
+  if (selected.length === 0) {
+    console.error(`No shots matched. Known: ${shots.map((s) => s.name).join(", ")}`);
+    process.exit(1);
+  }
+
+  const browser = await chromium.launch();
+  const statePath = await login(browser);
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: DEVICE_SCALE_FACTOR,
+    storageState: statePath,
+    colorScheme: "light",
+    // The app renders relative timestamps ("2 days ago") and locale-formatted dates. Pinning both
+    // keeps a re-run from producing a diff that is nothing but a clock tick.
+    locale: "en-US",
+    timezoneId: "UTC",
+  });
+
+  for (const shot of selected) {
+    const page = await context.newPage();
+    try {
+      const result = await shot.take(page);
+      const out = resolve(DOCS_IMAGES, shot.out);
+      await mkdir(dirname(out), { recursive: true });
+
+      // Capture PNG (lossless, so the encode below starts from a clean source), then re-encode to
+      // WebP. The docs are served to every reader: the same 14 shots weigh 1.4 MB as 2x PNG and
+      // ~200 KB as WebP, and at quality 90 UI text stays crisp. Every existing docs image is .webp,
+      // so this also keeps the tree consistent.
+      const png = await page.screenshot({ clip: result?.clip });
+      await sharp(png).webp({ quality: 90 }).toFile(out);
+
+      console.log(`  ✓ ${shot.name} -> docs/images/${shot.out}`);
+    } catch (error) {
+      console.error(`  ✗ ${shot.name}: ${error instanceof Error ? error.message : String(error)}`);
+      process.exitCode = 1;
+    } finally {
+      await page.close();
+    }
+  }
+
+  await context.close();
+  await browser.close();
+};
+
+void main();


### PR DESCRIPTION
Reopened at @jobenjada's request. @itsjavi, you are on this because the question is whether this belongs in the repo at all — the code is the easy part.

## What & why

**Was:** every docs screenshot was taken by hand, so the set drifted. 320 of 408 images predated the Blocks editor; only 19 postdated Formbricks 5. Sizes ranged from 1027×666 to 2420×1400 — three sizes across three images on one page.

**Now:** a Playwright script (`scripts/docs-capture/capture.ts`) and a seeded workspace (`db:seed:docs`), which together produced **every one of the ~55 images merged into `docs/` this week**.

Neither runs in CI. Both are run by hand against a local instance when a release changes what the product looks like:

```bash
pnpm --filter @formbricks/database db:seed       # admin user
pnpm --filter @formbricks/database db:seed:docs  # the ACME Inc. workspace
pnpm dev
pnpm tsx scripts/docs-capture/capture.ts                    # everything
pnpm tsx scripts/docs-capture/capture.ts surveys/…/recall   # or one shot
```

## Why it should live in the repo

The alternative is that it lives on one laptop, which is where it has been all week.

1. **A screenshot set is only a set if one thing makes it.** One viewport (1920×1200 @2x), one theme, one workspace, `locale: "en-US"`, `timezoneId: "UTC"` so a re-run does not diff on a clock tick. The first page shot by hand breaks that, and it cannot be un-broken without redoing everything.
2. **It encodes what the app does, not what it looks like.** Roughly a third of the file is comments recording things that cost real time to learn — element ids are not unique because the preview pane renders the same survey; a panel a toggle reveals is the row's *sibling*; a CTA pointing at an external URL means `networkidle` never fires. That knowledge is worth more than the script.
3. **Re-shooting is not a one-off.** Two releases invalidated 320 images. The next one will do it again, and the cost of responding is either "run a script" or "spend a week".
4. **It caught a real defect.** The Next.js dev-tools button sits over the viewport's bottom-left corner and had landed on the sidebar in **seven images already committed** across four PRs. Found by diffing a re-run against what was on the branches — which is only possible if a re-run is reproducible.

## What the fixture contains

An "ACME Inc." retail bank — financial services because it matches our ICP, so a prospect reading the docs recognises the survey. A link survey with all 16 element types at **fixed ids** (`acme-<type>`, so a shot never depends on question order), an app survey, 52 responses (38 finished / 14 partial, interleaved), hidden fields, variables, tags with uneven counts, 8 contacts, 7 attribute keys, segments, 6 user actions, 4 org members across all four roles, 2 teams, and two link surveys that exist only to photograph the PIN and email gates.

Everything is fictional. Every address is on `example.com`, which RFC 2606 reserves and which reaches nobody.

## Where to look

- [`scripts/docs-capture/capture.ts`](https://github.com/formbricks/formbricks/blob/chore/docs-capture-harness/scripts/docs-capture/capture.ts) — the `Shot` type and the `shots` array are the whole interface. A shot drives the app to a moment and returns a Locator, a clip box, or nothing.
- **`scripts/` and not `apps/web/`**, deliberately: `apps/web/tsconfig.json` has `"include": ["**/*.ts"]`, so anything under the app is typechecked by the Next build. A dev script that fails to compile takes the build down, and with it E2E and the v3 contract tests. That is not hypothetical — it cost a red CI run earlier this week.
- **`db:seed:docs` is separate from `db:seed`** because this fixture's content *ships*: it is visible in ~200 public images. `db:seed` is what every developer runs locally and shows up in nobody's output. Branding `seed.ts` as ACME would push a docs concern into every developer's database.

## Breaking changes

- [ ] This PR contains breaking changes

None. Two new files, one npm script, one `.gitignore` line. Nothing imports any of it, nothing runs in CI, and no existing behaviour changes.

## Migrations & env

- none. `db:seed:docs` is additive and idempotent — every write is an `upsert`, except responses, which are deleted and rewritten so counts stay stable across runs.

## How this was tested

Rerun: `pnpm --filter @formbricks/database db:seed:docs && pnpm tsx scripts/docs-capture/capture.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The harness produces the images actually merged | manual | ~55 images across 20 merged PRs came from this script |
| The seed is idempotent | manual | Run repeatedly against a live database this week; response count stays 52 |
| The fixture typechecks and lints clean | `pnpm --filter @formbricks/database typecheck`, eslint | Clean |
| Nothing under `apps/web` is touched | manual | Both files are outside it, for the tsconfig reason above |
| Session cookies cannot be committed | manual | `scripts/docs-capture/.auth.json` is gitignored — it holds a live login |
| `ANSWER_POOL` is honestly partial | source + run | Six of sixteen elements deliberately have no answers, so the response table has empty cells. Typed `Partial<Record<…>>`; a total `Record` types the miss away and hands `pick` an `undefined` to index — which is exactly what a lint fix nearly did here before the seed was re-run to check |

**Open gaps**

- **No CI check.** Nothing verifies the script still runs, so it can rot silently. A weekly job that runs it and fails on a thrown selector would fix that; not included because it needs a seeded database in CI.
- **Selectors are structural**, not `data-testid`. `.scroll-mt-16` for an editor card, `[data-radix-popper-content-wrapper]` for an open menu. They break when the DOM changes — that is the maintenance cost, and the comments exist to make the breakage diagnosable.
- **Images are verified by eye.** Nothing asserts a shot contains what it should.
- Two shots need a file argument (`DOCS_CAPTURE_LOGO`) and are not runnable without it.

**Risks**

- Nothing executes in CI or in the product. The risk is maintenance: an unmaintained script is worse than none, because the next person trusts it.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).
