### PR TITLE
fix(test): stop charging the route import to the first test's timeout

### DIFF
--- a/apps/web/modules/api/v2/management/responses/route.test.ts
+++ b/apps/web/modules/api/v2/management/responses/route.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { authenticatedApiClient } from "@/modules/api/v2/auth/authenticated-api-client";
+// Imported statically rather than with `await import("./route")` inside a test: `vi.mock` is hoisted
+// above imports either way, but a dynamic import charges the route graph's first transform to
+// whichever test runs first, which on a loaded CI runner exceeded the 5s testTimeout.
+import { GET } from "./route";
 
 const { mockAuthenticatedApiClient, mockGetResponses, mockHandleApiError, mockSuccessResponse } = vi.hoisted(
   () => ({
@@ -85,7 +89,6 @@ describe("GET /management/responses", () => {
       },
     });
 
-    const { GET } = await import("./route");
     const response = await GET(buildRequest() as any);
     const body = await response.json();
 
@@ -103,7 +106,6 @@ describe("GET /management/responses", () => {
       error: { type: "internal_server_error", details: [{ field: "responses", issue: "boom" }] },
     });
 
-    const { GET } = await import("./route");
     const response = await GET(buildRequest() as any);
 
     expect(mockSuccessResponse).not.toHaveBeenCalled();

--- a/apps/web/modules/api/v2/organizations/[organizationId]/teams/[teamId]/route.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/teams/[teamId]/route.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { authenticatedApiClient } from "@/modules/api/v2/auth/authenticated-api-client";
+import { DELETE, PUT } from "./route";
 
 const {
   mockAuthenticatedApiClient,
@@ -86,7 +87,6 @@ describe("PUT/DELETE /organizations/[organizationId]/teams/[teamId]", () => {
       mockGetApiKeyCreatorRole.mockResolvedValue(null);
       mockCanManageOrganizationUsers.mockReturnValue(false);
 
-      const { DELETE } = await import("./route");
       const response = await DELETE(buildRequest("DELETE"), {
         params: Promise.resolve({ organizationId, teamId }),
       });
@@ -107,7 +107,6 @@ describe("PUT/DELETE /organizations/[organizationId]/teams/[teamId]", () => {
       mockCanManageOrganizationUsers.mockReturnValue(true);
       mockDeleteTeam.mockResolvedValue({ ok: true, data: team });
 
-      const { DELETE } = await import("./route");
       const response = await DELETE(buildRequest("DELETE"), {
         params: Promise.resolve({ organizationId, teamId }),
       });
@@ -123,7 +122,6 @@ describe("PUT/DELETE /organizations/[organizationId]/teams/[teamId]", () => {
       mockGetApiKeyCreatorRole.mockResolvedValue(null);
       mockCanManageOrganizationUsers.mockReturnValue(false);
 
-      const { PUT } = await import("./route");
       const response = await PUT(buildRequest("PUT"), {
         params: Promise.resolve({ organizationId, teamId }),
       });
@@ -144,7 +142,6 @@ describe("PUT/DELETE /organizations/[organizationId]/teams/[teamId]", () => {
       mockCanManageOrganizationUsers.mockReturnValue(true);
       mockUpdateTeam.mockResolvedValue({ ok: true, data: { ...team, name: "Renamed Team" } });
 
-      const { PUT } = await import("./route");
       const response = await PUT(buildRequest("PUT"), {
         params: Promise.resolve({ organizationId, teamId }),
       });

--- a/apps/web/modules/api/v2/organizations/[organizationId]/teams/route.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/teams/route.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { authenticatedApiClient } from "@/modules/api/v2/auth/authenticated-api-client";
+import { POST } from "./route";
 
 const {
   mockAuthenticatedApiClient,
@@ -79,7 +80,6 @@ describe("POST /organizations/[organizationId]/teams", () => {
     mockGetApiKeyCreatorRole.mockResolvedValue(null);
     mockCanManageOrganizationUsers.mockReturnValue(false);
 
-    const { POST } = await import("./route");
     const response = await POST(buildRequest(), { params: Promise.resolve({ organizationId }) });
 
     expect(mockGetApiKeyCreatorRole).toHaveBeenCalledWith(apiKeyId, organizationId);
@@ -98,7 +98,6 @@ describe("POST /organizations/[organizationId]/teams", () => {
     mockCanManageOrganizationUsers.mockReturnValue(true);
     mockCreateTeam.mockResolvedValue({ ok: true, data: { id: "team123", ...teamInput, organizationId } });
 
-    const { POST } = await import("./route");
     const response = await POST(buildRequest(), { params: Promise.resolve({ organizationId }) });
 
     expect(mockGetApiKeyCreatorRole).toHaveBeenCalledWith(apiKeyId, organizationId);


### PR DESCRIPTION
No ticket — this came out of CI run logs, not the backlog.

## What & why

**Was:** the `GET /management/responses` spec intermittently failed with `Test timed out in 5000ms`, reddening CI on unrelated PRs.

**Now:** the route is imported once when the file is collected, so no single test's timeout pays for it.

- Three `api/v2` specs called `await import("./route")` inside a test, billing the graph's first transform to it.
- For `management/responses` that was 2719ms of the 5000ms budget on an idle machine; the next test cost 60ms.
- `vi.mock` hoists above imports either way, so a static import keeps the mocks and moves the cost off the clock.

## Where to look

- [responses/route.test.ts:1-10](https://github.com/formbricks/formbricks/blob/3b9399fb4a1c64a743c3d1585fe23dd4f7d64aef/apps/web/modules/api/v2/management/responses/route.test.ts#L1-L10) — static import sits above the `vi.hoisted`/`vi.mock` block
- [app/api/mcp/route.test.ts:19](https://github.com/formbricks/formbricks/blob/3b9399fb4a1c64a743c3d1585fe23dd4f7d64aef/apps/web/app/api/mcp/route.test.ts#L19) — same shape, already in the repo

## Breaking changes

- [ ] This PR contains breaking changes

None — test files only. No runtime code, API shape, env var or config key is touched.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && node ../../node_modules/.bin/vitest run --project unit modules/api/v2`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `GET /management/responses` still asserts pagination meta and the storage-URL rewrite | unit (guard) | passes; first test 2719ms → 4ms |
| The pre-fix spec does time out when the budget is tight | unit (red on main) | baseline copy at `--testTimeout=1000` timed out; patched file passed at 4ms |
| Import cost now sits outside the timeout budget | manual | at `--testTimeout=1` the file still collects (`import 2.43s`); only the 4ms body trips |
| Teams route specs behave identically | unit (guard) | 6 tests pass; their first tests 183ms/151ms → 14ms/13ms |

<details>
<summary>Commands behind rows 2 and 3</summary>

```bash
cd apps/web
# row 2 — restore the pre-fix spec beside the patched one and squeeze the budget
git show main:apps/web/modules/api/v2/management/responses/route.test.ts \
  > modules/api/v2/management/responses/route.baseline.test.ts
node ../../node_modules/.bin/vitest run --project unit --testTimeout=1000 \
  modules/api/v2/management/responses/route.baseline.test.ts \
  modules/api/v2/management/responses/route.test.ts
rm modules/api/v2/management/responses/route.baseline.test.ts

# row 3 — collection is not bounded by testTimeout
node ../../node_modules/.bin/vitest run --project unit --testTimeout=1 \
  modules/api/v2/management/responses/route.test.ts
```

</details>

**Open gaps**

- The real 5s failure needs a loaded runner. The proof here is its lowered-timeout equivalent, not the original conditions.
- `modules/auth/lib/utils.test.ts` dynamic-imports without `vi.resetModules()` — same latent shape, not audited or changed.
- Full-suite `pnpm test` never went green locally: `use-workflow-builder.test.ts` (untouched) flakes in half of runs.

**Risks**

- An import-time throw in a route now fails the whole spec file rather than one test. All 45 `modules/api/v2` files pass.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `xhigh`.
