### PR TITLE
feat(observability): record the outcome of every SSO callback (backport #9026 to release/5.4)

### DIFF
--- a/apps/web/app/api/auth/[...all]/route.ts
+++ b/apps/web/app/api/auth/[...all]/route.ts
@@ -1,4 +1,8 @@
 import { auth } from "@/modules/auth/lib/auth";
+import {
+  recordSsoCallbackOutcome,
+  recordSsoCallbackThrow,
+} from "@/modules/auth/lib/better-auth-observability";
 import { createAuthPathLabeller } from "@/modules/auth/lib/better-auth-path-label";
 import { runWithBetterAuthRequestContext } from "@/modules/auth/lib/better-auth-request-context";
 import { mapLegacySsoCallbackRequest } from "@/modules/auth/lib/legacy-sso-callback";
@@ -61,10 +65,24 @@ const handler = async (request: Request): Promise<Response> => {
   // neither is ours to change: the pinned SSO callback path, and `application_type` on dynamic client
   // registration (see each module). Both no-op for every other request.
   const mappedRequest = await normalizeDcrRequest(mapLegacySsoCallbackRequest(request));
-  return runWithBetterAuthRequestContext(
-    { path: labelAuthPath(mappedRequest.url), method: mappedRequest.method },
-    () => runWithSsoRequestContext(() => auth.handler(mappedRequest))
-  );
+  try {
+    const response = await runWithBetterAuthRequestContext(
+      { path: labelAuthPath(mappedRequest.url), method: mappedRequest.method },
+      () => runWithSsoRequestContext(() => auth.handler(mappedRequest))
+    );
+    // ENG-2551: the one place that sees the outcome of every SSO callback, whatever went wrong and
+    // whichever provider it was — a failed callback is a redirect carrying `?error=`, or a 4xx/5xx.
+    // Emitted here rather than from a hook because the failures that matter most are the ones Better
+    // Auth returns as a response rather than throwing, so no error-path hook observes them.
+    recordSsoCallbackOutcome(mappedRequest.url, response);
+    return response;
+  } catch (error) {
+    // A throw is the most severe callback failure there is — Next answers 500 and the user cannot sign
+    // in — so it must not be the one case the signal misses. Recorded, then rethrown unchanged so the
+    // existing error handling (and the Sentry capture in this module) behaves exactly as before.
+    recordSsoCallbackThrow(mappedRequest.url);
+    throw error;
+  }
 };
 
 export { handler as GET, handler as POST };

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -371,3 +371,243 @@ export const auditPasswordReset = async (userId: string): Promise<void> => {
     logger.withContext({ source: "better-auth" }).error("Failed to queue password-reset audit event");
   }
 };
