### PR TITLE
chore(docs): add the screenshot capture harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ stats.html
 docs/api-v3-reference/contract-tests/fixtures.json
 .schemathesis/
 __pycache__/
+
+# Playwright storage state written by the docs capture script — contains live session cookies
+scripts/docs-capture/.auth.json

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -55,6 +55,7 @@
     "db:push": "prisma db push --accept-data-loss --config ./prisma.config.ts",
     "db:seed": "dotenv -e ../../.env -- tsx src/seed.ts",
     "db:seed:clear": "dotenv -e ../../.env -- tsx src/seed.ts --clear",
+    "db:seed:docs": "dotenv -e ../../.env -- tsx src/scripts/seed-docs-fixtures.ts",
     "db:seed:contract": "dotenv -e ../../.env -- tsx src/scripts/seed-contract-fixtures.ts",
     "db:setup": "pnpm db:migrate:dev && pnpm db:create-saml-database:dev",
     "db:start": "pnpm db:setup",

--- a/packages/database/src/scripts/docs-fixture-ids.ts
+++ b/packages/database/src/scripts/docs-fixture-ids.ts
@@ -1,0 +1,25 @@
+/**
+ * Ids for the docs fixture, kept apart from the seed script that writes them.
+ *
+ * `seed-docs-fixtures.ts` constructs a `PrismaClient` and runs the production guard while the module
+ * evaluates, so anything that only needs the ids — `scripts/docs-capture/capture.ts` does — cannot
+ * import it without connecting to a database. Splitting the constants out lets both sides share one
+ * definition, so a renamed id breaks the capture script at compile time instead of at the first
+ * screenshot that silently photographs a 404.
+ *
+ * Values are fixed rather than generated because screenshots address surveys by URL: a shot must not
+ * depend on the order rows happened to be inserted in.
+ */
+export const DOCS_IDS = {
+  ORGANIZATION: "cldocsacmeorg00000000001",
+  WORKSPACE: "cldocsacmeworkspace000001",
+  SURVEY_ALL_ELEMENTS: "cldocsallelements00000001",
+  /** An app survey. Several settings — Visibility & Recontact, targeting — only exist for this type. */
+  SURVEY_APP: "cldocsappsurvey000000001",
+  /**
+   * Two link surveys that exist only to be photographed from the respondent's side: the PIN screen
+   * and the email gate come before the survey and cannot be shown from the editor.
+   */
+  SURVEY_PIN: "cldocspinsurvey000000001",
+  SURVEY_VERIFY_EMAIL: "cldocsverifyemail00000001",
+} as const;

