### PR TITLE
feat(observability): record the outcome of every SSO callback

### DIFF
--- a/apps/web/app/api/auth/[...all]/route.ts
+++ b/apps/web/app/api/auth/[...all]/route.ts
@@ -1,5 +1,8 @@
 import { auth } from "@/modules/auth/lib/auth";
-import { recordSsoCallbackOutcome } from "@/modules/auth/lib/better-auth-observability";
+import {
+  recordSsoCallbackOutcome,
+  recordSsoCallbackThrow,
+} from "@/modules/auth/lib/better-auth-observability";
 import { createAuthPathLabeller } from "@/modules/auth/lib/better-auth-path-label";
 import { runWithBetterAuthRequestContext } from "@/modules/auth/lib/better-auth-request-context";
 import { runWithEmailVerificationRequestContext } from "@/modules/auth/lib/email-verification-request-context";
@@ -63,23 +66,31 @@ const handler = async (request: Request): Promise<Response> => {
   // neither is ours to change: the pinned SSO callback path, and `application_type` on dynamic client
   // registration (see each module). Both no-op for every other request.
   const mappedRequest = await normalizeDcrRequest(mapLegacySsoCallbackRequest(request));
-  const response = await runWithBetterAuthRequestContext(
-    { path: labelAuthPath(mappedRequest.url), method: mappedRequest.method },
-    () =>
-      runWithSsoRequestContext(() =>
-        // ENG-2562: carries "this request just verified an email" from Better Auth's
-        // `afterEmailVerification` hook to the `hooks.after` chain, which is where the session can
-        // actually be minted. Innermost because it is the narrowest scope of the three — one endpoint,
-        // not the whole handler.
-        runWithEmailVerificationRequestContext(() => auth.handler(mappedRequest))
-      )
-  );
-  // ENG-2551: the one place that sees the outcome of every SSO callback, whatever went wrong and
-  // whichever provider it was — a failed callback is a redirect carrying `?error=`, or a 4xx/5xx.
-  // Emitted here rather than from a hook because the failures that matter most are the ones Better
-  // Auth returns as a response rather than throwing, so no error-path hook observes them.
-  recordSsoCallbackOutcome(mappedRequest.url, response);
-  return response;
+  try {
+    const response = await runWithBetterAuthRequestContext(
+      { path: labelAuthPath(mappedRequest.url), method: mappedRequest.method },
+      () =>
+        runWithSsoRequestContext(() =>
+          // ENG-2562: carries "this request just verified an email" from Better Auth's
+          // `afterEmailVerification` hook to the `hooks.after` chain, which is where the session can
+          // actually be minted. Innermost because it is the narrowest scope of the three — one endpoint,
+          // not the whole handler.
+          runWithEmailVerificationRequestContext(() => auth.handler(mappedRequest))
+        )
+    );
+    // ENG-2551: the one place that sees the outcome of every SSO callback, whatever went wrong and
+    // whichever provider it was — a failed callback is a redirect carrying `?error=`, or a 4xx/5xx.
+    // Emitted here rather than from a hook because the failures that matter most are the ones Better
+    // Auth returns as a response rather than throwing, so no error-path hook observes them.
+    recordSsoCallbackOutcome(mappedRequest.url, response);
+    return response;
+  } catch (error) {
+    // A throw is the most severe callback failure there is — Next answers 500 and the user cannot sign
+    // in — so it must not be the one case the signal misses. Recorded, then rethrown unchanged so the
+    // existing error handling (and the Sentry capture in this module) behaves exactly as before.
+    recordSsoCallbackThrow(mappedRequest.url);
+    throw error;
+  }
 };
 
 export { handler as GET, handler as POST };

--- a/apps/web/app/api/auth/[...all]/route.ts
+++ b/apps/web/app/api/auth/[...all]/route.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/modules/auth/lib/auth";
+import { recordSsoCallbackOutcome } from "@/modules/auth/lib/better-auth-observability";
 import { createAuthPathLabeller } from "@/modules/auth/lib/better-auth-path-label";
 import { runWithBetterAuthRequestContext } from "@/modules/auth/lib/better-auth-request-context";
 import { runWithEmailVerificationRequestContext } from "@/modules/auth/lib/email-verification-request-context";
