### PR TITLE
docs: fix four internal links that go nowhere (ENG-2757)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -308,6 +308,7 @@
           {
             "group": "Configuration",
             "pages": [
+              "self-hosting/configuration",
               "self-hosting/configuration/custom-ssl",
               "self-hosting/configuration/environment-variables",
               "self-hosting/configuration/job-runner",

--- a/docs/self-hosting/advanced/enterprise-features/oidc-sso.mdx
+++ b/docs/self-hosting/advanced/enterprise-features/oidc-sso.mdx
@@ -4,4 +4,8 @@ description: "Configure Single Sign-On with your Formbricks instance."
 icon: "key"
 ---
 
-Implement enterprise-grade authentication for your survey platform with [Open ID connect, Azure AD OAuth, Google OAuth, and SAML](/self-hosting/configuration/auth-sso)
+<Note>
+  Single Sign-On is part of the Formbricks [Enterprise Edition](/self-hosting/advanced/license).
+</Note>
+
+Implement enterprise-grade authentication for your survey platform with [Open ID Connect](/self-hosting/configuration/auth-sso/open-id-connect), [Azure AD OAuth](/self-hosting/configuration/auth-sso/azure-ad-oauth), [Google OAuth](/self-hosting/configuration/auth-sso/google-oauth), or [SAML](/self-hosting/configuration/auth-sso/saml-sso)

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -1,0 +1,97 @@
+---
+title: "Configuration"
+sidebarTitle: "Overview"
+description: "Everything you can configure on a self-hosted Formbricks instance, and where each setting lives."
+icon: "sliders"
+---
+
+A fresh instance runs with sensible defaults. Everything below is optional, and most of it is a matter of adding environment variables and restarting your containers.
+
+<Note>
+  Almost every setting on this page is an environment variable. [Environment
+  Variables](/self-hosting/configuration/environment-variables) is the full list, and the page to read
+  first.
+</Note>
+
+## Getting mail out
+
+Formbricks sends verification mail, invitations, email follow-ups and email surveys. None of that works until you point the instance at an SMTP server.
+
+<CardGroup cols={2}>
+  <Card title="SMTP" icon="envelope" href="/self-hosting/configuration/smtp">
+    Point Formbricks at a mail server.
+  </Card>
+
+  <Card title="Job Runner" icon="gears" href="/self-hosting/configuration/job-runner">
+    Run the background worker that sends the mail and processes queued work.
+  </Card>
+</CardGroup>
+
+## Reaching your instance
+
+Where Formbricks lives on the network, and how browsers get to it.
+
+<CardGroup cols={2}>
+  <Card title="Domain Configuration" icon="globe" href="/self-hosting/configuration/domain-configuration">
+    Set the public-facing URL your instance answers on.
+  </Card>
+
+  <Card title="Custom SSL Certificate" icon="lock" href="/self-hosting/configuration/custom-ssl">
+    Bring your own certificate to the One-Click setup.
+  </Card>
+
+  <Card title="Custom Subpath" icon="folder-tree" href="/self-hosting/configuration/custom-subpath">
+    Serve Formbricks under a path prefix instead of a domain root.
+  </Card>
+
+  <Card title="CDN" icon="server" href="/self-hosting/configuration/cdn">
+    Cache public traffic without serving stale survey assets after an upgrade.
+  </Card>
+</CardGroup>
+
+## Storing what people upload
+
+<Card title="File Uploads" icon="upload" href="/self-hosting/configuration/file-uploads">
+  Configure storage for survey images, file-upload answers and workspace assets.
+</Card>
+
+## Signing in
+
+Out of the box people sign in with an email address and a password. Point the instance at your own identity provider instead and sign-in follows the rules you already enforce there.
+
+<Note>
+  Single Sign-On is part of the [Enterprise Edition](/self-hosting/advanced/license) — every provider
+  below, not only SAML. SAML additionally needs the `saml` entitlement on the licence.
+</Note>
+
+<CardGroup cols={2}>
+  <Card title="Authentication Behavior" icon="user" href="/self-hosting/auth-behavior">
+    Who may sign up, and whether an invitation is required.
+  </Card>
+
+  <Card title="Open ID Connect" icon="id-card" href="/self-hosting/configuration/auth-sso/open-id-connect">
+    The generic OIDC setup. Start here if your provider is not listed separately.
+  </Card>
+
+  <Card title="Keycloak OIDC" icon="shield-halved" href="/self-hosting/configuration/auth-sso/keycloak-oidc">
+    OIDC against a Keycloak realm.
+  </Card>
+
+  <Card title="Azure AD OAuth" icon="microsoft" href="/self-hosting/configuration/auth-sso/azure-ad-oauth">
+    Microsoft Entra ID, formerly Azure AD.
+  </Card>
+
+  <Card title="Google OAuth" icon="google" href="/self-hosting/configuration/auth-sso/google-oauth">
+    Google Workspace accounts.
+  </Card>
+
+  <Card title="SAML SSO" icon="building-lock" href="/self-hosting/configuration/auth-sso/saml-sso">
+    SAML 2.0, for providers that do not speak OIDC.
+  </Card>
+</CardGroup>
+
+## Connecting third-party tools
+
+[Airtable](/self-hosting/configuration/integrations/airtable), [Google Sheets](/self-hosting/configuration/integrations/google-sheets), [Notion](/self-hosting/configuration/integrations/notion) and [Slack](/self-hosting/configuration/integrations/slack) each need an OAuth app you register with the service, and its credentials as environment variables. [n8n](/self-hosting/configuration/integrations/n8n), [Zapier](/self-hosting/configuration/integrations/zapier) and [ActivePieces](/self-hosting/configuration/integrations/activepieces) connect the other way round, through a Formbricks API key, and need no server configuration at all.
+
+Still struggling or something not working as expected? [Join our GitHub Discussions](https://github.com/formbricks/formbricks/discussions) and we'd be glad to assist you!

--- a/docs/surveys/best-practices/cancel-subscription.mdx
+++ b/docs/surveys/best-practices/cancel-subscription.mdx
@@ -76,7 +76,7 @@ To create the trigger for your Churn Survey, you have three options to choose fr
 
 Whenever a user visits this page, matches the filter conditions above and the recontact options (below) the survey will be displayed ✅
 
-Here is our complete [Actions manual](/surveys/website-app-surveys/actions/) covering [No-Code](/surveys/website-app-surveys/actions#setting-up-no-code-actions) and [Code](/surveys/website-app-surveys/actions#setting-up-code-actions) Actions.
+Here is our complete [Actions manual](/surveys/website-app-surveys/actions) covering [No-Code](/surveys/website-app-surveys/actions#setting-up-no-code-actions) and [Code](/surveys/website-app-surveys/actions#setting-up-code-actions) Actions.
 
 ### 5. Select Action in the “When to ask” card
 

--- a/docs/surveys/website-app-surveys/quickstart.mdx
+++ b/docs/surveys/website-app-surveys/quickstart.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "Quickstart"
 
 <Steps>
   <Step title="Create a Formbricks cloud account">
-    While you can [self-host](/self-hosting) Formbricks, the fastest and easiest way to get started is with the free Cloud plan. Simply [sign up](https://app.formbricks.com/auth/signup) here, follow the onboarding steps, and choose the "Formbricks Surveys" option.
+    While you can [self-host](/self-hosting/overview) Formbricks, the fastest and easiest way to get started is with the free Cloud plan. Simply [sign up](https://app.formbricks.com/auth/signup) here, follow the onboarding steps, and choose the "Formbricks Surveys" option.
     
     ![what are you here for](https://res.cloudinary.com/dwdb9tvii/image/upload/v1738113228/image_d11uiy.png)
   </Step>


### PR DESCRIPTION
Fixes ENG-2757

Redo of #9046, which was closed unmerged. Same four links, plus the Enterprise note that PR also carried. `/self-hosting/configuration/integrations` — the fifth link in the original — was fixed in the meantime by #9033.

## What & why

Four internal links in `docs/` point at paths that have no page.

None of them 404 for a reader. `errors.404.redirect: true` in `docs.json` silently redirects every dead internal path to the docs home, so a wrong link reads as a page that "just went somewhere odd". It is also why `mint broken-links` reports the docs as clean.

| Link | In | Now |
| --- | --- | --- |
| `/self-hosting/configuration` | `self-hosting/overview.mdx` | A new index page for the section |
| `/self-hosting/configuration/auth-sso` | `enterprise-features/oidc-sso.mdx` | Each provider linked to its own page |
| `/self-hosting` | `website-app-surveys/quickstart.mdx` | `/self-hosting/overview` |
| `/surveys/website-app-surveys/actions/` | `best-practices/cancel-subscription.mdx` | Same path without the trailing slash |

The first two are nav **groups**. A group is not a page, so linking its path in prose never resolves.

`oidc-sso.mdx` also gains the Enterprise note it never had. `getIsSsoEnabled` in `apps/web/modules/ee/license-check/lib/utils.ts` gates on the `sso` feature flag for **every** provider, and `getIsSamlSsoEnabled` requires `sso && saml` on top — so the whole page is Enterprise, not just its SAML paragraph.

### How they were found

Resolving every `](/…)` and `href="/…"` in `docs/**/*.mdx` against the page list in `docs.json`, rather than trusting the crawler:

```bash
python3 - <<'PY'
import json, os, re, glob
cfg = json.load(open("docs/docs.json")); pages = set()
def walk(n):
    if isinstance(n, str): pages.add(n)
    elif isinstance(n, list): [walk(x) for x in n]
    elif isinstance(n, dict):
        for k, v in n.items():
            if k in ("pages","groups","tabs","anchors","navigation","dropdowns","languages","versions"): walk(v)
walk(cfg["navigation"])
links = set()
for f in glob.glob("docs/**/*.mdx", recursive=True):
    t = open(f, encoding="utf-8").read()
    links |= {m.group(1).lstrip("/") for m in re.finditer(r'\]\((/[A-Za-z0-9/_\-]+)', t)}
    links |= {m.group(1).lstrip("/") for m in re.finditer(r'href="(/[A-Za-z0-9/_\-]+)', t)}
for p in sorted(links):
    if p not in pages and not os.path.exists(f"docs/{p}.mdx") and not p.startswith(("api-reference/","api-v2-reference/")):
        print("DEAD", p)
PY
```

On this branch it prints nothing. On `main` it prints four.

The two `api-*-reference/` prefixes are excluded because Mintlify generates those pages from the OpenAPI documents at build time — they are real, just not in `docs.json`.

## Where to look

- [self-hosting/configuration.mdx](https://github.com/formbricks/formbricks/blob/docs/dead-internal-links-v2/docs/self-hosting/configuration.mdx) — the only new prose. It groups the twelve configuration pages by what a reader is trying to do (get mail out, be reachable, store uploads, sign in, connect tools) rather than listing them.

## Breaking changes

- [ ] This PR contains breaking changes

None. Documentation prose and one nav entry. No code changes, and no existing page moves or changes path.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| No dead internal links remain | script above | 0 on this branch, 4 on `main` |
| The new page introduces none of its own | script above | Its `href=` cards resolve — the sweep covers attributes, not just markdown links |
| Every nav entry has a file | script | 0 missing |
| All SSO is licence-gated, not just SAML | source | `getIsSsoEnabled` → `sso` flag; `getIsSamlSsoEnabled` → `sso && saml` |
| `docs.json` parses and keeps its formatting | manual | `json.load` clean; prettier run so the diff is one line |

**Open gaps**

- `mint broken-links` still cannot catch this class of bug, and this PR does not change that. The sweep above is a shell one-liner, not a CI check — turning off `errors.404.redirect` would be the real fix, and that is a call for whoever owns the docs site.
- Only internal links are checked. External URLs are untouched.

**Risks**

- Nothing here executes.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).