+
+/**
+ * Providers whose id may appear in an SSO callback outcome record (ENG-2551).
+ *
+ * An allow-list rather than a sanitising regex, because the provider id comes from the request path
+ * and anyone can call `/api/auth/callback/<anything>`. A regex would bound the *shape* of the value
+ * but not the number of distinct values, so it would hand a caller unbounded control over a log
+ * field's cardinality — the thing that makes a log-based alert unusable. Anything unrecognised
+ * buckets to `unknown`.
+ *
+ * Deliberately not imported from the SSO provider config: this module must not depend on the EE
+ * surface, and the list answers a different question anyway ("what may we label") rather than "what
+ * is registered on this instance".
+ */
+const SSO_CALLBACK_PROVIDER_IDS = new Set(["google", "github", "azuread", "openid", "saml"]);
+
+/**
+ * A callback path, capturing the provider id.
+ *
+ * Answers two questions: which provider a request is for, and — applied to a *redirect target* —
+ * whether Better Auth is bouncing a `form_post` callback to its GET twin rather than concluding.
+ */
+const SSO_CALLBACK_PATH = /\/callback\/([^/?#]+)\/?$/;
+
+/**
+ * `success` and `failure` are the two an alert divides; `incomplete` is deliberately neither.
+ *
+ * A ratio of `failure / (success + failure)` stays meaningful only while both sides really are
+ * completed sign-ins or broken ones. Verify-before-link recovery is neither — it ends on the "check
+ * your inbox" page by design — so it gets its own value rather than being forced into one, and an
+ * alert should exclude it explicitly.
+ */
+type SsoCallbackRecord = { outcome: "success" | "failure" | "incomplete"; reason?: string };
+
+/**
+ * Better Auth mints the session cookie only on a completed sign-in, which is why this is the success
+ * signal rather than the redirect target: the success destination is the caller's `callbackURL` and
+ * the failure destination its `errorCallbackURL`, and both are ordinary app pages here.
+ */
+const hasSessionCookie = (response: Response): boolean =>
+  response.headers.getSetCookie().some((cookie) => cookie.includes("session_token"));
+
+/**
+ * Callback failure reasons that may be recorded verbatim (ENG-2551).
+ *
+ * This has to be an allow-list for the same reason the provider id does, and the reason is easy to
+ * miss: Better Auth **echoes the inbound `error` query parameter** into its own redirect
+ * (`api/routes/callback.mjs`, `if (error) redirectOnError(error, error_description)`). Any caller can
+ * obtain a parseable `state` by starting a sign-in and then request
+ * `/api/auth/callback/<id>?state=…&error=<anything>`, so the value that lands here is outside
+ * attacker control only if we bound it to a known set. A charset regex would bound the *shape* of the
+ * value but not the *number of distinct values*, which is the property an alert needs.
+ *
+ * Two consequences of that echo, both closed by bucketing to `other`: an outsider cannot inflate the
+ * cardinality of this field, and cannot forge a specific reason to make a real outage look like
+ * something else.
+ *
+ * Read from `better-auth/dist/oauth2/errors.mjs` (OAUTH_CALLBACK_ERROR_CODES), the two route-level
+ * codes in `api/routes/callback.mjs`, the five `StateError` codes in `state.mjs`, and the codes this
+ * app redirects with itself. A code that disappears upstream simply stops occurring; a new one
+ * buckets to `other` until it is added, which is the safe direction.
+ */
+const SSO_CALLBACK_REASONS = new Set([
+  // Better Auth OAUTH_CALLBACK_ERROR_CODES
+  "account_already_linked_to_different_user",
+  "email_does_not_match",
+  "email_not_found",
+  "email_not_verified",
+  "invalid_code",
+  "issuer_mismatch",
+  "issuer_missing",
+  "no_callback_url",
+  "no_code",
+  "nonce_binding_missing",
+  "oauth_provider_not_found",
+  "unable_to_get_user_info",
+  "unable_to_link_account",
+  // Better Auth callback route, and the codes its redirectOnError call sites pass. `internal_server_error`
+  // is the important one and was found by smoke-testing rather than by reading the enum: stopping the
+  // database mid-callback produces it, so it is the code an infrastructure outage actually arrives as.
+  "invalid_callback_request",
+  "internal_server_error",
+  "invalid_payload",
+  "invalid_profile",
+  "missing_profile",
+  "payload_expired",
+  "user_creation_failed",
+  // Better Auth StateError codes
+  "state_generation_error",
+  "state_invalid",
+  "state_mismatch",
+  "state_not_found",
+  "state_security_mismatch",
+  // Emitted by this app
+  "OAuthAccountNotLinked",
+  "account_not_linked",
+  "invalid_scope",
+  "unable_to_create_user",
+]);
+
+/**
+ * Record the outcome of an SSO callback, so a total sign-in outage announces itself (ENG-2551).
+ *
+ * The problem this solves is that every SSO outage so far has had a *novel cause* and an *identical
+ * symptom*. ENG-1800 (RFC 9207 `iss`), ENG-2555 (wrong `Account.issuer`), ENG-2750 (placeholder
+ * issuer) and the suppressed `state_mismatch` class each needed their own diagnosis, and each ended
+ * with the callback redirecting to `?error=…` instead of to the callbackURL. Alerting on causes means
+ * adding a rule after every incident; alerting on the outcome covers the next one for free.
+ *
+ * ENG-2750 is why this exists at all: it failed 100% of Cloud Microsoft sign-ins for ~18 hours and
+ * produced **no Sentry event**, because Better Auth logs that failure as a bare message with no
+ * `Error` argument, so the capture gate above never has anything to capture. A log line keyed on a
+ * stable field is what an alert can actually watch.
+ *
+ * Emits on success too: the useful alert threshold is a *ratio* ("failures exceed N% of callbacks
+ * over 15 minutes"), which survives traffic swings, campaigns and quiet weekends in a way an
+ * absolute count does not.
+ *
+ * Failures log at `warn`, not `error`. A single failed callback is routinely the user's own doing — a
+ * stale tab, an expired state, a declined consent — and promoting each one to `error` would degrade
+ * the signal this is meant to create. The alert keys on `ssoCallbackOutcome`, so the level is
+ * presentation, not meaning.
+ *
+ * Never throws: observability must not be able to fail a sign-in that otherwise succeeded.
+ */
+/** A response that minted no session: either a named failure, or a flow that never claimed to sign in. */
+const sessionlessOutcome = (target: URL): SsoCallbackRecord => {
+  const error = target.searchParams.get("error");
+
+  // `?error=` and a bare `?error` both read back as `""`. An error parameter that is present but
+  // empty says something went wrong without saying what, so it belongs on the failure side.
+  if (error !== null) {
+    return { outcome: "failure", reason: SSO_CALLBACK_REASONS.has(error) ? error : "other" };
+  }
+
+  // No session and no error is neither: verify-before-link recovery ends exactly here, redirecting to
+  // the "check your inbox" page on purpose (`ssoRecoveryAfterHandler`). Counting it as a failure would
+  // inflate the ratio during a perfectly healthy flow, and as a success would claim a sign-in that did
+  // not happen — so it is named and left out of both sides.
+  return { outcome: "incomplete", reason: "no_session" };
+};
+
+/** The outcome carried by a redirect, or `null` when this redirect decides nothing. */
+const redirectOutcome = (target: URL, response: Response): SsoCallbackRecord | null => {
+  // `response_mode=form_post`: Better Auth 1.7 turns a POST callback into a 302 to the GET callback
+  // *before* it validates state or exchanges the code (`api/routes/callback.mjs`), and
+  // `legacy-sso-callback.ts` deliberately preserves that flow. Recording the hop would score every
+  // form_post sign-in as one extra outcome, and — because the hop carries no `error` — it would score
+  // it as a success, capping a totally broken form_post flow at a 50% failure ratio. The GET that
+  // follows is the one that knows what happened, so say nothing here.
+  if (SSO_CALLBACK_PATH.test(target.pathname)) return null;
+
+  // A completed sign-in is the one thing that mints a session, and Better Auth decides that rather
+  // than it being inferred from where the browser is sent next. That matters because the success
+  // destination is the caller's `callbackURL` — `getSsoReturnToUrl` preserves its query string, so a
+  // legitimate target like `/page?error=retry` exists — while the failure destination is the caller's
+  // `errorCallbackURL` (`/auth/login` for every button here). Reading the `error` key off whichever
+  // URL came back cannot tell those apart; the session cookie can.
+  return hasSessionCookie(response) ? { outcome: "success" } : sessionlessOutcome(target);
+};
+
+export const recordSsoCallbackOutcome = (requestUrl: string, response: Response): void => {
+  emitSsoCallbackRecord(requestUrl, (): SsoCallbackRecord | null => {
+    // A 4xx/5xx on the callback is a failed sign-in too — this is how the SSO licence gate's 403 and
+    // any unhandled 500 present, and neither redirects.
+    if (response.status >= 400) return { outcome: "failure", reason: `http_${response.status}` };
+
+    if (response.status < 300) {
+      return hasSessionCookie(response)
+        ? { outcome: "success" }
+        : { outcome: "incomplete", reason: "no_session" };
+    }
+
+    // A redirect the browser cannot follow is a failed sign-in, not a quiet success. Both shapes below
+    // would otherwise corrupt the ratio rather than merely lose detail: a missing `Location` counted as
+    // success inflates the healthy side, and a malformed one threw into the outer catch, dropping the
+    // callback from both sides.
+    const location = response.headers.get("location");
+    if (!location) return { outcome: "failure", reason: "missing_location" };
+
+    // The catch guards the parse and nothing else: wrapping the classification too would relabel any
+    // fault inside it as a malformed `Location`, which is a different and misleading claim.
+    let target: URL;
+    try {
+      target = new URL(location, requestUrl);
+    } catch {
+      return { outcome: "failure", reason: "malformed_location" };
+    }
+
+    return redirectOutcome(target, response);
+  });
+};
+
+/**
+ * Record an SSO callback that threw rather than returning a response (ENG-2551).
+ *
+ * The most severe callback failure there is: the request never produces a redirect, Next answers 500,
+ * and the user simply cannot sign in. Recording only responses would have left exactly that case
+ * invisible to the alert this signal exists to feed.
+ */
+export const recordSsoCallbackThrow = (requestUrl: string): void => {
+  emitSsoCallbackRecord(requestUrl, () => ({ outcome: "failure", reason: "exception" }));
+};
+
+/**
+ * Shared emitter: resolves the provider from the path, applies the outcome, logs once. Never throws —
+ * observability must not be able to fail a sign-in that otherwise succeeded, nor mask the original
+ * error on the throwing path.
+ */
+const emitSsoCallbackRecord = (requestUrl: string, resolveOutcome: () => SsoCallbackRecord | null): void => {
+  try {
+    const path = new URL(requestUrl).pathname;
+    // The internal path Better Auth actually serves. `mapLegacySsoCallbackRequest` has already
+    // rewritten the pinned `/oauth2/callback/:id` form by the time a response exists, so matching the
+    // internal shape covers both.
+    const providerSegment = SSO_CALLBACK_PATH.exec(path)?.[1];
+    if (!providerSegment) return;
+
+    const provider = SSO_CALLBACK_PROVIDER_IDS.has(providerSegment.toLowerCase())
+      ? providerSegment.toLowerCase()
+      : "unknown";
+    // `null` means "this request is not the one that decides the outcome" — see the form_post hop.
+    const record = resolveOutcome();
+    if (!record) return;
+    const { outcome, reason } = record;
+
+    const contextLogger = logger.withContext({
+      source: "sso-callback",
+      ssoCallbackOutcome: outcome,
+      ssoProvider: provider,
+      ...(reason ? { ssoCallbackReason: reason } : {}),
+    });
+
+    if (outcome === "failure") contextLogger.warn("SSO callback failed");
+    else if (outcome === "incomplete") contextLogger.info("SSO callback did not complete a sign-in");
+    else contextLogger.info("SSO callback succeeded");
+  } catch {
+    // A malformed URL is not worth failing or logging a sign-in over.
+  }
+};


### PR DESCRIPTION
Ref ENG-2551

Backport of #9026 to `release/5.4`, for 5.4.1.

> [!IMPORTANT]
> This lands after `5.4.1-rc.2` was cut, so it needs an `rc.3` to ship in 5.4.1.

## What & why

**Was:** a total SSO outage produced **zero** Sentry events. The Microsoft failure that took Cloud sign-in down for every user was a redirect carrying `?error=`, which nothing observed — so the first signal was a user report.

**Now:** every SSO callback records its outcome — `success`, `failure` with a reason, or `incomplete` — labelled by provider.

Carried into 5.4.1 deliberately: `rc.2` fixes the outage, and this is the instrument that says whether it actually worked in production. That is worth most *before* the fix is confirmed good, not after.

## Where to look

- [`route.ts`](apps/web/app/api/auth/[...all]/route.ts) — `return handler(…)` becomes `await`, record, return; rethrow on the error path.
- [`better-auth-observability.ts`](apps/web/modules/auth/lib/better-auth-observability.ts) — classification, and the `catch` that makes it fail-safe.

## Breaking changes

- [ ] This PR contains breaking changes

None. Additive logging only; no API, schema, env or config surface changes.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && npx vitest run modules/auth/lib/better-auth-observability.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The pre-existing observability suite still passes | unit (guard) | 59 tests, green, untouched by this pick |
| The branch compiles on 5.4 | manual | `turbo typecheck --filter=@formbricks/web` — 12/12 tasks, exit 0 |
| The recorder cannot break the auth route | manual | `emitSsoCallbackRecord` wraps its whole body in a bare `catch`. Load-bearing here: the call sits inside the route's `try`, so an unguarded throw would turn every callback into a 500 |
| Outcomes are recorded for every provider, not just the fixed one | manual | On a live stack with all five configured: a completed `openid` sign-in recorded `success`; failing callbacks recorded `failure`/`state_mismatch` for google, github, azuread, openid and saml; an unregistered id bucketed to `unknown` |

**Open gaps**

- **The net-new test cases are not carried**, per the backport policy. Both touched files pre-exist on 5.4 (373 and 669 lines); the pre-existing suite is untouched and still green. Expect the Sonar coverage gate to fail on the new lines, as it did on #9028.
- The live-stack verification above was run on `main`, not on this branch.

**Risks**

- **The recorder sits inside the new `try`**, so a throw from it would turn every SSO callback into a 500 — on a release branch, while the outage fix in `rc.2` is still being confirmed. It cannot: `emitSsoCallbackRecord` wraps its whole body in a bare `catch`. That guarantee is the load-bearing one in this diff.
- `route.ts` conflicted on the pick because `main`'s version of that hunk also wraps the handler in `runWithEmailVerificationRequestContext`. That layer is left out because it is **ENG-2562, which does not exist on this branch** — `git grep runWithEmailVerificationRequestContext origin/release/5.4` returns nothing, and the module defining it is absent too, so carrying it would mean backporting a second, unrelated feature. The wrapper nesting is otherwise untouched, and the recorder classifies the returned response regardless of what wraps the handler.
- Log volume rises by one line per SSO callback.
