### PR TITLE
docs: stop promising Workflow actions that do not exist

### DIFF
--- a/docs/platform/what-is-formbricks.mdx
+++ b/docs/platform/what-is-formbricks.mdx
@@ -28,7 +28,7 @@ Formbricks covers the full experience-management loop — from collecting feedba
     Unify feedback from every source into one store, then visualize it with charts and shareable dashboards.
   </Card>
   <Card title="Act" icon="diagram-project" href="/workflows/overview">
-    Turn responses into action with Workflows that trigger emails and other automations — no code required.
+    Turn responses into action with Workflows that send an email when a response comes in — no code required.
   </Card>
 </CardGroup>
 

--- a/docs/self-hosting/advanced/enterprise-features/workflows.mdx
+++ b/docs/self-hosting/advanced/enterprise-features/workflows.mdx
@@ -5,6 +5,6 @@ icon: "https://d3gk2c5xim1je2.cloudfront.net/lucide/v1.16.0/workflow.svg"
 sidebarTitle: "Workflows"
 ---
 
-Workflows automate tasks in response to events in Formbricks. You choose a trigger, narrow down which events qualify with optional filters, and run an action such as sending an email.
+Workflows automate tasks in response to events in Formbricks. You choose a trigger, narrow down which events qualify with optional filters, and run an action. Today that action is sending an email.
 
 Read the full guide: [Workflows overview](/workflows/overview).

--- a/docs/surveys/general-features/email-followups.mdx
+++ b/docs/surveys/general-features/email-followups.mdx
@@ -5,9 +5,9 @@ icon: "envelope"
 ---
 
 <Warning>
-  Email Follow-ups are being deprecated in favor of [Workflows](/workflows/overview). Workflows
-  offer the same response- and ending-based email automation plus additional triggers and actions. We recommend
-  building new email automations as Workflows.
+  Email Follow-ups are being deprecated in favor of [Workflows](/workflows/overview). Workflows cover the
+  same ground — a completed response, optionally narrowed to specific ending cards, sending an email — and
+  are where this is being developed. We recommend building new email automations as Workflows.
 </Warning>
 
 <Note>


### PR DESCRIPTION
## What & why

Workflows can do exactly one thing today. `packages/workflows/src/types/actions/enum.ts` is:

```ts
export const WORKFLOW_ACTIONS = {
  SEND_EMAIL: "send_email",
} as const;
```

and `types/actions/` holds one module, `send-email.ts`. Three pages implied more.

| Page | Said | Now |
| --- | --- | --- |
| `what-is-formbricks.mdx` | "Workflows that trigger emails **and other automations**" | "Workflows that send an email when a response comes in" |
| `email-followups.mdx` | "Workflows offer the same email automation **plus additional triggers and actions**" | "Workflows cover the same ground … and are where this is being developed" |
| `enterprise-features/workflows.mdx` | "run an action **such as** sending an email" | "run an action. Today that action is sending an email." |

The middle one is the one that matters. It is a **deprecation notice** telling people to move off Email Follow-ups, and the reason it gives is capability that does not exist. Follow-ups trigger on a completed response or a specific ending and send an email; Workflows trigger on a completed response, optionally filter by ending card, and send an email. Same ground — so the honest argument for migrating is direction of development, not features.

`workflows/overview.mdx` and `workflows/build.mdx` were **already** accurate — the overview names the single trigger, filter and action in three places and explicitly lists what is *not* available yet ("webhooks, schedules, delays, and loops are not available yet"). Neither is touched.

### On the Webhooks line in #9014

Checked, and it is about a different feature. The Webhooks **integration** is live and independent of Workflows: `apps/web/modules/integrations/webhooks/` (table, create modal, actions), a settings page under Integrations that counts webhooks by source, `/api/v2/management/webhooks`, and documented `responseCreated` / `responseUpdated` / `responseFinished` triggers. Nothing about it is deprecated, and it is not a Workflow action. That bullet stands.

## Where to look

- [email-followups.mdx](https://github.com/formbricks/formbricks/blob/docs/workflows-only-send-email/docs/surveys/general-features/email-followups.mdx) — the deprecation notice

## Breaking changes

- [ ] This PR contains breaking changes

None. Three sentences of documentation. No code changes.

## Migrations & env

- none

## How this was tested

Rerun: `cat packages/workflows/src/types/actions/enum.ts && ls packages/workflows/src/types/actions/`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Exactly one workflow action exists | source | `WORKFLOW_ACTIONS` has one key; `types/actions/` has one module besides `enum.ts` and `index.ts` |
| Workflows do not exceed Follow-ups in triggers either | source + docs | Workflows: Response completed + ending-card filter. Follow-ups: response-based + ending-based. The same two cases |
| Every workflow mention in `docs/` was checked | manual | 31 files mention "workflow"; the rest are the workflow docs themselves (already accurate), API/MCP tool listings, or unrelated uses of the English word |
| `google-reviews.mdx` was not over-claiming | manual | It names the **Send email** action explicitly in its steps — left alone |

**Open gaps**

- `workflows/overview.mdx` promises "we will note breaking changes here" for a Beta feature. Nothing enforces that; it is a commitment the docs cannot keep on their own.
- The claim checked here is *what actions exist*. Whether each documented **field** of the Send email action behaves as described is not re-verified in this PR.

**Risks**

- If a second action lands soon, these three sentences need widening again. That is the correct direction to be wrong in.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).