--- a/packages/database/src/scripts/seed-docs-fixtures.ts
+++ b/packages/database/src/scripts/seed-docs-fixtures.ts
@@ -320,14 +320,19 @@ async function seedResponses(surveyId: string, finishedCount: number, partialCou
   const ordered = ACME_ELEMENTS.map((e) => e.id);
 
   const total = finishedCount + partialCount;
+  // Interleave rather than writing all the finished ones first. The response table sorts newest
+  // first, so a contiguous block of partials at the end lands at the *top* of the screenshot and
+  // makes the product look like nothing ever completes. Spreading them by rank rather than by a
+  // fixed modulus is what keeps the counts equal to the arguments for any pair of them.
+  const partialRows = new Set<number>();
+  for (let k = 0; k < partialCount; k++) {
+    partialRows.add(Math.floor(((k + 0.5) * total) / partialCount));
+  }
+
   for (let i = 0; i < total; i++) {
-    // Interleave rather than writing all the finished ones first. The response table sorts newest
-    // first, so a contiguous block of partials at the end lands at the *top* of the screenshot and
-    // makes the product look like nothing ever completes.
-    const finished = i % 4 !== 3 || i >= partialCount * 4;
+    const finished = !partialRows.has(i);
     // A partial stops somewhere in the first half, which is what makes the drop-off curve a curve.
     const answeredUpTo = finished ? ordered.length : 2 + (i % 5);
-    void total;
 
     const data: Record<string, unknown> = {};
     for (const id of ordered.slice(0, answeredUpTo)) {

--- a/packages/database/src/scripts/seed-docs-fixtures.ts
+++ b/packages/database/src/scripts/seed-docs-fixtures.ts
@@ -22,6 +22,7 @@ import { type TSurveyBlocks } from "@formbricks/types/surveys/blocks";
 import { PrismaClient } from "../prisma";
 import { createPrismaPgAdapter } from "../prisma-adapter";
 import { SEED_IDS } from "../seed/constants";
+import { DOCS_IDS } from "./docs-fixture-ids";
 
 const prisma = new PrismaClient({ adapter: createPrismaPgAdapter().adapter });
 
@@ -34,15 +35,9 @@ if (process.env.NODE_ENV === "production" && process.env.ALLOW_SEED !== "true") 
  * Fixed ids so the capture script can address a survey without querying for it, and so re-running
  * this script updates the same rows instead of accumulating duplicates.
  */
-export const DOCS_IDS = {
-  ORGANIZATION: "cldocsacmeorg00000000001",
-  WORKSPACE: "cldocsacmeworkspace000001",
-  SURVEY_ALL_ELEMENTS: "cldocsallelements00000001",
-  /** An app survey. Several settings — Visibility & Recontact, targeting — only exist for this type. */
-  SURVEY_APP: "cldocsappsurvey000000001",
-  SURVEY_PIN: "cldocspinsurvey000000001",
-  SURVEY_VERIFY_EMAIL: "cldocsverifyemail00000001",
-} as const;
+// Re-exported so existing importers of this module keep working; the ids themselves live in a
+// side-effect-free module that the capture script can import without opening a database connection.
+export { DOCS_IDS };
 
 /** Shown in the breadcrumb of nearly every screenshot, so it is part of the docs' visual identity. */
 const ORGANIZATION_NAME = "ACME Inc.";

--- a/packages/database/src/scripts/seed-docs-fixtures.ts
+++ b/packages/database/src/scripts/seed-docs-fixtures.ts
@@ -1,0 +1,907 @@
+/**
+ * Seeds the ACME Inc. workspace that every screenshot in `docs/` is captured from.
+ *
+ * Why a separate script rather than an addition to `seed.ts`: `db:seed` is what every developer runs
+ * to get a workable local instance, and its content shows up in nobody's published output. This
+ * fixture's content ships — it is visible in ~200 public documentation images — so it is versioned,
+ * reviewed and changed on its own terms. Editing `seed.ts` to brand it ACME would push a docs concern
+ * into every developer's database.
+ *
+ * The demo company is a financial services firm because that matches our ICP: a prospect reading the
+ * docs should recognise the survey they are looking at. Everything is fictional, and no email address
+ * in it resolves to a real inbox.
+ *
+ * Requires `db:seed` to have run first — the admin user comes from there, so one login
+ * (SEED_CREDENTIALS.ADMIN) reaches both the seed workspace and this one.
+ *
+ * Run: pnpm --filter @formbricks/database db:seed:docs
+ */
+import { createId } from "@paralleldrive/cuid2";
+import { logger } from "@formbricks/logger";
+import { type TSurveyBlocks } from "@formbricks/types/surveys/blocks";
+import { PrismaClient } from "../prisma";
+import { createPrismaPgAdapter } from "../prisma-adapter";
+import { SEED_IDS } from "../seed/constants";
+
+const prisma = new PrismaClient({ adapter: createPrismaPgAdapter().adapter });
+
+if (process.env.NODE_ENV === "production" && process.env.ALLOW_SEED !== "true") {
+  logger.error("ERROR: Seeding blocked in production. Set ALLOW_SEED=true to override.");
+  process.exit(1);
+}
+
+/**
+ * Fixed ids so the capture script can address a survey without querying for it, and so re-running
+ * this script updates the same rows instead of accumulating duplicates.
+ */
+export const DOCS_IDS = {
+  ORGANIZATION: "cldocsacmeorg00000000001",
+  WORKSPACE: "cldocsacmeworkspace000001",
+  SURVEY_ALL_ELEMENTS: "cldocsallelements00000001",
+  /** An app survey. Several settings — Visibility & Recontact, targeting — only exist for this type. */
+  SURVEY_APP: "cldocsappsurvey000000001",
+  SURVEY_PIN: "cldocspinsurvey000000001",
+  SURVEY_VERIFY_EMAIL: "cldocsverifyemail00000001",
+} as const;
+
+/** Shown in the breadcrumb of nearly every screenshot, so it is part of the docs' visual identity. */
+const ORGANIZATION_NAME = "ACME Inc.";
+const WORKSPACE_NAME = "Retail Banking";
+
+/**
+ * One survey carrying all 17 element types, in the order the Question Types nav lists them.
+ *
+ * This exists so the 15 question-type pages can be captured in a single pass: seed once, open the
+ * editor once, expand each card in turn. Copy is ACME's, not Formbricks' — a reader on
+ * `question-type/nps` should see a bank asking a bank's question.
+ *
+ * `pictureSelection` is deliberately absent: its choices are `ZStorageUrl` values, so it needs real
+ * uploaded files to render thumbnails rather than broken images. The capture script uploads those and
+ * appends the element, keeping this file free of storage paths that only exist on one machine.
+ */
+const ACME_ELEMENTS = [
+  {
+    id: "acme-openText",
+    type: "openText",
+    headline: { default: "What made you open an account with us?" },
+    subheader: { default: "A sentence or two is plenty." },
+    required: true,
+    placeholder: { default: "Type your answer here..." },
+    longAnswer: true,
+  },
+  {
+    id: "acme-multipleChoiceSingle",
+    type: "multipleChoiceSingle",
+    headline: { default: "Which account did you open?" },
+    required: true,
+    choices: [
+      { id: createId(), label: { default: "Everyday Checking" } },
+      { id: createId(), label: { default: "High-Yield Savings" } },
+      { id: createId(), label: { default: "Joint Account" } },
+      { id: createId(), label: { default: "Business Account" } },
+    ],
+  },
+  {
+    id: "acme-multipleChoiceMulti",
+    type: "multipleChoiceMulti",
+    headline: { default: "Which of these do you use at least monthly?" },
+    required: false,
+    choices: [
+      { id: createId(), label: { default: "Mobile app" } },
+      { id: createId(), label: { default: "Online banking" } },
+      { id: createId(), label: { default: "Branch visit" } },
+      { id: createId(), label: { default: "Telephone banking" } },
+    ],
+  },
+  {
+    id: "acme-nps",
+    type: "nps",
+    headline: { default: "How likely are you to recommend ACME to a friend or colleague?" },
+    required: true,
+    lowerLabel: { default: "Not at all likely" },
+    upperLabel: { default: "Extremely likely" },
+  },
+  {
+    id: "acme-csat",
+    type: "csat",
+    headline: { default: "How satisfied are you with your account opening experience?" },
+    required: true,
+    scale: "smiley",
+    range: 5,
+    lowerLabel: { default: "Very unsatisfied" },
+    upperLabel: { default: "Very satisfied" },
+    isColorCodingEnabled: true,
+  },
+  {
+    id: "acme-ces",
+    type: "ces",
+    headline: { default: "Opening my account was easy." },
+    required: true,
+    scale: "number",
+    range: 7,
+    lowerLabel: { default: "Strongly disagree" },
+    upperLabel: { default: "Strongly agree" },
+  },
+  {
+    id: "acme-rating",
+    type: "rating",
+    headline: { default: "How would you rate our mobile app?" },
+    required: true,
+    scale: "star",
+    range: 5,
+    lowerLabel: { default: "Poor" },
+    upperLabel: { default: "Excellent" },
+  },
+  {
+    id: "acme-ranking",
+    type: "ranking",
+    headline: { default: "Rank these by how much they matter to you." },
+    required: true,
+    choices: [
+      { id: createId(), label: { default: "No monthly fees" } },
+      { id: createId(), label: { default: "Higher interest rate" } },
+      { id: createId(), label: { default: "Faster support" } },
+      { id: createId(), label: { default: "Better mobile app" } },
+    ],
+  },
+  {
+    id: "acme-matrix",
+    type: "matrix",
+    headline: { default: "How do you feel about each of these?" },
+    required: true,
+    rows: [
+      { id: createId(), label: { default: "Opening an account" } },
+      { id: createId(), label: { default: "Making a transfer" } },
+      { id: createId(), label: { default: "Reaching support" } },
+    ],
+    columns: [
+      { id: createId(), label: { default: "Difficult" } },
+      { id: createId(), label: { default: "Neutral" } },
+      { id: createId(), label: { default: "Easy" } },
+    ],
+  },
+  {
+    id: "acme-date",
+    type: "date",
+    headline: { default: "When did you open your account?" },
+    required: false,
+    format: "M-d-y",
+  },
+  {
+    id: "acme-fileUpload",
+    type: "fileUpload",
+    headline: { default: "Upload a document to verify your address" },
+    subheader: { default: "A utility bill or bank statement from the last three months." },
+    required: false,
+    allowMultipleFiles: false,
+    maxSizeInMB: 10,
+  },
+  {
+    id: "acme-cal",
+    type: "cal",
+    headline: { default: "Book a call with an advisor" },
+    subheader: { default: "Pick a time that suits you." },
+    required: false,
+    calUserName: "acme-advisors",
+  },
+  {
+    id: "acme-consent",
+    type: "consent",
+    headline: { default: "Marketing preferences" },
+    required: false,
+    label: { default: "ACME may contact me about products and offers" },
+  },
+  {
+    id: "acme-contactInfo",
+    type: "contactInfo",
+    headline: { default: "How can we reach you?" },
+    required: false,
+    firstName: { show: true, required: true, placeholder: { default: "First name" } },
+    lastName: { show: true, required: true, placeholder: { default: "Last name" } },
+    email: { show: true, required: true, placeholder: { default: "Email" } },
+    phone: { show: true, required: false, placeholder: { default: "Phone" } },
+    company: { show: false, required: false, placeholder: { default: "Company" } },
+  },
+  {
+    id: "acme-address",
+    type: "address",
+    headline: { default: "What is your current address?" },
+    required: false,
+    addressLine1: { show: true, required: true, placeholder: { default: "Address line 1" } },
+    addressLine2: { show: true, required: false, placeholder: { default: "Address line 2" } },
+    city: { show: true, required: true, placeholder: { default: "City" } },
+    state: { show: true, required: true, placeholder: { default: "State" } },
+    zip: { show: true, required: true, placeholder: { default: "ZIP" } },
+    country: { show: true, required: true, placeholder: { default: "Country" } },
+  },
+  {
+    id: "acme-cta",
+    type: "cta",
+    headline: { default: "See how your savings could grow" },
+    required: false,
+    ctaButtonLabel: { default: "Open the calculator" },
+    buttonUrl: "https://example.com/acme/savings-calculator",
+    buttonExternal: true,
+  },
+];
+
+/**
+ * Answers keyed by element id. Written rather than randomised: these show up in the response table,
+ * the summary charts and the drop-off analysis in the docs, and random noise reads as broken data.
+ */
+/**
+ * Answers keyed by element id. Deliberately **partial**: six of the sixteen elements — address, cal,
+ * contactInfo, cta, date and fileUpload — are left unanswered so the response table has empty cells,
+ * which is what a real one looks like. Typed as `Partial` so the lookup below is honestly optional;
+ * a total `Record` would type the miss away and hand `pick` an `undefined` to index.
+ */
+const ANSWER_POOL: Partial<Record<string, unknown[]>> = {
+  "acme-openText": [
+    "The mobile app finally supports joint accounts, which is why I switched.",
+    "Better savings rate than my old bank, and the switch took ten minutes.",
+    "My employer moved payroll here so I opened an account to match.",
+    "I wanted an account I could open without visiting a branch.",
+  ],
+  "acme-multipleChoiceSingle": [
+    "Everyday Checking",
+    "High-Yield Savings",
+    "Joint Account",
+    "Business Account",
+  ],
+  "acme-multipleChoiceMulti": [
+    ["Mobile app", "Online banking"],
+    ["Mobile app"],
+    ["Online banking", "Branch visit"],
+    ["Mobile app", "Telephone banking"],
+  ],
+  "acme-nps": [9, 8, 10, 7, 6, 9],
+  "acme-csat": [5, 4, 5, 3, 4],
+  "acme-ces": [6, 7, 5, 7, 4],
+  "acme-rating": [5, 4, 5, 3, 4],
+  "acme-ranking": [
+    ["No monthly fees", "Higher interest rate", "Better mobile app", "Faster support"],
+    ["Higher interest rate", "No monthly fees", "Faster support", "Better mobile app"],
+  ],
+  "acme-matrix": [
+    { "Opening an account": "Easy", "Making a transfer": "Easy", "Reaching support": "Neutral" },
+    { "Opening an account": "Neutral", "Making a transfer": "Easy", "Reaching support": "Difficult" },
+  ],
+  "acme-consent": ["accepted", "dismissed"],
+};
+
+/**
+ * Plausible traffic mix, so the metadata card and its filters show something worth filtering.
+ *
+ * `source` deliberately carries campaign names on some rows and the bare survey type on others.
+ * That is exactly what the column holds in reality: `getWebSurveyMeta` in
+ * `packages/surveys/src/components/general/survey.tsx` writes `?source=` straight into it when the
+ * respondent arrives with one, and falls back to the survey's type when they do not. Every row
+ * reading "link" would make `source-tracking.mdx` impossible to illustrate.
+ */
+const RESPONSE_META = [
+  {
+    source: "newsletter",
+    url: "https://example.com/acme/welcome?source=newsletter",
+    country: "United States",
+    userAgent: { browser: "Chrome", os: "macOS", device: "desktop" },
+  },
+  {
+    source: "link",
+    url: "https://example.com/acme/welcome",
+    country: "United Kingdom",
+    userAgent: { browser: "Safari", os: "iOS", device: "phone" },
+  },
+  {
+    source: "app",
+    url: "https://app.example.com/accounts",
+    country: "Germany",
+    action: "Opened account page",
+    userAgent: { browser: "Firefox", os: "Windows", device: "desktop" },
+  },
+  {
+    source: "in-branch-qr",
+    url: "https://example.com/acme/welcome?source=in-branch-qr",
+    country: "Canada",
+    userAgent: { browser: "Chrome", os: "Android", device: "phone" },
+  },
+];
+
+const pick = <T>(pool: T[], i: number): T => pool[i % pool.length];
+
+/**
+ * Seeds responses for the ACME survey.
+ *
+ * A third are left unfinished on purpose. `partial-submissions.mdx` documents the "Analyze Drop-Offs"
+ * table on the survey summary, and that table has nothing to show if every response is complete.
+ */
+async function seedResponses(surveyId: string, finishedCount: number, partialCount: number): Promise<void> {
+  await prisma.response.deleteMany({ where: { surveyId } });
+
+  const ordered = ACME_ELEMENTS.map((e) => e.id);
+
+  const total = finishedCount + partialCount;
+  for (let i = 0; i < total; i++) {
+    // Interleave rather than writing all the finished ones first. The response table sorts newest
+    // first, so a contiguous block of partials at the end lands at the *top* of the screenshot and
+    // makes the product look like nothing ever completes.
+    const finished = i % 4 !== 3 || i >= partialCount * 4;
+    // A partial stops somewhere in the first half, which is what makes the drop-off curve a curve.
+    const answeredUpTo = finished ? ordered.length : 2 + (i % 5);
+    void total;
+
+    const data: Record<string, unknown> = {};
+    for (const id of ordered.slice(0, answeredUpTo)) {
+      const pool = ANSWER_POOL[id];
+      if (pool) data[id] = pick(pool, i);
+    }
+
+    // Hidden field values ride in the same `data` map as answers, keyed by field id. Seeded because
+    // `hidden-fields.mdx` documents reading them back in the response table, and empty columns show
+    // the reader nothing.
+    const campaign = pick(["newsletter", "google", "branch-flyer", "partner-site"], i);
+    const tier = pick(["basic", "plus", "premium"], i);
+    Object.assign(data, {
+      utm_source: campaign,
+      plan_tier: tier,
+      branch_code: `BR-${String(100 + (i % 7))}`,
+      referral_code: i % 3 === 0 ? `ACME-${String(2000 + i)}` : "",
+    });
+
+    const display = await prisma.display.create({ data: { surveyId } });
+    await prisma.response.create({
+      data: {
+        surveyId,
+        finished,
+        data: data as never,
+        meta: pick(RESPONSE_META, i) as never,
+        displayId: display.id,
+      },
+    });
+  }
+}
+
+/**
+ * Hidden fields and variables the docs pages photograph.
+ *
+ * Populated rather than left empty: `hidden-fields.mdx` and `variables.mdx` are about configuring
+ * these, and an empty-state screenshot ("No hidden fields yet") shows the reader nothing they came
+ * for. Names are ACME's — a bank passing campaign and tier context into a survey.
+ */
+const ACME_HIDDEN_FIELDS = {
+  enabled: true,
+  fieldIds: ["utm_source", "plan_tier", "branch_code", "referral_code"],
+};
+
+const ACME_VARIABLES = [
+  { id: createId(), name: "applicant_score", type: "number" as const, value: 0 },
+  { id: createId(), name: "product_line", type: "text" as const, value: "retail" },
+];
+
+/**
+ * Tags, applied to a share of the responses.
+ *
+ * `tags.mdx` documents the tag manager and its usage counts. Both are empty without this, and an
+ * empty tag manager is not what the page is trying to show.
+ */
+const ACME_TAGS = ["churn risk", "praise", "app bug", "branch feedback", "pricing"];
+
+async function seedTags(workspaceId: string, surveyId: string): Promise<void> {
+  const responses = await prisma.response.findMany({ where: { surveyId }, select: { id: true } });
+
+  for (const [index, name] of ACME_TAGS.entries()) {
+    const tag = await prisma.tag.upsert({
+      where: { workspaceId_name: { workspaceId, name } },
+      update: {},
+      create: { name, workspaceId },
+    });
+
+    // Uneven counts on purpose: the manager shows a usage column, and identical numbers down the
+    // column look like placeholder data.
+    const take = 3 + index * 4;
+    for (const response of responses.slice(index, index + take)) {
+      await prisma.tagsOnResponses.upsert({
+        where: { responseId_tagId: { responseId: response.id, tagId: tag.id } },
+        update: {},
+        create: { responseId: response.id, tagId: tag.id },
+      });
+    }
+  }
+}
+
+/**
+ * ACME's contacts, with the attributes a bank would actually hold.
+ *
+ * The Contacts area is a top-level nav item with three screens and no documentation (ENG-2720), and
+ * none of them show anything without contacts. Emails are on `example.com`, which cannot receive
+ * mail, so nothing here reaches a real inbox.
+ */
+const ACME_CONTACTS = [
+  {
+    email: "rosa.alvarez@example.com",
+    userId: "usr_1041",
+    firstName: "Rosa",
+    lastName: "Alvarez",
+    plan: "premium",
+    branch: "BR-100",
+    segment: "Joint account",
+  },
+  {
+    email: "t.okafor@example.com",
+    userId: "usr_1042",
+    firstName: "Tunde",
+    lastName: "Okafor",
+    plan: "plus",
+    branch: "BR-101",
+    segment: "Everyday checking",
+  },
+  {
+    email: "meera.iyer@example.com",
+    userId: "usr_1043",
+    firstName: "Meera",
+    lastName: "Iyer",
+    plan: "basic",
+    branch: "BR-102",
+    segment: "Savings",
+  },
+  {
+    email: "j.lindqvist@example.com",
+    userId: "usr_1044",
+    firstName: "Johan",
+    lastName: "Lindqvist",
+    plan: "premium",
+    branch: "BR-103",
+    segment: "Business",
+  },
+  {
+    email: "amara.diallo@example.com",
+    userId: "usr_1045",
+    firstName: "Amara",
+    lastName: "Diallo",
+    plan: "plus",
+    branch: "BR-104",
+    segment: "Joint account",
+  },
+  {
+    email: "w.nakamura@example.com",
+    userId: "usr_1046",
+    firstName: "Wataru",
+    lastName: "Nakamura",
+    plan: "basic",
+    branch: "BR-105",
+    segment: "Everyday checking",
+  },
+  {
+    email: "s.oconnell@example.com",
+    userId: "usr_1047",
+    firstName: "Siobhan",
+    lastName: "O'Connell",
+    plan: "premium",
+    branch: "BR-106",
+    segment: "Savings",
+  },
+  {
+    email: "d.petrov@example.com",
+    userId: "usr_1048",
+    firstName: "Dmitri",
+    lastName: "Petrov",
+    plan: "basic",
+    branch: "BR-100",
+    segment: "Business",
+  },
+];
+
+/** `email` and `userId` are default keys the app creates itself; the rest are ACME's own. */
+const CONTACT_ATTRIBUTE_KEYS = [
+  { key: "email", name: "Email", type: "default" as const },
+  { key: "userId", name: "User ID", type: "default" as const },
+  { key: "firstName", name: "First Name", type: "default" as const },
+  { key: "lastName", name: "Last Name", type: "default" as const },
+  { key: "plan", name: "Plan", type: "custom" as const },
+  { key: "branch", name: "Branch", type: "custom" as const },
+  { key: "segment", name: "Segment", type: "custom" as const },
+];
+
+async function seedContacts(workspaceId: string): Promise<void> {
+  const keyIds = new Map<string, string>();
+  for (const { key, name, type } of CONTACT_ATTRIBUTE_KEYS) {
+    const row = await prisma.contactAttributeKey.upsert({
+      where: { key_workspaceId: { key, workspaceId } },
+      update: { name },
+      create: { key, name, type, workspaceId },
+    });
+    keyIds.set(key, row.id);
+  }
+
+  for (const person of ACME_CONTACTS) {
+    // Keyed off the email attribute so re-running updates the same contact instead of adding a new one.
+    const existing = await prisma.contactAttribute.findFirst({
+      where: { attributeKeyId: keyIds.get("email"), value: person.email, contact: { workspaceId } },
+      select: { contactId: true },
+    });
+    const contactId = existing?.contactId ?? (await prisma.contact.create({ data: { workspaceId } })).id;
+
+    for (const [key, value] of Object.entries(person)) {
+      const attributeKeyId = keyIds.get(key);
+      if (!attributeKeyId) continue;
+      await prisma.contactAttribute.upsert({
+        where: { contactId_attributeKeyId: { contactId, attributeKeyId } },
+        update: { value },
+        create: { contactId, attributeKeyId, value },
+      });
+    }
+  }
+}
+
+/**
+ * One segment, so the Segments tab shows a segment rather than its empty state.
+ *
+ * Filter shape follows TBaseFilters: a list of groups, each `{ id, connector, resource }`, where the
+ * first group's connector must be null. Attribute filters key off `contactAttributeKey`, which is the
+ * attribute's key string, not its row id.
+ */
+async function seedSegment(workspaceId: string): Promise<void> {
+  const filters = [
+    {
+      id: createId(),
+      connector: null,
+      resource: {
+        id: createId(),
+        root: { type: "attribute", contactAttributeKey: "plan" },
+        qualifier: { operator: "equals" },
+        value: "premium",
+      },
+    },
+  ];
+
+  await prisma.segment.upsert({
+    where: { workspaceId_title: { workspaceId, title: "Premium account holders" } },
+    update: { filters: filters as never },
+    create: {
+      title: "Premium account holders",
+      description: "Contacts on the premium plan, for targeted follow-up.",
+      isPrivate: false,
+      workspaceId,
+      filters: filters as never,
+    },
+  });
+}
+
+/**
+ * A second survey, of type `app`.
+ *
+ * The editor hides whole sections for link surveys — Visibility & Recontact, and the targeting
+ * controls — so the pages documenting those cannot be captured against the all-elements survey,
+ * which is a link survey. Kept deliberately small: it exists to be photographed, not to demonstrate
+ * every element type.
+ */
+const APP_SURVEY_ELEMENTS = [
+  {
+    id: "acme-app-rating",
+    type: "rating",
+    headline: { default: "How is the mobile app working for you?" },
+    required: true,
+    scale: "star",
+    range: 5,
+    lowerLabel: { default: "Poor" },
+    upperLabel: { default: "Excellent" },
+  },
+  {
+    id: "acme-app-openText",
+    type: "openText",
+    headline: { default: "What would you change about it?" },
+    required: false,
+    placeholder: { default: "Type your answer here..." },
+    longAnswer: true,
+  },
+];
+
+/**
+ * The no-code and code actions an app survey can be triggered by.
+ *
+ * One of each type the product supports, so the User Actions list and the trigger picker both show
+ * something real. An empty list is the wrong picture for a page whose whole subject is the list.
+ */
+async function seedActions(workspaceId: string): Promise<void> {
+  const actions = [
+    {
+      name: "Clicked “Open a savings account”",
+      description: "The primary call to action on the savings landing page.",
+      type: "noCode" as const,
+      noCodeConfig: {
+        type: "click",
+        urlFilters: [{ rule: "contains", value: "/savings" }],
+        elementSelector: { innerHtml: "Open a savings account" },
+      },
+    },
+    {
+      name: "Viewed the mortgage calculator",
+      description: "Any visit to the mortgage calculator page.",
+      type: "noCode" as const,
+      noCodeConfig: { type: "pageView", urlFilters: [{ rule: "contains", value: "/mortgage-calculator" }] },
+    },
+    {
+      name: "About to abandon the application form",
+      description: "Pointer leaves the viewport while the account application is open.",
+      type: "noCode" as const,
+      noCodeConfig: {
+        type: "exitIntent",
+        urlFilters: [{ rule: "startsWith", value: "https://acme.example.com/apply" }],
+      },
+    },
+    {
+      name: "Read half the fees page",
+      description: "Scrolled 50% down the fees and charges page.",
+      type: "noCode" as const,
+      noCodeConfig: { type: "fiftyPercentScroll", urlFilters: [{ rule: "endsWith", value: "/fees" }] },
+    },
+    {
+      name: "Lingered on the rates page",
+      description: "Thirty seconds on the rates page without leaving.",
+      type: "noCode" as const,
+      noCodeConfig: {
+        type: "pageDwell",
+        urlFilters: [{ rule: "contains", value: "/rates" }],
+        timeInSeconds: 30,
+      },
+    },
+    {
+      name: "Completed a transfer",
+      description: "Fired from the app once a transfer settles.",
+      type: "code" as const,
+      key: "transfer_completed",
+    },
+  ];
+
+  for (const action of actions) {
+    await prisma.actionClass.upsert({
+      where: { name_workspaceId: { name: action.name, workspaceId } },
+      update: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- noCodeConfig is a typed Json column and its union does not narrow through the spread
+      create: { ...action, workspaceId } as any,
+    });
+  }
+}
+
+/**
+ * Two small link surveys that exist only so the respondent-facing gates can be photographed.
+ *
+ * The PIN screen and the email gate are what a respondent meets before the survey, and neither can
+ * be shown from the editor. Putting them on their own surveys keeps the main fixture untouched —
+ * flipping these settings on the 16-question survey would change every other shot taken from it.
+ */
+async function seedGatedSurveys(workspaceId: string): Promise<void> {
+  const gated = [
+    {
+      id: DOCS_IDS.SURVEY_PIN,
+      name: "Branch visit feedback",
+      pin: "1234",
+      isVerifyEmailEnabled: false,
+      headline: "How was your visit to the branch?",
+    },
+    {
+      id: DOCS_IDS.SURVEY_VERIFY_EMAIL,
+      name: "Quarterly account review",
+      pin: null,
+      isVerifyEmailEnabled: true,
+      headline: "How are we doing on your account this quarter?",
+    },
+  ];
+
+  for (const survey of gated) {
+    const blocks = [
+      {
+        id: createId(),
+        name: survey.name,
+        elements: [
+          {
+            id: createId(),
+            type: "rating",
+            headline: { default: survey.headline },
+            required: true,
+            scale: "star",
+            range: 5,
+            lowerLabel: { default: "Poor" },
+            upperLabel: { default: "Excellent" },
+            isDraft: false,
+          },
+        ],
+      },
+    ] as unknown as TSurveyBlocks;
+
+    await prisma.survey.upsert({
+      where: { id: survey.id },
+      update: { pin: survey.pin, isVerifyEmailEnabled: survey.isVerifyEmailEnabled, blocks },
+      create: {
+        id: survey.id,
+        name: survey.name,
+        workspaceId,
+        status: "inProgress",
+        type: "link",
+        pin: survey.pin,
+        isVerifyEmailEnabled: survey.isVerifyEmailEnabled,
+        blocks,
+      },
+    });
+  }
+}
+
+/**
+ * A handful of colleagues, so the members and teams screens are not a table with one row in it.
+ *
+ * The addresses are on `example.com`, which is reserved by RFC 2606 and reaches nobody. Every one
+ * of these people is invented; none of the names belongs to a Formbricks employee or customer.
+ */
+async function seedPeopleAndTeams(organizationId: string, workspaceId: string): Promise<void> {
+  const people = [
+    {
+      id: "cldocsuser0000000000001",
+      name: "Priya Raman",
+      email: "priya.raman@example.com",
+      role: "manager" as const,
+    },
+    {
+      id: "cldocsuser0000000000002",
+      name: "Tom Okafor",
+      email: "tom.okafor@example.com",
+      role: "member" as const,
+    },
+    {
+      id: "cldocsuser0000000000003",
+      name: "Lena Fischer",
+      email: "lena.fischer@example.com",
+      role: "member" as const,
+    },
+    {
+      id: "cldocsuser0000000000004",
+      name: "Sam Whitfield",
+      email: "sam.whitfield@example.com",
+      role: "billing" as const,
+    },
+  ];
+
+  for (const person of people) {
+    await prisma.user.upsert({
+      where: { id: person.id },
+      update: { name: person.name },
+      create: { id: person.id, name: person.name, email: person.email, emailVerified: true },
+    });
+    await prisma.membership.upsert({
+      where: { userId_organizationId: { userId: person.id, organizationId } },
+      update: { role: person.role },
+      create: { userId: person.id, organizationId, role: person.role, accepted: true },
+    });
+  }
+
+  const teams = [
+    { name: "Customer Research", members: [people[0].id, people[1].id], admin: people[0].id },
+    { name: "Retail Product", members: [people[2].id], admin: people[2].id },
+  ];
+
+  for (const team of teams) {
+    const record = await prisma.team.upsert({
+      where: { organizationId_name: { organizationId, name: team.name } },
+      update: {},
+      create: { name: team.name, organizationId },
+    });
+
+    for (const userId of team.members) {
+      await prisma.teamUser.upsert({
+        where: { teamId_userId: { teamId: record.id, userId } },
+        update: { role: userId === team.admin ? "admin" : "contributor" },
+        create: { teamId: record.id, userId, role: userId === team.admin ? "admin" : "contributor" },
+      });
+    }
+
+    await prisma.workspaceTeam.upsert({
+      where: { workspaceId_teamId: { workspaceId, teamId: record.id } },
+      update: {},
+      create: {
+        workspaceId,
+        teamId: record.id,
+        permission: team.name === "Customer Research" ? "readWrite" : "read",
+      },
+    });
+  }
+}
+
+async function main(): Promise<void> {
+  const organization = await prisma.organization.upsert({
+    where: { id: DOCS_IDS.ORGANIZATION },
+    update: { name: ORGANIZATION_NAME },
+    create: { id: DOCS_IDS.ORGANIZATION, name: ORGANIZATION_NAME },
+  });
+
+  // The admin from `db:seed` owns this org too, so one login reaches both workspaces and no
+  // screenshot session needs a second set of credentials.
+  await prisma.membership.upsert({
+    where: { userId_organizationId: { userId: SEED_IDS.USER_ADMIN, organizationId: organization.id } },
+    update: { role: "owner" },
+    create: { userId: SEED_IDS.USER_ADMIN, organizationId: organization.id, role: "owner", accepted: true },
+  });
+
+  const workspace = await prisma.workspace.upsert({
+    where: { id: DOCS_IDS.WORKSPACE },
+    update: { name: WORKSPACE_NAME },
+    create: { id: DOCS_IDS.WORKSPACE, name: WORKSPACE_NAME, organizationId: organization.id },
+  });
+
+  const blocks = [
+    {
+      id: createId(),
+      name: "Account opening feedback",
+      elements: ACME_ELEMENTS,
+    },
+  ] as unknown as TSurveyBlocks;
+
+  await prisma.survey.upsert({
+    where: { id: DOCS_IDS.SURVEY_ALL_ELEMENTS },
+    update: {
+      workspaceId: workspace.id,
+      blocks,
+      hiddenFields: ACME_HIDDEN_FIELDS as never,
+      variables: ACME_VARIABLES as never,
+    },
+    create: {
+      id: DOCS_IDS.SURVEY_ALL_ELEMENTS,
+      name: "Account opening feedback",
+      workspaceId: workspace.id,
+      status: "inProgress",
+      type: "link",
+      blocks,
+      hiddenFields: ACME_HIDDEN_FIELDS as never,
+      variables: ACME_VARIABLES as never,
+    },
+  });
+
+  const appBlocks = [
+    { id: createId(), name: "Mobile app feedback", elements: APP_SURVEY_ELEMENTS },
+  ] as unknown as TSurveyBlocks;
+
+  // An app survey needs its own private segment: that is the survey's targeting audience, and the
+  // editor fails to load without one ("This resource does not exist or you do not have the necessary
+  // rights"). Link surveys have no targeting, which is why the other survey needs none.
+  const appSegment = await prisma.segment.upsert({
+    where: { workspaceId_title: { workspaceId: workspace.id, title: DOCS_IDS.SURVEY_APP } },
+    update: {},
+    create: { title: DOCS_IDS.SURVEY_APP, isPrivate: true, workspaceId: workspace.id, filters: [] },
+  });
+
+  await prisma.survey.upsert({
+    where: { id: DOCS_IDS.SURVEY_APP },
+    update: { workspaceId: workspace.id, blocks: appBlocks, segmentId: appSegment.id },
+    create: {
+      id: DOCS_IDS.SURVEY_APP,
+      name: "Mobile app feedback",
+      workspaceId: workspace.id,
+      status: "inProgress",
+      type: "app",
+      blocks: appBlocks,
+      segmentId: appSegment.id,
+    },
+  });
+
+  await seedResponses(DOCS_IDS.SURVEY_ALL_ELEMENTS, 38, 14);
+  await seedTags(workspace.id, DOCS_IDS.SURVEY_ALL_ELEMENTS);
+  await seedContacts(workspace.id);
+  await seedSegment(workspace.id);
+  await seedActions(workspace.id);
+  await seedGatedSurveys(workspace.id);
+  await seedPeopleAndTeams(organization.id, workspace.id);
+
+  logger.info(
+    {
+      organization: ORGANIZATION_NAME,
+      workspace: WORKSPACE_NAME,
+      workspaceId: workspace.id,
+      elements: ACME_ELEMENTS.length,
+    },
+    "Docs fixtures seeded"
+  );
+}
+
+main()
+  .catch((error: unknown) => {
+    logger.error(error, "Failed to seed docs fixtures");
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/docs-capture/capture.ts
+++ b/scripts/docs-capture/capture.ts
@@ -1,0 +1,1412 @@
+/**
+ * Captures the screenshots that ship in `docs/`.
+ *
+ * Not a test: nothing here asserts, and it must stay out of the PR gate. It lives in `scripts/`
+ * rather than under `apps/web/playwright/` for a second reason — `apps/web/tsconfig.json` includes
+ * `**\/*.ts`, so anything under the app is typechecked by the Next build, and a dev script that
+ * fails to compile takes the whole build down with it. Run it by hand against a local instance when
+ * a release changes what the product looks like.
+ *
+ * Why a script rather than driving a browser by hand: 200-odd images only read as one set if every
+ * one shares a viewport, a theme and a workspace, and the set is worth nothing in eighteen months
+ * unless it can be regenerated. Both of those are properties of a script, not of a person clicking.
+ *
+ *   1. `pnpm --filter @formbricks/database db:seed`       (admin user)
+ *   2. `pnpm --filter @formbricks/database db:seed:docs`  (the ACME Inc. workspace)
+ *   3. `pnpm dev`
+ *   4. `pnpm tsx scripts/docs-capture/capture.ts [name ...]`
+ *
+ * With no arguments it captures everything registered in `shots`. With arguments it captures only
+ * the named shots, which is the loop you want while iterating on one page.
+ */
+import { type Browser, type Locator, type Page, chromium } from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "../..");
+const DOCS_IMAGES = resolve(REPO_ROOT, "docs/images");
+
+const BASE_URL = process.env.DOCS_CAPTURE_URL ?? "http://localhost:3000";
+
+/** Generated wordmark for the fictional bank, used by the logo-upload shots. */
+const LOGO_FILE = process.env.DOCS_CAPTURE_LOGO ?? "";
+
+/** Must match `SEED_CREDENTIALS.ADMIN` in `packages/database/src/seed/constants.ts`. */
+const LOGIN = { email: "admin@formbricks.com", password: "Password#123" };
+
+/** Must match `DOCS_IDS` in `packages/database/src/scripts/seed-docs-fixtures.ts`. */
+const ACME = {
+  workspaceId: "cldocsacmeworkspace000001",
+  surveyAllElements: "cldocsallelements00000001",
+  // An app survey. Visibility & Recontact and the targeting controls do not exist for link surveys.
+  surveyApp: "cldocsappsurvey000000001",
+  // Two link surveys that exist only to be photographed from the respondent's side: the PIN screen
+  // and the email gate come before the survey and cannot be shown from the editor.
+  surveyPin: "cldocspinsurvey000000001",
+  surveyVerifyEmail: "cldocsverifyemail00000001",
+  organizationId: "cldocsacmeorg00000000001",
+};
+
+/**
+ * One viewport for every shot. The three current screenshots in the docs are 1920x1200, 1027x666 and
+ * 2420x1400 — three sizes for three images, which is part of why the set never looked like a set.
+ *
+ * deviceScaleFactor 2 because these are read on retina displays; at 1x the UI text in a downscaled
+ * screenshot goes soft, which is the single most common way a docs image looks amateurish.
+ */
+const VIEWPORT = { width: 1920, height: 1200 };
+const DEVICE_SCALE_FACTOR = 2;
+
+interface Shot {
+  /** Selects this shot on the command line, and names nothing else. */
+  name: string;
+  /** Path under `docs/images/`, extension included. */
+  out: string;
+  /**
+   * Drives the app to the moment worth photographing, then says what to capture:
+   * a Locator (Playwright measures the element itself — prefer this), an explicit clip box for the
+   * cases where the interesting region spans more than one element, or nothing for the full page.
+   */
+  take: (
+    page: Page
+  ) => Promise<Locator | { clip: { x: number; y: number; width: number; height: number } } | void>;
+}
+
+/** The element the editor expands on load — see `openElementCard`. First in the fixture's order. */
+const AUTO_EXPANDED_ELEMENT_ID = "acme-openText";
+
+const editorUrl = (surveyId: string): string =>
+  `${BASE_URL}/workspaces/${ACME.workspaceId}/surveys/${surveyId}/edit`;
+
+const summaryUrl = (surveyId: string): string =>
+  `${BASE_URL}/workspaces/${ACME.workspaceId}/surveys/${surveyId}/summary`;
+const responsesUrl = (surveyId: string): string =>
+  `${BASE_URL}/workspaces/${ACME.workspaceId}/surveys/${surveyId}/responses`;
+
+/**
+ * Waits for the editor to stop moving. The block list mounts, then re-renders once the survey
+ * resolves; screenshotting between the two catches a half-drawn card.
+ */
+const settleEditor = async (page: Page): Promise<void> => {
+  await page.waitForSelector("text=Questions", { timeout: 30_000 });
+  // Wait on a concrete node rather than `networkidle`. The preview pane renders the survey, and a
+  // CTA element pointing at an external URL keeps requests in flight indefinitely, so networkidle
+  // never arrives and the whole shot times out — which is exactly how `statement-cta` failed.
+  // Wait for any element card, not a specific id: the app survey has different element ids from the
+  // link survey, and keying on one made every app-survey shot time out here.
+  await page.locator(".scroll-mt-16").first().waitFor({ state: "visible", timeout: 60_000 });
+};
+
+/**
+ * Opens one element's card in the editor and returns it, with every other card collapsed.
+ *
+ * The editor auto-expands the first element on load, so a card shot taken without collapsing it
+ * catches two cards open — which reads as a mistake rather than a choice. Elements are addressed by
+ * the fixed ids the fixture assigns (`acme-<type>`), so this never depends on question order or on
+ * matching headline text that the copy might later change.
+ */
+const openElementCard = async (page: Page, elementId: string) => {
+  // The element id is NOT unique on this page: the live preview pane renders the same survey, so
+  // every element id appears twice — once on the editor card, once inside the preview. `.scroll-mt-16`
+  // is the editor card wrapper and is what disambiguates them. Matching the bare id would sometimes
+  // photograph the preview instead of the card, which is the wrong picture for a question-type page.
+  //
+  // Attribute selector rather than `#id` because `CSS.escape` is a browser API, unavailable here.
+  const cardOf = (id: string) => page.locator(`[id="${id}"].scroll-mt-16`);
+  // `.cursor-pointer` picks the clickable summary row out of the other Radix nodes in a card that
+  // also carry `data-state`.
+  const headerOf = (id: string) => cardOf(id).locator("[data-state].cursor-pointer").first();
+
+  // The editor always mounts with the first element expanded. Collapse that one by id rather than
+  // sweeping every `[data-state="open"]` node: clicking mutates the set mid-iteration, so a sweep
+  // races itself and the later indices go stale.
+  if (elementId !== AUTO_EXPANDED_ELEMENT_ID) {
+    const first = headerOf(AUTO_EXPANDED_ELEMENT_ID);
+    if ((await first.getAttribute("data-state")) === "open") {
+      await first.click();
+      await page.waitForTimeout(200);
+    }
+  }
+
+  const card = cardOf(elementId);
+  await card.waitFor({ state: "visible", timeout: 30_000 });
+
+  const header = headerOf(elementId);
+  if ((await header.getAttribute("data-state")) === "closed") {
+    await header.click();
+  }
+
+  await card.scrollIntoViewIfNeeded();
+  // The card grows as it expands; screenshotting mid-transition clips it short.
+  await page.waitForTimeout(400);
+  return card;
+};
+
+/**
+ * Opens the survey editor's Settings tab and expands one of its collapsible sections.
+ *
+ * Five separate docs pages document a single toggle inside Response Options — response limits, spam
+ * protection, the back button, email verification and the PIN — so they all reach the app the same
+ * way and differ only in which row they photograph.
+ */
+const openSettingsSection = async (
+  page: Page,
+  section: string,
+  probe?: string,
+  surveyId: string = ACME.surveyAllElements
+): Promise<void> => {
+  await page.goto(editorUrl(surveyId));
+  await settleEditor(page);
+  await page.getByText("Settings", { exact: true }).first().click();
+  await page.waitForTimeout(1500);
+
+  const header = page.getByText(section, { exact: true }).first();
+  await header.waitFor({ state: "visible", timeout: 30_000 });
+
+  // Only click if the section is actually shut. Response Options is expanded on load, so an
+  // unconditional click closes it — and every row inside then times out looking for itself.
+  if (probe) {
+    const alreadyOpen = await page
+      .getByText(probe, { exact: true })
+      .first()
+      .isVisible()
+      .catch(() => false);
+    if (alreadyOpen) return;
+  }
+  await header.click();
+  // The section animates open; clipping mid-transition cuts the panel short.
+  await page.waitForTimeout(1200);
+};
+
+/**
+ * Opens the survey's response table and scrolls until a named column is on screen.
+ *
+ * Scrolling to a column rather than a pixel offset: the table is very wide (answers, then hidden
+ * fields, then metadata) and any fixed offset lands somewhere different the moment a column is added.
+ */
+const responseTableAtColumn = async (page: Page, column: string): Promise<void> => {
+  await page.goto(responsesUrl(ACME.surveyAllElements));
+  await page.waitForSelector("text=Response ID", { timeout: 90_000 });
+  await page.waitForTimeout(2500);
+  await page.getByText(column, { exact: true }).first().scrollIntoViewIfNeeded();
+  await page.waitForTimeout(1200);
+};
+
+/**
+ * A collapsible section on the editor's Questions tab (Hidden Fields, Variables, the welcome and
+ * ending cards), expanded and ready to photograph.
+ *
+ * These sit below the block list and are collapsed on load, unlike Response Options which is open.
+ */
+const openQuestionsSection = async (page: Page, label: string): Promise<Locator> => {
+  await page.goto(editorUrl(ACME.surveyAllElements));
+  await settleEditor(page);
+
+  const heading = page.getByText(label, { exact: true }).first();
+  await heading.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(400);
+
+  const trigger = heading.locator("xpath=ancestor::div[@data-state][1]");
+  if ((await trigger.getAttribute("data-state")) === "closed") {
+    await heading.click();
+    await page.waitForTimeout(1400);
+  }
+  await heading.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(500);
+  // The parent again: the expanded body is the trigger's sibling, so returning the trigger alone
+  // photographs a bare heading with nothing under it.
+  return trigger.locator("xpath=..");
+};
+
+/**
+ * Turns a setting on and returns its row, ready to photograph.
+ *
+ * Captured switched ON deliberately. A toggle in its default-off state shows nothing the reader came
+ * for — the spam-protection page is about the reCAPTCHA threshold, which does not exist until the
+ * toggle is on. The editor has auto-save disabled, so nothing here persists.
+ */
+const enabledSettingRow = async (page: Page, label: string): Promise<Locator> => {
+  const row = page.getByText(label, { exact: true }).first();
+  await row.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(300);
+
+  // The switch sits beside the label, not inside it; go up to the row and take its switch.
+  const toggle = row
+    .locator("xpath=ancestor::div[.//button[@role='switch']][1]")
+    .locator("button[role='switch']")
+    .first();
+  if ((await toggle.getAttribute("aria-checked")) === "false") {
+    await toggle.click();
+    await page.waitForTimeout(1500);
+  }
+
+  // The parent, not the row: the panel a toggle reveals is the row's *sibling*, so the row's own
+  // container excludes it entirely.
+  return row.locator("xpath=ancestor::div[.//button[@role='switch']][1]/..");
+};
+
+/**
+ * The survey editor on one of its top-level tabs.
+ */
+const openEditorTab = async (page: Page, tab: string): Promise<void> => {
+  await page.goto(editorUrl(ACME.surveyAllElements));
+  await settleEditor(page);
+  await page.getByText(tab, { exact: true }).first().click();
+  await page.waitForTimeout(3500);
+};
+
+/**
+ * Question 1's card with its media panel open, on the Image or the Video tab.
+ *
+ * The button that opens it is an icon with no accessible name, sitting to the right of the headline
+ * field, so it is found by position rather than by text.
+ */
+const openMediaPanel = async (page: Page, tab: "Image" | "Video"): Promise<Locator> => {
+  await page.goto(editorUrl(ACME.surveyAllElements));
+  await settleEditor(page);
+
+  const card = page.locator(`[id="${AUTO_EXPANDED_ELEMENT_ID}"].scroll-mt-16`);
+  await card.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(600);
+
+  const field = await card.locator("[contenteditable='true']").first().boundingBox();
+  const buttons = card.locator("button");
+  for (let i = 0; i < (await buttons.count()); i++) {
+    const box = await buttons.nth(i).boundingBox();
+    if (box && field && box.x > field.x + field.width - 20 && Math.abs(box.y - field.y) < 60) {
+      await buttons.nth(i).click();
+      break;
+    }
+  }
+  await page.waitForTimeout(2000);
+
+  if (tab === "Video") {
+    await card.getByText("Video", { exact: true }).first().click();
+    await page.waitForTimeout(1200);
+  }
+  await card.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(500);
+  return card;
+};
+
+/**
+ * A respondent-facing gate, cropped to the card rather than the page.
+ *
+ * These screens are a small dialog centred in an otherwise empty viewport, so a full-page shot is
+ * mostly white. The clip is built around the anchor text with a fixed margin — there is no wrapper
+ * element with sensible bounds to photograph instead.
+ */
+const gateClip = async (page: Page, anchor: string, width = 1000, height = 420, topMargin = 120) => {
+  const box = await page.getByText(anchor, { exact: false }).first().boundingBox();
+  if (!box) return undefined;
+  const cx = box.x + box.width / 2;
+  const x = Math.max(0, Math.min(cx - width / 2, VIEWPORT.width - width));
+  const y = Math.max(0, box.y - topMargin);
+  return { clip: { x, y, width, height: Math.min(height, VIEWPORT.height - y) } };
+};
+
+/**
+ * The survey's Share dialog, on one of its panels.
+ *
+ * Every way of distributing a link survey now lives in this one dialog — anonymous links, personal
+ * links, the embeds, and the three share settings. The pages this serves used to photograph screens
+ * that were scattered across the app.
+ */
+const openShareDialog = async (page: Page, panel?: string): Promise<Locator> => {
+  await page.goto(summaryUrl(ACME.surveyAllElements));
+  await page.waitForSelector("text=Summary", { timeout: 90_000 });
+  await page.waitForTimeout(4000);
+  await page.getByRole("button", { name: /share/i }).first().click();
+  await page.waitForTimeout(3000);
+
+  const dialog = page.locator("[role='dialog']").last();
+  if (panel) {
+    await dialog.getByText(panel, { exact: true }).first().click();
+    await page.waitForTimeout(2200);
+  }
+  return dialog;
+};
+
+/**
+ * The segment editor, open on its Settings tab where the targeting filters live.
+ *
+ * The dialog opens on Activity (counts and ids); Settings is the tab the targeting page is about.
+ */
+const openSegmentSettings = async (page: Page): Promise<Locator> => {
+  await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/segments`);
+  await page.waitForTimeout(6000);
+  await page.getByText("Premium account holders", { exact: true }).first().click();
+  await page.waitForTimeout(3500);
+
+  const dialog = page.locator("[role='dialog']").last();
+  await dialog.getByText("Settings", { exact: true }).first().click();
+  await page.waitForTimeout(2500);
+  return dialog;
+};
+
+/**
+ * The "Track New User Action" dialog, open on one of its two tabs.
+ *
+ * One dialog covers what used to be five screenshots: the five no-code types are a single row of
+ * buttons inside it, so photographing the dialog once shows the whole set rather than one type per
+ * picture.
+ */
+const openAddActionDialog = async (page: Page, tab: "No code" | "Code"): Promise<Locator> => {
+  await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/settings/workspace/user-actions`);
+  await page.waitForSelector("text=User Actions", { timeout: 90_000 });
+  await page.waitForTimeout(3000);
+  await page
+    .getByRole("button", { name: /add action/i })
+    .first()
+    .click();
+  await page.waitForTimeout(2000);
+
+  const dialog = page.locator("[role='dialog']").last();
+  if (tab === "Code") {
+    await dialog.getByText("Code", { exact: true }).first().click();
+    await page.waitForTimeout(1200);
+  }
+  return dialog;
+};
+
+/**
+ * Question 2's card with `@` typed at the end of its headline, which opens the recall menu.
+ *
+ * Question 2 and not question 1: there is nothing before the first question to recall, so the menu
+ * never opens there. The headline is a rich-text editor, so the caret has to be placed in it before
+ * the keystroke lands.
+ */
+const openRecallMenu = async (page: Page): Promise<Locator> => {
+  await page.goto(editorUrl(ACME.surveyAllElements));
+  await settleEditor(page);
+
+  const collapse = page
+    .locator(`[id="${AUTO_EXPANDED_ELEMENT_ID}"].scroll-mt-16`)
+    .locator("[data-state].cursor-pointer")
+    .first();
+  if ((await collapse.getAttribute("data-state")) === "open") {
+    await collapse.click();
+    await page.waitForTimeout(300);
+  }
+
+  const card = page.locator('[id="acme-multipleChoiceSingle"].scroll-mt-16');
+  await card.locator("[data-state].cursor-pointer").first().click();
+  await page.waitForTimeout(1200);
+
+  const headline = card.locator("[contenteditable='true']").first();
+  await headline.click();
+  await headline.press("End");
+  await page.keyboard.type(" @");
+  await page.waitForTimeout(1500);
+  // Typing moves the caret and the editor pane scrolls with it, which leaves the card off screen.
+  // Scroll back before anything tries to click inside the menu: Playwright needs a click point in
+  // the viewport even with `force`, and the menu follows its anchor.
+  await card.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(700);
+  return card;
+};
+
+/**
+ * Unions several elements' boxes with the menu that is currently open.
+ *
+ * Radix renders menus in a portal at the end of `<body>`, so they are never inside the element that
+ * anchors them and an element screenshot would show the trigger with nothing attached to it.
+ */
+const withMenuClip = async (page: Page, anchors: Locator[], widthFrom?: Locator, padding = 14) => {
+  const boxes = (await Promise.all(anchors.map((a) => a.boundingBox()))).filter(Boolean) as {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }[];
+  const menu = await page.locator("[data-radix-popper-content-wrapper]").last().boundingBox();
+  if (menu) boxes.push(menu);
+  if (boxes.length === 0) return undefined;
+
+  // `widthFrom` sets the sides without dragging the top and bottom with it, so a clip can span a
+  // whole card horizontally while still starting below its header.
+  const side = widthFrom ? await widthFrom.boundingBox() : null;
+  const x = Math.max(0, Math.min(...boxes.map((b) => b.x), side ? side.x : Infinity) - padding);
+  const y = Math.max(0, Math.min(...boxes.map((b) => b.y)) - padding);
+  const right = Math.max(...boxes.map((b) => b.x + b.width), side ? side.x + side.width : 0) + padding;
+  const bottom = Math.max(...boxes.map((b) => b.y + b.height)) + padding;
+  return {
+    clip: { x, y, width: Math.min(right, VIEWPORT.width) - x, height: Math.min(bottom, VIEWPORT.height) - y },
+  };
+};
+
+/**
+ * The editor with a block's Conditional Logic panel on screen, one rule added and filled in.
+ *
+ * Logic is a property of a *block* now, not of a question: there is exactly one `Add logic` button
+ * per block and it sits at the foot of the block card, under the question list. The 2024
+ * screenshots this replaces show a per-question logic editor that no longer exists.
+ *
+ * A second block is added first so `Jump to block` has somewhere to jump to — with one block the
+ * target select is empty, which is the one thing a reader most needs to see filled in. The block is
+ * added in the editor and never saved (auto-save is off), so the fixture keeps its single block.
+ */
+const blockLogicEditor = async (page: Page, addRule: boolean): Promise<void> => {
+  await page.goto(editorUrl(ACME.surveyAllElements));
+  await settleEditor(page);
+
+  // The editor mounts with the first question expanded, which pushes the logic panel down past the
+  // fold and makes every clip below taller than it needs to be.
+  const firstCard = page
+    .locator(`[id="${AUTO_EXPANDED_ELEMENT_ID}"].scroll-mt-16`)
+    .locator("[data-state].cursor-pointer")
+    .first();
+  if ((await firstCard.getAttribute("data-state")) === "open") {
+    await firstCard.click();
+    await page.waitForTimeout(300);
+  }
+
+  await page.getByText("Add Block", { exact: true }).first().click();
+  await page.waitForTimeout(900);
+  await page.getByText("Free text", { exact: true }).first().click();
+  await page.waitForTimeout(1800);
+
+  if (addRule) {
+    await page.getByText("Add logic", { exact: true }).first().click();
+    await page.waitForTimeout(1400);
+    await fillExampleRule(page);
+  }
+};
+
+/**
+ * The first block's only logic rule, as a container.
+ *
+ * Anchored on the `Then` label, which is unique on the page: the second block has no rule, so it
+ * contributes no `Then`. Scoping matters — the option texts inside these selects are the question
+ * headlines, which also appear in the block's question list above, and an unscoped `getByText` for
+ * one of them clicks the question card instead of the select.
+ *
+ * The rule holds six selects in document order: the condition's question, operator and value, then
+ * the action, the action's target, and the fallback ("all other answers will continue to ...").
+ * They are addressed by index because only two of them carry stable visible text.
+ */
+const logicRule = (page: Page): Locator =>
+  page.getByText("Then", { exact: true }).first().locator("xpath=ancestor::div[2]");
+
+const ruleSelects = (page: Page): Locator => logicRule(page).locator("[role='combobox']");
+
+const SELECT = { question: 0, operator: 1, value: 2, action: 3, actionTarget: 4 } as const;
+
+/** Picks an option out of the menu the last click opened. */
+const pickOption = async (page: Page, label: string): Promise<void> => {
+  await page
+    .locator("[data-radix-popper-content-wrapper]")
+    .last()
+    .getByText(label, { exact: true })
+    .first()
+    .click();
+  await page.waitForTimeout(1000);
+};
+
+/**
+ * Fills the freshly-added rule with a realistic example.
+ *
+ * An empty rule is three placeholder selects, which shows the reader nothing about what a condition
+ * is made of — the thing the page is about. The example routes people who opened a savings account
+ * to a different block, which is the shape a reader is most likely to want first.
+ */
+const fillExampleRule = async (page: Page): Promise<void> => {
+  const selects = ruleSelects(page);
+
+  // Swap the default (question 1, free text) for the single-select, so the value control offers a
+  // list of choices rather than an empty text box.
+  await selects.nth(SELECT.question).click();
+  await page.waitForTimeout(800);
+  await pickOption(page, "Which account did you open?");
+
+  await selects.nth(SELECT.value).click();
+  await page.waitForTimeout(800);
+  await pickOption(page, "High-Yield Savings");
+
+  // `Jump to block` is already the default action; it just has no target yet.
+  await selects.nth(SELECT.actionTarget).click();
+  await page.waitForTimeout(800);
+  await pickOption(page, "Block 2");
+};
+
+/**
+ * The clip covering one block's whole Conditional Logic panel, optionally unioned with a dropdown.
+ *
+ * Measured from two text anchors rather than from a container element: the panel's own wrapper also
+ * holds the block's question list, so photographing it would put sixteen collapsed questions above
+ * the subject. `Conditional Logic` is matched loosely because the heading grows a count badge as
+ * soon as a rule exists.
+ *
+ * Radix renders a select's menu in a portal at the end of `<body>`, so an element screenshot of the
+ * panel alone would show a closed select. `withMenu` unions the two boxes instead.
+ */
+const logicPanelClip = async (page: Page, withMenu = false) => {
+  const head = page.getByText("Conditional Logic", { exact: false }).first();
+  await head.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(600);
+
+  const top = await head.boundingBox();
+  const foot = await page.getByText("Add logic", { exact: true }).first().boundingBox();
+  if (!top || !foot) return undefined;
+
+  let x = top.x - 20;
+  let y = top.y - 16;
+  let right = x + 1220;
+  let bottom = foot.y + foot.height + 16;
+
+  if (withMenu) {
+    const menu = await page.locator("[data-radix-popper-content-wrapper]").last().boundingBox();
+    if (menu) {
+      x = Math.min(x, menu.x - 8);
+      y = Math.min(y, menu.y - 8);
+      right = Math.max(right, menu.x + menu.width + 8);
+      bottom = Math.max(bottom, menu.y + menu.height + 8);
+    }
+  }
+
+  x = Math.max(0, x);
+  y = Math.max(0, y);
+  return {
+    clip: {
+      x,
+      y,
+      width: Math.min(right, VIEWPORT.width) - x,
+      height: Math.min(bottom, VIEWPORT.height) - y,
+    },
+  };
+};
+
+/**
+ * The 15 question-type pages, keyed to the element ids in the fixture.
+ *
+ * `thank-you-card` is not here — it was re-shot on 2026-08-12 and is already current.
+ * `select-picture` is not here either; it needs uploaded images before it can be captured (ENG-2650).
+ */
+const QUESTION_TYPE_PAGES: { page: string; elementId: string }[] = [
+  { page: "csat", elementId: "acme-csat" },
+  { page: "ces", elementId: "acme-ces" },
+  { page: "free-text", elementId: "acme-openText" },
+  { page: "select-single", elementId: "acme-multipleChoiceSingle" },
+  { page: "select-multiple", elementId: "acme-multipleChoiceMulti" },
+  { page: "net-promoter-score", elementId: "acme-nps" },
+  { page: "rating", elementId: "acme-rating" },
+  { page: "ranking", elementId: "acme-ranking" },
+  { page: "matrix", elementId: "acme-matrix" },
+  { page: "date", elementId: "acme-date" },
+  { page: "file-upload", elementId: "acme-fileUpload" },
+  { page: "schedule-a-meeting", elementId: "acme-cal" },
+  { page: "consent", elementId: "acme-consent" },
+  { page: "contact-info", elementId: "acme-contactInfo" },
+  { page: "address", elementId: "acme-address" },
+  { page: "statement-cta", elementId: "acme-cta" },
+];
+
+/**
+ * Milestone 3, group 1: five pages whose subject is one row of Settings -> Response Options.
+ * `nextLabel` is the row below, used to bound the clip.
+ */
+const RESPONSE_OPTION_PAGES: { page: string; label: string; nextLabel: string }[] = [
+  {
+    page: "surveys/general-features/limit-submissions",
+    label: "Close survey on response limit",
+    nextLabel: "Spam protection",
+  },
+  {
+    page: "surveys/general-features/spam-protection",
+    label: "Spam protection",
+    nextLabel: "Adjust “Survey Closed” message",
+  },
+  {
+    page: "surveys/link-surveys/verify-email-before-survey",
+    label: "Verify email before submission",
+    nextLabel: "Protect survey with a PIN",
+  },
+  {
+    page: "surveys/link-surveys/pin-protected-surveys",
+    label: "Protect survey with a PIN",
+    nextLabel: "Auto-progress rating and NPS questions",
+  },
+  {
+    page: "surveys/general-features/hide-back-button",
+    label: "Hide “Back” button",
+    nextLabel: "Capture IP address",
+  },
+];
+
+const shots: Shot[] = [
+  {
+    name: "platform/features/styling-theme/logo-uploaded",
+    out: "platform/features/styling-theme/logo-uploaded.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/settings/workspace/look`);
+      await page.waitForSelector("text=Click or drag to upload files.", { timeout: 90_000 });
+      await page.waitForTimeout(3000);
+      // The logo upload steps cannot be shown from an empty dropzone, so upload one first. The file
+      // is a generated wordmark for the fictional bank, not any real company's mark.
+      await page.locator('input[type="file"]').first().setInputFiles(LOGO_FILE);
+      // Wait for the upload to finish, not just to start: at 9s the logo was still fading in behind
+      // a spinner, which reads as a rendering glitch rather than an uploaded logo.
+      await page
+        .waitForFunction(() => !document.querySelector('[class*="animate-spin"]'), undefined, {
+          timeout: 60_000,
+        })
+        .catch(() => undefined);
+      await page.waitForTimeout(4000);
+
+      // Save, then reload. Without saving, the workspace's logo stays null and the preview box
+      // renders empty — which looks like a broken image rather than an uploaded logo.
+      const logoCard = page
+        .getByText("Logo", { exact: true })
+        .first()
+        .locator("xpath=ancestor::div[contains(@class,'rounded')][1]");
+      await logoCard.getByRole("button", { name: /^Save$/ }).click();
+      await page.waitForTimeout(5000);
+      await page.reload();
+      await page.waitForSelector("text=Replace Logo", { timeout: 90_000 });
+      await page.waitForTimeout(4000);
+
+      const h = page.getByText("Logo", { exact: true }).first();
+      await h.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(800);
+      return h.locator("xpath=ancestor::div[contains(@class,'rounded')][1]");
+    },
+  },
+  {
+    name: "platform/features/styling-theme/overwrite",
+    out: "platform/features/styling-theme/enable-custom-styling.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/settings/workspace/look`);
+      await page.waitForSelector("text=Enable custom styling", { timeout: 90_000 });
+      await page.waitForTimeout(3000);
+      const row = page.getByText("Enable custom styling", { exact: true }).first();
+      await row.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(600);
+      return row.locator("xpath=ancestor::div[.//button[@role='switch']][1]");
+    },
+  },
+  {
+    name: "platform/features/styling-theme/logo",
+    out: "platform/features/styling-theme/logo.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/settings/workspace/look`);
+      await page.waitForSelector("text=Logo", { timeout: 90_000 });
+      await page.waitForTimeout(3500);
+      const h = page.getByText("Logo", { exact: true }).first();
+      await h.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(800);
+      return h.locator("xpath=ancestor::div[contains(@class,'rounded')][1]");
+    },
+  },
+  {
+    name: "surveys/website-app-surveys/show-survey-to-percent-of-users",
+    out: "surveys/website-app-surveys/show-survey-to-percent-of-users/display-settings.webp",
+    take: async (page: Page) => {
+      await openSettingsSection(page, "Survey Display Settings", undefined, ACME.surveyApp);
+      // The row, switched on, rather than the whole section: the page is about this one setting, and
+      // the percentage control only exists once the toggle is on.
+      return enabledSettingRow(page, "Show survey to % of users");
+    },
+  },
+  {
+    name: "surveys/website-app-surveys/recontact",
+    out: "surveys/website-app-surveys/recontact/visibility-and-recontact.webp",
+    take: async (page: Page) => {
+      await openSettingsSection(page, "Visibility & Recontact", "Recontact options", ACME.surveyApp);
+      const heading = page.getByText("Visibility & Recontact", { exact: true }).first();
+      await heading.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(1200);
+      return heading.locator("xpath=ancestor::div[@data-state][1]/..");
+    },
+  },
+  {
+    name: "surveys/analysis/responses",
+    out: "surveys/analysis/responses.webp",
+    take: async (page: Page) => {
+      await page.goto(responsesUrl(ACME.surveyAllElements));
+      await page.waitForSelector("text=Response ID", { timeout: 90_000 });
+      await page.waitForTimeout(3500);
+      return undefined;
+    },
+  },
+  {
+    name: "surveys/analysis/summary",
+    out: "surveys/analysis/summary.webp",
+    take: async (page: Page) => {
+      await page.goto(summaryUrl(ACME.surveyAllElements));
+      await page.waitForSelector("text=Summary", { timeout: 90_000 });
+      await page.waitForTimeout(6000);
+      return undefined;
+    },
+  },
+  {
+    name: "platform/features/contacts/list",
+    out: "platform/features/contacts/contacts-list.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/contacts`);
+      await page.waitForTimeout(8000);
+      return undefined;
+    },
+  },
+  {
+    name: "platform/features/contacts/attributes",
+    out: "platform/features/contacts/attribute-keys.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/attributes`);
+      await page.waitForTimeout(8000);
+      return undefined;
+    },
+  },
+  {
+    name: "platform/features/contacts/segments",
+    out: "platform/features/contacts/segments.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/segments`);
+      await page.waitForTimeout(8000);
+      return undefined;
+    },
+  },
+  {
+    name: "surveys/general-features/survey-scheduling",
+    out: "surveys/general-features/survey-scheduling/publish-and-close.webp",
+    take: async (page: Page) => {
+      await openSettingsSection(page, "Response Options", "Publish survey on date");
+      // Both dates together: they are one feature and adjacent rows, so two images would just be
+      // the same panel photographed twice.
+      const first = await enabledSettingRow(page, "Publish survey on date");
+      const second = await enabledSettingRow(page, "Close survey on date");
+      const a = await first.boundingBox();
+      const b = await second.boundingBox();
+      if (!a || !b) return first;
+      return { clip: { x: a.x - 10, y: a.y, width: a.width + 20, height: b.y + b.height - a.y + 10 } };
+    },
+  },
+  {
+    name: "surveys/website-app-surveys/cooldown-period",
+    out: "surveys/website-app-surveys/cooldown-period/workspace-setting.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/settings/workspace/general`);
+      await page.waitForTimeout(6000);
+      // The label is "Cooldown Period (across surveys)"; "Recontact Waiting Time" is pre-Formbricks-5.
+      const heading = page.getByText("Cooldown Period", { exact: false }).first();
+      await heading.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(800);
+      return heading.locator("xpath=ancestor::div[contains(@class,'rounded')][1]");
+    },
+  },
+  {
+    name: "platform/features/user-management/two-factor-auth",
+    out: "platform/features/user-management/two-factor-auth/setup.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/account/settings/profile`);
+      await page.waitForTimeout(6000);
+      const heading = page.getByText("Two-Factor Authentication", { exact: false }).first();
+      await heading.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(800);
+      return heading.locator("xpath=ancestor::div[contains(@class,'rounded')][1]");
+    },
+  },
+  {
+    name: "surveys/general-features/tags",
+    out: "surveys/general-features/tags/manager.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/settings/workspace/tags`);
+      await page.waitForSelector("text=Manage Tags", { timeout: 90_000 });
+      await page.waitForTimeout(2500);
+      // The settings shell has no <main>; take the card that holds the table instead.
+      return page
+        .getByText("Manage Tags", { exact: true })
+        .first()
+        .locator("xpath=ancestor::div[.//table][1]");
+    },
+  },
+  {
+    name: "surveys/general-features/quota-management",
+    out: "surveys/general-features/quota-management/quotas.webp",
+    take: async (page: Page) => {
+      await openSettingsSection(page, "Quotas");
+      const heading = page.getByText("Quotas", { exact: true }).first();
+      await heading.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(900);
+      return heading.locator("xpath=ancestor::div[@data-state][1]/..");
+    },
+  },
+  {
+    name: "surveys/general-features/hidden-fields-responses",
+    out: "surveys/general-features/hidden-fields/responses.webp",
+    take: async (page: Page) => {
+      // Viewport, not the table element: 52 rows exceeds WebP's dimension cap, and the reader only
+      // needs to see that the columns are there.
+      await responseTableAtColumn(page, "plan_tier");
+      return undefined;
+    },
+  },
+  {
+    name: "platform/features/styling-theme",
+    out: "platform/features/styling-theme/appearance.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/settings/workspace/look`);
+      await page.waitForTimeout(7000);
+      return undefined;
+    },
+  },
+  {
+    name: "surveys/general-features/hidden-fields",
+    out: "surveys/general-features/hidden-fields/editor.webp",
+    take: (page: Page) => openQuestionsSection(page, "Hidden fields"),
+  },
+  {
+    name: "surveys/general-features/variables",
+    out: "surveys/general-features/variables/editor.webp",
+    take: (page: Page) => openQuestionsSection(page, "Variables"),
+  },
+  {
+    name: "surveys/general-features/partial-submissions",
+    out: "surveys/general-features/partial-submissions/drop-offs.webp",
+    take: async (page: Page) => {
+      await page.goto(summaryUrl(ACME.surveyAllElements));
+      await page.waitForSelector("text=Drop-Offs", { timeout: 90_000 });
+      await page.waitForTimeout(4000);
+      // Drop-offs is a stat card that expands, not the "Analyze Drop-Offs" toggle the page still
+      // describes. Expand it so the per-question breakdown is what gets photographed.
+      const card = page
+        .getByText("Drop-Offs", { exact: true })
+        .first()
+        .locator("xpath=ancestor::div[contains(@class,'rounded')][1]");
+      await card
+        .locator("button, [role='button']")
+        .first()
+        .click()
+        .catch(() => undefined);
+      await page.waitForTimeout(2000);
+      return undefined;
+    },
+  },
+  {
+    name: "surveys/general-features/metadata",
+    out: "surveys/general-features/metadata/response-metadata.webp",
+    take: async (page: Page) => {
+      await responseTableAtColumn(page, "Source");
+      return undefined;
+    },
+  },
+  {
+    name: "platform/features/user-management/members",
+    out: "platform/features/user-management/organizations-and-roles/members.webp",
+    take: async (page: Page) => {
+      // Members live on the Teams page, not on General — the same screen holds both cards.
+      await page.goto(`${BASE_URL}/organizations/${ACME.organizationId}/settings/teams`);
+      await page.waitForSelector("text=Manage members", { timeout: 90_000 });
+      await page.waitForTimeout(3000);
+      return page
+        .getByText("Manage members", { exact: true })
+        .first()
+        .locator("xpath=ancestor::div[.//table][1]");
+    },
+  },
+  {
+    name: "platform/features/user-management/org-teams",
+    out: "platform/features/user-management/teams-and-roles/teams.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/organizations/${ACME.organizationId}/settings/teams`);
+      await page.waitForSelector("text=Create new team", { timeout: 90_000 });
+      await page.waitForTimeout(3000);
+      const card = page
+        .getByText("Assign members into teams and give teams access to workspaces.", { exact: true })
+        .first()
+        .locator("xpath=ancestor::div[.//table][1]");
+      await card.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(600);
+      return card;
+    },
+  },
+  {
+    name: "platform/features/user-management/workspace-access",
+    out: "platform/features/user-management/teams-and-roles/workspace-access.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/settings/workspace/teams`);
+      await page.waitForSelector("text=See which teams can access this workspace.", { timeout: 90_000 });
+      await page.waitForTimeout(2500);
+      return page
+        .getByText("See which teams can access this workspace.", { exact: true })
+        .first()
+        .locator("xpath=ancestor::div[.//table][1]");
+    },
+  },
+  {
+    name: "surveys/general-features/overwrite-styling/tab",
+    out: "surveys/general-features/overwrite-styling/styling-tab.webp",
+    take: async (page: Page) => {
+      await openEditorTab(page, "Styling");
+      return undefined;
+    },
+  },
+  {
+    name: "surveys/general-features/overwrite-styling/on",
+    out: "surveys/general-features/overwrite-styling/custom-styles.webp",
+    take: async (page: Page) => {
+      await openEditorTab(page, "Styling");
+      // Off, the four sections below are greyed out and nothing can be opened; the page is about
+      // what you do after switching it on.
+      const row = await enabledSettingRow(page, "Add custom styles");
+      await page.getByText("Survey styling", { exact: true }).first().click();
+      await page.waitForTimeout(1800);
+      void row;
+      return undefined;
+    },
+  },
+  {
+    name: "surveys/general-features/email-followups/tab",
+    out: "surveys/general-features/email-followups/followups-tab.webp",
+    take: async (page: Page) => {
+      await openEditorTab(page, "Follow-ups");
+      return undefined;
+    },
+  },
+  {
+    name: "surveys/general-features/email-followups/new",
+    out: "surveys/general-features/email-followups/new-followup.webp",
+    take: async (page: Page) => {
+      await openEditorTab(page, "Follow-ups");
+      await page.getByText("New follow-up", { exact: true }).first().click();
+      await page.waitForTimeout(3000);
+      return page.locator("[role='dialog']").last();
+    },
+  },
+  {
+    name: "surveys/general-features/add-image-or-video/image",
+    out: "surveys/general-features/add-image-or-video-question/media-panel.webp",
+    take: (page: Page) => openMediaPanel(page, "Image"),
+  },
+  {
+    name: "surveys/general-features/add-image-or-video/video",
+    out: "surveys/general-features/add-image-or-video-question/media-video.webp",
+    take: (page: Page) => openMediaPanel(page, "Video"),
+  },
+  {
+    name: "surveys/general-features/validation-rules",
+    out: "surveys/general-features/validation-rules/editor.webp",
+    take: async (page: Page) => {
+      await page.goto(editorUrl(ACME.surveyAllElements));
+      await settleEditor(page);
+      const card = page.locator(`[id="${AUTO_EXPANDED_ELEMENT_ID}"].scroll-mt-16`);
+      await card.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(600);
+      await card.getByText("Validation rules", { exact: true }).first().click();
+      await page.waitForTimeout(1500);
+      // A rule with a real number in it. The row defaults to "At least 0 characters", which is a
+      // rule that rejects nothing and reads like a placeholder.
+      const value = card.locator("input[type='number'], input").last();
+      await value.fill("20").catch(() => undefined);
+      await page.waitForTimeout(600);
+      await card.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(500);
+      return card;
+    },
+  },
+  {
+    name: "surveys/link-surveys/data-prefilling",
+    out: "surveys/link-surveys/data-prefilling/question-id.webp",
+    take: async (page: Page) => {
+      await page.goto(editorUrl(ACME.surveyAllElements));
+      await settleEditor(page);
+      const card = page.locator(`[id="${AUTO_EXPANDED_ELEMENT_ID}"].scroll-mt-16`);
+      await card.getByText("Show Question settings", { exact: false }).first().click();
+      await page.waitForTimeout(1500);
+      const label = card.getByText("Question ID", { exact: true }).first();
+      await label.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(700);
+      const a = await label.boundingBox();
+      const c = await card.boundingBox();
+      if (!a || !c) return card;
+      // The Question ID row alone. The card above it is the free-text editor, which this page is
+      // not about, and photographing all of it buries the one field a reader came for.
+      const y = Math.max(0, a.y - 56);
+      return { clip: { x: c.x, y, width: c.width, height: Math.min(150, VIEWPORT.height - y) } };
+    },
+  },
+  {
+    name: "surveys/link-surveys/pin-prompt",
+    out: "surveys/link-surveys/pin-protected-surveys/pin-prompt.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/s/${ACME.surveyPin}`);
+      await page.waitForTimeout(6000);
+      // No card behind this one — text and four boxes on white — so the crop has to be tight or the
+      // image is mostly nothing.
+      return gateClip(page, "This survey is protected", 760, 220, 50);
+    },
+  },
+  {
+    name: "surveys/link-surveys/email-gate",
+    out: "surveys/link-surveys/verify-email-before-survey/email-gate.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/s/${ACME.surveyVerifyEmail}`);
+      await page.waitForTimeout(6000);
+      return gateClip(page, "Verify your email", 1000, 470, 200);
+    },
+  },
+  {
+    name: "surveys/link-surveys/link-settings",
+    out: "surveys/link-surveys/link-settings/link-settings.webp",
+    take: (page: Page) => openShareDialog(page, "Link settings"),
+  },
+  {
+    name: "surveys/link-surveys/pretty-url",
+    out: "surveys/link-surveys/pretty-url/custom-slug.webp",
+    take: (page: Page) => openShareDialog(page, "Pretty URL"),
+  },
+  {
+    name: "surveys/link-surveys/personal-links",
+    out: "surveys/link-surveys/personal-links/generate.webp",
+    take: (page: Page) => openShareDialog(page, "Personal links"),
+  },
+  {
+    name: "surveys/link-surveys/single-use-links",
+    out: "surveys/link-surveys/single-use-links/single-use-links.webp",
+    take: async (page: Page) => {
+      const dialog = await openShareDialog(page, "Anonymous links");
+      // Switched on: off, the row is one sentence and shows none of the options the page describes.
+      const toggle = dialog
+        .getByText("Single-use links", { exact: true })
+        .first()
+        .locator("xpath=ancestor::div[.//button[@role='switch']][1]")
+        .locator("button[role='switch']")
+        .first();
+      if ((await toggle.getAttribute("aria-checked")) === "false") {
+        await toggle.click();
+        await page.waitForTimeout(1500);
+        // Switching single-use on turns the multi-use link off, which the app asks about first.
+        // Without confirming, the panel never changes and `.last()` photographs the confirmation.
+        await page
+          .getByRole("button", { name: "Disable multi-use link" })
+          .first()
+          .click()
+          .catch(() => undefined);
+        await page.waitForTimeout(2500);
+      }
+      return page.locator("[role='dialog']").first();
+    },
+  },
+  {
+    name: "surveys/website-app-surveys/targeting/segments",
+    out: "surveys/website-app-surveys/targeting/segments-list.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/segments`);
+      await page.waitForTimeout(7000);
+      return undefined;
+    },
+  },
+  {
+    name: "surveys/website-app-surveys/targeting/segment-editor",
+    out: "surveys/website-app-surveys/targeting/segment-editor.webp",
+    take: (page: Page) => openSegmentSettings(page),
+  },
+  {
+    name: "surveys/website-app-surveys/targeting/add-filter",
+    out: "surveys/website-app-surveys/targeting/add-filter.webp",
+    take: async (page: Page) => {
+      const dialog = await openSegmentSettings(page);
+      await dialog.getByText("Add filter", { exact: false }).first().click();
+      await page.waitForTimeout(2000);
+      // This one dialog is what used to be three screenshots: attributes, segments and devices are
+      // its tabs, and survey interaction sits in the same list.
+      return page.locator("[role='dialog']").last();
+    },
+  },
+  {
+    name: "surveys/website-app-surveys/targeting/survey-type",
+    out: "surveys/website-app-surveys/targeting/survey-type.webp",
+    take: async (page: Page) => {
+      await openSettingsSection(page, "Survey Type", "Website & App survey", ACME.surveyApp);
+      const heading = page.getByText("Survey Type", { exact: true }).first();
+      await heading.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(900);
+      return heading.locator("xpath=ancestor::div[@data-state][1]/..");
+    },
+  },
+  {
+    name: "surveys/website-app-surveys/targeting/target-audience",
+    out: "surveys/website-app-surveys/targeting/target-audience.webp",
+    take: async (page: Page) => {
+      await openSettingsSection(page, "Target Audience", undefined, ACME.surveyApp);
+      const heading = page.getByText("Target Audience", { exact: true }).first();
+      await heading.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(1200);
+      return heading.locator("xpath=ancestor::div[@data-state][1]/..");
+    },
+  },
+  {
+    name: "surveys/website-app-surveys/actions/list",
+    out: "surveys/website-app-surveys/actions/user-actions.webp",
+    take: async (page: Page) => {
+      await page.goto(`${BASE_URL}/workspaces/${ACME.workspaceId}/settings/workspace/user-actions`);
+      await page.waitForSelector("text=User Actions", { timeout: 90_000 });
+      await page.waitForTimeout(3500);
+      return page
+        .getByText("Actions", { exact: true })
+        .first()
+        .locator("xpath=ancestor::div[contains(@class,'rounded')][1]");
+    },
+  },
+  {
+    name: "surveys/website-app-surveys/actions/add-no-code",
+    out: "surveys/website-app-surveys/actions/add-action.webp",
+    take: (page: Page) => openAddActionDialog(page, "No code"),
+  },
+  {
+    name: "surveys/website-app-surveys/actions/add-code",
+    out: "surveys/website-app-surveys/actions/code-action.webp",
+    take: (page: Page) => openAddActionDialog(page, "Code"),
+  },
+  {
+    name: "surveys/website-app-surveys/actions/trigger",
+    out: "surveys/website-app-surveys/actions/survey-trigger.webp",
+    take: async (page: Page) => {
+      await openSettingsSection(
+        page,
+        "Survey Trigger",
+        "Trigger survey when one of the actions is fired…",
+        ACME.surveyApp
+      );
+      // With no action attached the section is one empty button, which is the wrong picture for a
+      // page about wiring a survey to an action. Nothing is saved — auto-save is off.
+      await page
+        .getByRole("button", { name: /^Add action$/ })
+        .first()
+        .click();
+      await page.waitForTimeout(1500);
+      await page
+        .locator("[data-radix-popper-content-wrapper], [role='dialog']")
+        .last()
+        .getByText("Viewed the mortgage calculator", { exact: true })
+        .first()
+        .click();
+      await page.waitForTimeout(1500);
+      const heading = page.getByText("Survey Trigger", { exact: true }).first();
+      await heading.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(900);
+      return heading.locator("xpath=ancestor::div[@data-state][1]/..");
+    },
+  },
+  {
+    name: "surveys/general-features/recall/menu",
+    out: "surveys/general-features/recall/recall-menu.webp",
+    take: async (page: Page) => {
+      const card = await openRecallMenu(page);
+      // The headline field and its label, not the whole card: the rest of a card is the question's
+      // own settings, which this page is not about, and editing a survey that already has responses
+      // raises a "changes may lead to inconsistencies" banner above the field — a warning triangle
+      // in a screenshot about recall reads as a warning about recall.
+      return withMenuClip(
+        page,
+        [
+          card.getByText("Question*", { exact: true }).first(),
+          card.locator("[contenteditable='true']").first(),
+        ],
+        card
+      );
+    },
+  },
+  {
+    name: "surveys/general-features/recall/fallback",
+    out: "surveys/general-features/recall/fallback.webp",
+    take: async (page: Page) => {
+      const card = await openRecallMenu(page);
+      await page
+        .locator("[data-radix-popper-content-wrapper]")
+        .last()
+        .getByText("What made", { exact: false })
+        .first()
+        .click();
+      await page.waitForTimeout(1800);
+      await card.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(700);
+      return withMenuClip(
+        page,
+        [
+          card.getByText("Question*", { exact: true }).first(),
+          card.locator("[contenteditable='true']").first(),
+        ],
+        card
+      );
+    },
+  },
+  {
+    name: "surveys/general-features/conditional-logic/add-logic",
+    out: "surveys/general-features/conditional-logic/add-logic.webp",
+    take: async (page: Page) => {
+      await blockLogicEditor(page, false);
+      // The foot of the block card, not the panel alone: an empty Conditional Logic section is a
+      // heading and a button, and on its own it says nothing about where in the editor to find it.
+      const top = page.getByText("Add question to block", { exact: true }).first();
+      await top.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(600);
+      const a = await top.boundingBox();
+      const b = await page.getByText("Show Block settings", { exact: true }).first().boundingBox();
+      // x from the heading, not from the button: `boundingBox` on a button returns its label's box,
+      // which is inset by the padding, and clipping to that shears the text off the left edge.
+      const left = await page.getByText("Conditional Logic", { exact: false }).first().boundingBox();
+      if (!a || !b || !left) return undefined;
+      const x = Math.max(0, left.x - 20);
+      const y = Math.max(0, a.y - 28);
+      return {
+        clip: {
+          x,
+          y,
+          width: Math.min(x + 1220, VIEWPORT.width) - x,
+          height: Math.min(b.y + b.height + 28, VIEWPORT.height) - y,
+        },
+      };
+    },
+  },
+  {
+    name: "surveys/general-features/conditional-logic/rule",
+    out: "surveys/general-features/conditional-logic/logic-rule.webp",
+    take: async (page: Page) => {
+      await blockLogicEditor(page, true);
+      return logicPanelClip(page);
+    },
+  },
+  {
+    name: "surveys/general-features/conditional-logic/operators",
+    out: "surveys/general-features/conditional-logic/condition-operators.webp",
+    take: async (page: Page) => {
+      await blockLogicEditor(page, true);
+      await logicPanelClip(page);
+      await ruleSelects(page).nth(SELECT.operator).click();
+      await page.waitForTimeout(900);
+      return logicPanelClip(page, true);
+    },
+  },
+  {
+    name: "surveys/general-features/conditional-logic/actions",
+    out: "surveys/general-features/conditional-logic/action-options.webp",
+    take: async (page: Page) => {
+      await blockLogicEditor(page, true);
+      await logicPanelClip(page);
+      await ruleSelects(page).nth(SELECT.action).click();
+      await page.waitForTimeout(900);
+      return logicPanelClip(page, true);
+    },
+  },
+  ...RESPONSE_OPTION_PAGES.map(({ page: docsPage, label }) => ({
+    name: docsPage,
+    out: `${docsPage.replace("surveys/", "surveys/")}/response-option.webp`,
+    take: async (page: Page) => {
+      await openSettingsSection(page, "Response Options", label);
+      return enabledSettingRow(page, label);
+    },
+  })),
+
+  ...QUESTION_TYPE_PAGES.map(({ page: docsPage, elementId }) => ({
+    name: `question-type/${docsPage}`,
+    // New home for these images. The originals live under the legacy
+    // `images/xm-and-surveys/core-features/question-type/` tree, which ENG-2662 retires.
+    out: `surveys/question-type/${docsPage}/editor.webp`,
+    take: async (page: Page) => {
+      await page.goto(editorUrl(ACME.surveyAllElements));
+      await settleEditor(page);
+      const card = await openElementCard(page, elementId);
+      const box = await card.boundingBox();
+      return box ? { clip: box } : undefined;
+    },
+  })),
+];
+
+const login = async (browser: Browser): Promise<string> => {
+  const page = await browser.newPage({ viewport: VIEWPORT });
+  await page.goto(`${BASE_URL}/auth/login`);
+  await page.getByRole("button", { name: /log in with email/i }).click();
+  await page.getByPlaceholder("work@email.com").fill(LOGIN.email);
+  await page.locator('input[type="password"]').fill(LOGIN.password);
+  await page.getByRole("button", { name: /log in with email/i }).click();
+  await page.waitForURL(/\/workspaces\//, { timeout: 60_000 });
+
+  const statePath = resolve(HERE, ".auth.json");
+  await page.context().storageState({ path: statePath });
+  await page.close();
+  return statePath;
+};
+
+const main = async (): Promise<void> => {
+  const wanted = process.argv.slice(2);
+  const selected = wanted.length > 0 ? shots.filter((s) => wanted.includes(s.name)) : shots;
+
+  if (selected.length === 0) {
+    console.error(`No shots matched. Known: ${shots.map((s) => s.name).join(", ")}`);
+    process.exit(1);
+  }
+
+  const browser = await chromium.launch();
+  const statePath = await login(browser);
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: DEVICE_SCALE_FACTOR,
+    storageState: statePath,
+    colorScheme: "light",
+    // The app renders relative timestamps ("2 days ago") and locale-formatted dates. Pinning both
+    // keeps a re-run from producing a diff that is nothing but a clock tick.
+    locale: "en-US",
+    timezoneId: "UTC",
+  });
+
+  // The Next.js dev-tools button floats over the bottom-left corner of every page, right on top of
+  // the sidebar's account row. It is dev-server chrome, not product UI, and it has no business in a
+  // docs screenshot — an init script rather than `addStyleTag` so the rule survives navigation.
+  // Passed as source text, not as a function: `tsx` compiles with esbuild's keepNames, which wraps
+  // named declarations in a `__name(...)` helper that does not exist in the page, so a function
+  // handed to `addInitScript` throws `__name is not defined` before it can do anything.
+  await context.addInitScript({
+    content: `document.addEventListener("DOMContentLoaded", function () {
+      var s = document.createElement("style");
+      s.textContent = "nextjs-portal { display: none !important; }";
+      document.head.appendChild(s);
+    });`,
+  });
+
+  // A cold route in the dev server can take well over the 30s default: Next compiles it on first
+  // request, and the response table pulls a lot of data.
+  context.setDefaultNavigationTimeout(120_000);
+  context.setDefaultTimeout(60_000);
+
+  for (const shot of selected) {
+    const page = await context.newPage();
+    try {
+      const result = await shot.take(page);
+      const out = resolve(DOCS_IMAGES, shot.out);
+      await mkdir(dirname(out), { recursive: true });
+
+      // Capture PNG (lossless, so the encode below starts from a clean source), then re-encode to
+      // WebP. The docs are served to every reader: the same 14 shots weigh 1.4 MB as 2x PNG and
+      // ~200 KB as WebP, and at quality 90 UI text stays crisp. Every existing docs image is .webp,
+      // so this also keeps the tree consistent.
+      // A Locator screenshots itself, which is why most shots return one: element bounds beat any
+      // arithmetic I can do against a moving layout.
+      // Three shapes, narrowed explicitly: a Locator screenshots itself, a clip box bounds a
+      // page shot, and nothing means the viewport.
+      let png: Buffer;
+      if (!result) {
+        png = await page.screenshot();
+      } else if ("screenshot" in result) {
+        png = await result.screenshot();
+      } else {
+        png = await page.screenshot({ clip: result.clip });
+      }
+      await sharp(png).webp({ quality: 90 }).toFile(out);
+
+      console.log(`  ✓ ${shot.name} -> docs/images/${shot.out}`);
+    } catch (error) {
+      console.error(`  ✗ ${shot.name}: ${error instanceof Error ? error.message : String(error)}`);
+      process.exitCode = 1;
+    } finally {
+      await page.close();
+    }
+  }
+
+  await context.close();
+  await browser.close();
+};
+
+void main();

