### PR TITLE
docs(self-hosting): add the missing integrations overview page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -321,6 +321,7 @@
                 "group": "Integrations",
                 "icon": "bridge",
                 "pages": [
+                  "self-hosting/configuration/integrations",
                   "self-hosting/configuration/integrations/airtable",
                   "self-hosting/configuration/integrations/google-sheets",
                   "self-hosting/configuration/integrations/n8n",

--- a/docs/self-hosting/configuration/integrations.mdx
+++ b/docs/self-hosting/configuration/integrations.mdx
@@ -1,0 +1,96 @@
+---
+title: "Third-party Integrations (On Premise)"
+sidebarTitle: "Overview"
+description: "Configure third-party integrations on a self-hosted Formbricks instance."
+icon: "bridge"
+---
+
+Formbricks connects to third-party tools such as Slack, Notion, or Google Sheets on behalf of your users. On
+Formbricks Cloud we register and operate the OAuth apps behind those connections, so they work out of the
+box. A self-hosted instance talks to those services under your own identity instead, which means you
+register the OAuth app yourself and hand its credentials to your instance.
+
+<Note>
+  Using Formbricks Cloud? You do not need any of this. Head to the [Cloud integration
+  guides](/platform/features/integrations/overview) instead.
+</Note>
+
+## Before you configure an integration
+
+<Steps>
+  <Step title="Know your public-facing URL">
+    Every OAuth app needs a redirect URL that points back at your instance, built from your own
+    `https://<your-public-facing-url>` rather than `app.formbricks.com`. The callback path differs per
+    service, so take it from the guide you are following.
+  </Step>
+
+  <Step title="Serve Formbricks over HTTPS">
+    Slack refuses to talk to an instance without a valid certificate, and the other providers expect HTTPS in
+    production too. See [Custom SSL](/self-hosting/configuration/custom-ssl) if you have not set this up yet.
+  </Step>
+
+  <Step title="Restart after changing environment variables">
+    Credentials go into the same place as every other setting — see [Environment
+    Variables](/self-hosting/configuration/environment-variables). Restart your containers for new values to
+    take effect.
+  </Step>
+</Steps>
+
+## What each integration needs
+
+The integrations fall into two groups. The first four need credentials from an OAuth app you register with
+the third-party service. The last three connect from the other side — through a Formbricks API key or your
+instance URL — and need no server configuration at all.
+
+| Integration                                                             | What you register                                      | Environment variables                                                                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| [Airtable](/self-hosting/configuration/integrations/airtable)           | An OAuth integration in the Airtable Developer hub     | `AIRTABLE_CLIENT_ID`                                                                   |
+| [Google Sheets](/self-hosting/configuration/integrations/google-sheets) | An OAuth client in a Google Cloud project              | `GOOGLE_SHEETS_CLIENT_ID`, `GOOGLE_SHEETS_CLIENT_SECRET`, `GOOGLE_SHEETS_REDIRECT_URL` |
+| [Notion](/self-hosting/configuration/integrations/notion)               | A public Notion integration                            | `NOTION_OAUTH_CLIENT_ID`, `NOTION_OAUTH_CLIENT_SECRET`                                 |
+| [Slack](/self-hosting/configuration/integrations/slack)                 | A Slack app with bot scopes and public distribution    | `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`                                               |
+| [n8n](/self-hosting/configuration/integrations/n8n)                     | Nothing — n8n authenticates with a Formbricks API key  | None                                                                                   |
+| [Zapier](/self-hosting/configuration/integrations/zapier)               | Nothing — Zapier authenticates with a Formbricks API key | None                                                                                 |
+| [ActivePieces](/self-hosting/configuration/integrations/activepieces)   | Nothing — point the connection at your instance URL    | None                                                                                   |
+
+## Configuration guides
+
+<CardGroup cols={2}>
+  <Card title="Airtable" icon="table" href="/self-hosting/configuration/integrations/airtable">
+    Send responses to an Airtable base.
+  </Card>
+
+  <Card title="Google Sheets" icon="file-spreadsheet" href="/self-hosting/configuration/integrations/google-sheets">
+    Send responses to a Google Sheet.
+  </Card>
+
+  <Card title="Notion" icon="book" href="/self-hosting/configuration/integrations/notion">
+    Send responses to a Notion database.
+  </Card>
+
+  <Card title="Slack" icon="slack" href="/self-hosting/configuration/integrations/slack">
+    Post responses to a Slack channel.
+  </Card>
+
+  <Card title="n8n" icon="diagram-project" href="/self-hosting/configuration/integrations/n8n">
+    Build automations on survey events with n8n.
+  </Card>
+
+  <Card title="Zapier" icon="bolt" href="/self-hosting/configuration/integrations/zapier">
+    Connect Formbricks to thousands of apps on Zapier.
+  </Card>
+
+  <Card title="ActivePieces" icon="puzzle-piece" href="/self-hosting/configuration/integrations/activepieces">
+    Build automations on survey events with ActivePieces.
+  </Card>
+</CardGroup>
+
+Once an integration is enabled on your instance, connecting it to a survey works exactly as it does on
+Formbricks Cloud. Follow the matching [Cloud guide](/platform/features/integrations/overview) from there.
+
+<Note>
+  For automations that stay inside Formbricks — without a third-party tool — use
+  [Workflows](/workflows/overview) to trigger actions such as sending an email when a response is completed.
+</Note>
+
+Still struggling or something not working as expected? [Join our Github
+Discussions](https://github.com/formbricks/formbricks/discussions) and we'd be glad to assist you!

--- a/docs/self-hosting/configuration/integrations.mdx
+++ b/docs/self-hosting/configuration/integrations.mdx
@@ -92,5 +92,5 @@ Formbricks Cloud. Follow the matching [Cloud guide](/platform/features/integrati
   [Workflows](/workflows/overview) to trigger actions such as sending an email when a response is completed.
 </Note>
 
-Still struggling or something not working as expected? [Join our Github
+Still struggling or something not working as expected? [Join our GitHub
 Discussions](https://github.com/formbricks/formbricks/discussions) and we'd be glad to assist you!


### PR DESCRIPTION
Fixes ENG-2752

## What & why

**Was:** Six pages linked to `/self-hosting/configuration/integrations`, a path with no MDX file, no navigation entry and no redirect. `errors.404.redirect` in `docs.json` sent readers to the docs home instead of a 404, so the dead link never surfaced.

**Now:** That path serves an overview of the seven self-hosting integration guides, listed first in the Integrations group under Self Hosting → Configuration.

- Written for a self-hoster: Cloud registers the OAuth apps, a self-hosted instance registers its own.
- A table splits the seven — four need OAuth credentials as env vars, three need no server config.
- The seven per-tool pages already resolved and are untouched; only the parent link was dead.

## Where to look

- `docs/self-hosting/configuration/integrations.mdx` — env var names read off the per-tool guides
- `docs/docs.json` — one nav line, first entry of the Integrations group

## Breaking changes

- [ ] This PR contains breaking changes

None. A new docs page and its nav entry add a route; no existing page, path or redirect changes.

## Migrations & env

- none

## How this was tested

Rerun: `cd docs && mint dev --port 3333` then open `/self-hosting/configuration/integrations`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The dead path resolves | manual | 200 in local Mintlify preview; previously a silent redirect to the docs home |
| Page renders its Mintlify components | manual | Steps, table and seven Cards all render — screenshot below |
| Sidebar placement | manual | "Overview" is the first entry of the Integrations group, siblings unchanged |
| Links out of the new page | manual | All 11 targets exist as `.mdx` and appear in `docs.json` navigation |
| `docs.json` still parses and is formatted | manual | Valid JSON; `prettier --check` clean |

<details>
<summary>Rendered page (local Mintlify preview)</summary>

![Self-hosting integrations overview page](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2752/integrations-overview.png)

Assets live on the `assets-pr-screenshots` branch and can be deleted after merge.

</details>

**Open gaps**

- Verified only against a local Mintlify preview, not the deployed docs.
- `mint broken-links` passes both before and after, so it does not confirm the fix — it cannot see this class of dead link while `errors.404.redirect` is on.

**Risks**

- `/self-hosting/configuration` (linked from `self-hosting/overview.mdx:25`) is dead the same way and stays dead — out of scope here.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.
