### PR TITLE
docs(self-hosting): note the 5.4.0 Microsoft SSO workaround

### DIFF
--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -255,6 +255,18 @@ verification, set your Directory (tenant) ID instead.
 `consumers` needs no action and is not affected: every personal Microsoft account lives in one
 well-known tenant, so that authority advertises a real issuer and keeps full id_token verification.
 
+<Warning>
+  That handling arrived in **5.4.1**. On **5.4.0**, `common` and `organizations` still take the
+  verification path, so every Microsoft sign-in fails with `?error=unable_to_get_user_info` and no
+  configuration of those two authorities works.
+
+  If you are on 5.4.0 and cannot upgrade yet, **unset `AZUREAD_TENANT_ID`** to restore sign-in: an
+  unset value skips verification on 5.4.0 as well. It needs no reverting after the upgrade, because
+  5.4.1 treats unset and `common` identically. Note that unset behaves as `common`, so an instance
+  that had `organizations` set will accept personal Microsoft accounts until it upgrades and can set
+  `organizations` again.
+</Warning>
+
 #### SSO callback URLs are unchanged
 
 Your SSO callback URLs stay exactly as they are:


### PR DESCRIPTION
No Linear ticket — filed from a session where the Linear integration was not authorized. Happy to attach one before merge.

## What & why

**Was:** the `AZUREAD_TENANT_ID` section of the 5.4 migration guide describes how Formbricks handles `common` and `organizations` — skip verification, take identity from userinfo — without saying which release does that. A self-hoster on **5.4.0** with either set reads it and concludes their configuration is handled.

**Now:** a warning names the release (5.4.1) and gives the workaround for 5.4.0.

It is not handled on 5.4.0: both authorities still take the verification path there, so every Microsoft sign-in fails with `?error=unable_to_get_user_info`. 5.4.0 was the Latest release for two days, and self-hosters routinely stay on a release for months, so the current text is actively misleading for exactly the people hitting the failure.

## Where to look

- [`migration.mdx`](docs/self-hosting/advanced/migration.mdx) — one `<Warning>` block after the `consumers` paragraph.

## Breaking changes

- [ ] This PR contains breaking changes

None. Documentation only.

## Migrations & env

- none. This documents an existing variable; it neither adds nor changes one.

## How this was tested

Rerun: n/a — prose only, no build-affecting change.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The claim about 5.4.0 is true | manual | `git show 5.4.0:apps/web/modules/ee/sso/lib/better-auth-providers.ts` — the branch is `AZUREAD_TENANT_ID ? discoveryUrl : explicit endpoints`, so any set value takes discovery and unset does not |
| The workaround works on 5.4.0 | manual | Same branch: unset is falsy, so it takes the explicit-endpoints path that never verifies id_tokens |
| Unset needs no reverting on 5.4.1 | manual | `5.4.1-rc.3` resolves `AZUREAD_TENANT_ID?.trim() \|\| "common"`, and `common` is in `AZURE_TEMPLATE_ISSUER_TENANTS`, so unset and `common` reach the same branch |
| `<Warning>` renders here | manual | Already used 10× in this file |

**Open gaps**

- Not previewed in a docs build; the component and surrounding structure match the rest of the file.

**Risks**

- The guide publishes from `main`, so this reaches readers on the next docs deploy regardless of the 5.4.1 release. That is intended — the audience is people stuck on 5.4.0.
