### PR TITLE
feat(surveys): split the browser-context flag so app surveys capture device meta [ENG-2472]

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/lib/utils.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/lib/utils.test.ts
@@ -222,7 +222,10 @@ describe("utils", () => {
       // assertion is what would fail if someone reintroduced a local `METADATA_FIELDS`.
       expect(RESERVED_COLUMN_ENTRIES.map((entry) => entry.name)).toContain("utmCampaign");
       expect(RESERVED_COLUMN_ENTRIES.map((entry) => entry.name)).toContain("timezone");
-      expect(RESERVED_COLUMN_ENTRIES).toHaveLength(20);
+      // `locale` is the entry that proved it: it was added to the catalog by ENG-2472 and became a
+      // column here with no edit beyond this count.
+      expect(RESERVED_COLUMN_ENTRIES.map((entry) => entry.name)).toContain("locale");
+      expect(RESERVED_COLUMN_ENTRIES).toHaveLength(21);
     });
 
     test("today's six columns are still visible by default, and the new ones are not", () => {

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -3501,6 +3501,7 @@ checksums:
     workspace/surveys/responses/how_to_identify_users: c886035d9d9a0cfc3fa9703972001044
     workspace/surveys/responses/ip_address: 8f2b4d42a165a4c165eca4d7639ce57e
     workspace/surveys/responses/last_name: 2c9a7de7738ca007ba9023c385149c26
+    workspace/surveys/responses/locale: f7085e279c3b4d53e701f3b2dd012767
     workspace/surveys/responses/more_context: bf030156c24007f2a9df863722c6c49e
     workspace/surveys/responses/not_completed: df34eab65a6291f2c5e15a0e349c4eba
     workspace/surveys/responses/os: a4c753bb2c004a58d02faeed6b4da476

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Wie Benutzer identifiziert werden",
         "ip_address": "IP-Adresse",
         "last_name": "Nachname",
+        "locale": "Gerätesprache",
         "more_context": "Mehr Kontext",
         "not_completed": "Nicht abgeschlossen ⏳",
         "os": "Betriebssystem",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "How to identify users",
         "ip_address": "IP Address",
         "last_name": "Last Name",
+        "locale": "Device Locale",
         "more_context": "More context",
         "not_completed": "Not Completed ⏳",
         "os": "OS",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Cómo identificar a los usuarios",
         "ip_address": "Dirección IP",
         "last_name": "Apellido",
+        "locale": "Configuración regional del dispositivo",
         "more_context": "Más contexto",
         "not_completed": "No completado ⏳",
         "os": "Sistema operativo",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Comment identifier les utilisateurs",
         "ip_address": "Adresse IP",
         "last_name": "Nom de famille",
+        "locale": "Paramètres régionaux de l'appareil",
         "more_context": "Plus de contexte",
         "not_completed": "Non terminé ⏳",
         "os": "Système d'exploitation",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Hogyan kell azonosítani a felhasználókat",
         "ip_address": "IP-cím",
         "last_name": "Vezetéknév",
+        "locale": "Eszköz területi beállítása",
         "more_context": "További kontextus",
         "not_completed": "Nincs befejezve ⏳",
         "os": "Operációs rendszer",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "ユーザーを識別する方法",
         "ip_address": "IPアドレス",
         "last_name": "姓",
+        "locale": "デバイスのロケール",
         "more_context": "詳細情報",
         "not_completed": "未完了 ⏳",
         "os": "OS",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Hoe gebruikers te identificeren",
         "ip_address": "IP-adres",
         "last_name": "Achternaam",
+        "locale": "Apparaatlocale",
         "more_context": "Meer context",
         "not_completed": "Niet voltooid ⏳",
         "os": "Besturingssysteem",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Como identificar usuários",
         "ip_address": "Endereço IP",
         "last_name": "Sobrenome",
+        "locale": "Localidade do dispositivo",
         "more_context": "Mais contexto",
         "not_completed": "Não Concluído ⏳",
         "os": "sistema operacional",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Como identificar utilizadores",
         "ip_address": "Endereço IP",
         "last_name": "Apelido",
+        "locale": "Localização do Dispositivo",
         "more_context": "Mais contexto",
         "not_completed": "Não Concluído ⏳",
         "os": "SO",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Cum să identifici utilizatorii",
         "ip_address": "Adresă IP",
         "last_name": "Nume de familie",
+        "locale": "Limbă dispozitiv",
         "more_context": "Mai mult context",
         "not_completed": "Necompletat ⏳",
         "os": "SO",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Как идентифицировать пользователей",
         "ip_address": "IP-адрес",
         "last_name": "Фамилия",
+        "locale": "Язык устройства",
         "more_context": "Больше контекста",
         "not_completed": "Не завершено ⏳",
         "os": "ОС",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Hur man identifierar användare",
         "ip_address": "IP-adress",
         "last_name": "Efternamn",
+        "locale": "Enhetsspråk",
         "more_context": "Mer sammanhang",
         "not_completed": "Inte slutförd ⏳",
         "os": "OS",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "Kullanıcılar nasıl tanımlanır",
         "ip_address": "IP Adresi",
         "last_name": "Soyadı",
+        "locale": "Cihaz Dili",
         "more_context": "Daha fazla bağlam",
         "not_completed": "Tamamlanmadı ⏳",
         "os": "İşletim Sistemi",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "如何 识别 用户",
         "ip_address": "IP地址",
         "last_name": "姓",
+        "locale": "设备区域设置",
         "more_context": "更多上下文",
         "not_completed": "未完成 ⏳",
         "os": "操作系统",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -3628,6 +3628,7 @@
         "how_to_identify_users": "如何識別使用者",
         "ip_address": "IP 位址",
         "last_name": "姓氏",
+        "locale": "裝置語言",
         "more_context": "更多內容",
         "not_completed": "未完成 ⏳",
         "os": "作業系統",

--- a/apps/web/modules/analysis/lib/reserved-field-display.ts
+++ b/apps/web/modules/analysis/lib/reserved-field-display.ts
@@ -6,6 +6,7 @@ import {
   FileTextIcon,
   FlagIcon,
   GlobeIcon,
+  LanguagesIcon,
   type LucideIcon,
   MegaphoneIcon,
   MonitorIcon,
@@ -18,7 +19,7 @@ import { formatFieldNameToTitleCase } from "@formbricks/types/safe-identifier";
 /**
  * The human-readable label for a reserved field (ENG-2540).
  *
- * **Every field either surface displays today has its own key.** All twenty `display !== "none"`
+ * **Every field either surface displays today has its own key.** All twenty-one `display !== "none"`
  * catalog entries are listed below, so `Page Path`, `UTM Source` and `Timezone` are translated in
  * every locale rather than rendered as English derived from the catalog name — which is what the
  * repo's i18n rule asks for, and what shipping them derived would have quietly broken.
@@ -52,9 +53,11 @@ export const getReservedFieldLabel = (name: string, t: TFunction): string => {
       return t("workspace.surveys.responses.source");
     case "url":
       return t("common.url");
-    // The thirteen `secondary` fields. `ipAddress` is the only one with copy older than ENG-1841.
+    // The fourteen `secondary` fields. `ipAddress` is the only one with copy older than ENG-1841.
     case "ipAddress":
       return t("workspace.surveys.responses.ip_address");
+    case "locale":
+      return t("workspace.surveys.responses.locale");
     case "pagePath":
       return t("workspace.surveys.responses.page_path");
     case "pageReferrer":
@@ -94,6 +97,7 @@ export const RESERVED_FIELD_ICONS: Record<string, LucideIcon> = {
   country: FlagIcon,
   deviceType: SmartphoneIcon,
   ipAddress: ShieldIcon,
+  locale: LanguagesIcon,
   os: AirplayIcon,
   pagePath: FileTextIcon,
   pageReferrer: ArrowUpFromDotIcon,

--- a/packages/surveys/src/lib/browser-context.test.ts
+++ b/packages/surveys/src/lib/browser-context.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { createWebSurveyMetaSnapshot, readBrowserContextMeta } from "./browser-context";
+import { createWebSurveyMetaSnapshot, readDeviceContextMeta, readPageContextMeta } from "./browser-context";
 
 /**
  * A real DOM environment, so these exercise the accessors rather than a mock of them. Each test sets
@@ -31,47 +31,54 @@ const setReferrer = (value: string): void => {
   Object.defineProperty(document, "referrer", { value, configurable: true });
 };
 
+const setLanguage = (value: unknown): void => {
+  Object.defineProperty(navigator, "language", { value, configurable: true });
+};
+
 let originalScreen: PropertyDescriptor | undefined;
+let originalLanguage: PropertyDescriptor | undefined;
 let originalIntl: typeof Intl;
 
 beforeEach(() => {
   originalScreen = Object.getOwnPropertyDescriptor(window, "screen");
+  originalLanguage = Object.getOwnPropertyDescriptor(navigator, "language");
   originalIntl = globalThis.Intl;
   setLocation("/pricing");
   setScreen(2560, 1440);
   setDimension("innerWidth", 1280);
   setDimension("innerHeight", 800);
   setReferrer("");
+  setLanguage("en-GB");
 });
 
 afterEach(() => {
   if (originalScreen) Object.defineProperty(window, "screen", originalScreen);
+  // `language` is a prototype getter until a test shadows it, so putting the descriptor back is
+  // not enough — the own property has to go, or the next test inherits this one's value.
+  if (originalLanguage) Object.defineProperty(navigator, "language", originalLanguage);
+  else Reflect.deleteProperty(navigator, "language");
   globalThis.Intl = originalIntl;
   vi.restoreAllMocks();
 });
 
-describe("readBrowserContextMeta", () => {
-  test("reads the page, viewport and screen the survey was displayed in", () => {
-    setLocation("/pricing?plan=team");
+describe("readPageContextMeta", () => {
+  test("reads the page the survey was displayed on", () => {
+    setLocation("/pricing?plan=team&source=cta");
     setReferrer("https://news.example.org/weekly");
 
-    const meta = readBrowserContextMeta();
+    const meta = readPageContextMeta();
 
-    expect(meta.url).toBe(`${ORIGIN}/pricing?plan=team`);
+    // `url` and `source` predate this snapshot and must keep behaving exactly as before.
+    expect(meta.url).toBe(`${ORIGIN}/pricing?plan=team&source=cta`);
+    expect(meta.source).toBe("cta");
     expect(meta.pagePath).toBe("/pricing");
     expect(meta.pageReferrer).toBe("https://news.example.org/weekly");
-    expect(meta.screenWidth).toBe(2560);
-    expect(meta.screenHeight).toBe(1440);
-    expect(meta.viewportWidth).toBe(1280);
-    expect(meta.viewportHeight).toBe(800);
-    // `url` and `source` predate this snapshot and must keep behaving exactly as before.
-    expect(meta.url).toBe(`${ORIGIN}/pricing?plan=team`);
   });
 
   test("parses every utm_* param from the page's own query string", () => {
     setLocation("/p?utm_source=news&utm_medium=email&utm_campaign=august&utm_term=pricing&utm_content=hero");
 
-    expect(readBrowserContextMeta()).toMatchObject({
+    expect(readPageContextMeta()).toMatchObject({
       utmSource: "news",
       utmMedium: "email",
       utmCampaign: "august",
@@ -85,7 +92,7 @@ describe("readBrowserContextMeta", () => {
     // string would show up in exports and filters as a campaign whose name happens to be blank.
     setLocation("/p?utm_source=news&utm_medium=&utm_term=%20");
 
-    const meta = readBrowserContextMeta();
+    const meta = readPageContextMeta();
 
     expect(meta.utmSource).toBe("news");
     expect(meta).not.toHaveProperty("utmMedium");
@@ -97,7 +104,60 @@ describe("readBrowserContextMeta", () => {
   test("omits pageReferrer when the respondent arrived directly", () => {
     setReferrer("");
 
-    expect(readBrowserContextMeta()).not.toHaveProperty("pageReferrer");
+    expect(readPageContextMeta()).not.toHaveProperty("pageReferrer");
+  });
+
+  test("reads no device field, so the two groups can be gated apart", () => {
+    // The split this whole file turns on (ENG-2472): a caller that wants only the page group must
+    // not receive a screen measurement it did not ask for.
+    const meta = readPageContextMeta();
+
+    for (const key of [
+      "screenWidth",
+      "screenHeight",
+      "viewportWidth",
+      "viewportHeight",
+      "timezone",
+      "locale",
+    ]) {
+      expect(meta).not.toHaveProperty(key);
+    }
+  });
+});
+
+describe("readDeviceContextMeta", () => {
+  test("reads the screen and the viewport the survey was rendered into", () => {
+    const meta = readDeviceContextMeta();
+
+    expect(meta.screenWidth).toBe(2560);
+    expect(meta.screenHeight).toBe(1440);
+    expect(meta.viewportWidth).toBe(1280);
+    expect(meta.viewportHeight).toBe(800);
+  });
+
+  test("reads no page field, so the two groups can be gated apart", () => {
+    setLocation("/pricing?utm_source=news&source=cta");
+    setReferrer("https://news.example.org/weekly");
+
+    const meta = readDeviceContextMeta();
+
+    for (const key of ["url", "source", "pagePath", "pageReferrer", "utmSource"]) {
+      expect(meta).not.toHaveProperty(key);
+    }
+  });
+
+  test("reads the device locale, which is not the language the respondent answered in", () => {
+    setLanguage("de-AT");
+
+    expect(readDeviceContextMeta().locale).toBe("de-AT");
+  });
+
+  test("omits the locale when the runtime reports none", () => {
+    // Some embedded engines expose `navigator` without `language`. An absent key reads as "could
+    // not observe", which is the truth; `""` would read as a locale that is blank.
+    setLanguage(undefined);
+
+    expect(readDeviceContextMeta()).not.toHaveProperty("locale");
   });
 
   test("omits the timezone rather than throwing when the runtime has no Intl API", () => {
@@ -106,12 +166,12 @@ describe("readBrowserContextMeta", () => {
     // @ts-expect-error -- deliberately modelling a runtime that does not provide Intl.
     globalThis.Intl = undefined;
 
-    const meta = readBrowserContextMeta();
+    const meta = readDeviceContextMeta();
 
     expect(meta).not.toHaveProperty("timezone");
     // Everything either side of the failed read still made it through.
-    expect(meta.pagePath).toBe("/pricing");
     expect(meta.viewportWidth).toBe(1280);
+    expect(meta.locale).toBe("en-GB");
   });
 
   test("omits the timezone when Intl exists but resolves no zone", () => {
@@ -119,7 +179,7 @@ describe("readBrowserContextMeta", () => {
       resolvedOptions: () => ({}) as Intl.ResolvedDateTimeFormatOptions,
     } as Intl.DateTimeFormat);
 
-    expect(readBrowserContextMeta()).not.toHaveProperty("timezone");
+    expect(readDeviceContextMeta()).not.toHaveProperty("timezone");
   });
 
   test("omits dimensions that are missing, zero or not finite", () => {
@@ -130,19 +190,19 @@ describe("readBrowserContextMeta", () => {
     // @ts-expect-error -- modelling a runtime without `screen`.
     delete window.screen;
 
-    const meta = readBrowserContextMeta();
+    const meta = readDeviceContextMeta();
 
     expect(meta).not.toHaveProperty("viewportWidth");
     expect(meta).not.toHaveProperty("viewportHeight");
     expect(meta).not.toHaveProperty("screenWidth");
     expect(meta).not.toHaveProperty("screenHeight");
-    expect(meta.pagePath).toBe("/pricing");
+    expect(meta.locale).toBe("en-GB");
   });
 
   test("rounds fractional dimensions, which a zoomed browser reports", () => {
     setDimension("innerWidth", 1279.6);
 
-    expect(readBrowserContextMeta().viewportWidth).toBe(1280);
+    expect(readDeviceContextMeta().viewportWidth).toBe(1280);
   });
 });
 
@@ -191,8 +251,43 @@ describe("createWebSurveyMetaSnapshot", () => {
     expect(getMeta().url).toBe(`${ORIGIN}/pricing`);
   });
 
-  test("captures nothing off the web, where there is no runtime to read", () => {
-    // React Native and SSR: `isWebEnvironment` is false and no accessor may run at all.
-    expect(createWebSurveyMetaSnapshot(false)()).toStrictEqual({});
+  test("off the web, keeps the device group and drops every page field", () => {
+    // A mobile SDK's WebView (ENG-2472). It loads its HTML with a null base URL, so `location.href`
+    // is `about:blank` and `document.referrer` is `""` — reporting the renderer's own address as
+    // the page the survey was shown on would look valid and mean nothing. But the same WebView has
+    // a real screen, a real viewport, a real `Intl` zone and a real configured locale, and those
+    // are honest measurements of the device the respondent answered on.
+    setLocation("/pricing?utm_source=news&source=cta");
+    setReferrer("https://news.example.org/weekly");
+
+    const meta = createWebSurveyMetaSnapshot(false)();
+
+    expect(meta).toStrictEqual({
+      screenWidth: 2560,
+      screenHeight: 1440,
+      viewportWidth: 1280,
+      viewportHeight: 800,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      locale: "en-GB",
+    });
+    // Every page-group key, absent — including the two that predate ENG-1841 and were already
+    // absent on mobile for the same reason.
+    for (const key of ["url", "source", "pagePath", "pageReferrer", "utmSource"]) {
+      expect(meta).not.toHaveProperty(key);
+    }
+  });
+
+  test("on the web, keeps both groups", () => {
+    // The other half of the split: the same runtime with the flag true captures everything, so the
+    // test above is the gate working rather than the device reads being unavailable here too.
+    setLocation("/pricing?utm_source=news&source=cta");
+
+    const meta = createWebSurveyMetaSnapshot(true)();
+
+    expect(meta.pagePath).toBe("/pricing");
+    expect(meta.utmSource).toBe("news");
+    expect(meta.source).toBe("cta");
+    expect(meta.viewportWidth).toBe(1280);
+    expect(meta.locale).toBe("en-GB");
   });
 });

--- a/packages/surveys/src/lib/browser-context.ts
+++ b/packages/surveys/src/lib/browser-context.ts
@@ -57,13 +57,13 @@ const UTM_PARAMS = [
 ] as const;
 
 /**
- * Reads the browser-runtime context **once**, at the moment it is called.
+ * The **page** group: everything whose meaning comes from `location` describing a host page the
+ * respondent navigated to. Gated on `isWebEnvironment` — see {@link createWebSurveyMetaSnapshot}.
  *
- * Callers must call this exactly once per survey display and reuse the result — see
- * `createWebSurveyMetaSnapshot`, which is the only intended entry point. Nothing here caches, so
- * calling it twice really does re-measure, which is precisely the bug the snapshot exists to prevent.
+ * Reads the runtime **once**, at the moment it is called. Nothing here caches, so calling it twice
+ * really does re-measure, which is precisely the bug the snapshot exists to prevent.
  */
-export const readBrowserContextMeta = (): TWebSurveyMeta => {
+export const readPageContextMeta = (): TWebSurveyMeta => {
   const searchParams = (() => {
     try {
       return new URL(window.location.href).searchParams;
@@ -86,30 +86,58 @@ export const readBrowserContextMeta = (): TWebSurveyMeta => {
     pagePath: readString(() => window.location.pathname),
     pageReferrer: readString(() => document.referrer),
     ...utm,
+  });
+};
+
+/**
+ * The **device** group: measurements of the machine and of the area the survey was rendered into,
+ * plus how that machine is configured. Read in every runtime, on and off the web — see
+ * {@link createWebSurveyMetaSnapshot} for why the two groups are gated differently.
+ *
+ * Same single-read rule as {@link readPageContextMeta}.
+ */
+export const readDeviceContextMeta = (): TWebSurveyMeta =>
+  compact({
     screenWidth: readDimension(() => window.screen.width),
     screenHeight: readDimension(() => window.screen.height),
     viewportWidth: readDimension(() => window.innerWidth),
     viewportHeight: readDimension(() => window.innerHeight),
     timezone: readString(() => Intl.DateTimeFormat().resolvedOptions().timeZone),
+    // The device's configured locale (`de-AT`), not the language the respondent is *answering* in —
+    // that is `language`, resolved from the survey's own language switch. A German speaker taking an
+    // English-only survey has `locale: "de-DE"` and `language: "en"`, and the pair is the finding.
+    locale: readString(() => navigator.language),
   });
-};
 
 /**
  * **Snapshot at display, then freeze.**
  *
- * Takes one reading of the browser runtime and hands back a getter that returns that same reading
- * for the rest of the survey's life. A respondent who rotates a phone, opens a devtools panel, or
- * resizes the window between question three and submit must not retroactively rewrite the viewport
- * the response was answered at; whatever the first card was rendered into is what the response
- * records.
+ * Takes one reading of the runtime and hands back a getter that returns that same reading for the
+ * rest of the survey's life. A respondent who rotates a phone, opens a devtools panel, or resizes
+ * the window between question three and submit must not retroactively rewrite the viewport the
+ * response was answered at; whatever the first card was rendered into is what the response records.
  *
  * The getter returns the very same object every time, so the freeze is observable by identity as
  * well as by value — see browser-context.test.ts, which mutates `window.innerWidth` between two
  * calls and asserts the second reading is unchanged.
  *
- * Off the web (React Native, SSR) there is no runtime to read and the snapshot is simply empty.
+ * **`isWebEnvironment` gates the page group only, and that is the whole meaning of the flag.** It
+ * asks "does this runtime's `location` describe a host page?", not "is this a browser". A mobile
+ * SDK's WebView answers no — all four load their HTML with a null base URL, so `location.href` is
+ * `about:blank` and `document.referrer` is `""`; reporting the renderer's own address as the page
+ * the survey was shown on would be an answer that looks valid and means nothing. But that same
+ * WebView has a real screen, a real viewport and a real `Intl` zone, so the device group is read
+ * everywhere. That is what gives app surveys the honest half of Tier-1 capture with no SDK release
+ * and no customer app rebuild (ENG-2472) — the renderer is loaded un-pinned from
+ * `{appUrl}/js/surveys.umd.cjs` by every installed app.
+ *
+ * Off the runtime entirely (SSR, a test harness with no `window`) every individual read is guarded
+ * and yields an absent key, so the snapshot degrades to `{}` rather than throwing.
  */
 export const createWebSurveyMetaSnapshot = (isWebEnvironment: boolean): (() => TWebSurveyMeta) => {
-  const snapshot: TWebSurveyMeta = isWebEnvironment ? readBrowserContextMeta() : {};
+  const snapshot: TWebSurveyMeta = {
+    ...(isWebEnvironment ? readPageContextMeta() : {}),
+    ...readDeviceContextMeta(),
+  };
   return () => snapshot;
 };

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -679,6 +679,7 @@ describe("RESERVED_FIELD_CATALOG", () => {
       viewportWidth: 1280,
       viewportHeight: 800,
       timezone: "Europe/Berlin",
+      locale: "de-AT",
     },
   };
 
@@ -823,6 +824,7 @@ describe("RESERVED_FIELD_CATALOG", () => {
         display: "secondary",
       },
       { name: "timezone", dataType: "string", availability: "client", privacy: "keep", display: "secondary" },
+      { name: "locale", dataType: "string", availability: "client", privacy: "keep", display: "secondary" },
     ]);
   });
 
@@ -863,6 +865,7 @@ describe("RESERVED_FIELD_CATALOG", () => {
       viewportWidth: 1280,
       viewportHeight: 800,
       timezone: "Europe/Berlin",
+      locale: "de-AT",
     });
   });
 