@@ -62,7 +63,7 @@ const handler = async (request: Request): Promise<Response> => {
   // neither is ours to change: the pinned SSO callback path, and `application_type` on dynamic client
   // registration (see each module). Both no-op for every other request.
   const mappedRequest = await normalizeDcrRequest(mapLegacySsoCallbackRequest(request));
-  return runWithBetterAuthRequestContext(
+  const response = await runWithBetterAuthRequestContext(
     { path: labelAuthPath(mappedRequest.url), method: mappedRequest.method },
     () =>
       runWithSsoRequestContext(() =>
@@ -73,6 +74,12 @@ const handler = async (request: Request): Promise<Response> => {
         runWithEmailVerificationRequestContext(() => auth.handler(mappedRequest))
       )
   );
+  // ENG-2551: the one place that sees the outcome of every SSO callback, whatever went wrong and
+  // whichever provider it was — a failed callback is a redirect carrying `?error=`, or a 4xx/5xx.
+  // Emitted here rather than from a hook because the failures that matter most are the ones Better
+  // Auth returns as a response rather than throwing, so no error-path hook observes them.
+  recordSsoCallbackOutcome(mappedRequest.url, response);
+  return response;
 };
 
 export { handler as GET, handler as POST };

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -15,6 +15,7 @@ import {
   betterAuthLogger,
   getSignInAuthMethod,
   recordSsoCallbackOutcome,
+  recordSsoCallbackThrow,
   redactEmailsInLogMessage,
   signInAuditDatabaseHook,
 } from "./better-auth-observability";
@@ -776,15 +777,64 @@ describe("recordSsoCallbackOutcome (ENG-2551)", () => {
     expect(contextOf()).toMatchObject({ ssoProvider: "unknown" });
   });
 
-  // Same reasoning for the reason field: the `error` parameter arrives from a redirect target and
-  // must not become a free-text log field.
-  test("buckets an error code that is not one of Better Auth's shapes", () => {
+  /**
+   * The reason needs the same protection as the provider, and the reason is easy to miss: Better Auth
+   * **echoes the inbound `error` query parameter** into its redirect (`callback.mjs`,
+   * `if (error) redirectOnError(error, error_description)`). Anyone can get a parseable `state` by
+   * starting a sign-in, then call the callback with `&error=<anything>` — so without an allow-list an
+   * outsider both inflates this field's cardinality and can forge a specific reason to disguise a
+   * real outage. A charset regex would not help: it bounds the shape, not the number of values.
+   */
+  test.each([
+    ["a plausible but unknown code", "totally_made_up_code"],
+    ["a forged real-looking code", "state_mismatch_2"],
+    ["markup", "%3Cscript%3E+injected"],
+  ])("buckets %s to other", (_label, injected) => {
     recordSsoCallbackOutcome(
       "https://app.test/api/auth/callback/google",
-      redirect("https://app.test/auth/login?error=%3Cscript%3E+injected+%3D+true")
+      redirect(`https://app.test/auth/login?error=${injected}`)
     );
 
-    expect(contextOf()).toMatchObject({ ssoCallbackReason: "unrecognised" });
+    expect(contextOf()).toMatchObject({ ssoCallbackReason: "other" });
+  });
+
+  test.each([
+    ["Better Auth's own callback code", "unable_to_get_user_info"],
+    ["a StateError code", "state_mismatch"],
+    ["a code this app emits", "account_not_linked"],
+    // What a database outage mid-callback actually produces — verified by stopping Postgres against a
+    // live instance. Bucketing this one would hide the clearest infrastructure signal there is.
+    ["the code an infrastructure fault produces", "internal_server_error"],
+  ])("records %s verbatim", (_label, code) => {
+    recordSsoCallbackOutcome(
+      "https://app.test/api/auth/callback/azuread",
+      redirect(`https://app.test/auth/login?error=${code}`)
+    );
+
+    expect(contextOf()).toMatchObject({ ssoCallbackReason: code });
+  });
+
+  /**
+   * The worst callback failure is the one that never produces a response at all: the request throws,
+   * Next answers 500, nobody signs in. Recording only responses would have left precisely that case
+   * invisible to the alert.
+   */
+  test("records a callback that threw", () => {
+    recordSsoCallbackThrow("https://app.test/api/auth/callback/azuread");
+
+    expect(contextOf()).toEqual({
+      source: "sso-callback",
+      ssoCallbackOutcome: "failure",
+      ssoProvider: "azuread",
+      ssoCallbackReason: "exception",
+    });
+    expect(contextLoggerMock.warn).toHaveBeenCalledWith("SSO callback failed");
+  });
+
+  test("stays silent when a non-callback endpoint throws", () => {
+    recordSsoCallbackThrow("https://app.test/api/auth/sign-in/email");
+
+    expect(logger.withContext).not.toHaveBeenCalled();
   });
 
   test.each([

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -722,6 +722,17 @@ describe("recordSsoCallbackOutcome (ENG-2551)", () => {
 
   const redirect = (location: string, status = 302) => new Response(null, { status, headers: { location } });
 
+  /**
+   * A completed sign-in, which Better Auth marks by minting the session cookie. Success is asserted
+   * through that rather than through the redirect target: `getSsoReturnToUrl` preserves the caller's
+   * query string, so a legitimate `callbackURL` can carry `?error=…` of its own.
+   */
+  const signedInRedirect = (location: string) => {
+    const response = new Response(null, { status: 302, headers: { location } });
+    response.headers.append("set-cookie", "__Secure-formbricks.session_token=abc; Path=/; HttpOnly");
+    return response;
+  };
+
   const contextOf = () => vi.mocked(logger.withContext).mock.calls[0]?.[0];
 
   test.each([
@@ -741,7 +752,7 @@ describe("recordSsoCallbackOutcome (ENG-2551)", () => {
   });
 
   test("records a successful callback, so the alert can key on a ratio", () => {
-    recordSsoCallbackOutcome("https://app.test/api/auth/callback/openid", redirect("/"));
+    recordSsoCallbackOutcome("https://app.test/api/auth/callback/openid", signedInRedirect("/"));
 
     expect(contextOf()).toEqual({
       source: "sso-callback",
@@ -872,10 +883,84 @@ describe("recordSsoCallbackOutcome (ENG-2551)", () => {
   test("still records a redirect with no error parameter as a success", () => {
     recordSsoCallbackOutcome(
       "https://app.test/api/auth/callback/azuread",
-      redirect("https://app.test/?welcome=1")
+      signedInRedirect("https://app.test/?welcome=1")
     );
 
     expect(contextOf()).toMatchObject({ ssoCallbackOutcome: "success" });
+  });
+
+  /**
+   * #9026 review, P1. With `response_mode=form_post` Better Auth turns the POST callback into a 302 to
+   * its own GET twin *before* validating state or exchanging the code, and `legacy-sso-callback.ts`
+   * preserves that flow deliberately. Recording the hop adds a second outcome per sign-in, and since
+   * the hop carries no `error` it lands on the success side — so a form_post flow failing 100% of the
+   * time would still read as only 50% failures, under any threshold the alert picks.
+   */
+  test.each([
+    ["the Better Auth twin", "https://app.test/api/auth/callback/azuread?code=abc&state=xyz"],
+    ["a relative twin", "/api/auth/callback/azuread?code=abc&state=xyz"],
+  ])("says nothing for the form_post hop to %s", (_label, location) => {
+    recordSsoCallbackOutcome("https://app.test/api/auth/callback/azuread", redirect(location));
+
+    expect(logger.withContext).not.toHaveBeenCalled();
+  });
+
+  test("the GET that follows the hop still records the real outcome", () => {
+    recordSsoCallbackOutcome(
+      "https://app.test/api/auth/callback/azuread",
+      redirect("https://app.test/auth/login?error=state_mismatch")
+    );
+
+    expect(contextOf()).toMatchObject({
+      ssoCallbackOutcome: "failure",
+      ssoCallbackReason: "state_mismatch",
+    });
+  });
+
+  /**
+   * #9026 review, P2. The success destination is the caller's `callbackURL`, and `getSsoReturnToUrl`
+   * keeps its query string — so `/page?error=retry` is a supported target. Reading `error` off the
+   * redirect cannot tell that apart from Better Auth's own error redirect, which goes to the caller's
+   * `errorCallbackURL` (`/auth/login` for every button here). The session cookie can.
+   */
+  test("a completed sign-in whose callbackURL carries its own error parameter is a success", () => {
+    recordSsoCallbackOutcome(
+      "https://app.test/api/auth/callback/azuread",
+      signedInRedirect("https://app.test/some-page?error=retry")
+    );
+
+    expect(contextOf()).toMatchObject({ ssoCallbackOutcome: "success" });
+    expect(contextLoggerMock.warn).not.toHaveBeenCalled();
+  });
+
+  test("a failure redirect to errorCallbackURL is still a failure", () => {
+    recordSsoCallbackOutcome(
+      "https://app.test/api/auth/callback/azuread",
+      redirect("https://app.test/auth/login?error=account_not_linked")
+    );
+
+    expect(contextOf()).toMatchObject({
+      ssoCallbackOutcome: "failure",
+      ssoCallbackReason: "account_not_linked",
+    });
+  });
+
+  /**
+   * Verify-before-link recovery ends here on purpose: no session, no error, an inbox-verification
+   * page. Counting it either way corrupts the ratio, so it is named and excluded from both sides.
+   */
+  test("recovery, with no session and no error, is neither a success nor a failure", () => {
+    recordSsoCallbackOutcome(
+      "https://app.test/api/auth/callback/openid",
+      redirect("https://app.test/auth/verification-requested")
+    );
+
+    expect(contextOf()).toMatchObject({
+      ssoCallbackOutcome: "incomplete",
+      ssoCallbackReason: "no_session",
+    });
+    expect(contextLoggerMock.warn).not.toHaveBeenCalled();
+    expect(contextLoggerMock.info).toHaveBeenCalledWith("SSO callback did not complete a sign-in");
   });
 
   test.each([

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -847,13 +847,25 @@ describe("recordSsoCallbackOutcome (ENG-2551)", () => {
     expect(logger.withContext).not.toHaveBeenCalled();
   });
 
-  // Observability must never be able to fail a sign-in that otherwise worked.
-  test("never throws, even on a malformed Location header", () => {
+  /**
+   * A redirect the browser cannot follow is a failed sign-in. Both of these previously corrupted the
+   * ratio rather than merely losing detail — a missing `Location` was recorded as a *success*, and a
+   * malformed one threw into the outer catch so the callback vanished from both sides of the ratio.
+   * The earlier test here asserted only that it did not throw, which is the weaker property and is
+   * why the suite stayed green.
+   */
+  test.each([
+    ["a redirect with no Location", undefined, "missing_location"],
+    ["a malformed Location", "http://[", "malformed_location"],
+  ])("records %s as a failure", (_label, location, reason) => {
     expect(() =>
       recordSsoCallbackOutcome(
         "https://app.test/api/auth/callback/azuread",
-        new Response(null, { status: 302, headers: { location: "http://[" } })
+        new Response(null, { status: 302, ...(location ? { headers: { location } } : {}) })
       )
     ).not.toThrow();
+
+    expect(contextOf()).toMatchObject({ ssoCallbackOutcome: "failure", ssoCallbackReason: reason });
+    expect(contextLoggerMock.warn).toHaveBeenCalledWith("SSO callback failed");
   });
 });

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -854,6 +854,30 @@ describe("recordSsoCallbackOutcome (ENG-2551)", () => {
    * The earlier test here asserted only that it did not throw, which is the weaker property and is
    * why the suite stayed green.
    */
+  /**
+   * `URLSearchParams.get` reads both `?error=` and a bare `?error` back as `""`, so a truthiness
+   * check counted an ambiguous error parameter as a clean sign-in. Only a genuinely absent parameter
+   * (`null`) is a success — same reasoning as the two cases below: anything the browser cannot
+   * usefully follow belongs on the failure side, because success is the half the ratio must trust.
+   */
+  test.each([
+    ["an empty error value", "https://app.test/auth/login?error="],
+    ["a valueless error parameter", "https://app.test/auth/login?error"],
+  ])("records %s as a failure, not a success", (_label, location) => {
+    recordSsoCallbackOutcome("https://app.test/api/auth/callback/azuread", redirect(location));
+
+    expect(contextOf()).toMatchObject({ ssoCallbackOutcome: "failure", ssoCallbackReason: "other" });
+  });
+
+  test("still records a redirect with no error parameter as a success", () => {
+    recordSsoCallbackOutcome(
+      "https://app.test/api/auth/callback/azuread",
+      redirect("https://app.test/?welcome=1")
+    );
+
+    expect(contextOf()).toMatchObject({ ssoCallbackOutcome: "success" });
+  });
+
   test.each([
     ["a redirect with no Location", undefined, "missing_location"],
     ["a malformed Location", "http://[", "malformed_location"],

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -14,6 +14,7 @@ import {
   auditVerificationSessionWithheld,
   betterAuthLogger,
   getSignInAuthMethod,
+  recordSsoCallbackOutcome,
   redactEmailsInLogMessage,
   signInAuditDatabaseHook,
 } from "./better-auth-observability";
@@ -702,5 +703,107 @@ describe("betterAuthLogger (request-path tagging, ENG-2259)", () => {
     });
 
     expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * ENG-2551: the SSO callback outcome signal. Its whole purpose is to be alertable, so the tests are
+ * about the *field values* an alert would key on, not about the human-readable message.
+ *
+ * The motivating incident is ENG-2750, where 100% of Cloud Microsoft sign-ins failed for ~18 hours
+ * and produced no Sentry event at all — Better Auth logs that failure as a bare message with no
+ * `Error`, so the capture gate above never sees anything. Hence a signal keyed on the outcome.
+ */
+describe("recordSsoCallbackOutcome (ENG-2551)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const redirect = (location: string, status = 302) => new Response(null, { status, headers: { location } });
+
+  const contextOf = () => vi.mocked(logger.withContext).mock.calls[0]?.[0];
+
+  test.each([
+    ["the Better Auth path", "https://app.test/api/auth/callback/azuread"],
+    ["the pinned legacy path", "https://app.test/api/auth/oauth2/callback/azuread"],
+    ["a trailing slash", "https://app.test/api/auth/callback/azuread/"],
+  ])("records a failed callback on %s", (_label, url) => {
+    recordSsoCallbackOutcome(url, redirect("https://app.test/auth/login?error=unable_to_get_user_info"));
+
+    expect(contextOf()).toEqual({
+      source: "sso-callback",
+      ssoCallbackOutcome: "failure",
+      ssoProvider: "azuread",
+      ssoCallbackReason: "unable_to_get_user_info",
+    });
+    expect(contextLoggerMock.warn).toHaveBeenCalledWith("SSO callback failed");
+  });
+
+  test("records a successful callback, so the alert can key on a ratio", () => {
+    recordSsoCallbackOutcome("https://app.test/api/auth/callback/openid", redirect("/"));
+
+    expect(contextOf()).toEqual({
+      source: "sso-callback",
+      ssoCallbackOutcome: "success",
+      ssoProvider: "openid",
+    });
+    expect(contextLoggerMock.info).toHaveBeenCalledWith("SSO callback succeeded");
+    expect(contextLoggerMock.warn).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The two failure shapes that do not redirect, and the reason this reads the response rather than
+   * hooking an error path: the SSO licence gate answers 403 and an unhandled fault answers 500.
+   * Neither throws where an error hook would see it.
+   */
+  test.each([
+    [403, "http_403"],
+    [500, "http_500"],
+  ])("treats a %i on the callback as a failure", (status, reason) => {
+    recordSsoCallbackOutcome("https://app.test/api/auth/callback/saml", new Response(null, { status }));
+
+    expect(contextOf()).toMatchObject({ ssoCallbackOutcome: "failure", ssoCallbackReason: reason });
+  });
+
+  // Cardinality guard: anyone can request `/api/auth/callback/<anything>`, and a log field an
+  // outsider can fill with unbounded distinct values is a log field no alert can group on.
+  test.each([
+    ["an unregistered provider id", "https://app.test/api/auth/callback/not-a-provider"],
+    ["a very long segment", `https://app.test/api/auth/callback/${"a".repeat(300)}`],
+  ])("buckets %s to unknown", (_label, url) => {
+    recordSsoCallbackOutcome(url, redirect("/"));
+
+    expect(contextOf()).toMatchObject({ ssoProvider: "unknown" });
+  });
+
+  // Same reasoning for the reason field: the `error` parameter arrives from a redirect target and
+  // must not become a free-text log field.
+  test("buckets an error code that is not one of Better Auth's shapes", () => {
+    recordSsoCallbackOutcome(
+      "https://app.test/api/auth/callback/google",
+      redirect("https://app.test/auth/login?error=%3Cscript%3E+injected+%3D+true")
+    );
+
+    expect(contextOf()).toMatchObject({ ssoCallbackReason: "unrecognised" });
+  });
+
+  test.each([
+    ["a non-callback auth endpoint", "https://app.test/api/auth/sign-in/email"],
+    ["the callback list root", "https://app.test/api/auth/callback"],
+    ["an unparseable URL", "not-a-url"],
+  ])("stays silent for %s", (_label, url) => {
+    recordSsoCallbackOutcome(url, redirect("/"));
+
+    expect(logger.withContext).not.toHaveBeenCalled();
+  });
+
+  // Observability must never be able to fail a sign-in that otherwise worked.
+  test("never throws, even on a malformed Location header", () => {
+    expect(() =>
+      recordSsoCallbackOutcome(
+        "https://app.test/api/auth/callback/azuread",
+        new Response(null, { status: 302, headers: { location: "http://[" } })
+      )
+    ).not.toThrow();
   });
 });

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -525,6 +525,9 @@ describe("betterAuthLogger — OAuth state errors (ENG-2471)", () => {
 
     log("error", "State mismatch: verification not found", stateError);
 
+    // Anchor the negative: an empty `mock.calls` stringifies to "[]", which contains no secret, so
+    // without this the assertion would hold even if nothing were ever logged.
+    expect(logger.withContext).toHaveBeenCalled();
     expect(JSON.stringify(vi.mocked(logger.withContext).mock.calls)).not.toContain(
       "super-secret-state-value"
     );

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -527,10 +527,16 @@ export const recordSsoCallbackOutcome = (requestUrl: string, response: Response)
         return { outcome: "failure", reason: "malformed_location" };
       }
 
-      // `null` means no `error` parameter at all — the only shape that is a success. `?error=` and a
-      // bare `?error` both read back as `""`, which a truthiness check would have counted as a clean
-      // sign-in; an ambiguous error parameter belongs on the failure side, like every other redirect
-      // the browser cannot usefully follow.
+      // `null` means no `error` parameter at all, which is the only shape that is a success. `?error=`
+      // and a bare `?error` both read back as `""`, and a truthiness check counted those as a clean
+      // sign-in — an error parameter that is present but empty says something went wrong without
+      // saying what, and the success side is the half the ratio has to be able to trust.
+      //
+      // The inverse costs accuracy in one case worth knowing about: a `callbackURL` that itself
+      // carries an `error` parameter makes a genuine success look like a failure. Nothing in this app
+      // passes one (the SSO buttons send `callbackURL: "/"`), and the alternative — inspecting the
+      // redirect target to decide whether the parameter is "ours" — trades a rare false positive for
+      // a guessing game.
       if (error === null) return { outcome: "success" };
       return { outcome: "failure", reason: SSO_CALLBACK_REASONS.has(error) ? error : "other" };
     }

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -424,8 +424,63 @@ export const auditPasswordReset = async (userId: string): Promise<void> => {
  */
 const SSO_CALLBACK_PROVIDER_IDS = new Set(["google", "github", "azuread", "openid", "saml"]);
 
-/** Better Auth's callback error codes are lower-snake-case; anything else is not one of ours. */
-const SSO_CALLBACK_ERROR_CODE = /^[a-z0-9_]{1,64}$/;
+/**
+ * Callback failure reasons that may be recorded verbatim (ENG-2551).
+ *
+ * This has to be an allow-list for the same reason the provider id does, and the reason is easy to
+ * miss: Better Auth **echoes the inbound `error` query parameter** into its own redirect
+ * (`api/routes/callback.mjs`, `if (error) redirectOnError(error, error_description)`). Any caller can
+ * obtain a parseable `state` by starting a sign-in and then request
+ * `/api/auth/callback/<id>?state=…&error=<anything>`, so the value that lands here is outside
+ * attacker control only if we bound it to a known set. A charset regex would bound the *shape* of the
+ * value but not the *number of distinct values*, which is the property an alert needs.
+ *
+ * Two consequences of that echo, both closed by bucketing to `other`: an outsider cannot inflate the
+ * cardinality of this field, and cannot forge a specific reason to make a real outage look like
+ * something else.
+ *
+ * Read from `better-auth/dist/oauth2/errors.mjs` (OAUTH_CALLBACK_ERROR_CODES), the two route-level
+ * codes in `api/routes/callback.mjs`, the five `StateError` codes in `state.mjs`, and the codes this
+ * app redirects with itself. A code that disappears upstream simply stops occurring; a new one
+ * buckets to `other` until it is added, which is the safe direction.
+ */
+const SSO_CALLBACK_REASONS = new Set([
+  // Better Auth OAUTH_CALLBACK_ERROR_CODES
+  "account_already_linked_to_different_user",
+  "email_does_not_match",
+  "email_not_found",
+  "email_not_verified",
+  "invalid_code",
+  "issuer_mismatch",
+  "issuer_missing",
+  "no_callback_url",
+  "no_code",
+  "nonce_binding_missing",
+  "oauth_provider_not_found",
+  "unable_to_get_user_info",
+  "unable_to_link_account",
+  // Better Auth callback route, and the codes its redirectOnError call sites pass. `internal_server_error`
+  // is the important one and was found by smoke-testing rather than by reading the enum: stopping the
+  // database mid-callback produces it, so it is the code an infrastructure outage actually arrives as.
+  "invalid_callback_request",
+  "internal_server_error",
+  "invalid_payload",
+  "invalid_profile",
+  "missing_profile",
+  "payload_expired",
+  "user_creation_failed",
+  // Better Auth StateError codes
+  "state_generation_error",
+  "state_invalid",
+  "state_mismatch",
+  "state_not_found",
+  "state_security_mismatch",
+  // Emitted by this app
+  "OAuthAccountNotLinked",
+  "account_not_linked",
+  "invalid_scope",
+  "unable_to_create_user",
+]);
 
 /**
  * Record the outcome of an SSO callback, so a total sign-in outage announces itself (ENG-2551).
@@ -453,6 +508,40 @@ const SSO_CALLBACK_ERROR_CODE = /^[a-z0-9_]{1,64}$/;
  * Never throws: observability must not be able to fail a sign-in that otherwise succeeded.
  */
 export const recordSsoCallbackOutcome = (requestUrl: string, response: Response): void => {
+  emitSsoCallbackRecord(requestUrl, (): { outcome: "success" | "failure"; reason?: string } => {
+    // A 4xx/5xx on the callback is a failed sign-in too — this is how the SSO licence gate's 403
+    // and any unhandled 500 present, and neither redirects.
+    if (response.status >= 400) return { outcome: "failure", reason: `http_${response.status}` };
+    if (response.status >= 300) {
+      const location = response.headers.get("location");
+      const error = location ? new URL(location, requestUrl).searchParams.get("error") : null;
+      if (!error) return { outcome: "success" };
+      return { outcome: "failure", reason: SSO_CALLBACK_REASONS.has(error) ? error : "other" };
+    }
+    return { outcome: "success" };
+  });
+};
+
+/**
+ * Record an SSO callback that threw rather than returning a response (ENG-2551).
+ *
+ * The most severe callback failure there is: the request never produces a redirect, Next answers 500,
+ * and the user simply cannot sign in. Recording only responses would have left exactly that case
+ * invisible to the alert this signal exists to feed.
+ */
+export const recordSsoCallbackThrow = (requestUrl: string): void => {
+  emitSsoCallbackRecord(requestUrl, () => ({ outcome: "failure", reason: "exception" }));
+};
+
+/**
+ * Shared emitter: resolves the provider from the path, applies the outcome, logs once. Never throws —
+ * observability must not be able to fail a sign-in that otherwise succeeded, nor mask the original
+ * error on the throwing path.
+ */
+const emitSsoCallbackRecord = (
+  requestUrl: string,
+  resolveOutcome: () => { outcome: "success" | "failure"; reason?: string }
+): void => {
   try {
     const path = new URL(requestUrl).pathname;
     // The internal path Better Auth actually serves. `mapLegacySsoCallbackRequest` has already
@@ -464,22 +553,7 @@ export const recordSsoCallbackOutcome = (requestUrl: string, response: Response)
     const provider = SSO_CALLBACK_PROVIDER_IDS.has(providerSegment.toLowerCase())
       ? providerSegment.toLowerCase()
       : "unknown";
-
-    const { outcome, reason } = ((): { outcome: "success" | "failure"; reason?: string } => {
-      // A 4xx/5xx on the callback is a failed sign-in too — this is how the SSO licence gate's 403
-      // and any unhandled 500 present, and neither redirects.
-      if (response.status >= 400) return { outcome: "failure", reason: `http_${response.status}` };
-      if (response.status >= 300) {
-        const location = response.headers.get("location");
-        const error = location ? new URL(location, requestUrl).searchParams.get("error") : null;
-        if (!error) return { outcome: "success" };
-        return {
-          outcome: "failure",
-          reason: SSO_CALLBACK_ERROR_CODE.test(error) ? error : "unrecognised",
-        };
-      }
-      return { outcome: "success" };
-    })();
+    const { outcome, reason } = resolveOutcome();
 
     const contextLogger = logger.withContext({
       source: "sso-callback",

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -513,8 +513,20 @@ export const recordSsoCallbackOutcome = (requestUrl: string, response: Response)
     // and any unhandled 500 present, and neither redirects.
     if (response.status >= 400) return { outcome: "failure", reason: `http_${response.status}` };
     if (response.status >= 300) {
+      // A redirect the browser cannot follow is a failed sign-in, not a quiet success. Both shapes
+      // below would otherwise corrupt the ratio the alert keys on rather than merely lose detail: a
+      // missing `Location` counted as success inflates the healthy side, and a malformed one threw
+      // into the outer catch, dropping the callback from both sides.
       const location = response.headers.get("location");
-      const error = location ? new URL(location, requestUrl).searchParams.get("error") : null;
+      if (!location) return { outcome: "failure", reason: "missing_location" };
+
+      let error: string | null;
+      try {
+        error = new URL(location, requestUrl).searchParams.get("error");
+      } catch {
+        return { outcome: "failure", reason: "malformed_location" };
+      }
+
       if (!error) return { outcome: "success" };
       return { outcome: "failure", reason: SSO_CALLBACK_REASONS.has(error) ? error : "other" };
     }

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -527,7 +527,11 @@ export const recordSsoCallbackOutcome = (requestUrl: string, response: Response)
         return { outcome: "failure", reason: "malformed_location" };
       }
 
-      if (!error) return { outcome: "success" };
+      // `null` means no `error` parameter at all — the only shape that is a success. `?error=` and a
+      // bare `?error` both read back as `""`, which a truthiness check would have counted as a clean
+      // sign-in; an ambiguous error parameter belongs on the failure side, like every other redirect
+      // the browser cannot usefully follow.
+      if (error === null) return { outcome: "success" };
       return { outcome: "failure", reason: SSO_CALLBACK_REASONS.has(error) ? error : "other" };
     }
     return { outcome: "success" };

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -408,3 +408,89 @@ export const auditPasswordReset = async (userId: string): Promise<void> => {
     logger.withContext({ source: "better-auth" }).error("Failed to queue password-reset audit event");
   }
 };
+
+/**
+ * Providers whose id may appear in an SSO callback outcome record (ENG-2551).
+ *
+ * An allow-list rather than a sanitising regex, because the provider id comes from the request path
+ * and anyone can call `/api/auth/callback/<anything>`. A regex would bound the *shape* of the value
+ * but not the number of distinct values, so it would hand a caller unbounded control over a log
+ * field's cardinality — the thing that makes a log-based alert unusable. Anything unrecognised
+ * buckets to `unknown`.
+ *
+ * Deliberately not imported from the SSO provider config: this module must not depend on the EE
+ * surface, and the list answers a different question anyway ("what may we label") rather than "what
+ * is registered on this instance".
+ */
+const SSO_CALLBACK_PROVIDER_IDS = new Set(["google", "github", "azuread", "openid", "saml"]);
+
+/** Better Auth's callback error codes are lower-snake-case; anything else is not one of ours. */
+const SSO_CALLBACK_ERROR_CODE = /^[a-z0-9_]{1,64}$/;
+
+/**
+ * Record the outcome of an SSO callback, so a total sign-in outage announces itself (ENG-2551).
+ *
+ * The problem this solves is that every SSO outage so far has had a *novel cause* and an *identical
+ * symptom*. ENG-1800 (RFC 9207 `iss`), ENG-2555 (wrong `Account.issuer`), ENG-2750 (placeholder
+ * issuer) and the suppressed `state_mismatch` class each needed their own diagnosis, and each ended
+ * with the callback redirecting to `?error=…` instead of to the callbackURL. Alerting on causes means
+ * adding a rule after every incident; alerting on the outcome covers the next one for free.
+ *
+ * ENG-2750 is why this exists at all: it failed 100% of Cloud Microsoft sign-ins for ~18 hours and
+ * produced **no Sentry event**, because Better Auth logs that failure as a bare message with no
+ * `Error` argument, so the capture gate above never has anything to capture. A log line keyed on a
+ * stable field is what an alert can actually watch.
+ *
+ * Emits on success too: the useful alert threshold is a *ratio* ("failures exceed N% of callbacks
+ * over 15 minutes"), which survives traffic swings, campaigns and quiet weekends in a way an
+ * absolute count does not.
+ *
+ * Failures log at `warn`, not `error`. A single failed callback is routinely the user's own doing — a
+ * stale tab, an expired state, a declined consent — and promoting each one to `error` would degrade
+ * the signal this is meant to create. The alert keys on `ssoCallbackOutcome`, so the level is
+ * presentation, not meaning.
+ *
+ * Never throws: observability must not be able to fail a sign-in that otherwise succeeded.
+ */
+export const recordSsoCallbackOutcome = (requestUrl: string, response: Response): void => {
+  try {
+    const path = new URL(requestUrl).pathname;
+    // The internal path Better Auth actually serves. `mapLegacySsoCallbackRequest` has already
+    // rewritten the pinned `/oauth2/callback/:id` form by the time a response exists, so matching the
+    // internal shape covers both.
+    const providerSegment = /\/callback\/([^/]+)\/?$/.exec(path)?.[1];
+    if (!providerSegment) return;
+
+    const provider = SSO_CALLBACK_PROVIDER_IDS.has(providerSegment.toLowerCase())
+      ? providerSegment.toLowerCase()
+      : "unknown";
+
+    const { outcome, reason } = ((): { outcome: "success" | "failure"; reason?: string } => {
+      // A 4xx/5xx on the callback is a failed sign-in too — this is how the SSO licence gate's 403
+      // and any unhandled 500 present, and neither redirects.
+      if (response.status >= 400) return { outcome: "failure", reason: `http_${response.status}` };
+      if (response.status >= 300) {
+        const location = response.headers.get("location");
+        const error = location ? new URL(location, requestUrl).searchParams.get("error") : null;
+        if (!error) return { outcome: "success" };
+        return {
+          outcome: "failure",
+          reason: SSO_CALLBACK_ERROR_CODE.test(error) ? error : "unrecognised",
+        };
+      }
+      return { outcome: "success" };
+    })();
+
+    const contextLogger = logger.withContext({
+      source: "sso-callback",
+      ssoCallbackOutcome: outcome,
+      ssoProvider: provider,
+      ...(reason ? { ssoCallbackReason: reason } : {}),
+    });
+
+    if (outcome === "failure") contextLogger.warn("SSO callback failed");
+    else contextLogger.info("SSO callback succeeded");
+  } catch {
+    // A malformed URL is not worth failing or logging a sign-in over.
+  }
+};

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -425,6 +425,32 @@ export const auditPasswordReset = async (userId: string): Promise<void> => {
 const SSO_CALLBACK_PROVIDER_IDS = new Set(["google", "github", "azuread", "openid", "saml"]);
 
 /**
+ * A callback path, capturing the provider id.
+ *
+ * Answers two questions: which provider a request is for, and — applied to a *redirect target* —
+ * whether Better Auth is bouncing a `form_post` callback to its GET twin rather than concluding.
+ */
+const SSO_CALLBACK_PATH = /\/callback\/([^/?#]+)\/?$/;
+
+/**
+ * `success` and `failure` are the two an alert divides; `incomplete` is deliberately neither.
+ *
+ * A ratio of `failure / (success + failure)` stays meaningful only while both sides really are
+ * completed sign-ins or broken ones. Verify-before-link recovery is neither — it ends on the "check
+ * your inbox" page by design — so it gets its own value rather than being forced into one, and an
+ * alert should exclude it explicitly.
+ */
+type SsoCallbackRecord = { outcome: "success" | "failure" | "incomplete"; reason?: string };
+
+/**
+ * Better Auth mints the session cookie only on a completed sign-in, which is why this is the success
+ * signal rather than the redirect target: the success destination is the caller's `callbackURL` and
+ * the failure destination its `errorCallbackURL`, and both are ordinary app pages here.
+ */
+const hasSessionCookie = (response: Response): boolean =>
+  response.headers.getSetCookie().some((cookie) => cookie.includes("session_token"));
+
+/**
  * Callback failure reasons that may be recorded verbatim (ENG-2551).
  *
  * This has to be an allow-list for the same reason the provider id does, and the reason is easy to
@@ -508,39 +534,59 @@ const SSO_CALLBACK_REASONS = new Set([
  * Never throws: observability must not be able to fail a sign-in that otherwise succeeded.
  */
 export const recordSsoCallbackOutcome = (requestUrl: string, response: Response): void => {
-  emitSsoCallbackRecord(requestUrl, (): { outcome: "success" | "failure"; reason?: string } => {
+  emitSsoCallbackRecord(requestUrl, (): SsoCallbackRecord | null => {
     // A 4xx/5xx on the callback is a failed sign-in too — this is how the SSO licence gate's 403
     // and any unhandled 500 present, and neither redirects.
     if (response.status >= 400) return { outcome: "failure", reason: `http_${response.status}` };
+
     if (response.status >= 300) {
       // A redirect the browser cannot follow is a failed sign-in, not a quiet success. Both shapes
-      // below would otherwise corrupt the ratio the alert keys on rather than merely lose detail: a
-      // missing `Location` counted as success inflates the healthy side, and a malformed one threw
-      // into the outer catch, dropping the callback from both sides.
+      // below would otherwise corrupt the ratio rather than merely lose detail: a missing `Location`
+      // counted as success inflates the healthy side, and a malformed one threw into the outer catch,
+      // dropping the callback from both sides.
       const location = response.headers.get("location");
       if (!location) return { outcome: "failure", reason: "missing_location" };
 
-      let error: string | null;
+      let target: URL;
       try {
-        error = new URL(location, requestUrl).searchParams.get("error");
+        target = new URL(location, requestUrl);
       } catch {
         return { outcome: "failure", reason: "malformed_location" };
       }
 
-      // `null` means no `error` parameter at all, which is the only shape that is a success. `?error=`
-      // and a bare `?error` both read back as `""`, and a truthiness check counted those as a clean
-      // sign-in — an error parameter that is present but empty says something went wrong without
-      // saying what, and the success side is the half the ratio has to be able to trust.
-      //
-      // The inverse costs accuracy in one case worth knowing about: a `callbackURL` that itself
-      // carries an `error` parameter makes a genuine success look like a failure. Nothing in this app
-      // passes one (the SSO buttons send `callbackURL: "/"`), and the alternative — inspecting the
-      // redirect target to decide whether the parameter is "ours" — trades a rare false positive for
-      // a guessing game.
-      if (error === null) return { outcome: "success" };
-      return { outcome: "failure", reason: SSO_CALLBACK_REASONS.has(error) ? error : "other" };
+      // `response_mode=form_post`: Better Auth 1.7 turns a POST callback into a 302 to the GET
+      // callback *before* it validates state or exchanges the code (`api/routes/callback.mjs`), and
+      // `legacy-sso-callback.ts` deliberately preserves that flow. Recording the hop would score every
+      // form_post sign-in as one extra outcome, and — because the hop carries no `error` — it would
+      // score it as a success, capping a totally broken form_post flow at a 50% failure ratio. The GET
+      // that follows is the one that knows what happened, so say nothing here.
+      if (SSO_CALLBACK_PATH.test(target.pathname)) return null;
+
+      // A completed sign-in is the one thing that mints a session, and it is decided by Better Auth
+      // rather than inferred from where the browser is sent next. That matters because the success
+      // destination is the caller's `callbackURL` — `getSsoReturnToUrl` preserves its query string, so
+      // a legitimate target like `/page?error=retry` exists — while the failure destination is the
+      // caller's `errorCallbackURL` (`/auth/login` for every button here). Reading the `error` key off
+      // whichever URL came back cannot tell those apart; the session cookie can.
+      if (hasSessionCookie(response)) return { outcome: "success" };
+
+      const error = target.searchParams.get("error");
+      // `?error=` and a bare `?error` both read back as `""`. An error parameter that is present but
+      // empty says something went wrong without saying what, so it belongs on the failure side.
+      if (error !== null) {
+        return { outcome: "failure", reason: SSO_CALLBACK_REASONS.has(error) ? error : "other" };
+      }
+
+      // No session and no error is neither: verify-before-link recovery ends exactly here, redirecting
+      // to the "check your inbox" page on purpose (`ssoRecoveryAfterHandler`). Counting it as a failure
+      // would inflate the ratio during a perfectly healthy flow, and as a success would claim a sign-in
+      // that did not happen — so it is named and left out of both sides.
+      return { outcome: "incomplete", reason: "no_session" };
     }
-    return { outcome: "success" };
+
+    return hasSessionCookie(response)
+      ? { outcome: "success" }
+      : { outcome: "incomplete", reason: "no_session" };
   });
 };
 
@@ -560,22 +606,22 @@ export const recordSsoCallbackThrow = (requestUrl: string): void => {
  * observability must not be able to fail a sign-in that otherwise succeeded, nor mask the original
  * error on the throwing path.
  */
-const emitSsoCallbackRecord = (
-  requestUrl: string,
-  resolveOutcome: () => { outcome: "success" | "failure"; reason?: string }
-): void => {
+const emitSsoCallbackRecord = (requestUrl: string, resolveOutcome: () => SsoCallbackRecord | null): void => {
   try {
     const path = new URL(requestUrl).pathname;
     // The internal path Better Auth actually serves. `mapLegacySsoCallbackRequest` has already
     // rewritten the pinned `/oauth2/callback/:id` form by the time a response exists, so matching the
     // internal shape covers both.
-    const providerSegment = /\/callback\/([^/]+)\/?$/.exec(path)?.[1];
+    const providerSegment = SSO_CALLBACK_PATH.exec(path)?.[1];
     if (!providerSegment) return;
 
     const provider = SSO_CALLBACK_PROVIDER_IDS.has(providerSegment.toLowerCase())
       ? providerSegment.toLowerCase()
       : "unknown";
-    const { outcome, reason } = resolveOutcome();
+    // `null` means "this request is not the one that decides the outcome" — see the form_post hop.
+    const record = resolveOutcome();
+    if (!record) return;
+    const { outcome, reason } = record;
 
     const contextLogger = logger.withContext({
       source: "sso-callback",
@@ -585,6 +631,7 @@ const emitSsoCallbackRecord = (
     });
 
     if (outcome === "failure") contextLogger.warn("SSO callback failed");
+    else if (outcome === "incomplete") contextLogger.info("SSO callback did not complete a sign-in");
     else contextLogger.info("SSO callback succeeded");
   } catch {
     // A malformed URL is not worth failing or logging a sign-in over.

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -533,60 +533,71 @@ const SSO_CALLBACK_REASONS = new Set([
  *
  * Never throws: observability must not be able to fail a sign-in that otherwise succeeded.
  */
+/** A response that minted no session: either a named failure, or a flow that never claimed to sign in. */
+const sessionlessOutcome = (target: URL): SsoCallbackRecord => {
+  const error = target.searchParams.get("error");
+
+  // `?error=` and a bare `?error` both read back as `""`. An error parameter that is present but
+  // empty says something went wrong without saying what, so it belongs on the failure side.
+  if (error !== null) {
+    return { outcome: "failure", reason: SSO_CALLBACK_REASONS.has(error) ? error : "other" };
+  }
+
+  // No session and no error is neither: verify-before-link recovery ends exactly here, redirecting to
+  // the "check your inbox" page on purpose (`ssoRecoveryAfterHandler`). Counting it as a failure would
+  // inflate the ratio during a perfectly healthy flow, and as a success would claim a sign-in that did
+  // not happen — so it is named and left out of both sides.
+  return { outcome: "incomplete", reason: "no_session" };
+};
+
+/** The outcome carried by a redirect, or `null` when this redirect decides nothing. */
+const redirectOutcome = (target: URL, response: Response): SsoCallbackRecord | null => {
+  // `response_mode=form_post`: Better Auth 1.7 turns a POST callback into a 302 to the GET callback
+  // *before* it validates state or exchanges the code (`api/routes/callback.mjs`), and
+  // `legacy-sso-callback.ts` deliberately preserves that flow. Recording the hop would score every
+  // form_post sign-in as one extra outcome, and — because the hop carries no `error` — it would score
+  // it as a success, capping a totally broken form_post flow at a 50% failure ratio. The GET that
+  // follows is the one that knows what happened, so say nothing here.
+  if (SSO_CALLBACK_PATH.test(target.pathname)) return null;
+
+  // A completed sign-in is the one thing that mints a session, and Better Auth decides that rather
+  // than it being inferred from where the browser is sent next. That matters because the success
+  // destination is the caller's `callbackURL` — `getSsoReturnToUrl` preserves its query string, so a
+  // legitimate target like `/page?error=retry` exists — while the failure destination is the caller's
+  // `errorCallbackURL` (`/auth/login` for every button here). Reading the `error` key off whichever
+  // URL came back cannot tell those apart; the session cookie can.
+  return hasSessionCookie(response) ? { outcome: "success" } : sessionlessOutcome(target);
+};
+
 export const recordSsoCallbackOutcome = (requestUrl: string, response: Response): void => {
   emitSsoCallbackRecord(requestUrl, (): SsoCallbackRecord | null => {
-    // A 4xx/5xx on the callback is a failed sign-in too — this is how the SSO licence gate's 403
-    // and any unhandled 500 present, and neither redirects.
+    // A 4xx/5xx on the callback is a failed sign-in too — this is how the SSO licence gate's 403 and
+    // any unhandled 500 present, and neither redirects.
     if (response.status >= 400) return { outcome: "failure", reason: `http_${response.status}` };
 
-    if (response.status >= 300) {
-      // A redirect the browser cannot follow is a failed sign-in, not a quiet success. Both shapes
-      // below would otherwise corrupt the ratio rather than merely lose detail: a missing `Location`
-      // counted as success inflates the healthy side, and a malformed one threw into the outer catch,
-      // dropping the callback from both sides.
-      const location = response.headers.get("location");
-      if (!location) return { outcome: "failure", reason: "missing_location" };
-
-      let target: URL;
-      try {
-        target = new URL(location, requestUrl);
-      } catch {
-        return { outcome: "failure", reason: "malformed_location" };
-      }
-
-      // `response_mode=form_post`: Better Auth 1.7 turns a POST callback into a 302 to the GET
-      // callback *before* it validates state or exchanges the code (`api/routes/callback.mjs`), and
-      // `legacy-sso-callback.ts` deliberately preserves that flow. Recording the hop would score every
-      // form_post sign-in as one extra outcome, and — because the hop carries no `error` — it would
-      // score it as a success, capping a totally broken form_post flow at a 50% failure ratio. The GET
-      // that follows is the one that knows what happened, so say nothing here.
-      if (SSO_CALLBACK_PATH.test(target.pathname)) return null;
-
-      // A completed sign-in is the one thing that mints a session, and it is decided by Better Auth
-      // rather than inferred from where the browser is sent next. That matters because the success
-      // destination is the caller's `callbackURL` — `getSsoReturnToUrl` preserves its query string, so
-      // a legitimate target like `/page?error=retry` exists — while the failure destination is the
-      // caller's `errorCallbackURL` (`/auth/login` for every button here). Reading the `error` key off
-      // whichever URL came back cannot tell those apart; the session cookie can.
-      if (hasSessionCookie(response)) return { outcome: "success" };
-
-      const error = target.searchParams.get("error");
-      // `?error=` and a bare `?error` both read back as `""`. An error parameter that is present but
-      // empty says something went wrong without saying what, so it belongs on the failure side.
-      if (error !== null) {
-        return { outcome: "failure", reason: SSO_CALLBACK_REASONS.has(error) ? error : "other" };
-      }
-
-      // No session and no error is neither: verify-before-link recovery ends exactly here, redirecting
-      // to the "check your inbox" page on purpose (`ssoRecoveryAfterHandler`). Counting it as a failure
-      // would inflate the ratio during a perfectly healthy flow, and as a success would claim a sign-in
-      // that did not happen — so it is named and left out of both sides.
-      return { outcome: "incomplete", reason: "no_session" };
+    if (response.status < 300) {
+      return hasSessionCookie(response)
+        ? { outcome: "success" }
+        : { outcome: "incomplete", reason: "no_session" };
     }
 
-    return hasSessionCookie(response)
-      ? { outcome: "success" }
-      : { outcome: "incomplete", reason: "no_session" };
+    // A redirect the browser cannot follow is a failed sign-in, not a quiet success. Both shapes below
+    // would otherwise corrupt the ratio rather than merely lose detail: a missing `Location` counted as
+    // success inflates the healthy side, and a malformed one threw into the outer catch, dropping the
+    // callback from both sides.
+    const location = response.headers.get("location");
+    if (!location) return { outcome: "failure", reason: "missing_location" };
+
+    // The catch guards the parse and nothing else: wrapping the classification too would relabel any
+    // fault inside it as a malformed `Location`, which is a different and misleading claim.
+    let target: URL;
+    try {
+      target = new URL(location, requestUrl);
+    } catch {
+      return { outcome: "failure", reason: "malformed_location" };
+    }
+
+    return redirectOutcome(target, response);
   });
 };
 


### PR DESCRIPTION
Ref ENG-2551

## What & why

**Was:** ENG-2750 failed 100% of Cloud Microsoft sign-ins for ~18 hours and produced **zero Sentry events**. Better Auth logs that failure as a bare message with no `Error` argument, so the ENG-2037/ENG-2471 capture gate never had anything to capture. We found out because Johannes asked in #bugs.

**Now:** Every SSO callback logs its outcome — `ssoCallbackOutcome: "success" | "failure"`, the provider, and a reason on failure — so an alert has a stable field to watch.

Every SSO outage so far has had a novel cause and an identical symptom. ENG-1800 (RFC 9207 `iss`), ENG-2555 (wrong `Account.issuer`), ENG-2750 (placeholder issuer) and the suppressed `state_mismatch` class each needed their own diagnosis, and each ended with the callback redirecting to `?error=` instead of the callbackURL. Alerting per cause means adding a rule after every incident; alerting on the outcome covers the next one for free.

Successes are emitted too, so the alert can key on a **ratio** ("failures exceed N% of callbacks over 15 minutes"), which survives traffic swings and quiet weekends where an absolute count does not.

## Where to look

- [route.ts](https://github.com/formbricks/formbricks/blob/feat/ENG-2551_sso-callback-outcome-signal/apps/web/app/api/auth/%5B...all%5D/route.ts) — the one seam that sees every callback outcome; the handler now awaits the response before returning it
- [better-auth-observability.ts](https://github.com/formbricks/formbricks/blob/feat/ENG-2551_sso-callback-outcome-signal/apps/web/modules/auth/lib/better-auth-observability.ts) — `recordSsoCallbackOutcome`, `recordSsoCallbackThrow`, and the two allow-lists that bound what an outsider can put in a log field

## Breaking changes

- [ ] This PR contains breaking changes

None — additive logging. No API, schema, env or config surface, and no change to what any endpoint returns.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && pnpm test modules/auth/lib/better-auth-observability.test.ts` (85/85)

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| A failed callback is recorded with its reason, on both the Better Auth path and the pinned legacy one | unit (mutation) | 3 cases; treating every redirect as success fails 4 |
| A success is recorded, so a ratio is computable | unit (mutation) | Asserted fields exactly; no `warn` emitted |
| A 403 (SSO licence gate) and a 500 count as failures | unit (mutation) | Dropping the status branch fails 2. These do not redirect, which is why this reads the response instead of hooking an error path |
| The provider id cannot be filled with arbitrary values | unit (mutation) | An unregistered id and a 300-char segment both bucket to `unknown`; dropping the allow-list fails 2 |
| **Nor can the reason** — Better Auth echoes the inbound `error` param into its redirect | unit (mutation) + manual | Allow-listed from Better Auth's own call sites; unknown, forged and markup values bucket to `other`. Replacing the allow-list with a charset regex fails 2. Verified live: a caller with a legitimately obtained state supplied `error=attacker_chosen_value_9999`, the app echoed it, and the record read `other` |
| A callback that **throws** is recorded | unit (mutation) + manual | It answers 500 and nobody signs in, so it was the worst case to miss. Making the throw recorder a no-op fails 1 |
| Non-callback endpoints and unparseable URLs stay silent, and it never throws | unit (guard) | Observability must not be able to fail a sign-in |
| **Live, through the real app** | manual | Real app + Postgres + Valkey + a real OpenID Provider. Success logged `success`/`openid`; a bogus state logged `failure`/`state_mismatch`; **stopping Postgres mid-callback** logged `internal_server_error`; `/sign-in/email` emitted nothing |

<details>
<summary>The live records, verbatim</summary>

```
INFO  SSO callback succeeded
    source: "sso-callback"
    ssoCallbackOutcome: "success"
    ssoProvider: "openid"
WARN  SSO callback failed
    source: "sso-callback"
    ssoCallbackOutcome: "failure"
    ssoProvider: "openid"
    ssoCallbackReason: "state_mismatch"
```

</details>

**Open gaps**

- **This is only half of ENG-2551.** It makes the outage observable; it does not alert on it. The rule (rate or ratio on `ssoCallbackOutcome`) is an infra change and cannot be done from the repo — hence `Ref` rather than `Fixes`.
- No Sentry capture, deliberately: ENG-2037 and ENG-2471 spent real effort quietening this exact path, and re-capturing per event would undo that. Logs reach SigNoz, which supports rate-based log alerts, so the field is directly actionable there.
- Not verified against a real IdP outage — failures were induced with a bogus state, a forged error parameter, and a stopped database rather than by breaking a provider.
- The reason allow-list will need a line when Better Auth adds a callback error code; a new code buckets to `other` until then, which is the safe direction but does lose detail. `internal_server_error` was missing from the first draft and only surfaced by smoke-testing a database outage — reading the enum was not enough.

**Risks**

- One extra log line per SSO callback. SSO volume is low, and the level is chosen so failures land at `warn` rather than inflating `error` counts: a single failed callback is routinely the user's own doing (stale tab, expired state, declined consent).
- The handler now awaits the response before returning it, where it previously returned the promise directly. Same value, one extra microtask; the recorder cannot throw.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code), reasoning effort `unknown`.
