### PR TITLE
chore: sync latest main into AuthZed epic

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -367,7 +367,7 @@ export const MainNavigation = ({
         }
       });
     },
-    [router, organization.id, workspace.id]
+    [router, organization.id]
   );
 
   const switcherTriggerClasses = cn(

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/notifications/components/NotificationSwitch.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/notifications/components/NotificationSwitch.tsx
@@ -114,6 +114,7 @@ export const NotificationSwitch = ({
           break;
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount; re-running would re-fire the switch change and toast
   }, []);
 
   return (

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/components/AddIntegrationModal.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/components/AddIntegrationModal.tsx
@@ -216,6 +216,7 @@ export const AddIntegrationModal = ({
     } else {
       reset();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-seed the form when edit mode toggles; adding the other deps would reset user edits
   }, [isEditMode]);
 
   const survey = watch("survey");

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/components/AddIntegrationModal.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/components/AddIntegrationModal.tsx
@@ -110,6 +110,17 @@ export const AddIntegrationModal = ({
         type: dbProperties[fieldKey].type,
       })) || []
     );
+    // The effect below re-seeds `selectedDatabase` with a fresh object literal whenever the
+    // `databases`/`surveys` server props change identity, which an RSC refresh does on unchanged
+    // content. Keying on the id keeps identical content from recomputing this list.
+    //
+    // The trade-off, stated so it is a choice rather than an oversight: if a refresh brings back
+    // *different* properties for the same database id — someone edited the Notion database's schema
+    // while this modal was open on it — the list here stays stale until the database is reselected.
+    // Fixing that by keying on the object trades a rare staleness for a recompute on every refresh;
+    // fixing it properly means not re-seeding with a fresh literal when the content is unchanged,
+    // which belongs in the effect rather than in this dep array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the database's identity, not the object's
   }, [selectedDatabase?.id]);
 
   const elementItems = useMemo(() => {
@@ -155,7 +166,10 @@ export const AddIntegrationModal = ({
     }));
 
     return [...mappedElements, ...variables, ...hiddenFields, ...Metadata, ...createdAt, ...personAttributes];
-  }, [selectedSurvey?.id, contactAttributeKeys]);
+    // Same as `dbItems` above: `selectedSurvey` is re-seeded from the `surveys` server prop, so its
+    // identity changes on a refresh that changed nothing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the survey's identity, not the object's
+  }, [contactAttributeKeys, elements, selectedSurvey?.id, t]);
 
   useEffect(() => {
     if (selectedIntegration) {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponsePage.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponsePage.tsx
@@ -48,11 +48,23 @@ export const ResponsePage = ({
   const [isFetchingFirstPage, setIsFetchingFirstPage] = useState<boolean>(false);
   const { selectedFilter, dateRange, resetState, registerAnalysisRefreshHandler } = useResponseFilter();
   const { t } = useTranslation();
-  const filters = useMemo(
+  const computedFilters = useMemo(
     () => getFormattedFilters(survey, selectedFilter, dateRange),
 
-    [selectedFilter, dateRange]
+    [survey, selectedFilter, dateRange]
   );
+
+  // `survey` is an RSC prop, so every `router.refresh()` (survey status dropdown, share modal, reset
+  // survey) hands down a freshly deserialized object and `computedFilters` takes a new identity for
+  // unchanged content. Memoized so the serialization happens when the filters actually recompute
+  // rather than on every render of this page — each scroll fetch, each row or tag edit.
+  const filtersKey = useMemo(() => JSON.stringify(computedFilters), [computedFilters]);
+
+  // The identity everything downstream keys on, held steady while the filter *value* is unchanged.
+  // Without it a refresh re-creates `fetchNextPage` and `refetchResponses`, which re-registers the
+  // analysis refresh handler and would collapse the infinite-scroll list back to page 1.
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the filter value, not its identity
+  const filters = useMemo(() => computedFilters, [filtersKey]);
 
   const searchParams = useSearchParams();
 
@@ -107,7 +119,7 @@ export const ResponsePage = ({
     } finally {
       setIsFetchingFirstPage(false);
     }
-  }, [filters, responsesPerPage, surveyId]);
+  }, [filters, responsesPerPage, surveyId, t]);
 
   useEffect(() => {
     return registerAnalysisRefreshHandler(refetchResponses);
@@ -162,7 +174,9 @@ export const ResponsePage = ({
     };
     fetchFilteredResponses();
     // page is intentionally omitted to avoid refetching after the initial page setup.
-  }, [filters, responsesPerPage, selectedFilter, dateRange, surveyId]);
+    // hasFilters is derived from selectedFilter/dateRange which are already deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- effect must run only when the filter value changes, not on page updates it sets internally
+  }, [filtersKey, responsesPerPage, selectedFilter, dateRange, surveyId]);
 
   return (
     <>

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/share-survey-modal.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/share-survey-modal.tsx
@@ -211,13 +211,13 @@ export const ShareSurveyModal = ({
     user.locale,
     surveyUrl,
     isReadOnly,
-    survey.workspaceId,
     segments,
     isContactsEnabled,
     isFormbricksCloud,
     email,
     isStorageConfigured,
     workspaceCustomScripts,
+    enterpriseLicenseRequestFormUrl,
   ]);
 
   const getDefaultActiveId = useCallback(() => {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/CustomFilter.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/CustomFilter.tsx
@@ -111,7 +111,7 @@ export const CustomFilter = ({ survey }: CustomFilterProps) => {
   const filters = useMemo(
     () => getFormattedFilters(survey, selectedFilter, dateRange),
 
-    [selectedFilter, dateRange]
+    [survey, selectedFilter, dateRange]
   );
 
   const datePickerRef = useRef<HTMLDivElement>(null);

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ResponseFilter.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ResponseFilter.tsx
@@ -161,6 +161,7 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
     if (!isOpen) {
       clearItem();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- clearItem is recreated each render; effect must fire only when isOpen toggles, not on every render
   }, [isOpen]);
 
   const handleAddNewFilter = () => {

--- a/apps/web/lib/useDocumentVisibility.test.ts
+++ b/apps/web/lib/useDocumentVisibility.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { useDocumentVisibility } from "./useDocumentVisibility";
+
+const setVisibilityState = (state: DocumentVisibilityState) =>
+  vi.spyOn(document, "visibilityState", "get").mockReturnValue(state);
+
+const fireVisibilityChange = () => document.dispatchEvent(new Event("visibilitychange"));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useDocumentVisibility", () => {
+  test("calls onVisible when the document becomes visible", () => {
+    setVisibilityState("visible");
+    const onVisible = vi.fn();
+    renderHook(() => useDocumentVisibility(onVisible));
+
+    fireVisibilityChange();
+
+    expect(onVisible).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not call onVisible while the document is hidden", () => {
+    setVisibilityState("hidden");
+    const onVisible = vi.fn();
+    renderHook(() => useDocumentVisibility(onVisible));
+
+    fireVisibilityChange();
+
+    expect(onVisible).not.toHaveBeenCalled();
+  });
+
+  test("invokes the latest callback after a re-render, exactly once", () => {
+    setVisibilityState("visible");
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const { rerender } = renderHook(({ onVisible }) => useDocumentVisibility(onVisible), {
+      initialProps: { onVisible: first },
+    });
+
+    rerender({ onVisible: second });
+    fireVisibilityChange();
+
+    // Called once, not twice: a re-render must not leave a second active listener behind.
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  test("stops listening after unmount", () => {
+    setVisibilityState("visible");
+    const onVisible = vi.fn();
+    const { unmount } = renderHook(() => useDocumentVisibility(onVisible));
+
+    unmount();
+    fireVisibilityChange();
+
+    expect(onVisible).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/useDocumentVisibility.ts
+++ b/apps/web/lib/useDocumentVisibility.ts
@@ -1,11 +1,18 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 // This hook will listen to the visibilitychange event and run the provided function whenever the document's visibility state changes to visible
 export const useDocumentVisibility = (onVisible: () => void) => {
+  // Keep the latest callback in a ref so the listener always calls the current
+  // `onVisible` without having to re-subscribe on every render.
+  const onVisibleRef = useRef(onVisible);
+  useEffect(() => {
+    onVisibleRef.current = onVisible;
+  }, [onVisible]);
+
   useEffect(() => {
     const listener = () => {
       if (document.visibilityState === "visible") {
-        onVisible();
+        onVisibleRef.current();
       }
     };
 

--- a/apps/web/modules/auth/signup/components/password-checks.tsx
+++ b/apps/web/modules/auth/signup/components/password-checks.tsx
@@ -25,11 +25,14 @@ const ValidationIcon = ({ state }: { state: boolean }) =>
 export const PasswordChecks = ({ password }: PasswordChecksProps) => {
   const { t } = useTranslation();
 
-  const DEFAULT_VALIDATIONS = [
-    { label: t("auth.signup.password_validation_uppercase_and_lowercase"), state: false },
-    { label: t("auth.signup.password_validation_minimum_8_and_maximum_128_characters"), state: false },
-    { label: t("auth.signup.password_validation_contain_at_least_1_number"), state: false },
-  ];
+  const DEFAULT_VALIDATIONS = useMemo(
+    () => [
+      { label: t("auth.signup.password_validation_uppercase_and_lowercase"), state: false },
+      { label: t("auth.signup.password_validation_minimum_8_and_maximum_128_characters"), state: false },
+      { label: t("auth.signup.password_validation_contain_at_least_1_number"), state: false },
+    ],
+    [t]
+  );
 
   const validations = useMemo(() => {
     if (password === null) return DEFAULT_VALIDATIONS;
@@ -48,7 +51,7 @@ export const PasswordChecks = ({ password }: PasswordChecksProps) => {
         state: PASSWORD_REGEX.NUMBER.test(password),
       },
     ];
-  }, [password]);
+  }, [password, DEFAULT_VALIDATIONS, t]);
 
   return (
     <div className="my-2 text-left text-slate-700 sm:text-sm">

--- a/apps/web/modules/ee/analysis/charts/components/chart-dropdown-menu.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-dropdown-menu.tsx
@@ -79,7 +79,7 @@ export function ChartDropdownMenu({ workspaceId, chart, onEdit }: Readonly<Chart
     return () => {
       cancelled = true;
     };
-  }, [isAddToDashboardDialogOpen, workspaceId, chart.id]);
+  }, [isAddToDashboardDialogOpen, workspaceId, chart.id, t]);
 
   const handleDeleteChart = async () => {
     setIsDeleting(true);

--- a/apps/web/modules/ee/contacts/attributes/components/attributes-table.tsx
+++ b/apps/web/modules/ee/contacts/attributes/components/attributes-table.tsx
@@ -137,6 +137,7 @@ export const AttributesTable = ({
         console.error(err);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- loads persisted column settings once per workspace; `table` is an unstable ref and would clobber user changes on every render
   }, [workspaceId]);
 
   // Hide select column when all attributes are system attributes

--- a/apps/web/modules/ee/contacts/components/contact-data-view.tsx
+++ b/apps/web/modules/ee/contacts/components/contact-data-view.tsx
@@ -43,11 +43,20 @@ export const ContactDataView = ({
       prevWorkspaceId.current = workspaceId;
       setContacts([...initialContacts]);
       setHasMore(initialHasMore);
-      isResettingSearch.current = true;
+      // Arm the skip only when there is a search to clear. `setSearchValue("")` on an already-empty
+      // value is a no-op, so the `[searchValue]` effect never runs to lower the flag again — and the
+      // next time the user does type, that effect consumes their first search as the "reset" it was
+      // waiting for. Switching workspace without having searched is the common path, so the flag was
+      // usually left armed.
+      if (searchValue) {
+        isResettingSearch.current = true;
+      }
       setSearchValue("");
       prevInitialContactsLength.current = initialContacts.length;
     }
-  }, [workspaceId, initialContacts, initialHasMore]);
+    // `searchValue` is read above, so it belongs here; the whole body is behind the workspace-change
+    // guard, which updates `prevWorkspaceId` immediately, so the extra runs are a comparison.
+  }, [workspaceId, initialContacts, initialHasMore, searchValue]);
 
   // Sync state when initialContacts changes from server refresh (e.g., after CSV upload)
   // Only update if we're viewing the first page without search
@@ -105,6 +114,7 @@ export const ContactDataView = ({
     if (isResettingSearch.current) {
       isResettingSearch.current = false;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- debounced search must fire only on searchValue change; `fetchContactsFromStart` is keyed on `searchValue` itself, so listing it would re-trigger the search whenever `workspaceId` or `itemsPerPage` changed too
   }, [searchValue]);
 
   useEffect(() => {

--- a/apps/web/modules/ee/contacts/components/contacts-table.tsx
+++ b/apps/web/modules/ee/contacts/components/contacts-table.tsx
@@ -142,6 +142,7 @@ export const ContactsTable = ({
     if (savedExpandedSettings !== null) {
       setIsExpanded(JSON.parse(savedExpandedSettings));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- loads persisted column settings once per workspace; `table` and `data` change every render and would clobber user changes
   }, [workspaceId]);
 
   // Save settings to localStorage when they change

--- a/apps/web/modules/survey/components/element-form-input/components/recall-wrapper.tsx
+++ b/apps/web/modules/survey/components/element-form-input/components/recall-wrapper.tsx
@@ -242,6 +242,7 @@ export const RecallWrapper = ({
     };
 
     setRenderedText(processInput());
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- re-render only on text/recall changes; `filterRecallItems` mutates internalValue/recallItems and would loop, localSurvey/usedLanguageCode are captured via those
   }, [internalValue, recallItems]);
 
   return (

--- a/apps/web/modules/survey/components/element-form-input/index.tsx
+++ b/apps/web/modules/survey/components/element-form-input/index.tsx
@@ -119,7 +119,7 @@ export const ElementFormInput = ({
       : isEndingCard
         ? localSurvey.endings[elementIdx - elements.length].id
         : currentElement.id;
-  }, [isWelcomeCard, isEndingCard, currentElement?.id]);
+  }, [isWelcomeCard, isEndingCard, currentElement?.id, elementIdx, elements.length, localSurvey.endings]);
   const endingCard = localSurvey.endings.find((ending) => ending.id === elementId);
 
   const surveyLanguageCodes = useMemo(

--- a/apps/web/modules/survey/components/template-list/components/template-tags.tsx
+++ b/apps/web/modules/survey/components/template-list/components/template-tags.tsx
@@ -2,7 +2,7 @@
 
 import { TFunction } from "i18next";
 import { SplitIcon } from "lucide-react";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { TTemplate, TTemplateFilter, TTemplateRole } from "@formbricks/types/templates";
 import { TWorkspaceConfigChannel, TWorkspaceConfigIndustry } from "@formbricks/types/workspace";
@@ -71,25 +71,28 @@ export const TemplateTags = ({ template, selectedFilter }: TemplateTagsProps) =>
 
   const roleTag = useMemo(
     () => getRoleMapping(t).find((roleMap) => roleMap.value === template.role)?.label,
-    [template.role]
+    [template.role, t]
   );
 
-  const channelTag = useMemo(() => getChannelTag(template.channels, t), [template.channels]);
-  const getIndustryTag = (industries: TWorkspaceConfigIndustry[] | undefined): string | undefined => {
-    // if user selects an industry e.g. eCommerce than the tag should not say "Multiple industries" anymore but "E-Commerce".
-    if (selectedFilter[1] !== null) {
-      const industry = getIndustryMapping(t).find((industry) => industry.value === selectedFilter[1]);
-      if (industry) return industry.label;
-    }
-    if (!industries || industries.length === 0) return undefined;
-    return industries.length > 1
-      ? t("workspace.surveys.templates.multiple_industries")
-      : getIndustryMapping(t).find((industry) => industry.value === industries[0])?.label;
-  };
+  const channelTag = useMemo(() => getChannelTag(template.channels, t), [template.channels, t]);
+  const getIndustryTag = useCallback(
+    (industries: TWorkspaceConfigIndustry[] | undefined): string | undefined => {
+      // if user selects an industry e.g. eCommerce than the tag should not say "Multiple industries" anymore but "E-Commerce".
+      if (selectedFilter[1] !== null) {
+        const industry = getIndustryMapping(t).find((industry) => industry.value === selectedFilter[1]);
+        if (industry) return industry.label;
+      }
+      if (!industries || industries.length === 0) return undefined;
+      return industries.length > 1
+        ? t("workspace.surveys.templates.multiple_industries")
+        : getIndustryMapping(t).find((industry) => industry.value === industries[0])?.label;
+    },
+    [selectedFilter, t]
+  );
 
   const industryTag = useMemo(
     () => getIndustryTag(template.industries),
-    [template.industries, selectedFilter]
+    [template.industries, getIndustryTag]
   );
 
   return (

--- a/apps/web/modules/survey/editor/components/address-element-form.tsx
+++ b/apps/web/modules/survey/editor/components/address-element-form.tsx
@@ -82,6 +82,7 @@ export const AddressElementForm = ({
       .every((field) => !field.required);
 
     updateElement(elementIdx, { required: !allFieldsAreOptional });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sync-only effect; adding updateElement/elementIdx would loop as it writes back into the survey
   }, [element.addressLine1, element.addressLine2, element.city, element.state, element.zip, element.country]);
 
   const [parent] = useAutoAnimate();

--- a/apps/web/modules/survey/editor/components/cal-element-form.tsx
+++ b/apps/web/modules/survey/editor/components/cal-element-form.tsx
@@ -44,6 +44,7 @@ export const CalElementForm = ({
     } else {
       updateElement(elementIdx, { calHost: element.calHost ?? "cal.com" });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only reacts to the toggle; adding element.calHost/updateElement/elementIdx would loop as it writes calHost back into the survey
   }, [isCalHostEnabled]);
 
   return (

--- a/apps/web/modules/survey/editor/components/contact-info-element-form.tsx
+++ b/apps/web/modules/survey/editor/components/contact-info-element-form.tsx
@@ -78,6 +78,7 @@ export const ContactInfoElementForm = ({
       .every((field) => !field.required);
 
     updateElement(elementIdx, { required: !allFieldsAreOptional });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sync-only effect; adding updateElement/elementIdx would loop as it writes back into the survey
   }, [element.firstName, element.lastName, element.email, element.phone, element.company]);
 
   const [parent] = useAutoAnimate();

--- a/apps/web/modules/survey/editor/components/elements-view.tsx
+++ b/apps/web/modules/survey/editor/components/elements-view.tsx
@@ -803,7 +803,7 @@ export const ElementsView = ({
       setActiveElementId(elementWithEmptyFallback.id);
       toast.error(t("workspace.surveys.edit.fallback_missing"));
     }
-  }, [activeElementId, setActiveElementId, localSurvey, selectedLanguageCode]);
+  }, [activeElementId, setActiveElementId, localSurvey, selectedLanguageCode, t]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {

--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -119,19 +119,15 @@ export const SurveyEditor = ({
 
   useDocumentVisibility(fetchLatestWorkspaceData);
 
+  // Recovery only: `localSurvey` is seeded from `survey` in its `useState` initializer, so this is a
+  // no-op unless something ever resets it to null (the `LoadingSkeleton` guard below is the state it
+  // recovers from). Written as an updater rather than reading `localSurvey`, because depending on it
+  // would re-run this on every keystroke in the editor to do nothing — and that shape becomes a real
+  // loop the moment someone edits the guard. The active element is not set here: the
+  // `[localSurvey?.type]` effect below already picks the first element whenever `localSurvey`
+  // appears.
   useEffect(() => {
-    if (survey) {
-      if (localSurvey) return;
-
-      const surveyClone = structuredClone(survey);
-      setLocalSurvey(surveyClone);
-
-      // Set first element from first block
-      const firstBlock = survey.blocks[0];
-      if (firstBlock) {
-        setActiveElementId(firstBlock.elements?.[0]?.id);
-      }
-    }
+    setLocalSurvey((current) => current ?? structuredClone(survey));
   }, [survey]);
 
   useEffect(() => {
@@ -158,6 +154,7 @@ export const SurveyEditor = ({
     if (firstBlock) {
       setActiveElementId(firstBlock.elements[0]?.id);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally resets active element only when the survey type changes, not on every block edit
   }, [localSurvey?.type]);
 
   useEffect(() => {

--- a/apps/web/modules/survey/follow-ups/components/follow-up-item.tsx
+++ b/apps/web/modules/survey/follow-ups/components/follow-up-item.tsx
@@ -117,7 +117,7 @@ export const FollowUpItem = ({
       ...prev,
       followUps: [...prev.followUps, newFollowUp],
     }));
-  }, [followUp, setLocalSurvey]);
+  }, [followUp, setLocalSurvey, t]);
 
   return (
     <>

--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -123,6 +123,10 @@ export const SurveyClientWrapper = ({
     }
   }, []);
 
+  // Serialized so the memo below is keyed on the field ids' contents rather than the array identity,
+  // which changes on every parent render (see ENG-2366).
+  const hiddenFieldIdsKey = JSON.stringify(survey.hiddenFields.fieldIds || []);
+
   // Extract hidden fields from URL parameters
   const hiddenFieldsRecord = useMemo(() => {
     const fieldsRecord: Record<string, string> = {};
@@ -131,8 +135,8 @@ export const SurveyClientWrapper = ({
       if (answer) fieldsRecord[field] = answer;
     }
     return fieldsRecord;
-    // eslint-disable-next-line react-hooks/use-memo -- migration ENG-2366
-  }, [searchParams, JSON.stringify(survey.hiddenFields.fieldIds || [])]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on hiddenFieldIdsKey so the record recomputes on field-id content changes, not on every new array instance
+  }, [searchParams, hiddenFieldIdsKey]);
 
   // Include verified email in hidden fields if available
   const getVerifiedEmail = useMemo<Record<string, string> | null>(() => {

--- a/apps/web/modules/survey/multi-language-surveys/components/manage-translations-modal.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/manage-translations-modal.tsx
@@ -109,6 +109,7 @@ export const ManageTranslationsModal = ({
       if (!aEmpty && bEmpty) return 1;
       return 0;
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `isDraftEmpty` is intentionally excluded so rows don't re-sort on every keystroke; the order snapshots on strings/missingFirst changes
   }, [strings, missingFirst]);
 
   // Merge draft translations into localSurvey so that the recall dropdown

--- a/apps/web/modules/ui/components/connect-integration/index.tsx
+++ b/apps/web/modules/ui/components/connect-integration/index.tsx
@@ -44,6 +44,7 @@ export const ConnectIntegration = ({
     if (error) {
       toast.error(t("workspace.integrations.connecting_integration_failed_please_try_again"));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount to surface an OAuth error query param; re-running on searchParams changes would re-fire the toast
   }, []);
 
   return (

--- a/apps/web/modules/ui/components/editor/components/toolbar-plugin.tsx
+++ b/apps/web/modules/ui/components/editor/components/toolbar-plugin.tsx
@@ -260,6 +260,7 @@ export const ToolbarPlugin = (
         }
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally reloads editor content only when updateTemplate/firstRender toggle; depending on editor/props would re-run on every unrelated prop change
   }, [props.updateTemplate, props.firstRender]);
 
   useEffect(() => {
@@ -275,6 +276,7 @@ export const ToolbarPlugin = (
         root.append(...nodes);
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-time firstRender initialization; adding editor/props would re-seed the editor on unrelated changes
   }, []);
 
   // Register text-saving update listener - always active for each editor instance

--- a/apps/web/modules/ui/components/file-input/index.tsx
+++ b/apps/web/modules/ui/components/file-input/index.tsx
@@ -223,6 +223,7 @@ export const FileInput = ({
         onFileUpload([videoUrlTemp], "video");
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- runs only on tab (fileType) change to sync temp URLs; adding the url/temp deps would re-fire uploads and loop
   }, [fileType]);
 
   return (

--- a/apps/web/modules/ui/components/multi-select/index.tsx
+++ b/apps/web/modules/ui/components/multi-select/index.tsx
@@ -70,6 +70,7 @@ export function MultiSelect<T extends string, K extends TOption<T>["value"][]>(
         setSelected(newSelected);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- syncs the `value` prop into local state; `selected` is only read for comparison, depending on it would re-run on every user selection
   }, [value, options]);
 
   // Sync user-initiated selected changes to parent via onChange (deferred to avoid render issues)
@@ -124,7 +125,7 @@ export function MultiSelect<T extends string, K extends TOption<T>["value"][]>(
         input.blur();
       }
     },
-    [onChange, disabled]
+    [disabled]
   );
 
   const selectableOptions = React.useMemo(() => {

--- a/apps/web/modules/ui/components/preview-survey/index.tsx
+++ b/apps/web/modules/ui/components/preview-survey/index.tsx
@@ -154,6 +154,7 @@ export const PreviewSurvey = ({
       resetProgress();
       surveyNameTemp = survey.name;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refresh preview only when `survey` changes; resetProgress is recreated each render, so depending on it would re-run every render
   }, [survey]);
 
   const resetProgress = () => {

--- a/apps/web/modules/ui/components/survey/index.tsx
+++ b/apps/web/modules/ui/components/survey/index.tsx
@@ -84,6 +84,7 @@ export const SurveyInline = (props: Omit<SurveyContainerProps, "containerId">) =
     };
 
     loadScript();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-time script load guarded by hasLoadedRef; depending on loadSurveyScript/renderInline would re-trigger the load
   }, [props]);
 
   useEffect(() => {


### PR DESCRIPTION
Ref ENG-2455

## What & why

**Was:** `epic/authzed` was synchronized through `main` commit `d8a3deb9c`, then a workspace-wide ESLint cleanup landed immediately afterward.

**Now:** Current `main` commit `475726e5f` is merged into the epic with a real merge commit, preserving the reviewed lint and hook behavior.

## Where to look

- [`apps/web/lib/useDocumentVisibility.ts`](https://github.com/formbricks/formbricks/blob/bhagya/sync-current-main-into-epic-authzed/apps/web/lib/useDocumentVisibility.ts) — external-store visibility hook
- [`apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx`](https://github.com/formbricks/formbricks/blob/bhagya/sync-current-main-into-epic-authzed/apps/web/app/%28app%29/workspaces/%5BworkspaceId%5D/components/MainNavigation.tsx) — stable callback dependencies
- [`apps/web/lib/useDocumentVisibility.test.ts`](https://github.com/formbricks/formbricks/blob/bhagya/sync-current-main-into-epic-authzed/apps/web/lib/useDocumentVisibility.test.ts) — merged behavior coverage

## Breaking changes

- [ ] This PR contains breaking changes

None. It synchronizes an already-merged product cleanup and changes no external contract.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run lib/useDocumentVisibility.test.ts lib/date-ranges.test.ts modules/ee/analysis/lib/date-presets.test.ts && pnpm --filter @formbricks/web typecheck && pnpm authzed:validate`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Visibility and date helpers | unit (guard) | 49 affected tests passed |
| AuthZed contract | unit (guard) | 157 assertions and 6 expected relations passed |
| Merge compatibility | unit (guard) | Web typecheck passed on merge head `b9a0b8506` |

**Open gaps**

- Review and remote CI are pending.

**Risks**

- A later authorization-sensitive `main` change invalidates candidate evidence and restarts sandbox validation.

---

> [!NOTE]
> **AI model used** — `GPT-5`, reasoning effort `unknown`.