@@ -1705,6 +1708,7 @@ describe("listDisplayableReservedFields", () => {
       viewportWidth: 1280,
       viewportHeight: 800,
       timezone: "Europe/Berlin",
+      locale: "de-AT",
     },
   };
 
@@ -1726,7 +1730,7 @@ describe("listDisplayableReservedFields", () => {
     ]);
   });
 
-  test("secondary carries ENG-1841's browser-runtime context, plus ipAddress", () => {
+  test("secondary carries the browser-runtime context, plus ipAddress", () => {
     expect(names("secondary")).toStrictEqual([
       "ipAddress",
       "pagePath",
@@ -1741,6 +1745,7 @@ describe("listDisplayableReservedFields", () => {
       "viewportWidth",
       "viewportHeight",
       "timezone",
+      "locale",
     ]);
   });
 

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -517,6 +517,24 @@ export const RESERVED_FIELD_CATALOG: readonly TReservedFieldCatalogEntry[] = [
     display: "secondary",
     read: (r) => r.meta.timezone,
   },
+  /**
+   * How the respondent's device is configured (`de-AT`), from `navigator.language`. Deliberately a
+   * different field from `language`, which is the language they *answered* in: a German speaker
+   * taking an English-only survey has `locale: "de-DE"` and `language: "en"`, and the gap between
+   * the two is the reason to capture both — it is what "should we translate this survey?" asks.
+   *
+   * `keep`: a UI language preference is a device setting the browser advertises to every site, not
+   * something the respondent disclosed about themselves. Same call as `timezone`, which it sits
+   * beside in every runtime that can report either.
+   */
+  {
+    name: "locale",
+    dataType: "string",
+    availability: "client",
+    privacy: "keep",
+    display: "secondary",
+    read: (r) => r.meta.locale,
+  },
 ];
 
 /**

--- a/packages/types/reserved-field-names.ts
+++ b/packages/types/reserved-field-names.ts
@@ -59,4 +59,5 @@ export const RESERVED_FIELD_NAMES: ReadonlySet<string> = new Set([
   "viewportwidth",
   "viewportheight",
   "timezone",
+  "locale",
 ]);

--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -353,6 +353,12 @@ export const ZAutoCapturedResponseMeta = z.object({
   viewportHeight: z.number().optional(),
   /** IANA zone from `Intl.DateTimeFormat().resolvedOptions().timeZone`, e.g. `Europe/Berlin`. */
   timezone: z.string().optional(),
+  /**
+   * The device's configured locale from `navigator.language`, e.g. `de-AT`. Not validated as a BCP-47
+   * tag: what the runtime reports is the finding, and rejecting an unusual tag would store nothing
+   * rather than something imperfect.
+   */
+  locale: z.string().optional(),
 });
 
 export type TAutoCapturedResponseMeta = z.infer<typeof ZAutoCapturedResponseMeta>;


### PR DESCRIPTION
## What & why

**Was:** a survey rendered by a mobile SDK carried none of the Tier-1 auto-capture — no viewport, no screen, no timezone. **Now:** it carries the half a WebView can honestly report, on the next web deploy, with no SDK release and no customer app rebuild.

`isWebEnvironment` gated the *whole* snapshot, but it conflates two unrelated groups:

| group | reads | honest in a WebView? |
| --- | --- | --- |
| **page** | `location.href`/`.pathname`, `document.referrer`, `utm_*`, `?source=` | **no** — all four SDKs load their HTML with a null base URL, so `location.href` is `about:blank` and `referrer` is `""` |
| **device** | `screen.*`, `window.inner*`, `Intl…timeZone`, `navigator.language` | **yes** — real measurements of the device and of the area the survey was rendered into |

So the flag's real meaning is *"this runtime's `location` describes a host page"*, not *"this is a browser"*. Split the reader in two and gate only the page group. All four SDKs resolve the renderer un-pinned from `{appUrl}/js/surveys.umd.cjs` at display time, so this reaches every already-installed app on the next deploy. `isWebEnvironment` keeps its name, default and meaning as a public `renderSurvey` prop, so shipped SDK versions need no change.

Also adds **`locale`** (`navigator.language`) to Tier-1 — schema key, catalog entry, blocklist name, label + icon — so mobile does not gain a field web lacks. Deliberately distinct from `language`, which is what the respondent *answered in*: a German speaker taking an English-only survey has `locale: "de-DE"` and `language: "en"`, and the gap is the finding. Both client ingest routes whitelist through `pickAutoCapturedResponseMeta`, which is derived from the schema, so neither route changes.

Still absent on mobile, correctly: `url`, `source`, `pagePath`, `pageReferrer`, `utm*`.

**Where to look:** `packages/surveys/src/lib/browser-context.ts` (the split and why the gate sits where it does) · `packages/types/embedded-data-resolver.ts` (the `locale` catalog entry) · `packages/surveys/src/lib/browser-context.test.ts` (the replaced off-web test).

## Linear ticket

https://linear.app/formbricks/issue/ENG-2472/mobile-sdk-parity-for-embedded-data-one-batched-release-per-sdk

## How this was tested

- `@formbricks/surveys` ✅ 28 files / 707 tests · `@formbricks/types` ✅ 8 files / 365 tests · `apps/web` analysis ✅
- `pnpm typecheck` ✅ for `types`, `surveys` and 24 of 25 tasks. `@formbricks/web#typecheck` fails on 8 files, all `Cannot find module '@formbricks/jobs'` — **verified identical on the unmodified base branch** (stashed the diff, same 8 files, 30 errors), so pre-existing and untouched by this PR.
- `pnpm lint` ✅ 0 errors for `types` and `surveys` (4 + 1 pre-existing warnings in files this PR does not touch) · prettier ✅ · `pnpm i18n` ✅ all locales complete.
- **Viewport derivation checked in headless Chromium** against the real SDK template — see the fold. This was the one thing that could have been wrong *and* plausible.

<details><summary>Tests added, and the viewport check</summary>

The old test `browser-context.test.ts:193` ("captures nothing off the web") encoded the decision this PR reverses, so it is replaced by its two successors: off-web keeps the device group and drops *every* page key; on-web keeps both — the second one is what proves the first is the gate working rather than the device reads being unavailable in that runtime too. The reader tests are regrouped into `readPageContextMeta` / `readDeviceContextMeta` describes, each with a "reads no field from the other group" assertion, and `locale` gets a read case and an omit case.

`readBrowserContextMeta` is deleted rather than kept: after the split nothing in production called it, and an export that exists only to be tested is dead code.

The anti-drift test in `embedded-data-resolver.test.ts` already fails if the catalog and `RESERVED_FIELD_NAMES` disagree about `locale`, so that pairing is enforced rather than reviewed.

**Viewport check.** All four SDK templates use `<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0">` with **no `width=device-width`**. If an engine fell back to a ~980px layout viewport, `viewportWidth` would be wrong and look completely plausible. Loaded that exact document in headless Chromium (Blink — the same engine as Android System WebView) under mobile emulation:

```
Pixel 5 (Blink, mobile)      innerWidth=393   screen=393x851 dpr=2.75   OK
Galaxy S9+ (Blink, mobile)   innerWidth=320   screen=320x658 dpr=4.5    OK
Pixel 7 landscape            innerWidth=863   screen=915x412 dpr=2.625  OK
```

Blink derives the layout viewport from `initial-scale` when `width` is absent, as specified. **iOS WKWebView still needs a device check** — listed under Risks below. Not pre-emptively adding `width=device-width`: if an engine were falling back today the survey would already render wrong, so the likely case is a no-op and the unlikely case is an unverifiable rendering change across four SDKs.
</details>

## Breaking changes

None. Additive: one optional `meta` key, one catalog entry, and a flag whose name, type and default are unchanged. Responses collected before this carry none of the new keys and keep validating — every key is optional and there is nothing to backfill, since the values only ever existed in a browser that has long since closed.

The one behaviour shift is intended and is the point of the PR: app-survey responses that previously carried no client-captured meta now carry `screenWidth/Height`, `viewportWidth/Height`, `timezone` and `locale`. Nothing that read those fields before stops working; a reader that assumed they were web-only now sees them populated on app responses too.

## QA / Test Plan

**How to test**

- [ ] Web link survey → submit → response card shows Page Path, UTM fields (if the link carried them), Screen/Viewport, Timezone and the new **Device Locale**. Nothing regressed from before.
- [ ] Web app survey on a host page → submit → same fields, describing the host page.
- [ ] **App survey on iOS / Android / RN / Flutter** → submit → the response card now shows Screen, Viewport, Timezone and Device Locale, and shows **no** Page Path, Page Referrer, UTM or Source. This is the change.
- [ ] Cross-check the mobile viewport against the device: `viewportWidth` should be the device's CSS-pixel width (e.g. 393 on a Pixel 5, 390 on an iPhone 14), **not** ~980. A value near 980 on one platform means that SDK's `<meta name="viewport">` needs `width=device-width` — a one-line fix in that SDK alone.
- [ ] Change the device's system language, retake an app survey → **Device Locale** reflects the new setting while **Language** still reflects the survey language answered in.
- [ ] Rotate the phone mid-survey, then submit → viewport is the one from when the survey appeared, not the rotated one (freeze-at-display still holds).
- [ ] Try to declare an Embedded Data field named `locale` in a survey → refused as a reserved name. A survey that already declares one keeps working and keeps winning inside that survey.

**Preconditions / test data**

- A workspace with an app survey, and at least one of the four mobile SDKs pointed at the deployed instance. Response card / response table are the readout.
- **After deploying, purge the CDN for `/js/surveys.umd.cjs`.** It is served `max-age=3600, s-maxage=2592000, stale-while-revalidate=3600` (`next.config.mjs`), so a cold edge can serve the old bundle and the mobile check would silently measure the previous renderer. Verify on device *after* the purge.

**Risks & regressions**

- **iOS WKWebView viewport is the one unverified item** (Blink is verified above). Wrong here would be wrong and plausible; check it on a real device as the first QA step.
- `screen.width` is orientation-invariant on iOS WKWebView and rotates on Android — a pre-existing web inconsistency that now shows up on mobile responses too. Worth a line in the docs (ENG-1849), not a fix.
- Anything reading `meta` on app responses now sees more keys than before. Every consumer goes through the catalog, and `pickAutoCapturedResponseMeta` bounds what ingest accepts, so an unexpected key cannot reach the database.

**Migrations / env / cutover**

- No DB migration, no env var. One cutover step: the CDN purge above.


---
_Generated by [Claude Code](https://claude.ai/code/session_018L6PrECN38Jbe1FEdFccTz)_