### PR TITLE
fix(auth): keep MCP OAuth resource seeding recoverable (backport #9065 to release/5.4)

### DIFF
--- a/patches/@better-auth__oauth-provider@1.7.0.patch
+++ b/patches/@better-auth__oauth-provider@1.7.0.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/authorize-BP2_wo6r.mjs b/dist/authorize-BP2_wo6r.mjs
+index 822f08f9af95267d9ef085448741d11370e77fc2..be9e0543e55c8b8d8555fc679df7191a71ae6e34 100644
+--- a/dist/authorize-BP2_wo6r.mjs
++++ b/dist/authorize-BP2_wo6r.mjs
+@@ -4401 +4401,8 @@ const oauthProvider = (options) => {
+-			await seedResources(ctx, opts);
++			try {
++				await seedResources(ctx, opts);
++			} catch (error) {
++				ctx.logger.warn(
++					"oauth-provider: resource seed failed during init; deferring to first resource access.",
++					error
++				);
++			}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ overrides:
   fast-uri@3: 3.1.5
   deepmerge-ts@7: 8.0.1
 
+patchedDependencies:
+  '@better-auth/oauth-provider@1.7.0': c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4
+
 importers:
 
   .:
@@ -349,7 +352,7 @@ importers:
         version: 1.7.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/oauth-provider':
         specifier: 1.7.0
-        version: 1.7.0(a7d5e9ad522ca47a6d8a16da19a4e45c)
+        version: 1.7.0(patch_hash=c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4)(a7d5e9ad522ca47a6d8a16da19a4e45c)
       '@better-auth/utils':
         specifier: 0.4.2
         version: 0.4.2
@@ -14046,7 +14049,7 @@ snapshots:
     optionalDependencies:
       mongodb: 7.1.0(@aws-sdk/credential-providers@3.1013.0)(socks@2.8.7)
 
-  '@better-auth/oauth-provider@1.7.0(a7d5e9ad522ca47a6d8a16da19a4e45c)':
+  '@better-auth/oauth-provider@1.7.0(patch_hash=c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4)(a7d5e9ad522ca47a6d8a16da19a4e45c)':
     dependencies:
       '@better-auth/core': 1.7.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
@@ -14076,7 +14079,7 @@ snapshots:
 
   '@better-auth/utils@0.5.0':
     dependencies:
-      '@noble/hashes': 2.0.1
+      '@noble/hashes': 2.3.0
 
   '@better-fetch/fetch@1.3.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -343,3 +343,11 @@ minimumReleaseAgeExclude:
   # a fresh hub bump isn't blocked. Version-pinned scoped entries (e.g. '@formbricks/hub@0.9.0') are not
   # reliably matched by the exclude, so match by name.
   - "@formbricks/hub"
+
+# ENG-2772 / better-auth#10887: oauth-provider eagerly seeds persisted resources while building its
+# plugin context. A transient database failure rejects Better Auth's process-lifetime context promise,
+# taking every auth endpoint down until restart. Keep eager seeding best-effort so initialization can
+# finish (including the provider's database hooks); its existing lazy resource lookup retries the seed.
+# Remove this version-pinned patch once upstream defers or safely handles eager seed failures.
+patchedDependencies:
+  "@better-auth/oauth-provider@1.7.0": patches/@better-auth__oauth-provider@1.7.0.patch


### PR DESCRIPTION
Ref ENG-2772

Backport of #9065 to `release/5.4`, for 5.4.1.

> [!IMPORTANT]
> Draft until #9065 merges — it is in the merge queue. Opened now so 5.4.1 is not waiting on it afterwards.

## What & why

**Was:** `oauth-provider` seeds persisted resources eagerly while building its plugin context. Better Auth creates that context **once** and every handler awaits the same promise, so one transient database failure during the seed rejects it for the life of the process — every `/api/auth/*` route returns 500, SSO and email login alike, until the pod is replaced.

**Now:** the eager seed is best-effort. Initialisation completes, still returns the provider's database hooks, and the existing lazy resource lookup retries the seed on first access.

This is live on 5.4.0 and on `5.4.1-rc.3`. It took staging down on 2026-08-28, and production is exposed through the same trigger (Sentry `FORMBRICKS-195`, escalating since 21 Aug). Replacing the pod is **not** a workaround — a fresh replica re-poisoned itself ~17s after start and Kubernetes still marked it Ready.

## Where to look

- [`patches/@better-auth__oauth-provider@1.7.0.patch`](patches/@better-auth__oauth-provider@1.7.0.patch) — the whole fix; 8 lines around one `await`.

## Breaking changes

- [ ] This PR contains breaking changes

None. Startup behaviour only; no API, schema, env or config surface changes.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The patch applies to the pinned dependency | manual | `git apply --check` against the installed `oauth-provider@1.7.0` — clean. Both branches pin `1.7.0`, so the version-pinned patch is valid here |
| The patch is exactly the one reviewed on `main` | manual | Patch file **byte-identical** to #9065, and the pnpm patch hash matches (`c902485a…`) |
| A transient seed failure no longer poisons the context | manual | Real `oauthProvider` driven with an adapter whose first `oauthResource` lookup throws: patched → context resolves, `/api/auth/ok` 200; reverted → context rejects and throws |
| No incidental dependency churn | manual | Lockfile regenerated with `--lockfile-only`; diff is 9 lines, all patch-related |

**Open gaps**

- **The net-new tests are not carried**, per policy — the integration test on `main` is what proves the patch works, so the evidence above stands in for it here.
- **The `better-auth-observability.ts` change from #9065 is deliberately not carried.** It exists to surface the patch's error argument; on 5.4 the warn branch ignores that argument harmlessly. Carrying it would put a security-sensitive redaction allowlist on a release branch with its test dropped, which is worse than not having it. The cost is less log detail when a seed fails.
- Not exercised against a real deployment on this branch.

**Risks**

- Patching a dependency's built output is pinned to `@better-auth/oauth-provider@1.7.0`; any bump invalidates it, and pnpm fails the install rather than silently dropping it. Removal condition and the upstream issue are recorded in `pnpm-workspace.yaml`.
- A seed that fails at startup now leaves the resource row absent until the first MCP resource access seeds it. Non-MCP auth is unaffected, and the lazy path resets on failure so it retries.
