### PR TITLE
fix: align Add Block trigger content to the left edge

### DIFF
--- a/apps/web/modules/survey/editor/components/add-element-button.tsx
+++ b/apps/web/modules/survey/editor/components/add-element-button.tsx
@@ -97,8 +97,10 @@ export const AddElementButton = ({ addElement, workspace, isCxMode }: AddElement
           open the element picker at all. Letting Radix render its own `<button>` fixes that and
           gives tests a real button role; the data-testid keeps them off the rendered copy, which
           also appears in the live preview. */}
-      <Collapsible.CollapsibleTrigger className="group h-full w-full" data-testid="add-element-trigger">
-        <div className="inline-flex">
+      <Collapsible.CollapsibleTrigger
+        className="group h-full w-full text-left"
+        data-testid="add-element-trigger">
+        <div className="flex">
           <div className="flex w-10 items-center justify-center rounded-l-[7px] bg-brand-dark group-aria-expanded:rounded-br group-aria-expanded:rounded-bl-none">
             <PlusIcon className="size-5 text-white" />
           </div>


### PR DESCRIPTION
<!-- No ticket: drive-by UI fix spotted in the survey editor while working on another branch. -->

## What & why

**Was:** the "Add Block" card in the survey editor floated in the middle of its container — the teal `+` block sat mid-row instead of hugging the card's left edge.

**Now:** the `+` block and its labels start at the left edge and the row fills the card's width.

- Radix renders `CollapsibleTrigger` as a `<button>`, which centers inline content by UA default.
- The content wrapper was `inline-flex`, so it stayed an inline-level box and the full-width button centered it.

## Where to look

- [add-element-button.tsx:100-101](https://github.com/formbricks/formbricks/blob/dhruwang/fix-add-block-trigger-alignment/apps/web/modules/survey/editor/components/add-element-button.tsx#L100-L101) — `flex` wrapper + `text-left` trigger

## Breaking changes

- [ ] This PR contains breaking changes

None — two Tailwind classes on one internal editor component.

Before:

<img width="1270" height="195" alt="Screenshot 2026-08-31 at 2 13 56 PM" src="https://github.com/user-attachments/assets/43864bbf-871d-473a-a6a1-f22e48ef48a7" />

After:

<img width="1296" height="139" alt="Screenshot 2026-08-31 at 2 33 57 PM" src="https://github.com/user-attachments/assets/eebf5c43-ec90-4dee-9539-a62cffa4c508" />


## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web dev` then open a survey in the editor

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| "Add Block" trigger content anchors to the card's left edge | manual | not yet observed in a running app — see Open gaps |

**Open gaps**

- Not verified in the running app: the local dev server never finished compiling in this session. The change is CSS-only and the mechanism is the `<button>` `text-align: center` default, but a screenshot of the editor still needs to be attached before merge.

**Risks**

- The row now stretches to the card's full width, so the hover/click target is wider than before. Visual only; the collapsible behaviour and `data-testid` are untouched.