--- a/scripts/docs-capture/capture.ts
+++ b/scripts/docs-capture/capture.ts
@@ -646,6 +646,12 @@ const shots: Shot[] = [
       await page.waitForTimeout(3000);
       // The logo upload steps cannot be shown from an empty dropzone, so upload one first. The file
       // is a generated wordmark for the fictional bank, not any real company's mark.
+      if (!LOGO_FILE) {
+        throw new Error(
+          "DOCS_CAPTURE_LOGO is not set. This shot uploads a logo, so it needs a path to an image file: " +
+            "DOCS_CAPTURE_LOGO=/path/to/wordmark.png pnpm docs:capture look-and-feel/logo-upload"
+        );
+      }
       await page.locator('input[type="file"]').first().setInputFiles(LOGO_FILE);
       // Wait for the upload to finish, not just to start: at 9s the logo was still fading in behind
       // a spinner, which reads as a rendering glitch rather than an uploaded logo.
@@ -1293,7 +1299,7 @@ const shots: Shot[] = [
   },
   ...RESPONSE_OPTION_PAGES.map(({ page: docsPage, label }) => ({
     name: docsPage,
-    out: `${docsPage.replace("surveys/", "surveys/")}/response-option.webp`,
+    out: `${docsPage}/response-option.webp`,
     take: async (page: Page) => {
       await openSettingsSection(page, "Response Options", label);
       return enabledSettingRow(page, label);
@@ -1332,12 +1338,17 @@ const login = async (browser: Browser): Promise<string> => {
 
 const main = async (): Promise<void> => {
   const wanted = process.argv.slice(2);
-  const selected = wanted.length > 0 ? shots.filter((s) => wanted.includes(s.name)) : shots;
-
-  if (selected.length === 0) {
-    console.error(`No shots matched. Known: ${shots.map((s) => s.name).join(", ")}`);
+  const known = new Set(shots.map((s) => s.name));
+  // A typo has to be loud. This is the single-page iteration loop, so `capture.ts a b` where only `a`
+  // matches would otherwise print one tick and exit 0 — the reader concludes both shots were retaken.
+  const unknown = wanted.filter((name) => !known.has(name));
+  if (unknown.length > 0) {
+    console.error(`Unknown shot name(s): ${unknown.join(", ")}`);
+    console.error(`Known: ${shots.map((s) => s.name).join(", ")}`);
     process.exit(1);
   }
+
+  const selected = wanted.length > 0 ? shots.filter((s) => wanted.includes(s.name)) : shots;
 
   const browser = await chromium.launch();
   const statePath = await login(browser);

--- a/scripts/docs-capture/capture.ts
+++ b/scripts/docs-capture/capture.ts
@@ -24,6 +24,8 @@ import { mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import sharp from "sharp";
+import { DOCS_IDS } from "../../packages/database/src/scripts/docs-fixture-ids";
+import { SEED_CREDENTIALS } from "../../packages/database/src/seed/constants";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "../..");
@@ -34,20 +36,20 @@ const BASE_URL = process.env.DOCS_CAPTURE_URL ?? "http://localhost:3000";
 /** Generated wordmark for the fictional bank, used by the logo-upload shots. */
 const LOGO_FILE = process.env.DOCS_CAPTURE_LOGO ?? "";
 
-/** Must match `SEED_CREDENTIALS.ADMIN` in `packages/database/src/seed/constants.ts`. */
-const LOGIN = { email: "admin@formbricks.com", password: "Password#123" };
+const LOGIN = SEED_CREDENTIALS.ADMIN;
 
-/** Must match `DOCS_IDS` in `packages/database/src/scripts/seed-docs-fixtures.ts`. */
+/**
+ * Imported rather than copied: a renamed id now fails to compile here instead of sending a shot to a
+ * 404 that still produces a plausible-looking screenshot. `docs-fixture-ids` is deliberately separate
+ * from the seed script, which opens a database connection while its module evaluates.
+ */
 const ACME = {
-  workspaceId: "cldocsacmeworkspace000001",
-  surveyAllElements: "cldocsallelements00000001",
-  // An app survey. Visibility & Recontact and the targeting controls do not exist for link surveys.
-  surveyApp: "cldocsappsurvey000000001",
-  // Two link surveys that exist only to be photographed from the respondent's side: the PIN screen
-  // and the email gate come before the survey and cannot be shown from the editor.
-  surveyPin: "cldocspinsurvey000000001",
-  surveyVerifyEmail: "cldocsverifyemail00000001",
-  organizationId: "cldocsacmeorg00000000001",
+  workspaceId: DOCS_IDS.WORKSPACE,
+  surveyAllElements: DOCS_IDS.SURVEY_ALL_ELEMENTS,
+  surveyApp: DOCS_IDS.SURVEY_APP,
+  surveyPin: DOCS_IDS.SURVEY_PIN,
+  surveyVerifyEmail: DOCS_IDS.SURVEY_VERIFY_EMAIL,
+  organizationId: DOCS_IDS.ORGANIZATION,
 };
 
 /**


### PR DESCRIPTION
Replaces #9024, which could not be reopened after its branch was force-pushed. @itsjavi, you are on this because the question is whether this belongs in the repo at all — the code is the easy part.

Since #9024 was opened the harness has roughly doubled: 231 → 1,412 lines of shots, and the fixture 282 → 907, covering everything shot this week.

## What & why

**Was:** every docs screenshot was taken by hand, so the set drifted. 320 of 408 images predated the Blocks editor; only 19 postdated Formbricks 5. Sizes ranged from 1027×666 to 2420×1400 — three sizes across three images on one page.

**Now:** a Playwright script (`scripts/docs-capture/capture.ts`) and a seeded workspace (`db:seed:docs`), which together define **74 shots** and produced the images merged for milestones 1–6.

<details>
<summary>What it does <em>not</em> cover yet, since a reviewer should not have to find this out</summary>

100 images changed on `main` since 20 Aug. This branch reproduces 72 of them. The remainder:

| Not covered | Why |
| --- | --- |
| 7 best-practice recipe shots (`feedback-box/*`, `quiz-time/*`, `google-reviews/ending`) | Milestone 7 landed after this branch was last pushed. The fixture surveys they need were built locally and never committed, so they are **not reproducible from this branch today.** |
| 13 `unify-feedback/dashboards-charts/*` | A different product area with its own fixture story; out of scope here. |
| 7 `multi-language-surveys/*` | Merged in #8978, before this harness existed. |
| `source-tracking/responses-table.webp` | Needs responses carrying `meta.source`, which the fixture does not seed. |

The recipe gap is the one that should be closed before this is much use to the next person; the shots and their fixture surveys are a follow-up, not a reason to hold the branch.

</details>

Neither runs in CI. Both are run by hand against a local instance when a release changes what the product looks like:

```bash
pnpm --filter @formbricks/database db:seed       # admin user
pnpm --filter @formbricks/database db:seed:docs  # the ACME Inc. workspace
pnpm dev
pnpm tsx scripts/docs-capture/capture.ts                    # everything
pnpm tsx scripts/docs-capture/capture.ts surveys/…/recall   # or one shot
```

## Why it should live in the repo

The alternative is that it lives on one laptop, which is where it has been all week.

1. **A screenshot set is only a set if one thing makes it.** One viewport (1920×1200 @2x), one theme, one workspace, `locale: "en-US"`, `timezoneId: "UTC"` so a re-run does not diff on a clock tick. The first page shot by hand breaks that, and it cannot be un-broken without redoing everything.
2. **It encodes what the app does, not what it looks like.** Roughly a third of the file is comments recording things that cost real time to learn — element ids are not unique because the preview pane renders the same survey; a panel a toggle reveals is the row's *sibling*; a CTA pointing at an external URL means `networkidle` never fires. That knowledge is worth more than the script.
3. **Re-shooting is not a one-off.** Two releases invalidated 320 images. The next one will do it again, and the cost of responding is either "run a script" or "spend a week".
4. **It caught a real defect.** The Next.js dev-tools button sits over the viewport's bottom-left corner and had landed on the sidebar in **seven images already committed** across four PRs. Found by diffing a re-run against what was on the branches — which is only possible if a re-run is reproducible.

## What the fixture contains

An "ACME Inc." retail bank — financial services because it matches our ICP, so a prospect reading the docs recognises the survey. A link survey with all 16 element types at **fixed ids** (`acme-<type>`, so a shot never depends on question order), an app survey, 52 responses (38 finished / 14 partial, interleaved — the split is exact for any pair of counts as of the review fixes; the first version silently produced 39/13), hidden fields, variables, tags with uneven counts, 8 contacts, 7 attribute keys, segments, 6 user actions, 4 org members across all four roles, 2 teams, and two link surveys that exist only to photograph the PIN and email gates.

Everything is fictional. Every address is on `example.com`, which RFC 2606 reserves and which reaches nobody.

## Where to look

- [`scripts/docs-capture/capture.ts`](https://github.com/formbricks/formbricks/blob/chore/docs-capture-harness/scripts/docs-capture/capture.ts) — the `Shot` type and the `shots` array are the whole interface. A shot drives the app to a moment and returns a Locator, a clip box, or nothing.
- **`scripts/` and not `apps/web/`**, deliberately: `apps/web/tsconfig.json` has `"include": ["**/*.ts"]`, so anything under the app is typechecked by the Next build. A dev script that fails to compile takes the build down, and with it E2E and the v3 contract tests. That is not hypothetical — it cost a red CI run earlier this week.
- **`db:seed:docs` is separate from `db:seed`** because this fixture's content *ships*: it is visible in ~200 public images. `db:seed` is what every developer runs locally and shows up in nobody's output. Branding `seed.ts` as ACME would push a docs concern into every developer's database.

## Breaking changes

- [ ] This PR contains breaking changes

None. Two new files, one npm script, one `.gitignore` line. Nothing imports any of it, nothing runs in CI, and no existing behaviour changes.

## Migrations & env

- none. `db:seed:docs` is additive and idempotent — every write is an `upsert`, except responses, which are deleted and rewritten so counts stay stable across runs.

## How this was tested

Rerun: `pnpm --filter @formbricks/database db:seed:docs && pnpm tsx scripts/docs-capture/capture.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The harness produces the images actually merged | manual | ~55 images across 20 merged PRs came from this script |
| The seed is idempotent | manual | Run repeatedly against a live database this week; response count stays 52 |
| The fixture typechecks and lints clean | `pnpm --filter @formbricks/database typecheck`, eslint | Clean |
| Nothing under `apps/web` is touched | manual | Both files are outside it, for the tsconfig reason above |
| Session cookies cannot be committed | manual | `scripts/docs-capture/.auth.json` is gitignored — it holds a live login |
| `ANSWER_POOL` is honestly partial | source + run | Six of sixteen elements deliberately have no answers, so the response table has empty cells. Typed `Partial<Record<…>>`; a total `Record` types the miss away and hands `pick` an `undefined` to index — which is exactly what a lint fix nearly did here before the seed was re-run to check |

**Open gaps**

- **No CI check.** Nothing verifies the script still runs, so it can rot silently. A weekly job that runs it and fails on a thrown selector would fix that; not included because it needs a seeded database in CI.
- **Selectors are structural**, not `data-testid`. `.scroll-mt-16` for an editor card, `[data-radix-popper-content-wrapper]` for an open menu. They break when the DOM changes — that is the maintenance cost, and the comments exist to make the breakage diagnosable.
- **Images are verified by eye.** Nothing asserts a shot contains what it should.
- Two shots need a file argument (`DOCS_CAPTURE_LOGO`) and are not runnable without it.

**Risks**

- Nothing executes in CI or in the product. The risk is maintenance: an unmaintained script is worse than none, because the next person trusts it.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).



