### PR TITLE
docs(surveys): note that spam protection is unavailable on EU Cloud

### DIFF
--- a/docs/surveys/general-features/spam-protection.mdx
+++ b/docs/surveys/general-features/spam-protection.mdx
@@ -13,6 +13,12 @@ Spam protection feature protects your Formbricks instance from spam and automate
   Edition](/self-hosting/advanced/license).
 </Note>
 
+<Warning>
+  **Not available on Formbricks EU Cloud.** Spam protection is built on Google reCAPTCHA, which we do not
+  run in the EU region for compliance reasons. The setting is unavailable there — everywhere else it works
+  as described below.
+</Warning>
+
 <Note>
   Spam protection does <strong>not</strong> work for surveys displayed with the Mobile SDKs(React Native, iOS,
   or Android SDKs). Enabling this setting in the Survey Editor will break the survey in those environments.


### PR DESCRIPTION
## What & why

**Was:** the Spam Protection page carried two availability caveats — paid feature, and broken under the mobile SDKs — but not the region one.

**Now:** a third, above them: it is unavailable on **Formbricks EU Cloud**, because it is built on Google reCAPTCHA, which we do not run in the EU region for compliance reasons.

Without it, a reader on EU Cloud follows the whole page — generate keys, set the threshold, save — and then finds the setting is not there. The note sits with the other availability caveats at the top, before any of the steps, rather than being discovered at the end.

`<Warning>` rather than `<Note>` deliberately: the other two are conditions, this one is a dead end for a whole region.

## Where to look

- `docs/surveys/general-features/spam-protection.mdx` — one block, above the mobile-SDK note.

## Breaking changes

- [ ] This PR contains breaking changes

None. One documentation note. No code changes.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The note lands before the setup steps | manual | Directly under the paid-feature note, above Key Generation |
| It does not contradict the rest of the page | manual | The page documents `RECAPTCHA_SITE_KEY` / `RECAPTCHA_SECRET_KEY` for self-hosters, which is unaffected — the note is scoped to EU Cloud, not to self-hosted EU deployments |

**Open gaps**

- **The claim is product knowledge, not something I could verify in the codebase.** Spam protection gates on `IS_RECAPTCHA_CONFIGURED` (`apps/web/lib/constants.ts`), which is just whether the two env vars are set — there is no region flag in the code, so the EU Cloud restriction is an operational fact I have taken as given from @jobenjada. Worth a second pair of eyes on the wording of *why*.
- Self-hosted instances in the EU are not addressed. They set their own reCAPTCHA keys, so the restriction presumably does not apply — but the note deliberately says "EU Cloud" rather than "the EU" to avoid implying otherwise. Say the word if self-hosters need their own line.

**Risks**

- Nothing here executes.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed by the tool in this environment).
