### PR TITLE
chore: add type param to license/pricing request form links

### DIFF
--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -184,7 +184,7 @@ export const DEBUG = env.DEBUG === "1";
 export const ENTERPRISE_LICENSE_KEY = env.ENTERPRISE_LICENSE_KEY;
 
 export const ENTERPRISE_LICENSE_REQUEST_FORM_URL =
-  "https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=ce";
+  "https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=ce&type=licenseRequest";
 
 export const REDIS_URL = env.REDIS_URL;
 export const RATE_LIMITING_DISABLED = env.RATE_LIMITING_DISABLED === "1";

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -1567,7 +1567,7 @@ export const PricingTable = ({
                 </div>
                 <Button variant="default" className="shrink-0" asChild>
                   <Link
-                    href="https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=cloud&source=billingView"
+                    href="https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=cloud&source=billingView&type=pricingRequest"
                     target="_blank"
                     rel="noopener noreferrer">
                     {t("workspace.settings.billing.contact_sales_cta")}

--- a/docs/self-hosting/advanced/license.mdx
+++ b/docs/self-hosting/advanced/license.mdx
@@ -8,7 +8,7 @@ The Formbricks core source code is licensed under AGPLv3 and available on GitHub
 
 <Note>
   Want to get your hands on the Enterprise Edition? [Request a free Enterprise Edition
-  Trial](https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=docs) License to build a fully functioning Proof of
+  Trial](https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=docs&type=licenseRequest) License to build a fully functioning Proof of
   Concept.
 </Note>
 
@@ -38,11 +38,11 @@ The Formbricks core application is licensed under the [AGPLv3 Open Source Licens
 
 ### The Enterprise Edition
 
-Additional to the AGPL licensed Formbricks core, this repository contains code licensed under an Enterprise license. The [code](https://github.com/formbricks/formbricks/tree/main/apps/web/modules/ee) and [license](https://github.com/formbricks/formbricks/blob/main/apps/web/modules/ee/LICENSE) for the enterprise functionality can be found in the `/apps/web/modules/ee` folder of this repository. This additional functionality is not part of the AGPLv3 licensed Formbricks core and is designed to meet the needs of larger teams and enterprises. This advanced functionality is already included in the Docker images, but you need an [Enterprise License Key](https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=docs) to unlock it.
+Additional to the AGPL licensed Formbricks core, this repository contains code licensed under an Enterprise license. The [code](https://github.com/formbricks/formbricks/tree/main/apps/web/modules/ee) and [license](https://github.com/formbricks/formbricks/blob/main/apps/web/modules/ee/LICENSE) for the enterprise functionality can be found in the `/apps/web/modules/ee` folder of this repository. This additional functionality is not part of the AGPLv3 licensed Formbricks core and is designed to meet the needs of larger teams and enterprises. This advanced functionality is already included in the Docker images, but you need an [Enterprise License Key](https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=docs&type=licenseRequest) to unlock it.
 
 <Note>
   Want to get your hands on the Enterprise Edition? [Request a free Enterprise Edition
-  Trial](https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=docs) License to build a fully functioning Proof of
+  Trial](https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=docs&type=licenseRequest) License to build a fully functioning Proof of
   Concept.
 </Note>
 


### PR DESCRIPTION
No ticket — small consistency chore, discussed ad hoc.

## What & why

**Was:** The enterprise license request and billing "contact sales" links carried `delivery`/`source` params but nothing distinguishing which flow generated the submission.
**Now:** Both links (and the two license-request links they're built from) carry a `type` param (`licenseRequest` or `pricingRequest`) so submissions can be attributed by entry point.

## Where to look

- [apps/web/lib/constants.ts](apps/web/lib/constants.ts) — `ENTERPRISE_LICENSE_REQUEST_FORM_URL`, consumed by every license-request CTA
- [apps/web/modules/ee/billing/components/pricing-table.tsx](apps/web/modules/ee/billing/components/pricing-table.tsx) — billing "contact sales" link

## Breaking changes

- [ ] This PR contains breaking changes

None — purely additive query param on outbound links, no API/SDK surface touched.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm format:check`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| License/pricing request links carry new `type` param | manual | Confirmed via diff review; `format:check` passes |

**Open gaps**

- Not manually clicked through in a running app — the change is a static string literal with no logic branch.

**Risks**

- none

---

> [!NOTE]
> **AI model used** — `claude-sonnet-5`, reasoning effort `low` (Claude Code).