### PR TITLE
docs: fix five internal links that go nowhere (ENG-2757)

### DIFF
--- a/docs/development/contribution/contribution.mdx
+++ b/docs/development/contribution/contribution.mdx
@@ -37,7 +37,7 @@ You can set up your environment using:
 
 - [**GitHub Codespaces**](/development/local-setup/github-codespaces)
 
-- [**Local Machine Setup**](/development/local-setup)
+- **Local Machine Setup** on [Linux](/development/local-setup/linux), [Mac](/development/local-setup/mac) or [Windows](/development/local-setup/windows)
 
 For junior developers, **Gitpod or GitHub Codespaces** are recommended as they allow you to start coding in minutes.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -297,6 +297,7 @@
           {
             "group": "Configuration",
             "pages": [
+              "self-hosting/configuration",
               "self-hosting/configuration/custom-ssl",
               "self-hosting/configuration/environment-variables",
               "self-hosting/configuration/job-runner",

--- a/docs/self-hosting/advanced/enterprise-features/oidc-sso.mdx
+++ b/docs/self-hosting/advanced/enterprise-features/oidc-sso.mdx
@@ -4,4 +4,8 @@ description: "Configure Single Sign-On with your Formbricks instance."
 icon: "key"
 ---
 
+<Note>
+  Single Sign-On is part of the Formbricks [Enterprise Edition](/self-hosting/advanced/license).
+</Note>
+
 Implement enterprise-grade authentication for your survey platform with [Open ID Connect](/self-hosting/configuration/auth-sso/open-id-connect), [Azure AD OAuth](/self-hosting/configuration/auth-sso/azure-ad-oauth), [Google OAuth](/self-hosting/configuration/auth-sso/google-oauth), or [SAML](/self-hosting/configuration/auth-sso/saml-sso)

--- a/docs/self-hosting/advanced/enterprise-features/oidc-sso.mdx
+++ b/docs/self-hosting/advanced/enterprise-features/oidc-sso.mdx
@@ -4,4 +4,4 @@ description: "Configure Single Sign-On with your Formbricks instance."
 icon: "key"
 ---
 
-Implement enterprise-grade authentication for your survey platform with [Open ID connect, Azure AD OAuth, Google OAuth, and SAML](/self-hosting/configuration/auth-sso)
+Implement enterprise-grade authentication for your survey platform with [Open ID Connect](/self-hosting/configuration/auth-sso/open-id-connect), [Azure AD OAuth](/self-hosting/configuration/auth-sso/azure-ad-oauth), [Google OAuth](/self-hosting/configuration/auth-sso/google-oauth), or [SAML](/self-hosting/configuration/auth-sso/saml-sso)

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -59,6 +59,11 @@ Where Formbricks lives on the network, and how browsers get to it.
 
 Out of the box people sign in with an email address and a password. Point the instance at your own identity provider instead and sign-in follows the rules you already enforce there.
 
+<Note>
+  Single Sign-On is part of the [Enterprise Edition](/self-hosting/advanced/license) — every provider
+  below, not only SAML. SAML additionally needs the `saml` entitlement on the licence.
+</Note>
+
 <CardGroup cols={2}>
   <Card title="Authentication Behavior" icon="user" href="/self-hosting/auth-behavior">
     Who may sign up, and whether an invitation is required.
@@ -81,14 +86,12 @@ Out of the box people sign in with an email address and a password. Point the in
   </Card>
 
   <Card title="SAML SSO" icon="building-lock" href="/self-hosting/configuration/auth-sso/saml-sso">
-    SAML 2.0, for providers that do not speak OIDC. Enterprise Edition.
+    SAML 2.0, for providers that do not speak OIDC.
   </Card>
 </CardGroup>
 
 ## Connecting third-party tools
 
-<Card title="Integrations" icon="bridge" href="/self-hosting/configuration/integrations">
-  Register the OAuth apps that Slack, Notion, Airtable and Google Sheets need.
-</Card>
+[Airtable](/self-hosting/configuration/integrations/airtable), [Google Sheets](/self-hosting/configuration/integrations/google-sheets), [Notion](/self-hosting/configuration/integrations/notion) and [Slack](/self-hosting/configuration/integrations/slack) each need an OAuth app you register with the service, and its credentials as environment variables. [n8n](/self-hosting/configuration/integrations/n8n), [Zapier](/self-hosting/configuration/integrations/zapier) and [ActivePieces](/self-hosting/configuration/integrations/activepieces) connect the other way round, through a Formbricks API key, and need no server configuration at all.
 
 Still struggling or something not working as expected? [Join our GitHub Discussions](https://github.com/formbricks/formbricks/discussions) and we'd be glad to assist you!

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -1,0 +1,94 @@
+---
+title: "Configuration"
+sidebarTitle: "Overview"
+description: "Everything you can configure on a self-hosted Formbricks instance, and where each setting lives."
+icon: "sliders"
+---
+
+A fresh instance runs with sensible defaults. Everything below is optional, and most of it is a matter of adding environment variables and restarting your containers.
+
+<Note>
+  Almost every setting on this page is an environment variable. [Environment
+  Variables](/self-hosting/configuration/environment-variables) is the full list, and the page to read
+  first.
+</Note>
+
+## Getting mail out
+
+Formbricks sends verification mail, invitations, email follow-ups and email surveys. None of that works until you point the instance at an SMTP server.
+
+<CardGroup cols={2}>
+  <Card title="SMTP" icon="envelope" href="/self-hosting/configuration/smtp">
+    Point Formbricks at a mail server.
+  </Card>
+
+  <Card title="Job Runner" icon="gears" href="/self-hosting/configuration/job-runner">
+    Run the background worker that sends the mail and processes queued work.
+  </Card>
+</CardGroup>
+
+## Reaching your instance
+
+Where Formbricks lives on the network, and how browsers get to it.
+
+<CardGroup cols={2}>
+  <Card title="Domain Configuration" icon="globe" href="/self-hosting/configuration/domain-configuration">
+    Set the public-facing URL your instance answers on.
+  </Card>
+
+  <Card title="Custom SSL Certificate" icon="lock" href="/self-hosting/configuration/custom-ssl">
+    Bring your own certificate to the One-Click setup.
+  </Card>
+
+  <Card title="Custom Subpath" icon="folder-tree" href="/self-hosting/configuration/custom-subpath">
+    Serve Formbricks under a path prefix instead of a domain root.
+  </Card>
+
+  <Card title="CDN" icon="server" href="/self-hosting/configuration/cdn">
+    Cache public traffic without serving stale survey assets after an upgrade.
+  </Card>
+</CardGroup>
+
+## Storing what people upload
+
+<Card title="File Uploads" icon="upload" href="/self-hosting/configuration/file-uploads">
+  Configure storage for survey images, file-upload answers and workspace assets.
+</Card>
+
+## Signing in
+
+Out of the box people sign in with an email address and a password. Point the instance at your own identity provider instead and sign-in follows the rules you already enforce there.
+
+<CardGroup cols={2}>
+  <Card title="Authentication Behavior" icon="user" href="/self-hosting/auth-behavior">
+    Who may sign up, and whether an invitation is required.
+  </Card>
+
+  <Card title="Open ID Connect" icon="id-card" href="/self-hosting/configuration/auth-sso/open-id-connect">
+    The generic OIDC setup. Start here if your provider is not listed separately.
+  </Card>
+
+  <Card title="Keycloak OIDC" icon="shield-halved" href="/self-hosting/configuration/auth-sso/keycloak-oidc">
+    OIDC against a Keycloak realm.
+  </Card>
+
+  <Card title="Azure AD OAuth" icon="microsoft" href="/self-hosting/configuration/auth-sso/azure-ad-oauth">
+    Microsoft Entra ID, formerly Azure AD.
+  </Card>
+
+  <Card title="Google OAuth" icon="google" href="/self-hosting/configuration/auth-sso/google-oauth">
+    Google Workspace accounts.
+  </Card>
+
+  <Card title="SAML SSO" icon="building-lock" href="/self-hosting/configuration/auth-sso/saml-sso">
+    SAML 2.0, for providers that do not speak OIDC. Enterprise Edition.
+  </Card>
+</CardGroup>
+
+## Connecting third-party tools
+
+<Card title="Integrations" icon="bridge" href="/self-hosting/configuration/integrations">
+  Register the OAuth apps that Slack, Notion, Airtable and Google Sheets need.
+</Card>
+
+Still struggling or something not working as expected? [Join our GitHub Discussions](https://github.com/formbricks/formbricks/discussions) and we'd be glad to assist you!

--- a/docs/surveys/best-practices/cancel-subscription.mdx
+++ b/docs/surveys/best-practices/cancel-subscription.mdx
@@ -76,7 +76,7 @@ To create the trigger for your Churn Survey, you have three options to choose fr
 
 Whenever a user visits this page, matches the filter conditions above and the recontact options (below) the survey will be displayed ✅
 
-Here is our complete [Actions manual](/surveys/website-app-surveys/actions/) covering [No-Code](/surveys/website-app-surveys/actions#setting-up-no-code-actions) and [Code](/surveys/website-app-surveys/actions#setting-up-code-actions) Actions.
+Here is our complete [Actions manual](/surveys/website-app-surveys/actions) covering [No-Code](/surveys/website-app-surveys/actions#setting-up-no-code-actions) and [Code](/surveys/website-app-surveys/actions#setting-up-code-actions) Actions.
 
 ### 5. Select Action in the “When to ask” card
 

--- a/docs/surveys/website-app-surveys/quickstart.mdx
+++ b/docs/surveys/website-app-surveys/quickstart.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Quickstart"
 
 <Steps>
   <Step title="Create a Formbricks cloud account">
-    While you can [self-host](/self-hosting) Formbricks, the fastest and easiest way to get started is with the free Cloud plan. Simply [sign up](https://app.formbricks.com/auth/signup) here, follow the onboarding steps, and choose the "Formbricks Surveys" option.
+    While you can [self-host](/self-hosting/overview) Formbricks, the fastest and easiest way to get started is with the free Cloud plan. Simply [sign up](https://app.formbricks.com/auth/signup) here, follow the onboarding steps, and choose the "Formbricks Surveys" option.
     
     ![what are you here for](https://res.cloudinary.com/dwdb9tvii/image/upload/v1738113228/image_d11uiy.png)
   </Step>


### PR DESCRIPTION
Fixes ENG-2757

## What & why

Five internal links in `docs/` point at paths that have no page.

None of them 404 for a reader. `errors.404.redirect: true` in `docs.json` silently redirects every dead internal path to the docs home, so a wrong link reads as a page that "just went to the wrong place". It is also why `mint broken-links` reports the docs as clean — it did so both before and after ENG-2752 fixed the same class of bug.

| Link | In | Now |
| --- | --- | --- |
| `/self-hosting/configuration` | `self-hosting/overview.mdx` | A new index page for the section |
| `/self-hosting/configuration/auth-sso` | `enterprise-features/oidc-sso.mdx` | Each provider linked to its own page |
| `/development/local-setup` | `contribution/contribution.mdx` | Linux / Mac / Windows, which are the pages that exist |
| `/self-hosting` | `website-app-surveys/quickstart.mdx` | `/self-hosting/overview` |
| `/surveys/website-app-surveys/actions/` | `best-practices/cancel-subscription.mdx` | Same path without the trailing slash |

The first four are nav **groups**. A group is not a page, so linking its path in prose never resolves.

### How they were found

Resolving every `](/…)` and `href="/…"` in `docs/**/*.mdx` against the page list in `docs.json`, rather than trusting the crawler:

```bash
python3 - <<'PY'
import json, os, re, glob
cfg = json.load(open("docs/docs.json")); pages = set()
def walk(n):
    if isinstance(n, str): pages.add(n)
    elif isinstance(n, list): [walk(x) for x in n]
    elif isinstance(n, dict):
        for k, v in n.items():
            if k in ("pages","groups","tabs","anchors","navigation","dropdowns","languages","versions"): walk(v)
walk(cfg["navigation"])
links = set()
for f in glob.glob("docs/**/*.mdx", recursive=True):
    t = open(f, encoding="utf-8").read()
    links |= {m.group(1).lstrip("/") for m in re.finditer(r'\]\((/[A-Za-z0-9/_\-]+)', t)}
    links |= {m.group(1).lstrip("/") for m in re.finditer(r'href="(/[A-Za-z0-9/_\-]+)', t)}
for p in sorted(links):
    if p not in pages and not os.path.exists(f"docs/{p}.mdx") and not p.startswith(("api-reference/","api-v2-reference/")):
        print("DEAD", p)
PY
```

Run on this branch it prints one line: `/self-hosting/configuration/integrations`, which #9033 fixes. On `main` it prints six.

The two `api-*-reference/` prefixes are excluded because Mintlify generates those pages from the OpenAPI documents at build time — they are real, just not listed in `docs.json`. Both such links were checked by hand against the operation's tag and summary, which is what the generated slug is built from.

## Where to look

- [self-hosting/configuration.mdx](https://github.com/formbricks/formbricks/blob/docs/dead-internal-links/docs/self-hosting/configuration.mdx) — the only new prose. It groups the twelve configuration pages by what a reader is trying to do (get mail out, be reachable, store uploads, sign in, connect tools) rather than listing them.

## Breaking changes

- [ ] This PR contains breaking changes

None. Documentation prose and one nav entry. No code changes, and no existing page moves or changes path.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| No dead internal links remain | script above | 1 left, fixed by #9033; was 6 |
| The new page introduces none of its own | script above | Its `href=` cards resolve — the sweep covers attributes, not just markdown links |
| `docs.json` still parses and the new page is in nav | manual | `json.load` clean; `self-hosting/configuration` is first in the Configuration group, matching how Integrations does it |
| Every page the new index links to exists | manual | Twelve links, each a page in the Configuration group or the auth-behavior page |
| The two API-reference links are not dead | manual | Tag `Management API - Surveys - Contact Links` and the summaries slugify to exactly the paths used |

**Open gaps**

- `mint broken-links` still cannot catch this class of bug, and this PR does not change that. The sweep above is a shell one-liner, not a CI check — turning off `errors.404.redirect` would be the real fix, and that is a call for whoever owns the docs site.
- Only internal links are checked. External URLs are untouched.

**Risks**

- The `docs.json` edit touches the same array as #9033. Different lines, so it should merge, but whichever lands second is worth a look.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).
