### PR TITLE
fix(charts): stop NPS reading 0 on empty days and summing on a big number

### DIFF
--- a/apps/web/modules/ee/analysis/api/lib/cube-client.test.ts
+++ b/apps/web/modules/ee/analysis/api/lib/cube-client.test.ts
@@ -166,7 +166,7 @@ describe("executeTenantScopedQuery", () => {
     expect(result).toEqual(rows);
   });
 
-  test("keeps a synthesized empty date bucket at 0 but preserves a real null in the same result", async () => {
+  test("leaves a ratio measure null in a synthesized empty date bucket, alongside a real null", async () => {
     const DAY = "FeedbackRecords.collectedAt.day";
     // The pivot invents 2026-01-03 to fill the gap; 2026-01-02 is a day Cube returned, where the
     // measure is genuinely NULL (responses that day, none of them answering this question).
@@ -192,8 +192,40 @@ describe("executeTenantScopedQuery", () => {
       { [DAY]: "2026-01-01", "FeedbackRecords.npsScore": "72.92" },
       // real bucket, nothing to compute → no data
       { [DAY]: "2026-01-02", "FeedbackRecords.npsScore": null },
-      // bucket the pivot invented → a measured zero
-      { [DAY]: "2026-01-03", "FeedbackRecords.npsScore": 0 },
+      // Invented bucket: nobody answered, so there is no NPS to report. A 0 here is a real score
+      // (as many detractors as promoters) and would pull the line down to the baseline.
+      { [DAY]: "2026-01-03", "FeedbackRecords.npsScore": null },
+    ]);
+  });
+
+  test("splits an invented bucket by measure: the count is 0, the ratio beside it stays null", async () => {
+    const DAY = "FeedbackRecords.collectedAt.day";
+    mockTablePivot.mockImplementation((pivotConfig?: { fillMissingDates?: boolean }) => {
+      const real = [{ [DAY]: "2026-01-01", "FeedbackRecords.count": 12, "FeedbackRecords.npsScore": "50" }];
+      if (pivotConfig?.fillMissingDates === false) return real;
+      return [
+        ...real,
+        {
+          [DAY]: "2026-01-02",
+          "FeedbackRecords.count": "__formbricks_null__",
+          "FeedbackRecords.npsScore": "__formbricks_null__",
+        },
+      ];
+    });
+
+    const { executeTenantScopedQuery } = await import("./cube-client");
+    const result = await executeTenantScopedQuery({
+      ...scopedInput,
+      query: {
+        measures: ["FeedbackRecords.count", "FeedbackRecords.npsScore"],
+        timeDimensions: [{ dimension: "FeedbackRecords.collectedAt", granularity: "day" }],
+      },
+    });
+
+    // One empty day, two answers: it genuinely collected zero responses, and it has no NPS at all.
+    expect(result).toEqual([
+      { [DAY]: "2026-01-01", "FeedbackRecords.count": 12, "FeedbackRecords.npsScore": "50" },
+      { [DAY]: "2026-01-02", "FeedbackRecords.count": 0, "FeedbackRecords.npsScore": null },
     ]);
   });
 

--- a/apps/web/modules/ee/analysis/api/lib/cube-client.ts
+++ b/apps/web/modules/ee/analysis/api/lib/cube-client.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import { logger } from "@formbricks/logger";
 import type { TChartQuery } from "@formbricks/types/analysis";
 import { expandPresetDateRanges } from "@/modules/ee/analysis/lib/date-presets";
+import { isRatioMeasure } from "@/modules/ee/analysis/lib/schema-definition";
 import type { TChartDataRow } from "@/modules/ee/analysis/types/analysis";
 import { queueAuditEventWithoutRequest } from "@/modules/ee/audit-logs/lib/handler";
 import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
@@ -82,8 +83,8 @@ const restoreNullMeasures = (
   rows: TChartDataRow[],
   measureKeys: string[],
   /**
-   * Rows this rejects were invented by the pivot to fill an empty date bucket, so their filled cells
-   * are a measured zero rather than a NULL. Defaults to treating every row as real.
+   * Rows this rejects were invented by the pivot to fill an empty date bucket, so their filled
+   * count cells are a measured zero rather than a NULL. Defaults to treating every row as real.
    */
   isRealRow: (row: TChartDataRow) => boolean = () => true
 ): TChartDataRow[] => {
@@ -97,9 +98,15 @@ const restoreNullMeasures = (
     const filled = Object.keys(row).filter((key) => row[key] === NULL_FILL_SENTINEL && measures.has(key));
     if (filled.length === 0) return row;
 
-    const replacement = isRealRow(row) ? null : 0;
+    const rowIsReal = isRealRow(row);
     const restored = { ...row };
-    for (const key of filled) restored[key] = replacement;
+    for (const key of filled) {
+      // An invented bucket counted zero of everything, but it has no ratio: there is no NPS for a
+      // day nobody answered, and zeroing it plots a real score of 0 (equal promoters and
+      // detractors) on every empty day, dragging the line to the baseline between the days that
+      // do have answers. Ratios stay null there so the line breaks instead.
+      restored[key] = rowIsReal || isRatioMeasure(key) ? null : 0;
+    }
     return restored;
   });
 };

--- a/apps/web/modules/ee/analysis/charts/components/advanced-chart-builder.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/advanced-chart-builder.tsx
@@ -8,6 +8,7 @@ import { FiltersPanel } from "@/modules/ee/analysis/charts/components/filters-pa
 import { MeasuresPanel } from "@/modules/ee/analysis/charts/components/measures-panel";
 import { TimeDimensionPanel } from "@/modules/ee/analysis/charts/components/time-dimension-panel";
 import { useChartQuery } from "@/modules/ee/analysis/charts/hooks/use-chart-query";
+import { prepareQueryForChartType } from "@/modules/ee/analysis/charts/lib/big-number";
 import {
   type ChartBuilderState,
   type FilterRow,
@@ -80,8 +81,10 @@ const chartBuilderReducer = (state: ChartBuilderState, action: Action): ChartBui
   }
 };
 
