### PR TITLE
docs(self-hosting): say which release handles the Microsoft multi-tenant authorities

### DIFF
--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -252,6 +252,12 @@ keeps restricting sign-in to work/school accounts, and an unset value behaves as
 logs a warning at startup when either is set and Microsoft SSO is enabled. To get full id_token
 verification, set your Directory (tenant) ID instead.
 
+<Warning>
+  This handling arrived in **5.4.1**. On 5.4.0 both authorities still take the verification path, so
+  every Microsoft sign-in fails with `?error=unable_to_get_user_info` — upgrade to 5.4.1, or unset
+  `AZUREAD_TENANT_ID` if you cannot upgrade immediately.
+</Warning>
+
 `consumers` needs no action and is not affected: every personal Microsoft account lives in one
 well-known tenant, so that authority advertises a real issuer and keeps full id_token verification.
 


### PR DESCRIPTION
No Linear ticket — a two-line docs correction found while wrapping up ENG-2750. Happy to attach one if preferred.

## What & why

**Was:** the `## v5.4` section describes how Formbricks handles the `common` and `organizations` authorities in the present tense, with no version named — "Formbricks therefore handles those two the way it already handles an unset `AZUREAD_TENANT_ID`".

**Now:** a callout names the release and says what 5.4.0 actually does.

That sentence is true of 5.4.1 and false of 5.4.0. A self-hoster upgrading to 5.4.0 with either value set reads it, concludes their configuration is handled, and gets a total Microsoft SSO outage the guide says nothing about — which is worse than the guide being silent. 5.4.0 was Latest for two days and self-hosters routinely sit on a release for months.

## Where to look

- [`migration.mdx`](docs/self-hosting/advanced/migration.mdx) — one `<Warning>`, 5 lines, in the `AZUREAD_TENANT_ID` subsection.

## Breaking changes

- [ ] This PR contains breaking changes

None. Documentation only.

## Migrations & env

- none. This documents an existing variable; it neither adds nor changes one.

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| The 5.4.0 claim is true | manual | `git show 5.4.0:…/better-auth-providers.ts` — the branch is `AZUREAD_TENANT_ID ? discoveryUrl : explicit endpoints`, so **any** set value takes the verification path |
| The 5.4.1 claim is true | manual | `git show 5.4.1:…/better-auth-providers.ts` — `AZURE_TEMPLATE_ISSUER_TENANTS = new Set(["common", "organizations"])` routes both to explicit endpoints |
| The stated workaround works on 5.4.0 | manual | Same branch: unset is falsy, so it takes the explicit-endpoints path that never verifies id_tokens |
| Renders and matches house style | manual | `prettier --check` clean; indentation and wrap width match the 10 existing `<Warning>` blocks in this file |

**Open gaps**

- Not previewed in a docs build; the component and structure match the rest of the file.

**Risks**

- none. Prose only, and the guide publishes from `main`, so no backport applies.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code), reasoning effort `unknown`.
