### PR TITLE
chore: sync current main into AuthZed epic

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/components/response-filter-context.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/components/response-filter-context.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementsComboBox";
 import { ElementFilterOptions } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ResponseFilter";
 import { getTodayDate } from "@/app/lib/surveys/surveys";
+import { type TDateRangePreset } from "@/lib/date-ranges";
 
 export interface FilterValue {
   elementType: Partial<ElementOption>;
@@ -31,6 +32,11 @@ interface SelectedFilterOptions {
 export interface DateRange {
   from: Date | undefined;
   to?: Date;
+  // Which preset produced this range, if any — set by the preset dropdown, cleared by the manual
+  // calendar picker. The label is read from here instead of reverse-matching the range, since several
+  // presets span byte-identical days on period-boundary dates (e.g. "this month" and "last 7 days" on
+  // the 7th of any month) and cannot be told apart by their bounds alone.
+  preset?: TDateRangePreset;
 }
 
 interface FilterDateContextProps {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/CustomFilter.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/CustomFilter.tsx
@@ -1,21 +1,7 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import {
-  differenceInDays,
-  endOfMonth,
-  endOfQuarter,
-  endOfYear,
-  format,
-  startOfDay,
-  startOfMonth,
-  startOfQuarter,
-  startOfYear,
-  subDays,
-  subMonths,
-  subQuarters,
-  subYears,
-} from "date-fns";
+import { format } from "date-fns";
 import { TFunction } from "i18next";
 import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -29,6 +15,11 @@ import {
 import { getResponsesDownloadUrlAction } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/actions";
 import { downloadResponsesFile } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/utils";
 import { getFormattedFilters, getTodayDate } from "@/app/lib/surveys/surveys";
+import {
+  type TDateRangePreset,
+  resolveDateRangeLabelPreset,
+  resolveDateRangePresetBounds,
+} from "@/lib/date-ranges";
 import { useClickOutside } from "@/lib/utils/hooks/useClickOutside";
 import { Calendar } from "@/modules/ui/components/calendar";
 import {
@@ -51,87 +42,49 @@ enum FilterDownload {
 
 const getFilterDropDownLabels = (t: TFunction) => ({
   ALL_TIME: t("workspace.surveys.summary.all_time"),
-  LAST_7_DAYS: t("workspace.surveys.summary.last_7_days"),
-  LAST_30_DAYS: t("workspace.surveys.summary.last_30_days"),
-  THIS_MONTH: t("workspace.surveys.summary.this_month"),
-  LAST_MONTH: t("workspace.surveys.summary.last_month"),
-  LAST_6_MONTHS: t("workspace.surveys.summary.last_6_months"),
-  THIS_QUARTER: t("workspace.surveys.summary.this_quarter"),
-  LAST_QUARTER: t("workspace.surveys.summary.last_quarter"),
-  THIS_YEAR: t("workspace.surveys.summary.this_year"),
-  LAST_YEAR: t("workspace.surveys.summary.last_year"),
   CUSTOM_RANGE: t("workspace.surveys.summary.custom_range"),
 });
+
+// The relative ranges this filter offers, in dropdown order. Picking one tags `dateRange` with its
+// preset, so the trigger label survives a remount without reverse-matching the bounds — several
+// presets span byte-identical days on period-boundary dates (on the 30th of a 30-day month, "last 30
+// days" and "this month" cover the same days) and can't be told apart from `{ from, to }` alone. Order
+// still breaks that tie for a manually picked custom range that happens to match a preset's bounds.
+// What each preset means lives in `@/lib/date-ranges`, shared with the chart time dimension so the
+// Summary tab and a chart over the same field agree.
+//
+// Labels are `t()` calls rather than bare key strings on purpose: the translation-key scanner
+// (`packages/i18n-utils`) only counts keys it can see inside a literal `t("…")`, and reports the rest
+// as unused.
+const DATE_RANGE_PRESETS: readonly { preset: TDateRangePreset; getLabel: (t: TFunction) => string }[] = [
+  { preset: "last 7 days", getLabel: (t) => t("workspace.surveys.summary.last_7_days") },
+  { preset: "last 30 days", getLabel: (t) => t("workspace.surveys.summary.last_30_days") },
+  { preset: "this month", getLabel: (t) => t("workspace.surveys.summary.this_month") },
+  { preset: "last month", getLabel: (t) => t("workspace.surveys.summary.last_month") },
+  { preset: "this quarter", getLabel: (t) => t("workspace.surveys.summary.this_quarter") },
+  { preset: "last quarter", getLabel: (t) => t("workspace.surveys.summary.last_quarter") },
+  { preset: "last 6 months", getLabel: (t) => t("workspace.surveys.summary.last_6_months") },
+  { preset: "this year", getLabel: (t) => t("workspace.surveys.summary.this_year") },
+  { preset: "last year", getLabel: (t) => t("workspace.surveys.summary.last_year") },
+];
+
+const DATE_RANGE_PRESET_NAMES = DATE_RANGE_PRESETS.map(({ preset }) => preset);
 
 interface CustomFilterProps {
   survey: TSurvey;
 }
 
-const getDateRangeLabel = (from: Date, to: Date, t: TFunction) => {
-  const dateRanges = [
-    {
-      label: getFilterDropDownLabels(t).LAST_7_DAYS,
-      matches: () => differenceInDays(to, from) === 7,
-    },
-    {
-      label: getFilterDropDownLabels(t).LAST_30_DAYS,
-      matches: () => differenceInDays(to, from) === 30,
-    },
-    {
-      label: getFilterDropDownLabels(t).THIS_MONTH,
-      matches: () =>
-        format(from, "yyyy-MM-dd") === format(startOfMonth(new Date()), "yyyy-MM-dd") &&
-        format(to, "yyyy-MM-dd") === format(getTodayDate(), "yyyy-MM-dd"),
-    },
-    {
-      label: getFilterDropDownLabels(t).LAST_MONTH,
-      matches: () =>
-        format(from, "yyyy-MM-dd") === format(startOfMonth(subMonths(new Date(), 1)), "yyyy-MM-dd") &&
-        format(to, "yyyy-MM-dd") === format(endOfMonth(subMonths(getTodayDate(), 1)), "yyyy-MM-dd"),
-    },
-    {
-      label: getFilterDropDownLabels(t).LAST_6_MONTHS,
-      matches: () =>
-        format(from, "yyyy-MM-dd") === format(startOfMonth(subMonths(new Date(), 6)), "yyyy-MM-dd") &&
-        format(to, "yyyy-MM-dd") === format(endOfMonth(getTodayDate()), "yyyy-MM-dd"),
-    },
-    {
-      label: getFilterDropDownLabels(t).THIS_QUARTER,
-      matches: () =>
-        format(from, "yyyy-MM-dd") === format(startOfQuarter(new Date()), "yyyy-MM-dd") &&
-        format(to, "yyyy-MM-dd") === format(endOfQuarter(getTodayDate()), "yyyy-MM-dd"),
-    },
-    {
-      label: getFilterDropDownLabels(t).LAST_QUARTER,
-      matches: () =>
-        format(from, "yyyy-MM-dd") === format(startOfQuarter(subQuarters(new Date(), 1)), "yyyy-MM-dd") &&
-        format(to, "yyyy-MM-dd") === format(endOfQuarter(subQuarters(getTodayDate(), 1)), "yyyy-MM-dd"),
-    },
-    {
-      label: getFilterDropDownLabels(t).THIS_YEAR,
-      matches: () =>
-        format(from, "yyyy-MM-dd") === format(startOfYear(new Date()), "yyyy-MM-dd") &&
-        format(to, "yyyy-MM-dd") === format(endOfYear(getTodayDate()), "yyyy-MM-dd"),
-    },
-    {
-      label: getFilterDropDownLabels(t).LAST_YEAR,
-      matches: () =>
-        format(from, "yyyy-MM-dd") === format(startOfYear(subYears(new Date(), 1)), "yyyy-MM-dd") &&
-        format(to, "yyyy-MM-dd") === format(endOfYear(subYears(getTodayDate(), 1)), "yyyy-MM-dd"),
-    },
-  ];
-
-  const matchedRange = dateRanges.find((range) => range.matches());
-  return matchedRange ? matchedRange.label : getFilterDropDownLabels(t).CUSTOM_RANGE;
+const getDateRangeLabel = (dateRange: DateRange, t: TFunction) => {
+  const preset = resolveDateRangeLabelPreset(dateRange, DATE_RANGE_PRESET_NAMES);
+  const matched = DATE_RANGE_PRESETS.find((p) => p.preset === preset);
+  return matched ? matched.getLabel(t) : getFilterDropDownLabels(t).CUSTOM_RANGE;
 };
 
 export const CustomFilter = ({ survey }: CustomFilterProps) => {
   const { t } = useTranslation();
   const { selectedFilter, dateRange, setDateRange, resetState } = useResponseFilter();
   const [filterRange, setFilterRange] = useState(
-    dateRange.from && dateRange.to
-      ? getDateRangeLabel(dateRange.from, dateRange.to, t)
-      : getFilterDropDownLabels(t).ALL_TIME
+    dateRange.from && dateRange.to ? getDateRangeLabel(dateRange, t) : getFilterDropDownLabels(t).ALL_TIME
   );
   const [selectingDate, setSelectingDate] = useState<DateSelected>(DateSelected.FROM);
   const [isDatePickerOpen, setIsDatePickerOpen] = useState<boolean>(false);
@@ -294,81 +247,16 @@ export const CustomFilter = ({ survey }: CustomFilterProps) => {
               }}>
               <p className="text-slate-700">{getFilterDropDownLabels(t).ALL_TIME}</p>
             </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                setFilterRange(getFilterDropDownLabels(t).LAST_7_DAYS);
-                setDateRange({ from: startOfDay(subDays(new Date(), 7)), to: getTodayDate() });
-              }}>
-              <p className="text-slate-700">{getFilterDropDownLabels(t).LAST_7_DAYS}</p>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                setFilterRange(getFilterDropDownLabels(t).LAST_30_DAYS);
-                setDateRange({ from: startOfDay(subDays(new Date(), 30)), to: getTodayDate() });
-              }}>
-              <p className="text-slate-700">{getFilterDropDownLabels(t).LAST_30_DAYS}</p>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                setFilterRange(getFilterDropDownLabels(t).THIS_MONTH);
-                setDateRange({ from: startOfMonth(new Date()), to: getTodayDate() });
-              }}>
-              <p className="text-slate-700">{getFilterDropDownLabels(t).THIS_MONTH}</p>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                setFilterRange(getFilterDropDownLabels(t).LAST_MONTH);
-                setDateRange({
-                  from: startOfMonth(subMonths(new Date(), 1)),
-                  to: endOfMonth(subMonths(getTodayDate(), 1)),
-                });
-              }}>
-              <p className="text-slate-700">{getFilterDropDownLabels(t).LAST_MONTH}</p>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                setFilterRange(getFilterDropDownLabels(t).THIS_QUARTER);
-                setDateRange({ from: startOfQuarter(new Date()), to: endOfQuarter(getTodayDate()) });
-              }}>
-              <p className="text-slate-700">{getFilterDropDownLabels(t).THIS_QUARTER}</p>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                setFilterRange(getFilterDropDownLabels(t).LAST_QUARTER);
-                setDateRange({
-                  from: startOfQuarter(subQuarters(new Date(), 1)),
-                  to: endOfQuarter(subQuarters(getTodayDate(), 1)),
-                });
-              }}>
-              <p className="text-slate-700">{getFilterDropDownLabels(t).LAST_QUARTER}</p>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                setFilterRange(getFilterDropDownLabels(t).LAST_6_MONTHS);
-                setDateRange({
-                  from: startOfMonth(subMonths(new Date(), 6)),
-                  to: endOfMonth(getTodayDate()),
-                });
-              }}>
-              <p className="text-slate-700">{getFilterDropDownLabels(t).LAST_6_MONTHS}</p>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                setFilterRange(getFilterDropDownLabels(t).THIS_YEAR);
-                setDateRange({ from: startOfYear(new Date()), to: endOfYear(getTodayDate()) });
-              }}>
-              <p className="text-slate-700">{getFilterDropDownLabels(t).THIS_YEAR}</p>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                setFilterRange(getFilterDropDownLabels(t).LAST_YEAR);
-                setDateRange({
-                  from: startOfYear(subYears(new Date(), 1)),
-                  to: endOfYear(subYears(getTodayDate(), 1)),
-                });
-              }}>
-              <p className="text-slate-700">{getFilterDropDownLabels(t).LAST_YEAR}</p>
-            </DropdownMenuItem>
+            {DATE_RANGE_PRESETS.map(({ preset, getLabel }) => (
+              <DropdownMenuItem
+                key={preset}
+                onClick={() => {
+                  setFilterRange(getLabel(t));
+                  setDateRange({ ...resolveDateRangePresetBounds(preset), preset });
+                }}>
+                <p className="text-slate-700">{getLabel(t)}</p>
+              </DropdownMenuItem>
+            ))}
             <DropdownMenuItem
               onClick={() => {
                 setIsDatePickerOpen(true);

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/CustomFilter.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/CustomFilter.tsx
@@ -80,7 +80,7 @@ const getDateRangeLabel = (dateRange: DateRange, t: TFunction) => {
   return matched ? matched.getLabel(t) : getFilterDropDownLabels(t).CUSTOM_RANGE;
 };
 
-export const CustomFilter = ({ survey }: CustomFilterProps) => {
+export const CustomFilter = ({ survey }: Readonly<CustomFilterProps>) => {
   const { t } = useTranslation();
   const { selectedFilter, dateRange, setDateRange, resetState } = useResponseFilter();
   const [filterRange, setFilterRange] = useState(

--- a/apps/web/lib/date-ranges.test.ts
+++ b/apps/web/lib/date-ranges.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "vitest";
+import {
+  type TDateRangePreset,
+  isSubDayDateRangePreset,
+  matchDateRangePreset,
+  resolveDateRangeLabelPreset,
+  resolveDateRangePreset,
+  resolveDateRangePresetBounds,
+} from "./date-ranges";
+
+// Mid-month, mid-quarter date that exercises month/quarter/year boundaries cleanly. Local time on
+// purpose: these ranges describe the viewer's calendar days, and every assertion below builds its
+// expected dates the same way, so the suite is timezone-invariant.
+const NOW = new Date(2026, 4, 21, 14, 30, 0); // May 21, 2026 14:30 local
+
+// The presets the survey summary filter offers, in the order it renders them.
+const SUMMARY_PRESETS: readonly TDateRangePreset[] = [
+  "last 7 days",
+  "last 30 days",
+  "this month",
+  "last month",
+  "this quarter",
+  "last quarter",
+  "last 6 months",
+  "this year",
+  "last year",
+];
+
+describe("resolveDateRangePreset", () => {
+  test("resolves 'last 7 days' to today plus the six days before it", () => {
+    expect(resolveDateRangePreset("last 7 days", NOW)).toEqual([
+      new Date(2026, 4, 15),
+      new Date(2026, 4, 21),
+    ]);
+  });
+
+  test("normalizes casing and surrounding whitespace", () => {
+    expect(resolveDateRangePreset("  Last 7 Days ", NOW)).toEqual(resolveDateRangePreset("last 7 days", NOW));
+  });
+
+  test("returns null for a string that is not a preset", () => {
+    expect(resolveDateRangePreset("from -3 days to now", NOW)).toBeNull();
+  });
+});
+
+describe("resolveDateRangePresetBounds", () => {
+  test("'last 7 days' spans seven whole calendar days ending tonight", () => {
+    expect(resolveDateRangePresetBounds("last 7 days", NOW)).toEqual({
+      from: new Date(2026, 4, 15, 0, 0, 0, 0),
+      to: new Date(2026, 4, 21, 23, 59, 59, 999),
+    });
+  });
+
+  test("'last 30 days' spans thirty whole calendar days ending tonight", () => {
+    expect(resolveDateRangePresetBounds("last 30 days", NOW)).toEqual({
+      from: new Date(2026, 3, 22, 0, 0, 0, 0),
+      to: new Date(2026, 4, 21, 23, 59, 59, 999),
+    });
+  });
+
+  test("day-granular presets end at the last millisecond of their final day", () => {
+    expect(resolveDateRangePresetBounds("last month", NOW)).toEqual({
+      from: new Date(2026, 3, 1, 0, 0, 0, 0),
+      to: new Date(2026, 3, 30, 23, 59, 59, 999),
+    });
+  });
+
+  test("presets covering the current period stop at the end of today, not the end of the period", () => {
+    expect(resolveDateRangePresetBounds("this year", NOW).to).toEqual(new Date(2026, 4, 21, 23, 59, 59, 999));
+  });
+
+  test("'last 24 hours' keeps its time of day instead of being widened to whole days", () => {
+    expect(resolveDateRangePresetBounds("last 24 hours", NOW)).toEqual({
+      from: new Date(2026, 4, 20, 14, 30, 0),
+      to: NOW,
+    });
+  });
+});
+
+describe("isSubDayDateRangePreset", () => {
+  test("is true only for presets carrying a time of day", () => {
+    expect(isSubDayDateRangePreset("last 24 hours")).toBe(true);
+    expect(isSubDayDateRangePreset("last 7 days")).toBe(false);
+    expect(isSubDayDateRangePreset("from -3 days to now")).toBe(false);
+  });
+});
+
+describe("matchDateRangePreset", () => {
+  test("maps every summary preset's own range back to that preset", () => {
+    for (const preset of SUMMARY_PRESETS) {
+      const { from, to } = resolveDateRangePresetBounds(preset, NOW);
+      expect(matchDateRangePreset(from, to, SUMMARY_PRESETS, NOW)).toBe(preset);
+    }
+  });
+
+  test("does not claim a hand-picked range that merely has the same width", () => {
+    // Seven days wide, but not the seven days ending today — this is a custom range, and labelling it
+    // "Last 7 days" would misreport which window the numbers on screen cover.
+    const from = new Date(2026, 0, 1, 0, 0, 0, 0);
+    const to = new Date(2026, 0, 7, 23, 59, 59, 999);
+    expect(matchDateRangePreset(from, to, SUMMARY_PRESETS, NOW)).toBeNull();
+  });
+
+  test("matches at day granularity, so a range picked earlier in the day still matches", () => {
+    const { from } = resolveDateRangePresetBounds("last 7 days", NOW);
+    const earlierToday = new Date(2026, 4, 21, 9, 15, 0);
+    expect(matchDateRangePreset(from, earlierToday, SUMMARY_PRESETS, NOW)).toBe("last 7 days");
+  });
+
+  test("returns null when no preset covers the range", () => {
+    expect(
+      matchDateRangePreset(new Date(2026, 4, 10), new Date(2026, 4, 12), SUMMARY_PRESETS, NOW)
+    ).toBeNull();
+  });
+
+  test("cannot tell 'this month' and 'last 7 days' apart on the 7th of a month", () => {
+    // Both presets end at the end of today by definition, so on the 7th they cover the same seven
+    // calendar days. This is the collision a stored preset tag is meant to avoid resolving through
+    // here at all — see `resolveDateRangeLabelPreset`.
+    const onThe7th = new Date(2026, 7, 7, 10, 0, 0);
+    const { from, to } = resolveDateRangePresetBounds("this month", onThe7th);
+    expect(matchDateRangePreset(from, to, SUMMARY_PRESETS, onThe7th)).toBe("last 7 days");
+  });
+});
+
+describe("resolveDateRangeLabelPreset", () => {
+  test("prefers the range's own recorded preset over reverse-matching its bounds", () => {
+    // On the 7th, "this month" and "last 7 days" resolve to identical bounds (see the
+    // matchDateRangePreset collision test above), so a reverse-match alone can't recover "this
+    // month" here — the recorded preset is the only thing that can.
+    const onThe7th = new Date(2026, 7, 7, 10, 0, 0);
+    const bounds = resolveDateRangePresetBounds("this month", onThe7th);
+    expect(resolveDateRangeLabelPreset({ ...bounds, preset: "this month" }, SUMMARY_PRESETS, onThe7th)).toBe(
+      "this month"
+    );
+  });
+
+  test("falls back to reverse-matching when no preset is recorded, for a hand-picked range", () => {
+    const { from, to } = resolveDateRangePresetBounds("last 7 days", NOW);
+    expect(resolveDateRangeLabelPreset({ from, to }, SUMMARY_PRESETS, NOW)).toBe("last 7 days");
+  });
+
+  test("returns null for a range with neither a recorded preset nor a bounds match", () => {
+    expect(
+      resolveDateRangeLabelPreset(
+        { from: new Date(2026, 4, 10), to: new Date(2026, 4, 12) },
+        SUMMARY_PRESETS,
+        NOW
+      )
+    ).toBeNull();
+  });
+
+  test("returns null when the range has no bounds at all (e.g. 'all time')", () => {
+    expect(resolveDateRangeLabelPreset({}, SUMMARY_PRESETS, NOW)).toBeNull();
+  });
+});

--- a/apps/web/lib/date-ranges.ts
+++ b/apps/web/lib/date-ranges.ts
@@ -1,0 +1,128 @@
+import {
+  addDays,
+  endOfDay,
+  endOfQuarter,
+  endOfYear,
+  format,
+  startOfDay,
+  startOfMonth,
+  startOfQuarter,
+  startOfYear,
+  subHours,
+  subMonths,
+  subQuarters,
+  subYears,
+} from "date-fns";
+
+// The one definition of what a relative date range means. Every analytics surface resolves here —
+// the survey summary filter, which queries `Response.createdAt` with timestamps, and the chart time
+// dimension, which sends date strings to Cube — so "last 7 days" cannot cover one window on the
+// Summary tab and a different one in a chart.
+//
+// Ranges are inclusive on both ends and include the current partial day, the convention every other
+// analytics tool follows (GA, Mixpanel, PostHog, ...): "last 7 days" is today plus the six days
+// before it, not today plus seven. Cube's native "last N days" strings exclude today, which is why
+// chart queries expand these into explicit ranges before they are sent.
+const PRESET_RESOLVERS = {
+  today: (now) => [startOfDay(now), startOfDay(now)],
+  yesterday: (now) => [addDays(startOfDay(now), -1), addDays(startOfDay(now), -1)],
+  "last 24 hours": (now) => [subHours(now, 24), now],
+  "last 7 days": (now) => [addDays(startOfDay(now), -6), startOfDay(now)],
+  "last 30 days": (now) => [addDays(startOfDay(now), -29), startOfDay(now)],
+  "this month": (now) => [startOfMonth(now), startOfDay(now)],
+  "last month": (now) => {
+    const firstOfThisMonth = startOfMonth(now);
+    const lastOfLastMonth = addDays(firstOfThisMonth, -1);
+    return [startOfMonth(lastOfLastMonth), lastOfLastMonth];
+  },
+  "this quarter": (now) => [startOfQuarter(now), startOfDay(now)],
+  "last quarter": (now) => {
+    const lastQuarter = subQuarters(now, 1);
+    return [startOfQuarter(lastQuarter), endOfQuarter(lastQuarter)];
+  },
+  "last 6 months": (now) => [startOfDay(subMonths(now, 6)), startOfDay(now)],
+  "this year": (now) => [startOfYear(now), startOfDay(now)],
+  "last year": (now) => {
+    const lastYear = subYears(now, 1);
+    return [startOfYear(lastYear), endOfYear(lastYear)];
+  },
+} satisfies Record<string, (now: Date) => [Date, Date]>;
+
+export type TDateRangePreset = keyof typeof PRESET_RESOLVERS;
+
+// Sub-day presets carry a time of day; the rest are calendar-day ranges and are widened to whole
+// days by the consumers that need real instants.
+const SUB_DAY_PRESETS: ReadonlySet<TDateRangePreset> = new Set<TDateRangePreset>(["last 24 hours"]);
+
+const isDateRangePreset = (value: string): value is TDateRangePreset =>
+  Object.hasOwn(PRESET_RESOLVERS, value);
+
+export const isSubDayDateRangePreset = (preset: string): boolean => {
+  const key = preset.toLowerCase().trim();
+  return isDateRangePreset(key) && SUB_DAY_PRESETS.has(key);
+};
+
+/**
+ * Resolves a preset name to its raw `[start, end]` pair, or `null` for anything that is not a known
+ * preset — the shape Cube's query expansion needs, where the incoming string may be a preset, an
+ * explicit range, or one of Cube's own expressions.
+ */
+export const resolveDateRangePreset = (preset: string, now: Date = new Date()): [Date, Date] | null => {
+  const key = preset.toLowerCase().trim();
+  return isDateRangePreset(key) ? PRESET_RESOLVERS[key](now) : null;
+};
+
+/**
+ * Resolves a preset to the absolute instants that bound it, for callers that filter on real
+ * timestamps rather than date strings. Cube widens a bare `yyyy-MM-dd` end to 23:59:59.999 itself; a
+ * Prisma `lte` does not, so day-granular presets are widened to whole days here.
+ */
+export const resolveDateRangePresetBounds = (
+  preset: TDateRangePreset,
+  now: Date = new Date()
+): { from: Date; to: Date } => {
+  const [start, end] = PRESET_RESOLVERS[preset](now);
+  return SUB_DAY_PRESETS.has(preset)
+    ? { from: start, to: end }
+    : { from: startOfDay(start), to: endOfDay(end) };
+};
+
+/**
+ * Finds the first preset covering exactly the same calendar days as `[from, to]`, for a range that
+ * arrived with no preset attached (a manually picked custom range) — callers that pick a preset from
+ * a list should keep that preset alongside the range instead of relying on this to recover it. Once
+ * every calendar-period preset ends at "today", several presets become genuinely indistinguishable by
+ * their bounds on period-boundary days (e.g. "this month" and "last 7 days" on the 7th of any month,
+ * or "last 30 days" and "this month" on the 30th of a 30-day month) — matching is day-granular, and
+ * `presets` order picks a winner among those ties, silently mislabeling the other.
+ */
+export const matchDateRangePreset = (
+  from: Date,
+  to: Date,
+  presets: readonly TDateRangePreset[],
+  now: Date = new Date()
+): TDateRangePreset | null => {
+  const day = (date: Date): string => format(date, "yyyy-MM-dd");
+  return (
+    presets.find((preset) => {
+      const bounds = resolveDateRangePresetBounds(preset, now);
+      return day(bounds.from) === day(from) && day(bounds.to) === day(to);
+    }) ?? null
+  );
+};
+
+/**
+ * Resolves the preset that should label `range` for display: the explicit `preset` it was tagged
+ * with, if any, otherwise a reverse-match of its bounds against `presets`. A caller that already
+ * knows which preset produced a range (e.g. a dropdown selection) should tag the range with it and
+ * pass that through here, rather than relying on the bounds alone — those can be genuinely ambiguous
+ * (see `matchDateRangePreset`), so the tag is the only reliable source once it exists.
+ */
+export const resolveDateRangeLabelPreset = (
+  range: { from?: Date; to?: Date; preset?: TDateRangePreset },
+  presets: readonly TDateRangePreset[],
+  now: Date = new Date()
+): TDateRangePreset | null => {
+  if (range.preset) return range.preset;
+  return range.from && range.to ? matchDateRangePreset(range.from, range.to, presets, now) : null;
+};

--- a/apps/web/modules/ee/analysis/lib/date-presets.test.ts
+++ b/apps/web/modules/ee/analysis/lib/date-presets.test.ts
@@ -1,6 +1,8 @@
+import { formatDate } from "date-fns";
 import { describe, expect, test } from "vitest";
 import type { TChartQuery } from "@formbricks/types/analysis";
-import { expandPresetDateRanges } from "./date-presets";
+import { isSubDayDateRangePreset, resolveDateRangePresetBounds } from "@/lib/date-ranges";
+import { DASHBOARD_DATE_PRESETS, expandPresetDateRanges } from "./date-presets";
 
 const queryWithDateRange = (dateRange: string | [string, string]): TChartQuery => ({
   measures: ["FeedbackRecords.count"],
@@ -116,4 +118,17 @@ describe("expandPresetDateRanges", () => {
     expandPresetDateRanges(q, NOW);
     expect(JSON.stringify(q)).toBe(before);
   });
+
+  // A chart and the survey summary filter set to the same preset must cover the same days, which only
+  // holds while both read their ranges from `@/lib/date-ranges`. Redefine either side and this fails.
+  test.each(DASHBOARD_DATE_PRESETS.filter((preset) => !isSubDayDateRangePreset(preset)))(
+    "'%s' covers the same days as the summary filter",
+    (preset) => {
+      const { from, to } = resolveDateRangePresetBounds(preset, NOW);
+      expect(expandPresetDateRanges(queryWithDateRange(preset), NOW).timeDimensions?.[0].dateRange).toEqual([
+        formatDate(from, "yyyy-MM-dd"),
+        formatDate(to, "yyyy-MM-dd"),
+      ]);
+    }
+  );
 });

--- a/apps/web/modules/ee/analysis/lib/date-presets.ts
+++ b/apps/web/modules/ee/analysis/lib/date-presets.ts
@@ -1,65 +1,26 @@
-import {
-  addDays,
-  endOfQuarter,
-  endOfYear,
-  formatDate,
-  startOfDay,
-  startOfMonth,
-  startOfQuarter,
-  startOfYear,
-  subHours,
-  subMonths,
-  subQuarters,
-  subYears,
-} from "date-fns";
+import { formatDate } from "date-fns";
 import type { TChartQuery } from "@formbricks/types/analysis";
+import { isSubDayDateRangePreset, resolveDateRangePreset } from "@/lib/date-ranges";
 
-// Cube's native "last N days" / "this month" / etc. strings exclude today; we expand them
-// to explicit inclusive ranges so charts behave like every other analytics tool (GA, Mixpanel,
-// PostHog, ...) and include the current partial day.
-const PRESET_RESOLVERS: Record<string, (now: Date) => [Date, Date]> = {
-  today: (now) => [startOfDay(now), startOfDay(now)],
-  yesterday: (now) => [addDays(startOfDay(now), -1), addDays(startOfDay(now), -1)],
-  "last 24 hours": (now) => [subHours(now, 24), now],
-  "last 7 days": (now) => [addDays(startOfDay(now), -6), startOfDay(now)],
-  "last 30 days": (now) => [addDays(startOfDay(now), -29), startOfDay(now)],
-  "this month": (now) => [startOfMonth(now), startOfDay(now)],
-  "last month": (now) => {
-    const firstOfThisMonth = startOfMonth(now);
-    const lastOfLastMonth = addDays(firstOfThisMonth, -1);
-    return [startOfMonth(lastOfLastMonth), lastOfLastMonth];
-  },
-  "this quarter": (now) => [startOfQuarter(now), startOfDay(now)],
-  "last quarter": (now) => {
-    const lastQuarter = subQuarters(now, 1);
-    return [startOfQuarter(lastQuarter), endOfQuarter(lastQuarter)];
-  },
-  "last 6 months": (now) => [startOfDay(subMonths(now, 6)), startOfDay(now)],
-  "this year": (now) => [startOfYear(now), startOfDay(now)],
-  "last year": (now) => {
-    const lastYear = subYears(now, 1);
-    return [startOfYear(lastYear), endOfYear(lastYear)];
-  },
-};
-
-// Sub-day presets need timestamp precision; day-granular presets stay date-only so charts keep
-// their existing calendar-day behavior.
-const TIME_PRECISION_PRESETS = new Set(["last 24 hours"]);
-
+// Cube's native "last N days" / "this month" / etc. strings exclude today; we expand them to the
+// explicit inclusive ranges defined in `@/lib/date-ranges` — shared with the survey summary filter so
+// both surfaces mean the same window — which include the current partial day the way every other
+// analytics tool does (GA, Mixpanel, PostHog, ...).
 export const expandPresetDateRanges = (query: TChartQuery, now: Date = new Date()): TChartQuery => {
   if (!query.timeDimensions?.length) return query;
 
   const expanded = query.timeDimensions.map((td) => {
-    if (typeof td.dateRange !== "string") return td;
-    const key = td.dateRange.toLowerCase().trim();
-    const resolver = PRESET_RESOLVERS[key];
-    if (!resolver) return td;
-    const [start, end] = resolver(now);
+    const preset = td.dateRange;
+    if (typeof preset !== "string") return td;
+    const range = resolveDateRangePreset(preset, now);
+    if (!range) return td;
+    const [start, end] = range;
     // Sub-day presets serialize as UTC ISO 8601 (with the `Z` offset, milliseconds truncated) so the
     // same instant produces the same string regardless of the server's timezone — Cube reads these
-    // bare timestamps as UTC. Day-granular presets stay date-only, keeping their calendar-day meaning.
+    // bare timestamps as UTC. Day-granular presets stay date-only, keeping their calendar-day meaning
+    // (Cube widens a date-only end to 23:59:59.999 itself).
     const serialize = (date: Date): string =>
-      TIME_PRECISION_PRESETS.has(key)
+      isSubDayDateRangePreset(preset)
         ? `${date.toISOString().slice(0, 19)}Z`
         : formatDate(date, "yyyy-MM-dd");
     return {
@@ -71,9 +32,9 @@ export const expandPresetDateRanges = (query: TChartQuery, now: Date = new Date(
   return { ...query, timeDimensions: expanded };
 };
 
-// Ordered preset list for the dashboard-level date filter. "all time" and "custom" are not
-// resolvers — they are handled by the filter UI / override helper — so they live only in the
-// component, not here. Values must match PRESET_RESOLVERS keys so they expand consistently.
+// Ordered preset list for the dashboard-level date filter. "all time" and "custom" are not presets —
+// they are handled by the filter UI / override helper — so they live only in the component, not here.
+// Values must match the preset names in `@/lib/date-ranges` so they expand consistently.
 export const DASHBOARD_DATE_PRESETS = [
   "last 24 hours",
   "last 7 days",


### PR DESCRIPTION
Ref ENG-2455

## What & why

**Was:** `epic/authzed` was one merged `main` change behind, so its cutover candidate did not include the latest date-filter behavior.

**Now:** Current `main` is merged into the epic with a real merge commit, and the imported component follows the repository readonly-props contract.

## Where to look

- [`apps/web/lib/date-ranges.ts`](https://github.com/formbricks/formbricks/blob/bhagya/sync-current-main-into-epic-authzed/apps/web/lib/date-ranges.ts) — shared preset calculation
- [`apps/web/modules/ee/analysis/lib/date-presets.ts`](https://github.com/formbricks/formbricks/blob/bhagya/sync-current-main-into-epic-authzed/apps/web/modules/ee/analysis/lib/date-presets.ts) — analysis preset mapping
- [`apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/CustomFilter.tsx`](https://github.com/formbricks/formbricks/blob/bhagya/sync-current-main-into-epic-authzed/apps/web/app/%28app%29/workspaces/%5BworkspaceId%5D/surveys/%5BsurveyId%5D/components/CustomFilter.tsx) — readonly props

## Breaking changes

- [ ] This PR contains breaking changes

None. It synchronizes an already-released product fix and changes no external contract.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm build --filter=@formbricks/web^... && pnpm exec prettier --check "apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/CustomFilter.tsx" && pnpm --filter @formbricks/web exec vitest run lib/date-ranges.test.ts modules/ee/analysis/lib/date-presets.test.ts && pnpm --filter @formbricks/web typecheck && pnpm authzed:validate`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Shared date presets | unit (guard) | 45 affected tests passed |
| AuthZed contract | unit (guard) | 157 assertions and 6 expected relations passed |
| Component typing | unit (guard) | Prettier, ESLint, and web typecheck passed |

**Open gaps**

- Review and refreshed remote CI are pending.

**Risks**

- Rebuild and re-run sandbox gates if `main` changes authorization-sensitive behavior again.

---

> [!NOTE]
> **AI model used** — `GPT-5`, reasoning effort `unknown`.