-const toComparableQueryJson = (query: TChartQuery): string =>
-  JSON.stringify(buildCubeQuery({ ...initialState, ...parseQueryToState(query) }));
+const toComparableQueryJson = (query: TChartQuery, chartType: TChartType): string =>
+  JSON.stringify(
+    prepareQueryForChartType(buildCubeQuery({ ...initialState, ...parseQueryToState(query) }), chartType)
+  );
 
 export function AdvancedChartBuilder({
   workspaceId,
@@ -117,13 +120,19 @@ export function AdvancedChartBuilder({
   const timeDimensionOpen = state.timeDimension != null;
   const filtersOpen = state.filters.length > 0;
 
-  const currentQuery = useMemo(() => buildCubeQuery(state), [state]);
+  // The executed query depends on the chart type as well as the form: a big number has nowhere to
+  // put groups, so its query drops them (see prepareQueryForChartType). Switching the chart type
+  // therefore changes the query and re-runs it, rather than re-rendering stale grouped rows.
+  const currentQuery = useMemo(
+    () => prepareQueryForChartType(buildCubeQuery(state), chartType),
+    [state, chartType]
+  );
   const currentQueryJson = JSON.stringify(currentQuery);
 
   // The last query that was executed (or arrived pre-executed via initialQuery, e.g. from the
   // AI section or a saved chart). Auto-run only fires when the form drifts away from it.
   const lastRunQueryJsonRef = useRef<string | null>(
-    initialQuery ? toComparableQueryJson(initialQuery) : null
+    initialQuery ? toComparableQueryJson(initialQuery, chartType) : null
   );
 
   const appliedInitialQueryRef = useRef<TChartQuery | null>(null);
@@ -132,10 +141,14 @@ export function AdvancedChartBuilder({
     if (appliedInitialQueryRef.current === initialQuery) return;
     appliedInitialQueryRef.current = initialQuery;
     const parsed = parseQueryToState(initialQuery);
-    lastRunQueryJsonRef.current = JSON.stringify(buildCubeQuery({ ...initialState, ...parsed }));
+    lastRunQueryJsonRef.current = JSON.stringify(
+      prepareQueryForChartType(buildCubeQuery({ ...initialState, ...parsed }), chartType)
+    );
     dispatch({ type: ACTION.INIT_FROM_QUERY, payload: parsed });
     setDimensionsOpen((parsed.selectedDimensions?.length ?? 0) > 0);
-  }, [initialQuery]);
+    // chartType only feeds the baseline above; a later switch is caught by the guard and left to
+    // drift detection, which is what re-runs the query for the new type.
+  }, [initialQuery, chartType]);
 
   // Incomplete configs (no measure yet, half-filled filter row) are skipped silently instead of
   // surfacing validation toasts on every keystroke; the preview keeps its last valid state.

--- a/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/cn";
 import { BreakdownBars } from "@/modules/ee/analysis/charts/components/breakdown-bars";
 import { CartesianChart } from "@/modules/ee/analysis/charts/components/cartesian-chart";
 import { PolishedChartTooltip } from "@/modules/ee/analysis/charts/components/polished-tooltip";
+import { computeBigNumberValue } from "@/modules/ee/analysis/charts/lib/big-number";
 import { resolveChartDisplay } from "@/modules/ee/analysis/charts/lib/chart-display";
 import {
   CHART_BRAND_DARK,
@@ -545,18 +546,13 @@ export function ChartRenderer({
       );
     case "big_number": {
       // A measure with nothing to compute comes back as NULL (see restoreNullMeasures in
-      // cube-client, which maps the pivot's sentinel back to null). Summing it as 0 would print a
-      // confident "0" for "never asked", so count the numeric rows and fall back to a no-data glyph.
-      const numericValues = data
-        .map((row) => row[dataKey])
-        .filter((value) => value !== null && value !== undefined && value !== "")
-        .map(Number)
-        .filter((value) => Number.isFinite(value));
-      const hasValue = numericValues.length > 0;
-      const total = numericValues.reduce((sum, value) => sum + value, 0);
+      // cube-client, which maps the pivot's sentinel back to null). Printing it as 0 would be a
+      // confident "0" for "never asked", so fall back to a no-data glyph instead.
+      const value = computeBigNumberValue(data, dataKey);
+      const hasValue = value !== null;
       // formatCellValue caps at two fraction digits, so a big number and a bar label now agree on
       // precision instead of showing 4.705 next to 4.7.
-      const formatted = hasValue ? formatCellValue(total) : NO_DATA_PLACEHOLDER;
+      const formatted = hasValue ? formatCellValue(value) : NO_DATA_PLACEHOLDER;
       return (
         <div className="flex h-full items-center justify-center p-4">
           <div className="text-center">

--- a/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
+++ b/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
@@ -13,6 +13,7 @@ import {
   getChartAction,
   updateChartAction,
 } from "@/modules/ee/analysis/charts/actions";
+import { prepareQueryForChartType } from "@/modules/ee/analysis/charts/lib/big-number";
 import { sanitizeChartDisplay } from "@/modules/ee/analysis/charts/lib/chart-display";
 import { resolveChartType } from "@/modules/ee/analysis/charts/lib/chart-utils";
 import { addChartToDashboardAction, getDashboardsAction } from "@/modules/ee/analysis/dashboards/actions";
@@ -127,9 +128,12 @@ export function useChartDialog({
         setChartConfig(chart.config ?? {});
         setSelectedDirectoryId(chart.feedbackDirectoryId);
 
+        // Charts saved before a big number's query stopped carrying groups can still hold a
+        // granularity or a dimension; normalize on read so the value shown is the measure over the
+        // whole range, not a fold of per-group values.
         const queryResult = await executeQueryAction({
           workspaceId,
-          query: chart.query,
+          query: prepareQueryForChartType(chart.query, resolveChartType(chart.type)),
           feedbackDirectoryId: chart.feedbackDirectoryId,
         });
         if (cancelled) return;

--- a/apps/web/modules/ee/analysis/charts/lib/ai-chart-query.server.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/ai-chart-query.server.ts
@@ -11,6 +11,7 @@ import {
 } from "@/modules/ee/analysis/lib/schema-definition";
 import { type TChartType, ZChartType } from "@/modules/ee/analysis/types/analysis";
 import { getAIChartPromptError } from "./ai-chart-errors.server";
+import { prepareQueryForChartType } from "./big-number";
 
 const CUBE_NAME = "FeedbackRecords";
 const DEFAULT_MEASURE = `${CUBE_NAME}.count`;
@@ -173,7 +174,12 @@ const normalizeChartQuery = (output: AIQueryResponse): AIChartQueryResult => {
     }));
   }
 
-  const result: AIChartQueryResult = { chartType: output.chartType, query };
+  // A big number has no axis for a grouping, so the model asking for one (a granularity, a
+  // dimension) is dropped rather than folded into the single value it renders.
+  const result: AIChartQueryResult = {
+    chartType: output.chartType,
+    query: prepareQueryForChartType(query, output.chartType),
+  };
 
   const name = output.name?.trim();
   if (name) {

--- a/apps/web/modules/ee/analysis/charts/lib/ai-chart-query.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/ai-chart-query.test.ts
@@ -91,6 +91,42 @@ describe("generateAIChartQuery", () => {
     });
   });
 
+  test("strips a grouping the model put on a big number, which has no axis for it", async () => {
+    mocks.generateOrganizationAIObject.mockResolvedValueOnce({
+      object: {
+        name: null,
+        measures: ["FeedbackRecords.npsScore"],
+        dimensions: ["FeedbackRecords.sourceName"],
+        timeDimensions: [
+          {
+            dimension: "FeedbackRecords.collectedAt",
+            granularity: "day",
+            dateRange: "last 30 days",
+          },
+        ],
+        chartType: "big_number",
+        filters: null,
+      },
+    });
+
+    const result = await generateAIChartQuery({
+      organizationId: "organization-1",
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      prompt: "NPS score for the last 30 days as a big number",
+    });
+
+    // The date range survives as a filter; the grouping it was paired with does not, because the
+    // single value cannot be recovered from per-day NPS readings.
+    expect(result).toEqual({
+      chartType: "big_number",
+      query: {
+        measures: ["FeedbackRecords.npsScore"],
+        timeDimensions: [{ dimension: "FeedbackRecords.collectedAt", dateRange: "last 30 days" }],
+      },
+    });
+  });
+
   test("falls back to the total count measure when the AI returns no measures", async () => {
     mocks.generateOrganizationAIObject.mockResolvedValueOnce({
       object: {

--- a/apps/web/modules/ee/analysis/charts/lib/big-number.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/big-number.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import type { TChartQuery } from "@formbricks/types/analysis";
+import {
+  computeBigNumberValue,
+  prepareQueryForChartType,
+  toSingleValueQuery,
+} from "@/modules/ee/analysis/charts/lib/big-number";
+
+describe("toSingleValueQuery", () => {
+  test("drops the time granularity but keeps the date range, which is a filter", () => {
+    const query: TChartQuery = {
+      measures: ["FeedbackRecords.npsScore"],
+      timeDimensions: [
+        {
+          dimension: "FeedbackRecords.collectedAt",
+          granularity: "day",
+          dateRange: "last 30 days",
+        },
+      ],
+    };
+
+    expect(toSingleValueQuery(query)).toEqual({
+      measures: ["FeedbackRecords.npsScore"],
+      timeDimensions: [{ dimension: "FeedbackRecords.collectedAt", dateRange: "last 30 days" }],
+    });
+  });
+
+  test("drops dimensions and order, and keeps filters", () => {
+    const query: TChartQuery = {
+      measures: ["FeedbackRecords.count"],
+      dimensions: ["FeedbackRecords.sourceName"],
+      order: [["FeedbackRecords.sourceName", "asc"]],
+      filters: [{ member: "FeedbackRecords.fieldType", operator: "equals", values: ["nps"] }],
+    };
+
+    expect(toSingleValueQuery(query)).toEqual({
+      measures: ["FeedbackRecords.count"],
+      filters: [{ member: "FeedbackRecords.fieldType", operator: "equals", values: ["nps"] }],
+    });
+  });
+
+  test("leaves a query that already returns one row untouched", () => {
+    const query: TChartQuery = { measures: ["FeedbackRecords.npsScore"] };
+    expect(toSingleValueQuery(query)).toEqual(query);
+  });
+});
+
+describe("prepareQueryForChartType", () => {
+  const grouped: TChartQuery = {
+    measures: ["FeedbackRecords.npsScore"],
+    timeDimensions: [{ dimension: "FeedbackRecords.collectedAt", granularity: "day" }],
+  };
+
+  test("normalizes a big number", () => {
+    expect(prepareQueryForChartType(grouped, "big_number")).toEqual({
+      measures: ["FeedbackRecords.npsScore"],
+      timeDimensions: [{ dimension: "FeedbackRecords.collectedAt" }],
+    });
+  });
+
+  test.each(["line", "area", "bar", "pie"] as const)("leaves a %s chart grouped", (chartType) => {
+    expect(prepareQueryForChartType(grouped, chartType)).toBe(grouped);
+  });
+});
+
+describe("computeBigNumberValue", () => {
+  test("reads the value off the single row a normalized query returns", () => {
+    expect(computeBigNumberValue([{ "FeedbackRecords.npsScore": "51.85" }], "FeedbackRecords.npsScore")).toBe(
+      51.85
+    );
+  });
+
+  test("refuses to fold a ratio spread over several rows", () => {
+    // A chart saved before the query was normalized can still arrive grouped. Adding these gave
+    // 1350 for a period whose real NPS was 51.85, so the caller shows a no-data glyph instead.
+    const rows = [
+      { "FeedbackRecords.npsScore": "100.00" },
+      { "FeedbackRecords.npsScore": "-100.00" },
+      { "FeedbackRecords.npsScore": "100.00" },
+    ];
+    expect(computeBigNumberValue(rows, "FeedbackRecords.npsScore")).toBeNull();
+  });
+
+  test("adds up a count across rows, which is additive", () => {
+    const rows = [{ "FeedbackRecords.count": "3" }, { "FeedbackRecords.count": "2" }];
+    expect(computeBigNumberValue(rows, "FeedbackRecords.count")).toBe(5);
+  });
+
+  test("returns null when the measure had nothing to compute", () => {
+    expect(
+      computeBigNumberValue([{ "FeedbackRecords.npsScore": null }], "FeedbackRecords.npsScore")
+    ).toBeNull();
+    expect(computeBigNumberValue([], "FeedbackRecords.npsScore")).toBeNull();
+  });
+
+  test("keeps a real zero, which is a score and not a missing value", () => {
+    expect(computeBigNumberValue([{ "FeedbackRecords.npsScore": "0.00" }], "FeedbackRecords.npsScore")).toBe(
+      0
+    );
+  });
+
+  test("skips non-numeric cells rather than counting them as zero", () => {
+    const rows = [
+      { "FeedbackRecords.count": "4" },
+      { "FeedbackRecords.count": "n/a" },
+      { "FeedbackRecords.count": "" },
+    ];
+    expect(computeBigNumberValue(rows, "FeedbackRecords.count")).toBe(4);
+  });
+});

--- a/apps/web/modules/ee/analysis/charts/lib/big-number.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/big-number.ts
@@ -1,0 +1,50 @@
+import type { TChartQuery } from "@formbricks/types/analysis";
+import { isRatioMeasure } from "@/modules/ee/analysis/lib/schema-definition";
+import type { TChartDataRow, TChartType } from "@/modules/ee/analysis/types/analysis";
+
+/**
+ * A big number renders one value and has no axis to put groups on, but the builder's grouping
+ * panels stay live when the chart type is switched — so a big number can carry a time granularity
+ * or a dimension it cannot show, and the renderer is left with N rows to fold into one.
+ *
+ * There is no fold that works: adding the per-group values of a ratio is meaningless (a week of
+ * daily NPS readings of 100 and -100 summed to 1350 where the period's real NPS was 51.85), and
+ * averaging them is wrong too, since each day carries a different number of responses. Even a count
+ * cannot always be added — the same person answering on two days is one unique respondent, not two.
+ *
+ * So the grouping is dropped from the query instead and Cube recomputes each measure over the whole
+ * range, which is right for every measure type. The date range stays: it is a filter, not a
+ * grouping. `order` goes with the grouping, since it may name a member that is no longer selected
+ * and there is only one row left to order.
+ */
+export const toSingleValueQuery = (query: TChartQuery): TChartQuery => {
+  const { dimensions: _dimensions, order: _order, ...rest } = query;
+  const timeDimensions = query.timeDimensions?.map(({ granularity: _granularity, ...timeDim }) => timeDim);
+  return timeDimensions ? { ...rest, timeDimensions } : rest;
+};
+
+/** Apply the query normalization a chart type needs. Only big numbers need one today. */
+export const prepareQueryForChartType = (query: TChartQuery, chartType: TChartType): TChartQuery =>
+  chartType === "big_number" ? toSingleValueQuery(query) : query;
+
+const toFiniteNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined || value === "") return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+/**
+ * The single value a big number shows, or null when there is none to show (the caller renders a
+ * no-data glyph rather than a confident number).
+ *
+ * With {@link toSingleValueQuery} applied there is exactly one row, so this is that row's value. It
+ * still folds several rows for an additive measure, but refuses to for a ratio: charts saved before
+ * the normalization existed can still arrive grouped, and a summed NPS is worse than no number.
+ */
+export const computeBigNumberValue = (rows: TChartDataRow[], measureKey: string): number | null => {
+  const values = rows.map((row) => toFiniteNumber(row[measureKey])).filter((v): v is number => v !== null);
+  if (values.length === 0) return null;
+  if (values.length === 1) return values[0];
+  if (isRatioMeasure(measureKey)) return null;
+  return values.reduce((sum, value) => sum + value, 0);
+};

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
@@ -7,6 +7,8 @@ import { getAISmartToolsUnavailableReason, getOrganizationAIConfig } from "@/lib
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { executeTenantScopedQuery } from "@/modules/ee/analysis/api/lib/cube-client";
+import { prepareQueryForChartType } from "@/modules/ee/analysis/charts/lib/big-number";
+import { resolveChartType } from "@/modules/ee/analysis/charts/lib/chart-utils";
 import { resolveOptionGrouping } from "@/modules/ee/analysis/charts/lib/option-grouping";
 import { AnalysisPageLayout } from "@/modules/ee/analysis/components/analysis-page-layout";
 import { checkFeedbackDirectoryAccess } from "@/modules/ee/analysis/lib/access";
@@ -149,7 +151,12 @@ export async function DashboardDetailPage({
     widgetDataPromises.set(
       widget.id,
       executeWidgetQuery(
-        applyDashboardDateFilter(widget.chart.query, dateFilter),
+        // A big number's query is normalized here too, not only in the builder: widgets saved
+        // before that existed still carry a grouping the single value cannot come from.
+        prepareQueryForChartType(
+          applyDashboardDateFilter(widget.chart.query, dateFilter),
+          resolveChartType(widget.chart.type)
+        ),
         widget.chart.feedbackDirectoryId,
         workspaceId,
         organization.id,

--- a/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
@@ -19,6 +19,7 @@ import {
   getTranslatedFieldLabel,
   isEnrichmentDimensionId,
   isNotEnrichedDimensionValue,
+  isRatioMeasure,
   isSelectableValueDimension,
   sortMeasureIdsForCategoryAxis,
   sortRowsByEnumDimension,
@@ -142,6 +143,23 @@ describe("schema-definition", () => {
       expect(getMeasureById("FeedbackRecords.promoterCount")?.group).toBe("count");
       expect(getMeasureById("FeedbackRecords.npsAverage")?.group).toBe("average");
       expect(getMeasureById("FeedbackRecords.npsScore")?.group).toBe("score");
+    });
+
+    test("classifies scores and averages as ratios, and counts as additive", () => {
+      // Drives two decisions that must not diverge: whether an empty bucket means 0 or "no value",
+      // and whether per-group values may be folded into one.
+      expect(isRatioMeasure("FeedbackRecords.npsScore")).toBe(true);
+      expect(isRatioMeasure("FeedbackRecords.csatScore")).toBe(true);
+      expect(isRatioMeasure("FeedbackRecords.npsAverage")).toBe(true);
+      expect(isRatioMeasure("FeedbackRecords.sentimentAverage")).toBe(true);
+
+      expect(isRatioMeasure("FeedbackRecords.count")).toBe(false);
+      expect(isRatioMeasure("FeedbackRecords.promoterCount")).toBe(false);
+      expect(isRatioMeasure("FeedbackRecords.uniqueRespondents")).toBe(false);
+
+      // Not a measure, and not in the schema at all: both keep the additive default.
+      expect(isRatioMeasure("FeedbackRecords.sourceName")).toBe(false);
+      expect(isRatioMeasure("FeedbackRecords.notAMeasure")).toBe(false);
     });
 
     test("only exposes members present in the deployed Cube schema", () => {

--- a/apps/web/modules/ee/analysis/lib/schema-definition.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.ts
@@ -396,6 +396,19 @@ export const FEEDBACK_MEASURE_IDS: string[] = FEEDBACK_FIELDS.measures.map((m) =
 export const getMeasureAxisMaxCandidates = (measureId: string): readonly number[] | undefined =>
   FEEDBACK_FIELDS.measures.find((m) => m.id === measureId)?.axisMaxCandidates;
 
+/**
+ * True for a measure computed *over* the responses in a group — a score or an average — rather
+ * than by counting them. The distinction decides what an empty group means: a count genuinely
+ * counted zero there, while a ratio has nothing to divide, so it has no value at all. It also
+ * decides whether per-group values can be folded into one, since ratios cannot be added.
+ *
+ * False for anything not in the schema, so an unrecognized column keeps the additive treatment.
+ */
+export const isRatioMeasure = (measureId: string): boolean => {
+  const group = FEEDBACK_FIELDS.measures.find((m) => m.id === measureId)?.group;
+  return group === "score" || group === "average";
+};
+
 export const FEEDBACK_DIMENSION_IDS: string[] = FEEDBACK_FIELDS.dimensions.map((d) => d.id);
 
 export const FEEDBACK_TIME_DIMENSION_IDS: string[] = FEEDBACK_FIELDS.dimensions


### PR DESCRIPTION
No Linear ticket: found while investigating a report that "the NPS score looks broken" in the chart builder.

## What & why

**Was:** an NPS chart read 0 on every day nobody answered, and a Big Number on NPS added the per-day scores together — 1350 for a period whose real NPS was 51.85.

**Now:** a day with no answers leaves a gap in the line, and a Big Number asks Cube for the measure over the whole range instead of folding rows.

- Both come from treating a ratio (NPS/CSAT score, every average) like a count. A count of nothing is 0 and counts can be added; a ratio over nothing has no value and ratios cannot.
- A Big Number's query now drops the grouping the chart cannot render. The date range stays — it is a filter, not a grouping.
- Saved charts and dashboard widgets are normalized on read, so ones stored before this still show the right number.

## Where to look

- [cube-client.ts:108](apps/web/modules/ee/analysis/api/lib/cube-client.ts#L108) — empty bucket: 0 for a count, null for a ratio
- [big-number.ts:20](apps/web/modules/ee/analysis/charts/lib/big-number.ts#L20) — what a big number's query drops, and what it keeps
- [advanced-chart-builder.tsx:126](apps/web/modules/ee/analysis/charts/components/advanced-chart-builder.tsx#L126) — chart type now feeds the query, so switching type re-runs it

## Breaking changes

- [ ] This PR contains breaking changes

None — all of it is internal to `apps/web`. No API, SDK, route, env var or stored shape changes; saved chart queries are read as they are and normalized in memory, never rewritten.

## Migrations & env

- none

## How this was tested

### Before / after

Same tenant, same 385 NPS answers landing on 7 of the 30 days in the range, same
`Last 30 days`. Ground truth straight from SQL over that window is **44.16**;
**315.83** is what you get by adding the seven per-day scores together.

**Big Number — a ratio was being summed**

| Before | After |
| --- | --- |
| <img alt="Big Number before the fix: 315.83" src="https://github.com/user-attachments/assets/b03832e2-733f-4be8-b950-0dd60c56e4b0" /> | <img alt="Big Number after the fix: 44.16" src="https://github.com/user-attachments/assets/97edb57b-5bbe-41cc-89b7-e56d3d1e631c" /> |
| `315.83` — the seven daily scores added up | `44.16` — the measure recomputed over the whole range |
| Granularity stays `Day`: switching the chart type did not re-run the query | Granularity resets to `None (filter only)`; the date range survives as a filter |

**Line chart — empty days were a measured zero**

| Before | After |
| --- | --- |
| <img alt="Line chart before the fix: empty days plotted at zero" src="https://github.com/user-attachments/assets/b4045a45-c539-4625-8f49-e15cc6e2c372" /> | <img alt="Line chart after the fix: empty days left as a gap" src="https://github.com/user-attachments/assets/c11bca15-8e05-4922-9b4e-9311a9af39ee" /> |
| The 23 days nobody answered are plotted at `0`, dragging the line onto the baseline between the days that do have answers | Those days have no value, so the line is drawn only where there is data |
| Y axis `0`–`80` | Y axis `20`–`80` |

The seven days that *do* have answers read identically on both sides — 39.06,
42.19, 40.63, 42.19, 51.76, 25.00, 75.00 — so nothing moved except the empty
buckets and the fold.


Rerun: `pnpm --filter @formbricks/web test -- modules/ee/analysis/api/lib/cube-client.test.ts modules/ee/analysis/charts/lib/big-number.test.ts modules/ee/analysis/charts/lib/ai-chart-query.test.ts modules/ee/analysis/lib/schema-definition.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Ratio measure in an invented empty date bucket | unit (red on main) | Stays null; the two `cube-client.test.ts` day-bucket cases fail against the old code |
| Count in that same empty bucket | unit (red on main) | Still 0 — one empty day, two different right answers |
| Big number query drops granularity, dimensions, order | unit (mutation) | Keeps the date range; mutate `big-number.ts:22` |
| Big number refuses to add up a grouped ratio | unit (mutation) | Renders the no-data glyph, not 1350; mutate `big-number.ts:48` |
| AI-generated big number arrives ungrouped | unit (guard) | Granularity and dimension stripped, date range kept (`ai-chart-query.test.ts`) |
| Real numbers behind the fix | manual | See fold — live Cube, seeded tenant |

<details>
<summary>Live Cube check, seeded local tenant, last 30 days</summary>

`FeedbackRecords.npsScore` over the range, ungrouped: **51.85**. The same measure by day returns 27 buckets which the old big number summed to **1350**. Three days at the end of the range have no rows at all; Cube omits them, the client pivot invents them, and before this PR they came back as a measured `0.00`.

```
2026-07-30 -100.00   2026-08-04 (null)   2026-08-10 50.00
2026-08-18 -100.00   2026-08-26..28 no rows returned
```

</details>

**Open gaps**

- Not re-checked against a real dashboard — widget normalization is covered by the same pure function, not by a widget test.

**Risks**

- A saved Big Number over a grouped query will change value on next load. That is the fix, but the number moves.
- Sparse ratio series now render as broken lines rather than continuous ones at 0.
- Day buckets are still UTC while the date range is built from the local calendar. Untouched here; it shifts responses near midnight into the neighbouring day.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code), reasoning effort `xhigh`.

