### PR TITLE
chore(a11y): scan the answered-state cards and script the manual screen-reader pass

### DIFF
--- a/apps/web/playwright/survey-accessibility.spec.ts
+++ b/apps/web/playwright/survey-accessibility.spec.ts
@@ -89,11 +89,10 @@ const MAX_STEPS = 25;
 
 // The file the answered-states walk attaches to the (required) file-upload card. Built in
 // memory rather than read from disk so the spec owns its own fixture, and kept to an SVG the
-// storage mock already serves for unknown names (see `mockStorageUploads`). The stem is
-// asserted against the delete control's accessible name, which the app derives from the stored
-// file name — so it must survive the upload round-trip.
-const UPLOAD_FIXTURE_STEM = "a11y-answered-states";
-const UPLOAD_FIXTURE_FILE_NAME = `${UPLOAD_FIXTURE_STEM}.svg`;
+// storage mock already serves for unknown names (see `mockStorageUploads`). The name is asserted
+// exactly against the delete control's accessible name, which the app derives from the stored file
+// name — so it must survive the upload round-trip unchanged.
+const UPLOAD_FIXTURE_FILE_NAME = "a11y-answered-states.svg";
 const UPLOAD_FIXTURE_BODY = Buffer.from(
   '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><rect width="32" height="32" fill="#0f172a"/></svg>',
   "utf8"
@@ -652,101 +651,109 @@ test.describe("Survey accessibility (axe-core) @slow", () => {
 
     const variant = "answered-states";
     const violations: ViolationRow[] = [];
+    let cardId = "";
 
-    // 1. Date — scan the card once a day is actually selected.
-    const dateCardId = await openFirstQuestionCard(page, seeded.answeredStatesSurveyUrl);
-    const dateCard = page.locator(`[id="${dateCardId}"]`);
-    await expect(
-      dateCard.getByRole("heading", { level: 2, name: DATE_HEADLINE }),
-      "the answered-states walk should open on the date card"
-    ).toBeVisible({ timeout: CARD_TIMEOUT });
+    await test.step("selected day cell", async () => {
+      cardId = await openFirstQuestionCard(page, seeded.answeredStatesSurveyUrl);
+      const card = page.locator(`[id="${cardId}"]`);
+      await expect(
+        card.getByRole("heading", { level: 2, name: DATE_HEADLINE }),
+        "the answered-states walk should open on the date card"
+      ).toBeVisible({ timeout: CARD_TIMEOUT });
 
-    // The single-h1 contract (ENG-2336) is asserted on the kitchen sink further down, but it is a
-    // per-survey property of the renderer, so hold the second fixture to it here too.
-    await expect(
-      page.locator("#fbjs").getByRole("heading", { level: 1 }),
-      "the answered-states survey should expose its name as the page's one h1"
-    ).toHaveText(A11Y_ANSWERED_STATES_SURVEY_NAME);
+      // The single-h1 contract (ENG-2336) is asserted on the kitchen sink further down, but it is
+      // a per-survey property of the renderer, so hold the second fixture to it here too.
+      await expect(
+        page.locator("#fbjs").getByRole("heading", { level: 1 }),
+        "the answered-states survey should expose its name as the page's one h1"
+      ).toHaveText(A11Y_ANSWERED_STATES_SURVEY_NAME);
 
-    await answerCurrentCard(page, dateCard);
-    await expect(
-      dateCard.locator('button[data-selected-single="true"]'),
-      "a day must be selected before the selected-day state can be scanned"
-    ).toHaveCount(1);
-    await waitForCardSettled(page, dateCardId);
-    await scan(page, variant, "date-day-selected", violations);
-
-    // 2. External CTA — the extra in-card button is the whole point of this card, so assert it
-    //    rendered. It is never clicked: it opens a new tab.
-    const ctaCardId = await advanceToNextCard(page, dateCardId);
-    const ctaCard = page.locator(`[id="${ctaCardId}"]`);
-    await expect(
-      ctaCard.getByRole("heading", { level: 2, name: CTA_EXTERNAL_HEADLINE }),
-      "the date card should advance to the external CTA card"
-    ).toBeVisible({ timeout: CARD_TIMEOUT });
-    await expect(
-      ctaCard.getByRole("button", { name: CTA_EXTERNAL_BUTTON_LABEL }),
-      "the external CTA button should render, named by its ctaButtonLabel"
-    ).toBeVisible({ timeout: ACTION_TIMEOUT });
-    await waitForCardSettled(page, ctaCardId);
-    await scan(page, variant, "cta-external-button", violations);
-
-    // 3. File upload — attach a file through the mocked storage boundary, then scan the state
-    //    the walker skips. The card is REQUIRED, so advancing past it (step 4) is only possible
-    //    if the upload really produced a response value.
-    const uploadCardId = await advanceToNextCard(page, ctaCardId);
-    const uploadCard = page.locator(`[id="${uploadCardId}"]`);
-    await expect(
-      uploadCard.getByRole("heading", { level: 2, name: FILE_UPLOAD_HEADLINE }),
-      "the CTA card should advance to the file upload card"
-    ).toBeVisible({ timeout: CARD_TIMEOUT });
-
-    await uploadCard.locator('input[type="file"]').setInputFiles({
-      name: UPLOAD_FIXTURE_FILE_NAME,
-      mimeType: "image/svg+xml",
-      buffer: UPLOAD_FIXTURE_BODY,
+      await answerCurrentCard(page, card);
+      // Asserted through `aria-selected` rather than the styling hook: it is what a screen reader
+      // consumes, and it is the state whose brand-on-brand contrast this scan exists to measure.
+      await expect(
+        card.getByRole("gridcell", { selected: true }),
+        "a day must be exposed as selected before the selected-day state can be scanned"
+      ).toHaveCount(1);
+      await waitForCardSettled(page, cardId);
+      await scan(page, variant, "date-day-selected", violations);
     });
 
-    const deleteControl = uploadCard.getByRole("button", { name: /^Delete / });
-    await expect(
-      deleteControl,
-      "the uploaded file should render exactly one delete control, named after the file"
-    ).toHaveCount(1);
-    await expect(deleteControl).toHaveAccessibleName(new RegExp(`^Delete .*${UPLOAD_FIXTURE_STEM}`));
-    await expect(
-      uploadCard.locator('input[type="file"]'),
-      "single-file upload hides the dropzone once a file is attached — that is the state under scan"
-    ).toHaveCount(0);
-    await waitForCardSettled(page, uploadCardId);
-    await scan(page, variant, "file-upload-attached", violations);
+    await test.step("external CTA button", async () => {
+      cardId = await advanceToNextCard(page, cardId);
+      const card = page.locator(`[id="${cardId}"]`);
+      await expect(
+        card.getByRole("heading", { level: 2, name: CTA_EXTERNAL_HEADLINE }),
+        "the date card should advance to the external CTA card"
+      ).toBeVisible({ timeout: CARD_TIMEOUT });
+      // The extra in-card button is the whole point of this card, so assert it rendered. It is
+      // never clicked: it opens a new tab.
+      await expect(
+        card.getByRole("button", { name: CTA_EXTERNAL_BUTTON_LABEL }),
+        "the external CTA button should render, named by its ctaButtonLabel"
+      ).toBeVisible({ timeout: ACTION_TIMEOUT });
+      await waitForCardSettled(page, cardId);
+      await scan(page, variant, "cta-external-button", violations);
+    });
 
-    // 4. Cal.com scheduler — our wrapper only. The embed origin is aborted, so the container
-    //    must be empty; assert that, or this scan would be grading third-party markup.
-    const calCardId = await advanceToNextCard(page, uploadCardId);
-    const calCard = page.locator(`[id="${calCardId}"]`);
-    await expect(
-      calCard.getByRole("heading", { level: 2, name: CAL_HEADLINE }),
-      "a required file upload must accept the mocked upload and advance to the scheduler card"
-    ).toBeVisible({ timeout: CARD_TIMEOUT });
+    await test.step("attached file", async () => {
+      cardId = await advanceToNextCard(page, cardId);
+      const card = page.locator(`[id="${cardId}"]`);
+      await expect(
+        card.getByRole("heading", { level: 2, name: FILE_UPLOAD_HEADLINE }),
+        "the CTA card should advance to the file upload card"
+      ).toBeVisible({ timeout: CARD_TIMEOUT });
 
-    const calContainer = calCard.locator('[id^="cal-embed-"]');
-    await expect(calContainer, "the scheduler wrapper should render").toHaveCount(1);
-    await expect(
-      calContainer.locator("iframe"),
-      "the third-party Cal.com embed must stay blocked: this scan covers our wrapper only"
-    ).toHaveCount(0);
-    await waitForCardSettled(page, calCardId);
-    await scan(page, variant, "cal-scheduler-wrapper", violations);
+      await card.locator('input[type="file"]').setInputFiles({
+        name: UPLOAD_FIXTURE_FILE_NAME,
+        mimeType: "image/svg+xml",
+        buffer: UPLOAD_FIXTURE_BODY,
+      });
 
-    // Prove the whole walk completed rather than stalling on a card we could not answer.
-    // `advanceToNextCard` is not reused here: the next state is the ending card, which has no
-    // card id of its own, so it would fail that helper's "landed on the next card" assertion.
-    await advanceButton(calCard).first().click({ timeout: ACTION_TIMEOUT });
-    await waitForCardTransition(page, calCardId);
-    await expect(
-      endingCardLocator(page).first(),
-      "the answered-states walk should reach the ending card"
-    ).toBeVisible({ timeout: CARD_TIMEOUT });
+      // The delete control only exists once a file is attached, and its accessible name IS the
+      // stored file name — so one assertion proves both that the mocked upload landed and that the
+      // control a respondent needs in order to undo it says which file it removes.
+      await expect(
+        card.getByRole("button", { name: `Delete ${UPLOAD_FIXTURE_FILE_NAME}`, exact: true }),
+        "the attached file should render one delete control named after it"
+      ).toHaveCount(1);
+      await waitForCardSettled(page, cardId);
+      await scan(page, variant, "file-upload-attached", violations);
+    });
+
+    await test.step("scheduler wrapper", async () => {
+      // The upload card is REQUIRED, so landing here at all proves the upload produced a response.
+      cardId = await advanceToNextCard(page, cardId);
+      const card = page.locator(`[id="${cardId}"]`);
+      await expect(
+        card.getByRole("heading", { level: 2, name: CAL_HEADLINE }),
+        "a required file upload must accept the mocked upload and advance to the scheduler card"
+      ).toBeVisible({ timeout: CARD_TIMEOUT });
+
+      // Not a markup check but a scope check: if the embed ever loads, this scan silently starts
+      // grading Cal.com's DOM, which nobody here can fix. Fail loudly instead.
+      const calContainer = card.locator('[id^="cal-embed-"]');
+      await expect(calContainer, "the scheduler wrapper should render").toHaveCount(1);
+      await expect(
+        calContainer.locator("iframe"),
+        "the third-party Cal.com embed must stay blocked: this scan covers our wrapper only"
+      ).toHaveCount(0);
+      await waitForCardSettled(page, cardId);
+      await scan(page, variant, "cal-scheduler-wrapper", violations);
+    });
+
+    await test.step("reaches the ending card", async () => {
+      // `advanceToNextCard` is not reused here: the next state is the ending card, which has no
+      // card id of its own, so it would fail that helper's "landed on the next card" assertion.
+      await advanceButton(page.locator(`[id="${cardId}"]`))
+        .first()
+        .click({ timeout: ACTION_TIMEOUT });
+      await waitForCardTransition(page, cardId);
+      await expect(
+        endingCardLocator(page).first(),
+        "the answered-states walk should reach the ending card"
+      ).toBeVisible({ timeout: CARD_TIMEOUT });
+    });
 
     reportAndAssert(variant, violations);
   });

--- a/apps/web/playwright/survey-accessibility.spec.ts
+++ b/apps/web/playwright/survey-accessibility.spec.ts
@@ -3,8 +3,15 @@ import { type Locator, type Page, expect } from "@playwright/test";
 import { logger } from "@formbricks/logger";
 import { test } from "./lib/fixtures";
 import {
+  A11Y_ANSWERED_STATES_SURVEY_NAME,
   A11Y_SURVEY_NAME,
+  CAL_EMBED_ORIGIN,
+  CAL_HEADLINE,
+  CTA_EXTERNAL_BUTTON_LABEL,
+  CTA_EXTERNAL_HEADLINE,
+  DATE_HEADLINE,
   ENDING_CARD_HEADLINE,
+  FILE_UPLOAD_HEADLINE,
   OPEN_TEXT_HEADLINE,
   SINGLE_SELECT_HEADLINE,
   type SeededAccessibilitySurveys,
@@ -21,6 +28,11 @@ import { mockStorageUploads } from "./utils/helper";
  * empty-submit, back-nav, and a multi-language RTL pass) and asserts zero WCAG 2.1
  * / 2.2 AA violations. A silent stall fails the test rather than passing as "clean":
  * the walker proves it advanced and reached the ending card.
+ *
+ * A tenth variant scans the second, "answered states" fixture (ENG-1298): the cards
+ * whose DOM only exists after an interaction, which the walker — which scans each card
+ * once, before answering it — structurally cannot reach, plus the Cal.com scheduler
+ * wrapper, which cannot live in the kitchen sink at all.
  *
  * Tagged @slow — it provisions surveys and walks them across many variants. It runs
  * in the standard `pnpm test:e2e` job (testMatch **\/*.spec.ts); the tag is metadata
@@ -55,8 +67,10 @@ interface AllowlistEntry {
 }
 
 // Currently empty: every violation the suite found was fixed at the source instead
-// (file-upload dropzone restructure, branding contrast) and the Cal.com third-party
-// iframe was removed from the fixture. Add entries only for justified wontfixes.
+// (file-upload dropzone restructure, branding contrast), and the Cal.com third-party
+// iframe needs no entry because it never renders — the answered-states walk blocks the
+// embed origin and asserts the container stayed empty, so only our own wrapper is
+// graded. Add entries only for justified wontfixes.
 const ALLOWLIST: AllowlistEntry[] = [];
 
 type ViolationRow = {
@@ -72,6 +86,18 @@ type ViolationRow = {
 const CARD_TIMEOUT = 15_000;
 const ACTION_TIMEOUT = 8_000;
 const MAX_STEPS = 25;
+
+// The file the answered-states walk attaches to the (required) file-upload card. Built in
+// memory rather than read from disk so the spec owns its own fixture, and kept to an SVG the
+// storage mock already serves for unknown names (see `mockStorageUploads`). The stem is
+// asserted against the delete control's accessible name, which the app derives from the stored
+// file name — so it must survive the upload round-trip.
+const UPLOAD_FIXTURE_STEM = "a11y-answered-states";
+const UPLOAD_FIXTURE_FILE_NAME = `${UPLOAD_FIXTURE_STEM}.svg`;
+const UPLOAD_FIXTURE_BODY = Buffer.from(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><rect width="32" height="32" fill="#0f172a"/></svg>',
+  "utf8"
+);
 
 const isAllowlisted = (ruleId: string, target: string): boolean =>
   ALLOWLIST.some(
@@ -480,6 +506,39 @@ const openFirstQuestionCard = async (page: Page, surveyUrl: string): Promise<str
   return firstCardId ?? "";
 };
 
+/**
+ * Aborts every request to the Cal.com embed origin, so the scheduler's third-party snippet
+ * (packages/surveys cal-embed.tsx loads it from `https://cal.com/embed.js`) never runs and
+ * never injects its cross-origin iframe.
+ *
+ * This is what makes a `cal` card scannable unattended at all. Left unblocked, the card's
+ * axe result would depend on external network and on markup Formbricks neither owns nor can
+ * fix — the reason the kitchen-sink fixture excludes the type outright. Blocked, what renders
+ * is exactly the wrapper that IS ours: headline, subheader, and the embed container. The test
+ * asserts the container stayed iframe-free, so the scan cannot silently grade Cal.com's DOM.
+ */
+const blockCalEmbedRequests = (page: Page): Promise<void> =>
+  page.route(
+    (url) => url.hostname === CAL_EMBED_ORIGIN || url.hostname.endsWith(`.${CAL_EMBED_ORIGIN}`),
+    (route) => route.abort()
+  );
+
+/**
+ * Clicks the current card's advance button and waits for a stable next card, asserting that
+ * one arrived. Used by the answered-states walk, which needs the next card's id to scope its
+ * assertions — unlike `walkAndScan`, which only needs to know it moved.
+ */
+const advanceToNextCard = async (page: Page, fromCardId: string): Promise<string> => {
+  const advance = advanceButton(page.locator(`[id="${fromCardId}"]`)).first();
+  await expect(advance, `advance button should be present on ${fromCardId}`).toBeVisible({
+    timeout: ACTION_TIMEOUT,
+  });
+  await advance.click({ timeout: ACTION_TIMEOUT });
+  const nextCardId = await waitForCardTransition(page, fromCardId);
+  expect(nextCardId, `advancing past ${fromCardId} should land on the next card`).toBeTruthy();
+  return nextCardId ?? "";
+};
+
 const reportAndAssert = (variant: string, failSink: ViolationRow[]): void => {
   if (failSink.length > 0) {
     logger.error(`\n=== ${failSink.length} WCAG AA violation(s) for variant "${variant}" ===`);
@@ -562,6 +621,134 @@ test.describe("Survey accessibility (axe-core) @slow", () => {
     await waitForCardSettled(page, firstCardId);
     await scan(page, "desktop-back-nav", "first-card-after-back", violations);
     reportAndAssert("desktop-back-nav", violations);
+  });
+
+  /**
+   * Answered-state coverage (ENG-1298).
+   *
+   * The walks above scan each card exactly once, BEFORE answering it, and deliberately never
+   * answer the file input — so the markup a card renders only AFTER an interaction has never
+   * reached axe. This scans that markup on the second fixture, one card per state:
+   *
+   * - the SELECTED day cell, whose `bg-brand` + `text-primary-foreground` pairing is chosen for
+   *   contrast in packages/survey-ui but has never been measured by axe;
+   * - the external CTA's in-card link button, a branch the kitchen sink never renders because it
+   *   sets `buttonExternal: false`;
+   * - the uploaded-file chip and its delete control, with the dropzone gone (single-file mode
+   *   hides the uploader once a file is attached);
+   * - the Cal.com scheduler wrapper, which cannot live in the kitchen sink at all.
+   *
+   * Every state is asserted BEFORE it is scanned, so a click that silently did nothing fails
+   * here instead of being reported as clean — the same rule the walker's stall detection applies.
+   *
+   * One test, desktop only. These are card-local DOM states, so a second viewport, theme or
+   * direction would re-scan the same nodes for the price of another full walk.
+   */
+  test("answered states: selected date, external CTA, uploaded file and scheduler wrapper have no WCAG AA violations", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    await blockCalEmbedRequests(page);
+
+    const variant = "answered-states";
+    const violations: ViolationRow[] = [];
+
+    // 1. Date — scan the card once a day is actually selected.
+    const dateCardId = await openFirstQuestionCard(page, seeded.answeredStatesSurveyUrl);
+    const dateCard = page.locator(`[id="${dateCardId}"]`);
+    await expect(
+      dateCard.getByRole("heading", { level: 2, name: DATE_HEADLINE }),
+      "the answered-states walk should open on the date card"
+    ).toBeVisible({ timeout: CARD_TIMEOUT });
+
+    // The single-h1 contract (ENG-2336) is asserted on the kitchen sink further down, but it is a
+    // per-survey property of the renderer, so hold the second fixture to it here too.
+    await expect(
+      page.locator("#fbjs").getByRole("heading", { level: 1 }),
+      "the answered-states survey should expose its name as the page's one h1"
+    ).toHaveText(A11Y_ANSWERED_STATES_SURVEY_NAME);
+
+    await answerCurrentCard(page, dateCard);
+    await expect(
+      dateCard.locator('button[data-selected-single="true"]'),
+      "a day must be selected before the selected-day state can be scanned"
+    ).toHaveCount(1);
+    await waitForCardSettled(page, dateCardId);
+    await scan(page, variant, "date-day-selected", violations);
+
+    // 2. External CTA — the extra in-card button is the whole point of this card, so assert it
+    //    rendered. It is never clicked: it opens a new tab.
+    const ctaCardId = await advanceToNextCard(page, dateCardId);
+    const ctaCard = page.locator(`[id="${ctaCardId}"]`);
+    await expect(
+      ctaCard.getByRole("heading", { level: 2, name: CTA_EXTERNAL_HEADLINE }),
+      "the date card should advance to the external CTA card"
+    ).toBeVisible({ timeout: CARD_TIMEOUT });
+    await expect(
+      ctaCard.getByRole("button", { name: CTA_EXTERNAL_BUTTON_LABEL }),
+      "the external CTA button should render, named by its ctaButtonLabel"
+    ).toBeVisible({ timeout: ACTION_TIMEOUT });
+    await waitForCardSettled(page, ctaCardId);
+    await scan(page, variant, "cta-external-button", violations);
+
+    // 3. File upload — attach a file through the mocked storage boundary, then scan the state
+    //    the walker skips. The card is REQUIRED, so advancing past it (step 4) is only possible
+    //    if the upload really produced a response value.
+    const uploadCardId = await advanceToNextCard(page, ctaCardId);
+    const uploadCard = page.locator(`[id="${uploadCardId}"]`);
+    await expect(
+      uploadCard.getByRole("heading", { level: 2, name: FILE_UPLOAD_HEADLINE }),
+      "the CTA card should advance to the file upload card"
+    ).toBeVisible({ timeout: CARD_TIMEOUT });
+
+    await uploadCard.locator('input[type="file"]').setInputFiles({
+      name: UPLOAD_FIXTURE_FILE_NAME,
+      mimeType: "image/svg+xml",
+      buffer: UPLOAD_FIXTURE_BODY,
+    });
+
+    const deleteControl = uploadCard.getByRole("button", { name: /^Delete / });
+    await expect(
+      deleteControl,
+      "the uploaded file should render exactly one delete control, named after the file"
+    ).toHaveCount(1);
+    await expect(deleteControl).toHaveAccessibleName(new RegExp(`^Delete .*${UPLOAD_FIXTURE_STEM}`));
+    await expect(
+      uploadCard.locator('input[type="file"]'),
+      "single-file upload hides the dropzone once a file is attached — that is the state under scan"
+    ).toHaveCount(0);
+    await waitForCardSettled(page, uploadCardId);
+    await scan(page, variant, "file-upload-attached", violations);
+
+    // 4. Cal.com scheduler — our wrapper only. The embed origin is aborted, so the container
+    //    must be empty; assert that, or this scan would be grading third-party markup.
+    const calCardId = await advanceToNextCard(page, uploadCardId);
+    const calCard = page.locator(`[id="${calCardId}"]`);
+    await expect(
+      calCard.getByRole("heading", { level: 2, name: CAL_HEADLINE }),
+      "a required file upload must accept the mocked upload and advance to the scheduler card"
+    ).toBeVisible({ timeout: CARD_TIMEOUT });
+
+    const calContainer = calCard.locator('[id^="cal-embed-"]');
+    await expect(calContainer, "the scheduler wrapper should render").toHaveCount(1);
+    await expect(
+      calContainer.locator("iframe"),
+      "the third-party Cal.com embed must stay blocked: this scan covers our wrapper only"
+    ).toHaveCount(0);
+    await waitForCardSettled(page, calCardId);
+    await scan(page, variant, "cal-scheduler-wrapper", violations);
+
+    // Prove the whole walk completed rather than stalling on a card we could not answer.
+    // `advanceToNextCard` is not reused here: the next state is the ending card, which has no
+    // card id of its own, so it would fail that helper's "landed on the next card" assertion.
+    await advanceButton(calCard).first().click({ timeout: ACTION_TIMEOUT });
+    await waitForCardTransition(page, calCardId);
+    await expect(
+      endingCardLocator(page).first(),
+      "the answered-states walk should reach the ending card"
+    ).toBeVisible({ timeout: CARD_TIMEOUT });
+
+    reportAndAssert(variant, violations);
   });
 
   test("mobile: full walk has no WCAG AA violations", async ({ page }) => {

--- a/apps/web/playwright/utils/accessibility.ts
+++ b/apps/web/playwright/utils/accessibility.ts
@@ -26,6 +26,11 @@ type TLegacyQuestions = Parameters<typeof transformQuestionsToBlocks>[0];
  * row + `SurveyLanguage` join, and patches Arabic translation keys into the
  * stored blocks so axe scans genuine RTL content; `?lang=ar-EG` then renders the
  * survey with `dir="rtl"` (see packages/surveys/src/lib/utils.ts `isRTLLanguage`).
+ *
+ * A THIRD fixture — the "answered states" survey — carries the cards whose
+ * post-interaction DOM the kitchen-sink walker can never reach, plus the one
+ * question type the kitchen sink cannot hold at all (ENG-1298). See
+ * `buildAnsweredStatesQuestions` for what each card is there to expose.
  */
 
 type I18n = { default: string; [lang: string]: string };
@@ -130,6 +135,8 @@ const buildKitchenSinkQuestions = (baseURL: string) => [
   // NOTE: no `cal` question on purpose — the Cal.com embed loads a live third-party
   // iframe, which would make the unattended axe walk depend on external network and
   // markup we do not control (its violations would all be wontfix-allowlisted anyway).
+  // The wrapper Formbricks DOES own is scanned in `buildAnsweredStatesQuestions`
+  // below, where the spec blocks the embed origin instead of loading it.
   {
     id: createId(),
     type: "pictureSelection",
@@ -152,10 +159,74 @@ const buildKitchenSinkQuestions = (baseURL: string) => [
 ];
 
 /**
+ * Builds the "answered states" question list (ENG-1298).
+ *
+ * The kitchen-sink walker scans each card exactly once, BEFORE it answers it, and
+ * skips the file input entirely — so a whole class of DOM has never reached axe:
+ * the markup a card only renders once the respondent has interacted with it. Each
+ * card below is here for one specific unscanned state, and the spec asserts it
+ * actually reached that state before scanning (a no-op must not pass as clean).
+ *
+ * | Card                        | State axe has never seen                                         |
+ * | --------------------------- | ---------------------------------------------------------------- |
+ * | `date`                      | the SELECTED day cell (`bg-brand` + `text-primary-foreground`)   |
+ * | `cta` with `buttonExternal` | the in-card external-link button; the kitchen sink sets it false |
+ * | `fileUpload`                | the uploaded-file chip + its `Delete …` control, uploader hidden |
+ * | `cal`                       | our wrapper around the scheduler — never scanned at all          |
+ *
+ * `fileUpload` is deliberately REQUIRED here: advancing past it is then only
+ * possible if the mocked upload really registered a response, which is what makes
+ * the "fully exercised" claim checkable rather than asserted.
+ */
+const buildAnsweredStatesQuestions = (baseURL: string) => [
+  {
+    id: createId(),
+    type: "date",
+    headline: i18nValue(DATE_HEADLINE),
+    subheader: i18nValue("Pick any day that suits you."),
+    required: true,
+    format: "M-d-y",
+  },
+  {
+    id: createId(),
+    type: "cta",
+    headline: i18nValue(CTA_EXTERNAL_HEADLINE),
+    subheader: i18nValue("The guide opens in a new tab."),
+    required: false,
+    buttonExternal: true,
+    // Same-origin on purpose: `buttonUrl` has to satisfy `isSafeLinkUrl`, and a
+    // fixture must never point a click at a live external site. The transform
+    // moves `buttonLabel` to `ctaButtonLabel`, which is what the button renders.
+    buttonUrl: new URL("/", baseURL).toString(),
+    buttonLabel: i18nValue(CTA_EXTERNAL_BUTTON_LABEL),
+  },
+  {
+    id: createId(),
+    type: "fileUpload",
+    headline: i18nValue(FILE_UPLOAD_HEADLINE),
+    required: true,
+    allowMultipleFiles: false,
+  },
+  {
+    id: createId(),
+    type: "cal",
+    headline: i18nValue(CAL_HEADLINE),
+    subheader: i18nValue("Any 30 minute slot works."),
+    // Optional because a real booking is impossible here: the only value the
+    // element ever writes is "booked", and that comes from Cal's own iframe.
+    required: false,
+    calUserName: CAL_USER_NAME,
+  },
+];
+
+/**
  * Survey name of the single-language kitchen-sink fixture. The public survey exposes it as its
  * one top-level `<h1>` (ENG-2336), so the heading-structure spec asserts against it.
  */
 export const A11Y_SURVEY_NAME = "A11y Kitchen Sink";
+
+/** Survey name of the answered-states fixture, exposed as that survey's one `<h1>`. */
+export const A11Y_ANSWERED_STATES_SURVEY_NAME = "A11y Answered States";
 
 /** Welcome-card headline, exposed as an `<h2>` like every other card headline. */
 export const WELCOME_CARD_HEADLINE = "Welcome to our feedback survey";
@@ -165,6 +236,35 @@ export const OPEN_TEXT_HEADLINE = "What feedback do you have for us?";
 
 /** Headline of the single-select question, which names its radiogroup via aria-labelledby. */
 export const SINGLE_SELECT_HEADLINE = "Which plan are you on?";
+
+/**
+ * Headlines of the answered-states cards. The spec walks that survey by headline rather than by
+ * card index so reordering the fixture cannot silently point a scan at the wrong card.
+ */
+export const DATE_HEADLINE = "Which day works best for you?";
+export const CTA_EXTERNAL_HEADLINE = "Read the setup guide";
+export const FILE_UPLOAD_HEADLINE = "Attach a screenshot of the problem";
+export const CAL_HEADLINE = "Book a call with our team";
+
+/**
+ * Label of the CTA card's in-card external-link button. The transform renames the legacy
+ * `buttonLabel` to `ctaButtonLabel`, which is the field that button renders from — so this is
+ * also the assertion that the rename still holds.
+ */
+export const CTA_EXTERNAL_BUTTON_LABEL = "Open the setup guide";
+
+/**
+ * Cal.com handle for the scheduler fixture. Deliberately not a real one: the spec aborts every
+ * request to `CAL_EMBED_ORIGIN` so the third-party snippet never loads, never resolves this
+ * handle, and never injects its iframe. Only the wrapper around it is ours to scan.
+ */
+export const CAL_USER_NAME = "formbricks-a11y-fixture/30min";
+
+/**
+ * Origin the Cal.com embed snippet is fetched from (see packages/surveys cal-embed.tsx). The spec
+ * blocks it, so the unattended axe run stays free of external network and of markup we do not own.
+ */
+export const CAL_EMBED_ORIGIN = "cal.com";
 
 const buildWelcomeCard = () => ({
   enabled: true,
@@ -189,18 +289,23 @@ const buildEndings = () => [
   },
 ];
 
+/** The two fixture question lists this file can create a survey from. */
+type FixtureQuestionList =
+  | ReturnType<typeof buildKitchenSinkQuestions>
+  | ReturnType<typeof buildAnsweredStatesQuestions>;
+
 /**
- * Creates a published kitchen-sink link survey directly through Prisma. The legacy
- * `questions` list is converted to blocks with the same transform the v1 management
+ * Creates a published link survey directly through Prisma from a legacy `questions`
+ * list. The list is converted to blocks with the same transform the v1 management
  * API applies server-side, so the stored shape cannot drift from the API contract.
  */
-const createKitchenSinkSurvey = async (
+const createLinkSurvey = async (
   workspaceId: string,
   createdBy: string,
   name: string,
-  baseURL: string
+  questionList: FixtureQuestionList
 ): Promise<string> => {
-  const questions = buildKitchenSinkQuestions(baseURL) as unknown as TLegacyQuestions;
+  const questions = questionList as unknown as TLegacyQuestions;
   const endings = buildEndings() as unknown as TSurveyEnding[];
   const blocks = transformQuestionsToBlocks(questions, endings);
 
@@ -310,12 +415,14 @@ export interface SeededAccessibilitySurveys {
   surveyUrl: string;
   /** Published multi-language kitchen-sink survey link forced to Arabic, e.g. `/s/<id>?lang=ar-EG`. */
   rtlSurveyUrl: string;
+  /** Published answered-states survey link (date / external CTA / file upload / cal), e.g. `/s/<id>`. */
+  answeredStatesSurveyUrl: string;
 }
 
 /**
- * Seeds a workspace user plus two published kitchen-sink link surveys (one
- * default-language, one with an Arabic RTL variant) entirely through Prisma —
- * no login or dashboard interaction — and returns their public `/s/<id>` links.
+ * Seeds a workspace user plus three published link surveys — the kitchen sink, its
+ * Arabic RTL twin, and the answered-states fixture — entirely through Prisma, with
+ * no login or dashboard interaction, and returns their public `/s/<id>` links.
  */
 export const seedAccessibilitySurveys = async (
   users: UsersFixture,
@@ -327,9 +434,15 @@ export const seedAccessibilitySurveys = async (
     throw new Error("users.create() did not return a workspaceId");
   }
 
-  const [mainSurveyId, rtlSurveyId] = await Promise.all([
-    createKitchenSinkSurvey(workspaceId, user.id, A11Y_SURVEY_NAME, baseURL),
-    createKitchenSinkSurvey(workspaceId, user.id, `${A11Y_SURVEY_NAME} (RTL)`, baseURL),
+  const [mainSurveyId, rtlSurveyId, answeredStatesSurveyId] = await Promise.all([
+    createLinkSurvey(workspaceId, user.id, A11Y_SURVEY_NAME, buildKitchenSinkQuestions(baseURL)),
+    createLinkSurvey(workspaceId, user.id, `${A11Y_SURVEY_NAME} (RTL)`, buildKitchenSinkQuestions(baseURL)),
+    createLinkSurvey(
+      workspaceId,
+      user.id,
+      A11Y_ANSWERED_STATES_SURVEY_NAME,
+      buildAnsweredStatesQuestions(baseURL)
+    ),
   ]);
   await attachArabicLanguage(rtlSurveyId, workspaceId);
 
@@ -337,5 +450,6 @@ export const seedAccessibilitySurveys = async (
     workspaceId,
     surveyUrl: `/s/${mainSurveyId}`,
     rtlSurveyUrl: `/s/${rtlSurveyId}?lang=ar-EG`,
+    answeredStatesSurveyUrl: `/s/${answeredStatesSurveyId}`,
   };
 };

--- a/docs/development/standards/qa/screen-reader-pass.mdx
+++ b/docs/development/standards/qa/screen-reader-pass.mdx
@@ -1,0 +1,173 @@
+---
+title: "Screen Reader Pass"
+description: "The manual screen-reader and keyboard walkthrough of a rendered survey, and how to record what it finds."
+icon: "ear-listen"
+---
+
+Automated accessibility rules catch roughly a third of WCAG failures. Per Deque, axe-core detects
+about 30–40% of issues on a page; the rest — whether alt text says anything useful, whether a
+heading structure reflects the real hierarchy, whether a status change is announced at all, where
+focus actually lands after an interaction — needs a person with a screen reader.
+
+That gap is not theoretical here. The survey validation errors that were rendered but never
+announced (WCAG 4.1.3) passed the axe gate cleanly for months and were found by a manual pass. This
+page is the walkthrough that found it, written down so it can be repeated by someone who has not
+done it before.
+
+<Note>
+  This is a procedure, not a CI gate. Run it when the survey renderer's structure, focus handling,
+  or status messaging changes, and before a release that carries such a change. A single UI detail
+  inside an already-covered flow does not need a full pass.
+</Note>
+
+---
+
+## What The Automated Gate Already Covers
+
+Do not spend the pass re-checking these. They run on every pull request, and if one regresses the
+Playwright job fails before a human ever looks:
+
+| Already asserted in CI                                                      | Where                          |
+| --------------------------------------------------------------------------- | ------------------------------ |
+| Zero WCAG 2.1/2.2 AA axe violations on every card, in 10 variants           | `survey-accessibility.spec.ts` |
+| One `h1` naming the survey, card headlines as `h2`, no skipped level        | `survey-accessibility.spec.ts` |
+| Validation errors reach a resolvable live region; failed submit moves focus | `survey-keyboard.spec.ts`      |
+| Progress is a determinate `progressbar` matching the painted width          | `survey-progress-a11y.spec.ts` |
+| Arrow keys browse without selecting; Space selects and advances once        | `survey-keyboard.spec.ts`      |
+
+What is left for a human is everything above that involves judgement or hearing: whether the
+announcement that fires is the *right* one, whether the focus stop that exists is the *expected*
+one, and whether the text a screen reader reads out means anything.
+
+---
+
+## Before You Start
+
+<Steps>
+  <Step title="Get a survey with every question type in it">
+    The accessibility suite already seeds exactly this. Run any one of its tests against your local
+    stack and the fixtures are left behind in your dev database — an "A11y Kitchen Sink" survey
+    covering every renderable question type, and an "A11y Answered States" survey carrying the date
+    picker, an external CTA, a required file upload and the Cal.com scheduler:
+
+    ```bash
+    pnpm test:e2e survey-accessibility -g "heading structure"
+    psql "$DATABASE_URL" -c "select name, id from \"Survey\" where name like 'A11y%' limit 3;"
+    ```
+
+    They are published link surveys, so `http://localhost:3000/s/<id>` opens one with no login. Use
+    the kitchen sink for the walkthrough below and the answered-states survey for the composite
+    controls step.
+  </Step>
+  <Step title="Pick one screen reader and browser pair">
+    NVDA with Firefox or Chrome on Windows, or VoiceOver with Safari on macOS. Use one pair for the
+    whole pass and write down which — a finding is only reproducible if the pair is known, and the
+    same markup can behave differently in another one.
+  </Step>
+  <Step title="Turn the screen off, or turn the display curtain on">
+    VoiceOver has one built in (`Ctrl+Option+Shift+F11`). The point is to stop yourself from
+    resolving an ambiguity with your eyes, which is the failure mode of every sighted screen-reader
+    pass.
+  </Step>
+</Steps>
+
+---
+
+## The Pass
+
+Walk the survey from the link to the end screen. Each step below names what to do and what a pass
+looks like; anything else is a finding.
+
+<Steps>
+  <Step title="Read the page before touching it">
+    Ask the screen reader for the page title and the heading list (NVDA: `Insert+F7`; VoiceOver:
+    `Ctrl+Option+U`).
+
+    **Pass:** the title identifies the survey and your position in it. The heading list has one
+    level-1 heading — the survey's name — and the current card's prompt as a level 2. You can tell
+    what you are being asked without reading the body.
+  </Step>
+  <Step title="Tab through every card">
+    On each card, `Tab` from the top to the last stop, then `Shift+Tab` back.
+
+    **Pass:** every stop is announced with a name that matches its visible text, and its focus
+    indicator is visible. The order matches the visual order. Nothing off-screen takes focus — the
+    stacked layout keeps neighbouring cards mounted, so a focus stop inside a card you cannot see is
+    a finding. You never get stuck.
+  </Step>
+  <Step title="Submit a required card empty">
+    Leave the first required question blank and activate the submit control.
+
+    **Pass:** you hear the error without moving focus yourself, focus lands on the control that
+    caused it, and you are still on the same card. The error text says which field and what to do.
+  </Step>
+  <Step title="Advance a card and listen">
+    Answer the card and submit.
+
+    **Pass:** something tells you the card changed — the new prompt, the progress, or both — without
+    you having to go looking. Silence here is the highest-value finding this pass produces.
+  </Step>
+  <Step title="Go back">
+    Activate the back control.
+
+    **Pass:** you are told you moved back, your previous answer is still there and is announced as
+    selected, and focus is somewhere useful rather than back at the top of the document.
+  </Step>
+  <Step title="Exercise the composite controls">
+    The date picker, the file upload, the ranking list and the matrix are the four that do not
+    reduce to a single native input.
+
+    **Pass:** the date picker announces the selected day as selected and is operable from the
+    keyboard alone. The file upload announces the upload starting, the file that was attached, and
+    the control that removes it. Ranking announces an item's new position after it moves. Each
+    matrix row announces which row it belongs to, not just the column.
+  </Step>
+  <Step title="Reach the end screen">
+    Complete the survey.
+
+    **Pass:** you hear that the survey is finished. Nothing is left focusable behind the end screen.
+  </Step>
+  <Step title="Re-read anything carrying meaning through colour or an image">
+    Required markers, selected states, error states, images used as choices.
+
+    **Pass:** each one is also carried by text or by an accessible name. Turn the screen back on and
+    squint: if a state is only a colour, it is a finding regardless of its contrast ratio.
+  </Step>
+</Steps>
+
+---
+
+## Known Third-Party Gaps
+
+These are already known and do not need re-filing. Both live inside a cross-origin iframe that
+Formbricks embeds but does not control:
+
+- **Cal.com scheduler.** Only the wrapper around it — the headline, description and container — is
+  ours, and that is the part the axe gate scans. Barriers inside the booker itself belong upstream.
+- **Embedded video** (YouTube, Vimeo, Loom). Formbricks provides no route to captions, a transcript
+  or an audio description, and it reduces the embedded player's controls. The gap and its workaround
+  are published under [Known Limitations](/platform/accessibility#known-limitations).
+
+---
+
+## Recording What You Find
+
+One finding per barrier, in the accessibility findings log, then a ticket for each one worth fixing.
+A finding that someone else can act on carries five things:
+
+1. The screen reader and browser pair, and the platform.
+2. The survey link and the card, by its prompt text.
+3. The keystrokes, in order, from opening the link.
+4. What was announced — quoted, as heard — or "nothing".
+5. What should have been announced instead, and the WCAG criterion it maps to.
+
+Barriers reported from outside the team arrive through the
+[accessibility issue template](https://github.com/formbricks/formbricks/issues/new?labels=accessibility&template=accessibility.yml);
+use the same shape for what you find here.
+
+<Note>
+  When a pass produces a finding that automation could have caught, fix the gate too: an assertion
+  in the relevant spec is cheaper than remembering to look next time. Where that assertion belongs
+  is decided the same way as any other test — see [Testing
+  Methodology](/development/standards/qa/testing-methodology).
+</Note>

--- a/docs/development/standards/qa/screen-reader-pass.mdx
+++ b/docs/development/standards/qa/screen-reader-pass.mdx
@@ -22,7 +22,7 @@ done it before.
 
 ---
 
-## What The Automated Gate Already Covers
+## What the automated gate already covers
 
 Do not spend the pass re-checking these. They run on every pull request, and if one regresses the
 Playwright job fails before a human ever looks:
@@ -41,7 +41,7 @@ one, and whether the text a screen reader reads out means anything.
 
 ---
 
-## Before You Start
+## Before you start
 
 <Steps>
   <Step title="Get a survey with every question type in it">
@@ -73,7 +73,7 @@ one, and whether the text a screen reader reads out means anything.
 
 ---
 
-## The Pass
+## The pass
 
 Walk the survey from the link to the end screen. Each step below names what to do and what a pass
 looks like; anything else is a finding.
@@ -137,7 +137,7 @@ looks like; anything else is a finding.
 
 ---
 
-## Known Third-Party Gaps
+## Known third-party gaps
 
 These are already known and do not need re-filing. Both live inside a cross-origin iframe that
 Formbricks embeds but does not control:
@@ -150,7 +150,7 @@ Formbricks embeds but does not control:
 
 ---
 
-## Recording What You Find
+## Recording what you find
 
 One finding per barrier, in the accessibility findings log, then a ticket for each one worth fixing.
 A finding that someone else can act on carries five things:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -423,7 +423,8 @@
                 "icon": "shield",
                 "pages": [
                   "development/standards/qa/code-reviews",
-                  "development/standards/qa/testing-methodology"
+                  "development/standards/qa/testing-methodology",
+                  "development/standards/qa/screen-reader-pass"
                 ]
               }
             ]


### PR DESCRIPTION
Ref ENG-1298

## What & why

**Was:** the axe walk scanned each card once, *before* answering it, and never answered the file input — so the markup a card renders only after an interaction had never reached axe. The Cal.com scheduler could not be in the fixture at all, because scanning it meant pulling a live third-party embed into an unattended run.

**Now:** a second seeded survey carries the four cards that expose those states, and one desktop test steps through them, asserting each state before it scans it.

- The Cal.com embed origin is aborted and the container asserted iframe-free, so only the wrapper we own is graded.
- The file upload is `required`, so advancing past it proves the upload registered a response.
- The manual half of the ticket needs a real screen reader, so it ships as a repeatable procedure rather than a one-off pass.

## Where to look

- [`utils/accessibility.ts#L162-L220` — the four cards and why each is there](https://github.com/formbricks/formbricks/blob/claude/a11y-test-coverage-scan-je3244/apps/web/playwright/utils/accessibility.ts#L162-L220)
- [`survey-accessibility.spec.ts#L509-L523` — what makes a `cal` card scannable unattended](https://github.com/formbricks/formbricks/blob/claude/a11y-test-coverage-scan-je3244/apps/web/playwright/survey-accessibility.spec.ts#L509-L523)
- [`survey-accessibility.spec.ts#L626-L759` — the five steps, one state each](https://github.com/formbricks/formbricks/blob/claude/a11y-test-coverage-scan-je3244/apps/web/playwright/survey-accessibility.spec.ts#L626-L759)

## Breaking changes

- [ ] This PR contains breaking changes

None — test fixtures and a docs page. Nothing outside this repo reaches either.

## Migrations & env

- none

## How this was tested

Rerun: `CI=1 pnpm test:e2e survey-accessibility --retries=0`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Four post-interaction states reach axe | `e2e` — `apps/web/playwright/survey-accessibility.spec.ts`, "answered states" | Passes in ~10s; 0 AA violations, 1 AAA warning on the selected day |
| Each scan can fail | `e2e (mutation)` — `apps/web/playwright/survey-accessibility.spec.ts:679,696,721,742` | An alt-less `<img>` inserted before each `scan()` reddens all four card labels |
| Each state guard can fail | `e2e (mutation)` — same file, `:671` and `:707` | Deleting the day click fails `› selected day cell`; the upload, `› attached file` |
| The existing 9 variants survive the reseed | `e2e` — same spec | 11/11 pass, 1.5m at 2 workers |
| Second fixture keeps the single-`h1` contract | `e2e` — same spec, "answered states" | `#fbjs` h1 is "A11y Answered States" |
| Playwright specs typecheck | `manual` | 14 errors, 13 pre-existing in the same file; the dir is excluded from CI typecheck and lint |

<details>
<summary>E2E cost, review changes, and what the pre-screen found</summary>

**Cost.** One desktop test, ~10s. Desktop only: these are card-local DOM states, so a second viewport, theme or direction would re-scan the same nodes for the price of another full walk. The four cards are one survey rather than four additions to the kitchen sink, because a `cal` card in the kitchen sink would put a live third-party embed in the middle of nine existing walks.

**From review (8f12053).** Phases are now `test.step`s, so a failure names the card. The selected day is asserted through `aria-selected` on the gridcell rather than the `data-selected-single` styling hook — it is what a screen reader consumes and it survives a restyle. The dropzone-count assertion is gone as redundant, and the delete control's accessible name is asserted exactly. Two suggestions were declined on the threads: the heading locators (role + accessible name is how the test knows which card it is on, and only one of four cards is `required` so transitions cannot substitute) and the iframe check (a scope assertion, not a markup one — without it a broken origin block silently starts grading Cal.com's DOM).

**Findings from the sandbox pre-screen.** Machine-checkable parts of the manual pass, run headlessly so the human walkthrough starts from a shortlist. None is fixed here — each needs its own ticket:

1. **File upload announces nothing, and loses focus on completion.** Mid-upload: "Uploading…" is a plain paragraph, no `aria-busy` anywhere on the page, the only polite live region empty. On completion single-file mode unmounts the focused file input, so `document.activeElement` becomes the document body. WCAG 4.1.3 and 2.4.3. Measured, not inferred.
2. **Picture-selection choices have no author-supplied alt text.** `ZSurveyPictureChoice` is `{ id, imageUrl }`, and both the `alt` and the radio's accessible name come from `getImageAltFromUrl(choice.imageUrl)` — the uploaded filename. A real survey announces "IMG 4821". axe passes because `alt` is non-empty, so the gate can never catch this. WCAG 1.1.1 / 4.1.2.
3. **Card transitions have no live-region announcement** — the polite region stays empty across them. Focus does move into the new card, so the headline is heard where it names the focused control. Needs a real screen reader to judge per card type.
4. **The end screen announces via focus, not a live region** — focus lands on the ending-card container carrying "Thank you! We appreciate your feedback.", and the document title updates to "Page 12 of 12". Plausible; confirm by ear.

**Not a finding.** Tab order could not be measured headlessly: `blur()` does not reset Chromium's sequential focus navigation starting point, so a scripted `Tab` sweep resumes mid-document and reports stops that a real user reaches in a different order. That is the walkthrough's step 2, and it stays a human job.

</details>

**Open gaps**

- No screen reader ran. NVDA and VoiceOver do not exist in a headless Linux sandbox; the four findings above are DOM and source evidence, not heard behaviour.
- The four findings are not logged in the findings log and have no tickets yet.
- The docs page is a judgement call: the ticket asked for one pass, this makes it repeatable. Say the word and it comes out.

**Risks**

- `desktop: full walk` flaked once locally with 47 `color-contrast` findings — the mid-fade artifact `waitForSettled` exists to prevent, on a cold server with two workers. 3/3 green once warm, and green in CI. Pre-existing, untouched by this diff, worth its own look if it recurs.
- The `cal` scan depends on `blockCalEmbedRequests` matching the origin the snippet loads. If that hostname changes, the iframe-free assertion fails loudly rather than scanning third-party markup.
- The upload assertion depends on `mockStorageUploads`. A change to the storage response shape shows up as a missing delete control, not a silent skip.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code 2.1.247), reasoning effort `max`.