### PR TITLE
chore(a11y): lint packages/surveys and packages/email with jsx-a11y

### DIFF
--- a/packages/config-eslint/README.md
+++ b/packages/config-eslint/README.md
@@ -7,7 +7,7 @@ Shared [ESLint 9 flat config](https://eslint.org/docs/latest/use/configure/confi
 | `./base`        | building blocks shared by every tier: turbo env-var checks, prettier compat (always last), the `@vitest` `test`-over-`it` convention, unused-vars `_`-prefix convention, common ignores, TS parsing | (composed by the tiers below)                                                                   |
 | `./library`     | eslint + typescript-eslint recommendedTypeChecked (type-aware) + `no-unnecessary-condition`, node globals — exported as a factory taking `tsconfigRootDir`                                          | ai, cache, database, i18n-utils, jobs, js-core, logger, storage, types, vite-plugins, workflows |
 | `./react`       | library baseline + react / react-hooks / jsx-a11y recommended, browser globals — exported as a factory taking `tsconfigRootDir`                                                                     | survey-ui                                                                                       |
-| `./react-hooks` | lite tier mirroring the old `legacy-react`: react-hooks only, no full react/TS rule sets — move consumers to `./react` when ready                                                                   | email, surveys                                                                                  |
+| `./react-hooks` | lite tier mirroring the old `legacy-react`: react-hooks + jsx-a11y recommended, no full react/TS rule sets — move consumers to `./react` when ready                                                 | email, surveys                                                                                  |
 | `./next`        | `eslint-config-next` (flat) + the legacy-next rule parity overrides                                                                                                                                 | apps/web                                                                                        |
 
 Usage in a package (`library` and `react` are factories so the type-aware rules resolve
@@ -27,3 +27,10 @@ Notes:
   rules switched off (`disableTypeChecked`), and `*.config.*` / declaration files are ignored.
 - `apps/storybook` keeps a self-contained flat config. The reason it originally had to (it needed `eslint-plugin-react-hooks` v7 while these tiers pinned v5) is gone — ENG-1689 moved the plugin into the pnpm catalog, so every tier is on v7 and uses `configs.flat.*`. Folding the storybook config into these tiers is now unblocked, tracked under ENG-2366.
 - Stale `eslint-disable` directives are reported as warnings workspace-wide (`reportUnusedDisableDirectives` in `base.mjs`).
+- `jsx-a11y` runs at its recommended (error) severity in both the `react` and `react-hooks` tiers, so
+  `packages/surveys` — the renderer respondents actually see — has the same static a11y floor as the
+  `survey-ui` components it renders, instead of resting solely on the axe gate in
+  `apps/web/playwright/survey-accessibility.spec.ts`. `packages/email` gets it from the same tier rather
+  than being carved out: it is already clean, and while email clients ignore most ARIA they do honour
+  `alt` text and heading/anchor content, which is what the rules that can fire on react-email's DOM
+  elements check. Carving it out would cost a second tier to maintain and buy nothing.

--- a/packages/config-eslint/react-hooks.mjs
+++ b/packages/config-eslint/react-hooks.mjs
@@ -1,11 +1,12 @@
+import jsxA11y from "eslint-plugin-jsx-a11y";
 import reactHooks from "eslint-plugin-react-hooks";
 import globals from "globals";
 import { base, commonIgnores, reactCompilerRulesOptOut, typescriptParsing } from "./base.mjs";
 
 /*
  * Flat config mirroring the old `legacy-react.js` tier: turbo + prettier +
- * react-hooks + the vitest convention, without the full react/typescript-eslint rule sets.
- * Used by packages (email, surveys) that predate the stricter tiers — move them to
+ * react-hooks + jsx-a11y + the vitest convention, without the full react/typescript-eslint
+ * rule sets. Used by packages (email, surveys) that predate the stricter tiers — move them to
  * `react.mjs` when they are ready.
  */
 export const reactHooksConfig = [
@@ -14,6 +15,10 @@ export const reactHooksConfig = [
   // v7 exposes flat configs under `configs.flat.*`; the top-level `recommended-latest`
   // is the legacy eslintrc format and crashes ESLint 9.
   reactHooks.configs.flat.recommended,
+  // Accessibility rules, at the same severity as the `react.mjs` tier already runs them for
+  // survey-ui: `packages/surveys` renders the survey respondents actually see, so it gets the
+  // same static a11y floor as the component library it renders (ENG-2262).
+  jsxA11y.flatConfigs.recommended,
   {
     languageOptions: {
       globals: {

--- a/packages/surveys/src/components/general/render-survey.tsx
+++ b/packages/surveys/src/components/general/render-survey.tsx
@@ -112,6 +112,7 @@ export function RenderSurvey(props: Readonly<SurveyContainerProps>) {
       <Survey
         {...props}
         onLanguageChange={handleLanguageChange}
+        // eslint-disable-next-line jsx-a11y/no-autofocus -- renamed to autoFocusEnabled; focus is imperative
         autoFocus={autoFocus}
         clickOutside={hasOverlay ? props.clickOutside : true}
         onClose={close}


### PR DESCRIPTION
Fixes ENG-2262

## What & why

**Was:** `packages/surveys` and `packages/email` linted with `eslint-plugin-react-hooks` only, so the survey renderer respondents actually see had no static accessibility rules — its whole a11y gate was the axe sweep over the nine variants `survey-accessibility.spec.ts` seeds.

**Now:** both packages run `jsx-a11y`'s recommended set at error, the severity `survey-ui` already uses, so a bare `<img>` or a click handler on a `<div>` is caught before it reaches a browser.

- Landed at error rather than `warn`: nothing to ratchet, and warnings never fail CI here.
- The one finding was a false positive — `<Survey autoFocus>` becomes `autoFocusEnabled` and is applied via `.focus()`, never the DOM attribute. Disabled inline with that reason.
- `packages/email` follows on the shared tier: already clean, and email clients do honour `alt` text.

## Where to look

- [`react-hooks.mjs`](https://github.com/formbricks/formbricks/blob/a766b276dc0a5c084fb5036effc90374f0ccf78a/packages/config-eslint/react-hooks.mjs#L18-L21) — error, not warn
- [`render-survey.tsx:115`](https://github.com/formbricks/formbricks/blob/a766b276dc0a5c084fb5036effc90374f0ccf78a/packages/surveys/src/components/general/render-survey.tsx#L115) — the only inline disable

## Breaking changes

- [ ] This PR contains breaking changes

None — lint configuration plus one comment. No runtime code and no exported signature changes.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm lint`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Both packages pass at the new severity | manual | full-workspace run: 21/21 tasks green, 0 errors |
| A violation in `packages/surveys` fails | manual | probe `<div onClick>` + bare `<img>` → 3 errors; probe deleted |
| A violation in `packages/email` fails | manual | probe bare `<img>` → `jsx-a11y/alt-text` error; probe deleted |

**Open gaps**

- Rules read DOM elements, so props forwarded through custom components (`<Survey>`, react-email's `<Img>`) stay unchecked.
- Nothing guards the tier itself against regressing to no a11y rules; `pnpm lint` is the only check.

**Risks**

- A branch already carrying a new a11y violation now fails lint instead of passing.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `max`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X3xufsPWC36uQkaPVGWpWH)_