### PR TITLE
chore: resolve the open SonarQube findings and the remaining super-linear regexes

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
@@ -1,11 +1,42 @@
-const EMAIL_DOCTYPE_PATTERN = /<!DOCTYPE[^>]*>/i;
-const EMAIL_BODY_PATTERN = /<body\b[^>]*>([\s\S]*?)<\/body>/i;
+// The attribute run is length-capped so a `<body`/`<!DOCTYPE` repeated with no closing `>` cannot
+// make the engine rescan to the end from every occurrence (O(N^2) — measured 1.3s on 200k chars).
+// The cap is ~30x the longest tag these emails carry, so every real document matches exactly as
+// before; past it the tag is left alone rather than stripped, which degrades to "keep the markup",
+// never to corrupted output.
+const EMAIL_TAG_ATTRIBUTES_MAX = 4096;
+const EMAIL_DOCTYPE_PATTERN = new RegExp(`<!DOCTYPE[^>]{0,${EMAIL_TAG_ATTRIBUTES_MAX}}>`, "i");
+const EMAIL_BODY_OPEN_TAG_PATTERN = new RegExp(`<body\\b[^>]{0,${EMAIL_TAG_ATTRIBUTES_MAX}}>`, "i");
+const EMAIL_BODY_CLOSE_TAG = "</body>";
 const EMAIL_REACT_SERVER_MARKER_PATTERN = /<!--\/?\$-->/g;
+
+/**
+ * The body content, or null when the document has no `<body>…</body>`.
+ *
+ * Two index scans rather than `<body\b[^>]*>([\s\S]*?)<\/body>`: capping the attribute run alone did
+ * not help that pattern (measured 766ms before and after on 200k chars), because the cost is in the
+ * lazy `([\s\S]*?)` — it expands to the end of the document looking for a `</body>` that never
+ * arrives, once per `<body>` occurrence. Capping the CONTENT instead is not an option: that group is
+ * the whole email, legitimately large.
+ *
+ * Same result as the regex. It matched the leftmost `<body…>` that has a `</body>` after it, and if
+ * none follows the first opening tag then none follows a later one either — so taking the first
+ * opening tag and the first close after it picks exactly the same span.
+ */
+const extractBodyContent = (html: string): string | null => {
+  const openTag = EMAIL_BODY_OPEN_TAG_PATTERN.exec(html);
+  if (!openTag) return null;
+
+  const contentStart = openTag.index + openTag[0].length;
+  // `indexOf` on a lowercased copy keeps the regex's case-insensitivity at one linear pass, rather
+  // than the per-position retry a case-insensitive search would cost.
+  const contentEnd = html.toLowerCase().indexOf(EMAIL_BODY_CLOSE_TAG, contentStart);
+
+  return contentEnd === -1 ? null : html.slice(contentStart, contentEnd);
+};
 
 export const extractEmailBodyFragment = (html: string): string => {
   const htmlWithoutDoctype = html.replace(EMAIL_DOCTYPE_PATTERN, "").trim();
-  const bodyMatch = EMAIL_BODY_PATTERN.exec(htmlWithoutDoctype);
-  const fragment = bodyMatch?.[1].trim() ?? htmlWithoutDoctype;
+  const fragment = extractBodyContent(htmlWithoutDoctype)?.trim() ?? htmlWithoutDoctype;
 
   return fragment.replaceAll(EMAIL_REACT_SERVER_MARKER_PATTERN, "").trim();
 };

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
@@ -1,6 +1,5 @@
-import { findOpeningTag } from "@/lib/utils/html-opening-tag";
+import { findClosingTag, findOpeningTag } from "@/lib/utils/html-opening-tag";
 
-const EMAIL_BODY_CLOSE_TAG = "</body>";
 const EMAIL_REACT_SERVER_MARKER_PATTERN = /<!--\/?\$-->/g;
 
 /**
@@ -21,25 +20,9 @@ const extractBodyContent = (html: string): string | null => {
   if (!openTag) return null;
 
   const contentStart = openTag.index + openTag.length;
-  const contentEnd = findCloseTagIndex(html, contentStart);
+  const contentEnd = findClosingTag(html, "body", contentStart);
 
   return contentEnd === -1 ? null : html.slice(contentStart, contentEnd);
-};
-
-/**
- * `</body>` is matched case-insensitively, like the `i` flag did. Deliberately not
- * `html.toLowerCase().indexOf(...)`: lowercasing is not length-preserving (U+0130 becomes two code
- * units), so a document containing one would return an index into a differently-sized string.
- */
-const findCloseTagIndex = (html: string, from: number): number => {
-  for (let index = from; index <= html.length - EMAIL_BODY_CLOSE_TAG.length; index++) {
-    if (html.startsWith(EMAIL_BODY_CLOSE_TAG, index)) return index;
-    // Only the ASCII letters differ in case here, so a case-folded comparison of the slice is exact.
-    if (html.slice(index, index + EMAIL_BODY_CLOSE_TAG.length).toLowerCase() === EMAIL_BODY_CLOSE_TAG) {
-      return index;
-    }
-  }
-  return -1;
 };
 
 export const extractEmailBodyFragment = (html: string): string => {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
@@ -5,7 +5,7 @@
 // never to corrupted output.
 const EMAIL_TAG_ATTRIBUTES_MAX = 4096;
 const EMAIL_DOCTYPE_PATTERN = new RegExp(`<!DOCTYPE[^>]{0,${EMAIL_TAG_ATTRIBUTES_MAX}}>`, "i");
-const EMAIL_BODY_OPEN_TAG_PATTERN = new RegExp(`<body\\b[^>]{0,${EMAIL_TAG_ATTRIBUTES_MAX}}>`, "i");
+const EMAIL_BODY_OPEN_TAG_PATTERN = new RegExp(String.raw`<body\b[^>]{0,${EMAIL_TAG_ATTRIBUTES_MAX}}>`, "i");
 const EMAIL_BODY_CLOSE_TAG = "</body>";
 const EMAIL_REACT_SERVER_MARKER_PATTERN = /<!--\/?\$-->/g;
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
@@ -1,8 +1,14 @@
 // The attribute run is length-capped so a `<body`/`<!DOCTYPE` repeated with no closing `>` cannot
 // make the engine rescan to the end from every occurrence (O(N^2) — measured 1.3s on 200k chars).
 // The cap is ~30x the longest tag these emails carry, so every real document matches exactly as
-// before; past it the tag is left alone rather than stripped, which degrades to "keep the markup",
-// never to corrupted output.
+// before.
+//
+// Past it the behaviour is NOT simply "leave the tag alone": if the over-long attribute run itself
+// contains another `<body`/`<!DOCTYPE`, the engine restarts there and matches THAT tag instead, so
+// a crafted document can have a different span extracted. Reaching it needs a >4096-character tag
+// containing a second opening tag, which nothing that renders these emails produces — but it is a
+// wrong-span outcome rather than a no-op, and worth knowing before the cap is relied on elsewhere.
+// Tracked in ENG-2789.
 const EMAIL_TAG_ATTRIBUTES_MAX = 4096;
 const EMAIL_DOCTYPE_PATTERN = new RegExp(`<!DOCTYPE[^>]{0,${EMAIL_TAG_ATTRIBUTES_MAX}}>`, "i");
 const EMAIL_BODY_OPEN_TAG_PATTERN = new RegExp(String.raw`<body\b[^>]{0,${EMAIL_TAG_ATTRIBUTES_MAX}}>`, "i");

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplateFragment.ts
@@ -1,47 +1,53 @@
-// The attribute run is length-capped so a `<body`/`<!DOCTYPE` repeated with no closing `>` cannot
-// make the engine rescan to the end from every occurrence (O(N^2) — measured 1.3s on 200k chars).
-// The cap is ~30x the longest tag these emails carry, so every real document matches exactly as
-// before.
-//
-// Past it the behaviour is NOT simply "leave the tag alone": if the over-long attribute run itself
-// contains another `<body`/`<!DOCTYPE`, the engine restarts there and matches THAT tag instead, so
-// a crafted document can have a different span extracted. Reaching it needs a >4096-character tag
-// containing a second opening tag, which nothing that renders these emails produces — but it is a
-// wrong-span outcome rather than a no-op, and worth knowing before the cap is relied on elsewhere.
-// Tracked in ENG-2789.
-const EMAIL_TAG_ATTRIBUTES_MAX = 4096;
-const EMAIL_DOCTYPE_PATTERN = new RegExp(`<!DOCTYPE[^>]{0,${EMAIL_TAG_ATTRIBUTES_MAX}}>`, "i");
-const EMAIL_BODY_OPEN_TAG_PATTERN = new RegExp(String.raw`<body\b[^>]{0,${EMAIL_TAG_ATTRIBUTES_MAX}}>`, "i");
+import { findOpeningTag } from "@/lib/utils/html-opening-tag";
+
 const EMAIL_BODY_CLOSE_TAG = "</body>";
 const EMAIL_REACT_SERVER_MARKER_PATTERN = /<!--\/?\$-->/g;
 
 /**
  * The body content, or null when the document has no `<body>…</body>`.
  *
- * Two index scans rather than `<body\b[^>]*>([\s\S]*?)<\/body>`: capping the attribute run alone did
- * not help that pattern (measured 766ms before and after on 200k chars), because the cost is in the
- * lazy `([\s\S]*?)` — it expands to the end of the document looking for a `</body>` that never
- * arrives, once per `<body>` occurrence. Capping the CONTENT instead is not an option: that group is
- * the whole email, legitimately large.
+ * Two scans rather than `<body\b[^>]*>([\s\S]*?)<\/body>`. That pattern is quadratic twice over: the
+ * attribute run rescans from every `<body` when no `>` follows, and the lazy content group expands
+ * to the end of the document once per `<body>` when no `</body>` follows. Capping fixes neither —
+ * the content group is the whole email and cannot be capped, and capping the attribute run makes an
+ * over-long tag match a LATER `<body>` instead, extracting the wrong span.
  *
  * Same result as the regex. It matched the leftmost `<body…>` that has a `</body>` after it, and if
- * none follows the first opening tag then none follows a later one either — so taking the first
+ * none follows the first opening tag then none follows a later one either, so taking the first
  * opening tag and the first close after it picks exactly the same span.
  */
 const extractBodyContent = (html: string): string | null => {
-  const openTag = EMAIL_BODY_OPEN_TAG_PATTERN.exec(html);
+  const openTag = findOpeningTag(html, "body");
   if (!openTag) return null;
 
-  const contentStart = openTag.index + openTag[0].length;
-  // `indexOf` on a lowercased copy keeps the regex's case-insensitivity at one linear pass, rather
-  // than the per-position retry a case-insensitive search would cost.
-  const contentEnd = html.toLowerCase().indexOf(EMAIL_BODY_CLOSE_TAG, contentStart);
+  const contentStart = openTag.index + openTag.length;
+  const contentEnd = findCloseTagIndex(html, contentStart);
 
   return contentEnd === -1 ? null : html.slice(contentStart, contentEnd);
 };
 
+/**
+ * `</body>` is matched case-insensitively, like the `i` flag did. Deliberately not
+ * `html.toLowerCase().indexOf(...)`: lowercasing is not length-preserving (U+0130 becomes two code
+ * units), so a document containing one would return an index into a differently-sized string.
+ */
+const findCloseTagIndex = (html: string, from: number): number => {
+  for (let index = from; index <= html.length - EMAIL_BODY_CLOSE_TAG.length; index++) {
+    if (html.startsWith(EMAIL_BODY_CLOSE_TAG, index)) return index;
+    // Only the ASCII letters differ in case here, so a case-folded comparison of the slice is exact.
+    if (html.slice(index, index + EMAIL_BODY_CLOSE_TAG.length).toLowerCase() === EMAIL_BODY_CLOSE_TAG) {
+      return index;
+    }
+  }
+  return -1;
+};
+
 export const extractEmailBodyFragment = (html: string): string => {
-  const htmlWithoutDoctype = html.replace(EMAIL_DOCTYPE_PATTERN, "").trim();
+  const doctype = findOpeningTag(html, "!DOCTYPE", { requireWordBoundary: false });
+  const htmlWithoutDoctype = (
+    doctype ? html.slice(0, doctype.index) + html.slice(doctype.index + doctype.length) : html
+  ).trim();
+
   const fragment = extractBodyContent(htmlWithoutDoctype)?.trim() ?? htmlWithoutDoctype;
 
   return fragment.replaceAll(EMAIL_REACT_SERVER_MARKER_PATTERN, "").trim();

--- a/apps/web/lib/utils/client-ip.ts
+++ b/apps/web/lib/utils/client-ip.ts
@@ -19,7 +19,7 @@ export const UNTRUSTED_CLIENT_IP = "untrusted-client-ip";
 
 const CLIENT_IP_WARNING_INTERVAL_MS = 10 * 60 * 1000;
 const VALID_DECIMAL_PORT = /^[1-9]\d{0,4}$/;
-const BRACKETED_ADDRESS = /^\[([^\[\]]+)\](?::([^:]+))?$/;
+const BRACKETED_ADDRESS = /^\[([^[\]]+)\](?::([^:]+))?$/;
 const IPV4_SOCKET = /^([^:]+):(\d+)$/;
 
 type ClientIpWarningReason = "disabled" | "invalid-selected-hop" | "missing-chain" | "short-chain";

--- a/apps/web/lib/utils/html-opening-tag.test.ts
+++ b/apps/web/lib/utils/html-opening-tag.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "vitest";
+import { findOpeningTag, replaceOpeningTags } from "./html-opening-tag";
+
+// The regexes this module replaces, kept here as the oracle every case is compared against.
+const asRegex = (name: string, wordBoundary = true) =>
+  new RegExp(`<${name}${wordBoundary ? String.raw`\b` : ""}([^>]*)>`, "gi");
+
+const CASES: { name: string; wordBoundary?: boolean }[] = [
+  { name: "p" },
+  { name: "li" },
+  { name: "body" },
+  { name: "!DOCTYPE", wordBoundary: false },
+];
+
+const FIXED = [
+  "",
+  "<p>a</p>",
+  '<p style="margin:0" class="x">a</p>',
+  "<p >spaced</p><P>upper</P>",
+  "<pre>not a p</pre>",
+  "<p",
+  "<p unclosed",
+  "<li><p>nested</p></li>",
+  "<!DOCTYPE html><body>x</body>",
+  "<!DOCTYPEhtml>",
+  "<body\ndata-x='1'\n>multiline",
+  "<p a><p b><p c>",
+  "text with no tags at all",
+  "<p></p><p></p>",
+  "<p_underscore>",
+  // The shapes a length cap got wrong: an over-long run containing another opening tag.
+  `<p ${"a".repeat(5000)}<p style="x">tail`,
+  `<li ${"a".repeat(5000)}<li style="x">tail`,
+  `<body ${"a".repeat(5000)}<body class="x">inner`,
+  `<!DOCTYPE ${"a".repeat(5000)}<!DOCTYPE html>rest`,
+  // U+0130 lowercases to two code units; a toLowerCase()-based scan would misalign here.
+  "İ<p style='x'>after a length-changing character</p>",
+];
+
+const ALPHABET = "<>/plibodyPLIBODY!DCTYPE \n\t\"'=-0_";
+const random = Array.from({ length: 20000 }, () => {
+  const n = Math.floor(Math.random() * 40);
+  let s = "";
+  for (let i = 0; i < n; i++) s += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
+  return s;
+});
+const CORPUS = [...FIXED, ...random];
+
+describe("html opening tag scanner", () => {
+  test.each(CASES)("replaceOpeningTags matches the regex it replaces ($name)", ({ name, wordBoundary }) => {
+    for (const source of CORPUS) {
+      const viaRegex = source.replace(asRegex(name, wordBoundary), (_m, attrs: string) => `[${attrs}]`);
+      const viaScan = replaceOpeningTags(source, name, (attrs) => `[${attrs}]`, {
+        requireWordBoundary: wordBoundary,
+      });
+
+      expect(viaScan, `input: ${JSON.stringify(source.slice(0, 60))}`).toBe(viaRegex);
+    }
+  });
+
+  test.each(CASES)(
+    "findOpeningTag reports the regex's index and capture ($name)",
+    ({ name, wordBoundary }) => {
+      for (const source of CORPUS) {
+        const expected = asRegex(name, wordBoundary).exec(source);
+        const actual = findOpeningTag(source, name, { requireWordBoundary: wordBoundary });
+
+        if (expected === null) {
+          expect(actual, `input: ${JSON.stringify(source.slice(0, 60))}`).toBeNull();
+          continue;
+        }
+        expect(actual, `input: ${JSON.stringify(source.slice(0, 60))}`).toEqual({
+          index: expected.index,
+          length: expected[0].length,
+          attributes: expected[1],
+        });
+      }
+    }
+  );
+
+  test("stays linear where the regex was quadratic", () => {
+    // `<p ` repeated with no `>` anywhere: the regex rescans to the end from every occurrence.
+    const pathological = "<p ".repeat(70000);
+
+    const startedAt = performance.now();
+    const result = replaceOpeningTags(pathological, "p", (attrs) => `[${attrs}]`);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(result).toBe(pathological);
+    expect(elapsedMs).toBeLessThan(500);
+  });
+});

--- a/apps/web/lib/utils/html-opening-tag.test.ts
+++ b/apps/web/lib/utils/html-opening-tag.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { findOpeningTag, replaceOpeningTags } from "./html-opening-tag";
+import { findClosingTag, findOpeningTag, replaceOpeningTags } from "./html-opening-tag";
 
 // The regexes this module replaces, kept here as the oracle every case is compared against.
 const asRegex = (name: string, wordBoundary = true) =>
@@ -77,6 +77,23 @@ describe("html opening tag scanner", () => {
       }
     }
   );
+
+  test("findClosingTag matches the case-insensitive close the regex used", () => {
+    const iDot = String.fromCharCode(0x130); // lowercases to two code units
+    const cases = [
+      ["</body>", 0],
+      ["<body>x</BODY>", 7],
+      ["<body>x</BoDy>rest", 7],
+      ["no close here", -1],
+      // A toLowerCase()-based search would report an index into a longer string here.
+      [`<BODY>prefix${iDot}suffix</BoDy>`, `<BODY>prefix${iDot}suffix`.length],
+      [`${iDot.repeat(20)}</body>`, 20],
+    ] as const;
+
+    for (const [source, expected] of cases) {
+      expect(findClosingTag(source, "body"), JSON.stringify(source)).toBe(expected);
+    }
+  });
 
   test("stays linear where the regex was quadratic", () => {
     // `<p ` repeated with no `>` anywhere: the regex rescans to the end from every occurrence.

--- a/apps/web/lib/utils/html-opening-tag.ts
+++ b/apps/web/lib/utils/html-opening-tag.ts
@@ -94,6 +94,13 @@ export const findOpeningTag = (
 };
 
 /**
+ * Index of the first `</name>` at or after `from`, or -1. The counterpart to `findOpeningTag`, and
+ * case-insensitive the same way.
+ */
+export const findClosingTag = (source: string, name: string, from = 0): number =>
+  indexOfAsciiCaseInsensitive(source, `</${name}>`, from);
+
+/**
  * Replace every `<name …>` with `replace(attributes, tag)`, matching `/<name\b([^>]*)>/gi` under
  * `replaceAll`. Like the regex, scanning resumes after the replaced tag's `>`, so a replacement
  * that itself contains a tag is never rescanned.

--- a/apps/web/lib/utils/html-opening-tag.ts
+++ b/apps/web/lib/utils/html-opening-tag.ts
@@ -13,13 +13,19 @@
  */
 
 /** `\b` after an ASCII-letter tag name: the next character must exist and not be a word character. */
-const isWordCharacterCode = (code: number): boolean =>
-  (code >= 48 && code <= 57) || // 0-9
-  (code >= 65 && code <= 90) || // A-Z
-  (code >= 97 && code <= 122) || // a-z
-  code === 95; // _
+const isWordCharacterCode = (code: number | undefined): boolean =>
+  code !== undefined &&
+  ((code >= 48 && code <= 57) || // 0-9
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 97 && code <= 122) || // a-z
+    code === 95); // _
 
-const toAsciiLowerCode = (code: number): number => (code >= 65 && code <= 90 ? code + 32 : code);
+/**
+ * Past the end of the string `codePointAt` yields `undefined`, which never equals another position's
+ * code — the same outcome `charCodeAt`'s `NaN` produced, so the scans below are unchanged.
+ */
+const toAsciiLowerCode = (code: number | undefined): number | undefined =>
+  code !== undefined && code >= 65 && code <= 90 ? code + 32 : code;
 
 /**
  * ASCII-case-insensitive `indexOf`, matching the `i` flag's behaviour on the ASCII literals used
@@ -32,7 +38,7 @@ const indexOfAsciiCaseInsensitive = (haystack: string, needle: string, from: num
     let offset = 0;
     while (
       offset < needle.length &&
-      toAsciiLowerCode(haystack.charCodeAt(start + offset)) === toAsciiLowerCode(needle.charCodeAt(offset))
+      toAsciiLowerCode(haystack.codePointAt(start + offset)) === toAsciiLowerCode(needle.codePointAt(offset))
     ) {
       offset++;
     }
@@ -72,7 +78,7 @@ export const findOpeningTag = (
     const afterPrefix = start + prefix.length;
     // `\b` fails when the next character continues the word, e.g. `<p` inside `<pre>`. The regex
     // would then retry one position later, so the scan does too.
-    if (requireWordBoundary && isWordCharacterCode(source.charCodeAt(afterPrefix))) {
+    if (requireWordBoundary && isWordCharacterCode(source.codePointAt(afterPrefix))) {
       searchFrom = start + 1;
       continue;
     }

--- a/apps/web/lib/utils/html-opening-tag.ts
+++ b/apps/web/lib/utils/html-opening-tag.ts
@@ -1,0 +1,124 @@
+/**
+ * Locate HTML opening tags the way `/<tag\b[^>]*>/gi` did, without the regex.
+ *
+ * Why not the regex: `[^>]*` is unbounded, so on a run of `<p` with no `>` after it the engine
+ * rescans to the end of the document from every occurrence — O(N^2), measured 7.4s on 200k
+ * characters. Capping the run is not a fix either: when the over-long run itself contains another
+ * `<p`, the engine restarts there and normalizes a DIFFERENT tag, which is a wrong-output failure
+ * rather than a no-op.
+ *
+ * A forward scan has neither problem. `[^>]*` cannot cross a `>`, so a tag always ends at the first
+ * `>` after its name — one `indexOf` — and if no `>` follows the first opening tag then none follows
+ * a later one either, so the scan stops rather than retrying. Same matches, one pass, no cap.
+ */
+
+/** `\b` after an ASCII-letter tag name: the next character must exist and not be a word character. */
+const isWordCharacterCode = (code: number): boolean =>
+  (code >= 48 && code <= 57) || // 0-9
+  (code >= 65 && code <= 90) || // A-Z
+  (code >= 97 && code <= 122) || // a-z
+  code === 95; // _
+
+const toAsciiLowerCode = (code: number): number => (code >= 65 && code <= 90 ? code + 32 : code);
+
+/**
+ * ASCII-case-insensitive `indexOf`, matching the `i` flag's behaviour on the ASCII literals used
+ * here. Deliberately not `haystack.toLowerCase().indexOf(...)`: lowercasing is not length-preserving
+ * (U+0130 becomes two code units), so a document containing one would misalign every later index.
+ */
+const indexOfAsciiCaseInsensitive = (haystack: string, needle: string, from: number): number => {
+  const lastStart = haystack.length - needle.length;
+  for (let start = Math.max(0, from); start <= lastStart; start++) {
+    let offset = 0;
+    while (
+      offset < needle.length &&
+      toAsciiLowerCode(haystack.charCodeAt(start + offset)) === toAsciiLowerCode(needle.charCodeAt(offset))
+    ) {
+      offset++;
+    }
+    if (offset === needle.length) return start;
+  }
+  return -1;
+};
+
+export interface OpeningTagMatch {
+  /** Index of the `<`. */
+  readonly index: number;
+  /** Length of the whole tag, `<` through `>`. */
+  readonly length: number;
+  /** Everything between the tag name and the `>` — the regex's capture group. */
+  readonly attributes: string;
+}
+
+/**
+ * The first `<name …>` at or after `from`, or null when there is none.
+ *
+ * `requireWordBoundary` mirrors whether the pattern had `\b` after the name: `<p\b` must not match
+ * `<pre`, while `<!DOCTYPE[^>]*>` has no such constraint and matches `<!DOCTYPEhtml>`.
+ */
+export const findOpeningTag = (
+  source: string,
+  name: string,
+  { requireWordBoundary = true }: { requireWordBoundary?: boolean } = {},
+  from = 0
+): OpeningTagMatch | null => {
+  const prefix = `<${name}`;
+  let searchFrom = from;
+
+  while (searchFrom <= source.length) {
+    const start = indexOfAsciiCaseInsensitive(source, prefix, searchFrom);
+    if (start === -1) return null;
+
+    const afterPrefix = start + prefix.length;
+    // `\b` fails when the next character continues the word, e.g. `<p` inside `<pre>`. The regex
+    // would then retry one position later, so the scan does too.
+    if (requireWordBoundary && isWordCharacterCode(source.charCodeAt(afterPrefix))) {
+      searchFrom = start + 1;
+      continue;
+    }
+
+    const close = source.indexOf(">", afterPrefix);
+    // `[^>]*` cannot cross a `>`, so a tag ends at the first one. No `>` after this opening tag
+    // means none after any later one either — the regex would scan the rest of the document to
+    // discover that; there is nothing left to find.
+    if (close === -1) return null;
+
+    return {
+      index: start,
+      length: close - start + 1,
+      attributes: source.slice(afterPrefix, close),
+    };
+  }
+
+  return null;
+};
+
+/**
+ * Replace every `<name …>` with `replace(attributes, tag)`, matching `/<name\b([^>]*)>/gi` under
+ * `replaceAll`. Like the regex, scanning resumes after the replaced tag's `>`, so a replacement
+ * that itself contains a tag is never rescanned.
+ *
+ * `tag` is the matched text exactly as it appeared, which callers that pass a tag through unchanged
+ * need: rebuilding it from `name` would normalize `<LI …>` to `<li …>`.
+ */
+export const replaceOpeningTags = (
+  source: string,
+  name: string,
+  replace: (attributes: string, tag: string) => string,
+  options: { requireWordBoundary?: boolean } = {}
+): string => {
+  let result = "";
+  let copiedTo = 0;
+
+  for (
+    let match = findOpeningTag(source, name, options, 0);
+    match !== null;
+    match = findOpeningTag(source, name, options, copiedTo)
+  ) {
+    const tag = source.slice(match.index, match.index + match.length);
+    result += source.slice(copiedTo, match.index) + replace(match.attributes, tag);
+    copiedTo = match.index + match.length;
+  }
+
+  return copiedTo === 0 ? source : result + source.slice(copiedTo);
+};

--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -33,10 +33,19 @@ export const extractIds = (text: string): string[] => {
 };
 
 // Extracts the fallback value from a string containing the "fallback" pattern.
+// An index scan, not `/fallback:([^#]*)#/`: that pattern is O(N^2) on a long run of `fallback:`
+// with no `#` after it, because the engine rescans to the end from every occurrence. Identical
+// result — `[^#]*` cannot cross a `#`, so the regex ends at the first `#` after the FIRST
+// `fallback:`, and if none follows that one none follows a later one either.
+const FALLBACK_MARKER = "fallback:";
+
 export const extractFallbackValue = (text: string): string => {
-  const pattern = /fallback:([^#]*)#/;
-  const match = text.match(pattern);
-  return match?.[1] ?? "";
+  const markerStart = text.indexOf(FALLBACK_MARKER);
+  if (markerStart === -1) return "";
+
+  const valueStart = markerStart + FALLBACK_MARKER.length;
+  const valueEnd = text.indexOf("#", valueStart);
+  return valueEnd === -1 ? "" : text.slice(valueStart, valueEnd);
 };
 
 // Extracts the complete recall information (ID and fallback) from a headline string.

--- a/apps/web/lib/utils/video-upload.test.ts
+++ b/apps/web/lib/utils/video-upload.test.ts
@@ -137,3 +137,34 @@ describe("extractLoomId", () => {
     expect(extractLoomId("https://loom.com/invalid/abcdef123456")).toBeNull();
   });
 });
+
+describe("extractYoutubeId — stored-value denial of service (ENG-2789)", () => {
+  // The pattern list this replaced used `youtube\\.com.*v=(…)`, whose `.*` backtracks once per
+  // `youtube.com`. `ZStorageUrl` is an unbounded `z.string()`, so a value this long persists and
+  // reaches the RESPONDENT renderer, where `element-media.tsx` converts it twice per render.
+  test("a long repeated-host URL resolves fast instead of blocking the thread", () => {
+    const stored = `https://youtube.com/${"youtube.com/".repeat(25_600)}`; // 307,220 characters
+
+    const startedAt = performance.now();
+    const result = extractYoutubeId(stored);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(result).toBeNull();
+    // ~6700ms per call before, and the renderer calls it twice.
+    expect(elapsedMs).toBeLessThan(200);
+  });
+
+  // Greedy `.*` took the LAST marker on the line and backtracked to an earlier one when the last
+  // had no id after it. Both are load-bearing, so they are pinned rather than left to the corpus.
+  test.each([
+    ["https://www.youtube.com/watch?x=v=FIRST&v=SECOND", "SECOND"],
+    ["https://youtube.com/embed/abc/embed/def", "def"],
+    ["https://youtube.com/watch?v=&v=OK", "OK"],
+    ["https://youtube.com/watch?v=&v=", null],
+    // `.` cannot cross a line terminator, so a marker on the next line is not reachable.
+    ["youtube.com\nv=NEXTLINE", null],
+    ["youtube.com v=SAMELINE\nyoutube.com v=SECOND", "SAMELINE"],
+  ])("resolves %s to %s, as the pattern did", (url, expected) => {
+    expect(extractYoutubeId(url)).toBe(expected);
+  });
+});

--- a/apps/web/lib/utils/video-upload.test.ts
+++ b/apps/web/lib/utils/video-upload.test.ts
@@ -150,8 +150,11 @@ describe("extractYoutubeId — stored-value denial of service (ENG-2789)", () =>
     const elapsedMs = performance.now() - startedAt;
 
     expect(result).toBeNull();
-    // ~6700ms per call before, and the renderer calls it twice.
-    expect(elapsedMs).toBeLessThan(200);
+    // Budget chosen from measurements, not a round number: the scan costs 6ms uninstrumented but
+    // ~330ms under the coverage run CI uses, which slows tight character loops far more than it
+    // slows a native regex. The pattern this replaced takes ~3300ms on the same input either way,
+    // so 2000ms sits above the instrumented pass and below the regression it guards against.
+    expect(elapsedMs).toBeLessThan(2000);
   });
 
   // Greedy `.*` took the LAST marker on the line and backtracked to an earlier one when the last

--- a/apps/web/lib/utils/video-upload.ts
+++ b/apps/web/lib/utils/video-upload.ts
@@ -56,8 +56,8 @@ export const extractYoutubeId = (url: string): string | null => {
   // Regular expressions for various YouTube URL formats
   const regExpList = [
     /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.*v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
-    /youtube\.com.*embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
+    /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]{1,64})/, // youtube.com/watch?v=<id>
+    /youtube\.com.{0,2048}embed\/([a-zA-Z0-9_-]{1,64})/, // youtube.com/embed/<id>
     /youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
   ];
 

--- a/apps/web/lib/utils/video-upload.ts
+++ b/apps/web/lib/utils/video-upload.ts
@@ -56,8 +56,8 @@ export const extractYoutubeId = (url: string): string | null => {
   // Regular expressions for various YouTube URL formats
   const regExpList = [
     /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]{1,64})/, // youtube.com/watch?v=<id>
-    /youtube\.com.{0,2048}embed\/([a-zA-Z0-9_-]{1,64})/, // youtube.com/embed/<id>
+    /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
+    /youtube\.com.{0,2048}embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
     /youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
   ];
 

--- a/apps/web/lib/utils/video-upload.ts
+++ b/apps/web/lib/utils/video-upload.ts
@@ -53,17 +53,15 @@ export const checkForLoomUrl = (url: string): boolean => {
 export const extractYoutubeId = (url: string): string | null => {
   let id = "";
 
-  // The `.{0,2048}` caps replace an unbounded `.*`, which rescanned to the end from every start
-  // position (O(N^2) — measured 1.6s on 200k chars). Greedy on purpose: `.*v=` resolves the LAST
-  // `v=`, and a lazy cap would silently switch it to the first.
-  //
-  // The cap is not free: a `v=` more than 2048 characters past `youtube.com`, or a second
-  // `youtube.com` in the string, can make this resolve a different id than the uncapped form did.
-  // No real watch URL is that long, but it is a wrong-id outcome rather than a no-match. ENG-2789.
+  // Unbounded `.*` here is quadratic in theory (measured 1.6s on 200k characters), but the input is
+  // a video URL from a form field, so that length cannot occur. A `.{0,2048}` cap was tried and
+  // removed: it bought nothing reachable and could resolve a DIFFERENT id than the uncapped form —
+  // a `v=` beyond the cap, or a second `youtube.com`, shifts which match wins. Exactness matters
+  // more than a bound that never binds. See ENG-2789.
   const regExpList = [
     /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
-    /youtube\.com.{0,2048}embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
+    /youtube\.com.*v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
+    /youtube\.com.*embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
     /youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
   ];
 

--- a/apps/web/lib/utils/video-upload.ts
+++ b/apps/web/lib/utils/video-upload.ts
@@ -1,4 +1,6 @@
-import { extractIdAfterHostMarker } from "@formbricks/survey-ui/youtube-id";
+import { extractYoutubeId } from "@formbricks/survey-ui/youtube-id";
+
+export { extractYoutubeId };
 
 export const checkForYoutubeUrl = (url: string): boolean => {
   try {
@@ -50,29 +52,6 @@ export const checkForLoomUrl = (url: string): boolean => {
   } catch {
     return false;
   }
-};
-
-export const extractYoutubeId = (url: string): string | null => {
-  // Order preserved from the pattern list this replaces: youtu.be, then `v=`, then `embed/`, then
-  // youtube-nocookie. The first and last carry no `.*`, so they stay as regexes.
-  for (const [pattern, marker] of [
-    [/youtu\.be\/([a-zA-Z0-9_-]+)/, null],
-    [null, "v="],
-    [null, "embed/"],
-    [/youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, null],
-  ] as [RegExp | null, string | null][]) {
-    if (pattern) {
-      const match = pattern.exec(url);
-      const id = match ? match[1] : null;
-      if (id) return id;
-      continue;
-    }
-
-    const id = extractIdAfterHostMarker(url, marker as string);
-    if (id) return id;
-  }
-
-  return null;
 };
 
 export const extractVimeoId = (url: string): string | null => {

--- a/apps/web/lib/utils/video-upload.ts
+++ b/apps/web/lib/utils/video-upload.ts
@@ -50,31 +50,88 @@ export const checkForLoomUrl = (url: string): boolean => {
   }
 };
 
-export const extractYoutubeId = (url: string): string | null => {
-  let id = "";
+// `youtube.com` followed later by `v=` or `embed/`, scanned rather than matched with
+// `/youtube\.com.*v=(…)/`. That pattern is quadratic: `.*` runs to the end of the line and
+// backtracks once per `youtube.com`, so a stored value of `"youtube.com/".repeat(25_600)` took
+// 6.7s per call — and `element-media.tsx` calls the converter twice, blocking the RESPONDENT's
+// main thread for ~13s. `ZStorageUrl` is an unbounded `z.string()`, so nothing caps the value on
+// its way into the database (ENG-2789).
+//
+// A length cap was rejected: it would resolve a different id than the pattern did when a marker
+// sits beyond it. This reproduces the pattern exactly instead.
+//
+// The equivalence rests on three properties of the original:
+//   - `.` excludes line terminators, so the marker shares a line with the host it follows.
+//   - `.*` is greedy, so the LAST marker on that line wins, and it backtracks to an earlier one
+//     when the last has no id character after it.
+//   - If the first host on a line has no usable marker, no later host on that line can either —
+//     its search region is a suffix of the first's — so the scan skips the line instead of
+//     retrying every position, which is what makes it linear.
+const YOUTUBE_HOST = "youtube.com";
 
-  // Unbounded `.*` here is quadratic in theory (measured 1.6s on 200k characters), but the input is
-  // a video URL from a form field, so that length cannot occur. A `.{0,2048}` cap was tried and
-  // removed: it bought nothing reachable and could resolve a DIFFERENT id than the uncapped form —
-  // a `v=` beyond the cap, or a second `youtube.com`, shifts which match wins. Exactness matters
-  // more than a bound that never binds. See ENG-2789.
-  const regExpList = [
-    /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.*v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
-    /youtube\.com.*embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
-    /youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
-  ];
+const isYoutubeIdCharacter = (character: string | undefined): boolean =>
+  character !== undefined && /[a-zA-Z0-9_-]/.test(character);
 
-  regExpList.some((regExp) => {
-    const match = regExp.exec(url);
-    if (match?.[1]) {
-      id = match[1];
-      return true;
+const isLineTerminator = (character: string): boolean =>
+  character === "\n" || character === "\r" || character === "\u2028" || character === "\u2029";
+
+/** Greedy run of id characters at `start`, or "" when there is none. */
+const readYoutubeId = (url: string, start: number): string => {
+  let end = start;
+  while (end < url.length && isYoutubeIdCharacter(url[end])) end++;
+  return url.slice(start, end);
+};
+
+/**
+ * The id the pattern `youtube\.com.*<marker>([a-zA-Z0-9_-]+)` would capture, or "" when it would
+ * not match.
+ */
+const extractIdAfterHostMarker = (url: string, marker: string): string => {
+  let searchFrom = 0;
+
+  while (searchFrom <= url.length) {
+    const host = url.indexOf(YOUTUBE_HOST, searchFrom);
+    if (host === -1) return "";
+
+    const regionStart = host + YOUTUBE_HOST.length;
+    let lineEnd = regionStart;
+    while (lineEnd < url.length && !isLineTerminator(url[lineEnd])) lineEnd++;
+
+    // Greedy `.*` takes the last usable marker on the line, falling back to earlier ones when the
+    // id run after it is empty.
+    for (let at = lineEnd - marker.length; at >= regionStart; at--) {
+      if (!url.startsWith(marker, at)) continue;
+      const id = readYoutubeId(url, at + marker.length);
+      if (id) return id;
     }
-    return false;
-  });
 
-  return id || null;
+    searchFrom = lineEnd + 1;
+  }
+
+  return "";
+};
+
+export const extractYoutubeId = (url: string): string | null => {
+  // Order preserved from the pattern list this replaces: youtu.be, then `v=`, then `embed/`, then
+  // youtube-nocookie. The first and last carry no `.*`, so they stay as regexes.
+  for (const [pattern, marker] of [
+    [/youtu\.be\/([a-zA-Z0-9_-]+)/, null],
+    [null, "v="],
+    [null, "embed/"],
+    [/youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, null],
+  ] as [RegExp | null, string | null][]) {
+    if (pattern) {
+      const match = pattern.exec(url);
+      const id = match ? match[1] : null;
+      if (id) return id;
+      continue;
+    }
+
+    const id = extractIdAfterHostMarker(url, marker as string);
+    if (id) return id;
+  }
+
+  return null;
 };
 
 export const extractVimeoId = (url: string): string | null => {

--- a/apps/web/lib/utils/video-upload.ts
+++ b/apps/web/lib/utils/video-upload.ts
@@ -1,3 +1,5 @@
+import { extractIdAfterHostMarker } from "@formbricks/survey-ui/youtube-id";
+
 export const checkForYoutubeUrl = (url: string): boolean => {
   try {
     const youtubeUrl = new URL(url);
@@ -48,67 +50,6 @@ export const checkForLoomUrl = (url: string): boolean => {
   } catch {
     return false;
   }
-};
-
-// `youtube.com` followed later by `v=` or `embed/`, scanned rather than matched with
-// `/youtube\.com.*v=(…)/`. That pattern is quadratic: `.*` runs to the end of the line and
-// backtracks once per `youtube.com`, so a stored value of `"youtube.com/".repeat(25_600)` took
-// 6.7s per call — and `element-media.tsx` calls the converter twice, blocking the RESPONDENT's
-// main thread for ~13s. `ZStorageUrl` is an unbounded `z.string()`, so nothing caps the value on
-// its way into the database (ENG-2789).
-//
-// A length cap was rejected: it would resolve a different id than the pattern did when a marker
-// sits beyond it. This reproduces the pattern exactly instead.
-//
-// The equivalence rests on three properties of the original:
-//   - `.` excludes line terminators, so the marker shares a line with the host it follows.
-//   - `.*` is greedy, so the LAST marker on that line wins, and it backtracks to an earlier one
-//     when the last has no id character after it.
-//   - If the first host on a line has no usable marker, no later host on that line can either —
-//     its search region is a suffix of the first's — so the scan skips the line instead of
-//     retrying every position, which is what makes it linear.
-const YOUTUBE_HOST = "youtube.com";
-
-const isYoutubeIdCharacter = (character: string | undefined): boolean =>
-  character !== undefined && /[a-zA-Z0-9_-]/.test(character);
-
-const isLineTerminator = (character: string): boolean =>
-  character === "\n" || character === "\r" || character === "\u2028" || character === "\u2029";
-
-/** Greedy run of id characters at `start`, or "" when there is none. */
-const readYoutubeId = (url: string, start: number): string => {
-  let end = start;
-  while (end < url.length && isYoutubeIdCharacter(url[end])) end++;
-  return url.slice(start, end);
-};
-
-/**
- * The id the pattern `youtube\.com.*<marker>([a-zA-Z0-9_-]+)` would capture, or "" when it would
- * not match.
- */
-const extractIdAfterHostMarker = (url: string, marker: string): string => {
-  let searchFrom = 0;
-
-  while (searchFrom <= url.length) {
-    const host = url.indexOf(YOUTUBE_HOST, searchFrom);
-    if (host === -1) return "";
-
-    const regionStart = host + YOUTUBE_HOST.length;
-    let lineEnd = regionStart;
-    while (lineEnd < url.length && !isLineTerminator(url[lineEnd])) lineEnd++;
-
-    // Greedy `.*` takes the last usable marker on the line, falling back to earlier ones when the
-    // id run after it is empty.
-    for (let at = lineEnd - marker.length; at >= regionStart; at--) {
-      if (!url.startsWith(marker, at)) continue;
-      const id = readYoutubeId(url, at + marker.length);
-      if (id) return id;
-    }
-
-    searchFrom = lineEnd + 1;
-  }
-
-  return "";
 };
 
 export const extractYoutubeId = (url: string): string | null => {

--- a/apps/web/lib/utils/video-upload.ts
+++ b/apps/web/lib/utils/video-upload.ts
@@ -53,7 +53,13 @@ export const checkForLoomUrl = (url: string): boolean => {
 export const extractYoutubeId = (url: string): string | null => {
   let id = "";
 
-  // Regular expressions for various YouTube URL formats
+  // The `.{0,2048}` caps replace an unbounded `.*`, which rescanned to the end from every start
+  // position (O(N^2) — measured 1.6s on 200k chars). Greedy on purpose: `.*v=` resolves the LAST
+  // `v=`, and a lazy cap would silently switch it to the first.
+  //
+  // The cap is not free: a `v=` more than 2048 characters past `youtube.com`, or a second
+  // `youtube.com` in the string, can make this resolve a different id than the uncapped form did.
+  // No real watch URL is that long, but it is a wrong-id outcome rather than a no-match. ENG-2789.
   const regExpList = [
     /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
     /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
@@ -40,7 +40,9 @@ export const SingleResponseCardBody = ({
     // Content between #/ and \#, with the span length-capped. Unbounded, `(.*?)` rescans to the end
     // from every `#/` when no closing `\#` follows (O(N^2) — measured 5.0s on 200k characters), and
     // this runs over RESPONDENT-submitted text in the admin's browser. The cap is far longer than any
-    // recall label; past it the text renders unhighlighted rather than not at all.
+    // recall label; past it a span containing a second `#/` highlights from there instead, so a
+    // crafted answer can shift which text is highlighted. Display only — React escapes every part —
+    // but it is a different render rather than none. Tracked in ENG-2789.
     const regex = /#\/(.{0,1024}?)\\#/g;
     const parts = text.split(regex);
 

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
@@ -12,7 +12,7 @@ import { getSurveyDateFormatMap } from "@/lib/utils/date-display";
 import { parseRecallInfo } from "@/lib/utils/recall";
 import { ResponseCardQuotas } from "@/modules/ee/quotas/components/single-response-card-quotas";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
-import { isValidValue } from "../util";
+import { isValidValue, splitRecallHighlights } from "../util";
 import { ElementSkip } from "./ElementSkip";
 import { HiddenFields } from "./HiddenFields";
 import { RenderResponse } from "./RenderResponse";
@@ -37,14 +37,7 @@ export const SingleResponseCardBody = ({
   const isFirstElementAnswered = elements[0] ? !!response.data[elements[0].id] : false;
   const { t } = useTranslation();
   const formatTextWithSlashes = (text: string) => {
-    // Content between #/ and \#, with the span length-capped. Unbounded, `(.*?)` rescans to the end
-    // from every `#/` when no closing `\#` follows (O(N^2) — measured 5.0s on 200k characters), and
-    // this runs over RESPONDENT-submitted text in the admin's browser. The cap is far longer than any
-    // recall label; past it a span containing a second `#/` highlights from there instead, so a
-    // crafted answer can shift which text is highlighted. Display only — React escapes every part —
-    // but it is a different render rather than none. Tracked in ENG-2789.
-    const regex = /#\/(.{0,1024}?)\\#/g;
-    const parts = text.split(regex);
+    const parts = splitRecallHighlights(text);
 
     return parts.map((part, index) => {
       // Check if the part was inside #/ and \#

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
@@ -37,8 +37,11 @@ export const SingleResponseCardBody = ({
   const isFirstElementAnswered = elements[0] ? !!response.data[elements[0].id] : false;
   const { t } = useTranslation();
   const formatTextWithSlashes = (text: string) => {
-    // Updated regex to match content between #/ and \#
-    const regex = /#\/(.*?)\\#/g;
+    // Content between #/ and \#, with the span length-capped. Unbounded, `(.*?)` rescans to the end
+    // from every `#/` when no closing `\#` follows (O(N^2) — measured 5.0s on 200k characters), and
+    // this runs over RESPONDENT-submitted text in the admin's browser. The cap is far longer than any
+    // recall label; past it the text renders unhighlighted rather than not at all.
+    const regex = /#\/(.{0,1024}?)\\#/g;
     const parts = text.split(regex);
 
     return parts.map((part, index) => {

--- a/apps/web/modules/analysis/components/SingleResponseCard/util.test.ts
+++ b/apps/web/modules/analysis/components/SingleResponseCard/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { isSubmissionTimeMoreThan5Minutes, isValidValue } from "./util";
+import { isSubmissionTimeMoreThan5Minutes, isValidValue, splitRecallHighlights } from "./util";
 
 describe("isValidValue", () => {
   test("returns false for an empty string", () => {
@@ -47,5 +47,55 @@ describe("isSubmissionTimeMoreThan5Minutes", () => {
     const currentTime = new Date();
     const recentTime = new Date(currentTime.getTime() - 4 * 60 * 1000); // 4 minutes ago
     expect(isSubmissionTimeMoreThan5Minutes(recentTime)).toBe(false);
+  });
+});
+
+describe("splitRecallHighlights", () => {
+  // The regex this replaces, as the oracle every case is compared against.
+  const viaRegex = (text: string): string[] => text.split(/#\/(.*?)\\#/g);
+
+  const FIXED = [
+    "",
+    "plain text",
+    "before #/name\\# after",
+    "#/a\\# and #/b\\#",
+    "#/\\#",
+    "#/unclosed",
+    "#/spans\nnewline\\#",
+    "#/one\\#\n#/two\\#",
+    "text with \\# but no opener",
+    "#/back\\slash inside\\#",
+    "#/#/nested\\#",
+    "#/a\\#trailing",
+    "##//weird\\#",
+    "#/\r\n\\#",
+    "#/ \\#",
+    // What a length cap got wrong: an over-long span containing another opener.
+    `#/${"a".repeat(2000)}#/short\\#tail`,
+  ];
+  const ALPHABET = "#/\\ab\n\r ";
+  const random = Array.from({ length: 30000 }, () => {
+    const n = Math.floor(Math.random() * 24);
+    let s = "";
+    for (let i = 0; i < n; i++) s += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
+    return s;
+  });
+
+  test("matches the regex it replaces", () => {
+    for (const text of [...FIXED, ...random]) {
+      expect(splitRecallHighlights(text), `input: ${JSON.stringify(text)}`).toEqual(viaRegex(text));
+    }
+  });
+
+  test("stays linear where the regex was quadratic", () => {
+    // `#/` repeated with no closing `\#`: the regex expands to the end from every opener.
+    const pathological = "#/".repeat(100000);
+
+    const startedAt = performance.now();
+    const parts = splitRecallHighlights(pathological);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(parts).toEqual([pathological]);
+    expect(elapsedMs).toBeLessThan(500);
   });
 });

--- a/apps/web/modules/analysis/components/SingleResponseCard/util.test.ts
+++ b/apps/web/modules/analysis/components/SingleResponseCard/util.test.ts
@@ -69,7 +69,7 @@ describe("splitRecallHighlights", () => {
     "#/a\\#trailing",
     "##//weird\\#",
     "#/\r\n\\#",
-    "#/ \\#",
+    "#/\u2028\\#",
     // What a length cap got wrong: an over-long span containing another opener.
     `#/${"a".repeat(2000)}#/short\\#tail`,
   ];

--- a/apps/web/modules/analysis/components/SingleResponseCard/util.ts
+++ b/apps/web/modules/analysis/components/SingleResponseCard/util.ts
@@ -15,3 +15,60 @@ export const isSubmissionTimeMoreThan5Minutes = (submissionTimeISOString: Date) 
   const timeDifference: number = (currentTime.getTime() - submissionTime.getTime()) / (1000 * 60); // Convert milliseconds to minutes
   return timeDifference > 5;
 };
+
+const RECALL_HIGHLIGHT_OPEN = "#/";
+const RECALL_HIGHLIGHT_CLOSE = "\\#";
+
+/** The characters `.` excludes, so a highlighted span can never cross one. */
+const isLineTerminator = (character: string): boolean =>
+  character === "\n" || character === "\r" || character === " " || character === " ";
+
+/**
+ * Split recall-highlighted text into alternating plain and highlighted parts, exactly as
+ * `text.split(/#\/(.*?)\\#/g)` did: even indices are plain text, odd indices are the highlighted
+ * spans.
+ *
+ * A scan rather than the regex. `(.*?)` is unbounded, so on a run of `#/` with no `\#` after it the
+ * engine expands to the end of the text from every one — O(N^2), measured 4.9s on 200k characters,
+ * over text that carries respondent-submitted answers into the admin's browser. Capping the span is
+ * not a fix: when the over-long span contains another `#/`, the match restarts there and highlights
+ * a different range.
+ *
+ * Linear because a failed span skips to the next line rather than to the next character: `.` cannot
+ * cross a line terminator, so if no `\#` precedes the next one, no later `#/` on that line has one
+ * either.
+ */
+export const splitRecallHighlights = (text: string): string[] => {
+  const parts: string[] = [];
+  let copiedTo = 0;
+  let searchFrom = 0;
+
+  while (searchFrom <= text.length) {
+    const open = text.indexOf(RECALL_HIGHLIGHT_OPEN, searchFrom);
+    if (open === -1) break;
+
+    const contentStart = open + RECALL_HIGHLIGHT_OPEN.length;
+    let close = -1;
+    let scan = contentStart;
+    while (scan < text.length && !isLineTerminator(text[scan])) {
+      if (text.startsWith(RECALL_HIGHLIGHT_CLOSE, scan)) {
+        close = scan;
+        break;
+      }
+      scan++;
+    }
+
+    if (close === -1) {
+      // No close before the line ends, so nothing on the rest of this line can close either.
+      searchFrom = scan < text.length ? scan + 1 : text.length + 1;
+      continue;
+    }
+
+    parts.push(text.slice(copiedTo, open), text.slice(contentStart, close));
+    copiedTo = close + RECALL_HIGHLIGHT_CLOSE.length;
+    searchFrom = copiedTo;
+  }
+
+  parts.push(text.slice(copiedTo));
+  return parts;
+};

--- a/apps/web/modules/analysis/components/SingleResponseCard/util.ts
+++ b/apps/web/modules/analysis/components/SingleResponseCard/util.ts
@@ -17,7 +17,7 @@ export const isSubmissionTimeMoreThan5Minutes = (submissionTimeISOString: Date) 
 };
 
 const RECALL_HIGHLIGHT_OPEN = "#/";
-const RECALL_HIGHLIGHT_CLOSE = "\\#";
+const RECALL_HIGHLIGHT_CLOSE = String.raw`\#`;
 
 /** The characters `.` excludes, so a highlighted span can never cross one. */
 const isLineTerminator = (character: string): boolean =>

--- a/apps/web/modules/analysis/components/SingleResponseCard/util.ts
+++ b/apps/web/modules/analysis/components/SingleResponseCard/util.ts
@@ -21,7 +21,7 @@ const RECALL_HIGHLIGHT_CLOSE = "\\#";
 
 /** The characters `.` excludes, so a highlighted span can never cross one. */
 const isLineTerminator = (character: string): boolean =>
-  character === "\n" || character === "\r" || character === " " || character === " ";
+  character === "\n" || character === "\r" || character === "\u2028" || character === "\u2029";
 
 /**
  * Split recall-highlighted text into alternating plain and highlighted parts, exactly as

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
@@ -378,7 +378,7 @@ export const updateUser = async (
       const results = await prisma.$transaction(operations);
 
       // Retrieve the updated user result. Since the update was the last operation, it is the last item.
-      updatedUser = results[results.length - 1];
+      updatedUser = results.at(-1);
     }
 
     await reconcileOrganizationMembership(organizationId, updatedUser.id);

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -270,6 +270,67 @@ const isUnactionableStateError = (code: string | undefined): boolean =>
   code !== undefined && UNACTIONABLE_STATE_ERROR_CODES.has(code);
 
 /**
+ * Emit a Better Auth `warn`-level log, attaching the safe error context when the entry carried an
+ * `Error`.
+ *
+ * `safeMessage` is `unknown` because Better Auth's logger signature is: the message is usually a
+ * string, but a couple of call sites pass the `Error` itself. pino's two-argument form needs a string
+ * in the message slot, hence the narrowing — a non-string falls back to a fixed label rather than
+ * being stringified, since the `Error` is already carried by the context object.
+ */
+const logWarning = (
+  contextLogger: ReturnType<typeof logger.withContext>,
+  safeMessage: unknown,
+  cause: Error | undefined
+): void => {
+  if (!cause) {
+    contextLogger.warn(safeMessage);
+    return;
+  }
+
+  contextLogger.warn(
+    getSafeWarningErrorContext(cause),
+    typeof safeMessage === "string" ? safeMessage : "Better Auth warning"
+  );
+};
+
+/**
+ * Capture a Better Auth `error`-level log to Sentry, but only when it is a GENUINE internal fault.
+ *
+ * Split out of `betterAuthLogger.log` rather than inlined: the three stacked conditions below carried
+ * most of that function's branching, and the decision "does this page?" is a separate concern from
+ * "how is this logged". Behaviour is unchanged — the gate, its order, and the tag set are the same.
+ *
+ * Skips handled rejections: a bare string code (no Error), a client-facing APIError, or a
+ * client/timing-caused OAuth `StateError` (ENG-2471) — so Sentry stays actionable (see the reason-split
+ * on `betterAuthLogger` and UNACTIONABLE_STATE_ERROR_CODES).
+ */
+const captureInternalAuthFault = (
+  cause: Error | undefined,
+  stateErrorCode: string | undefined,
+  request: ReturnType<typeof getBetterAuthRequestContext>
+): void => {
+  if (!SENTRY_DSN || !IS_PRODUCTION) return;
+  if (!cause || isAPIError(cause) || isUnactionableStateError(stateErrorCode)) return;
+
+  // ENG-2259: Better Auth's router logs a non-APIError as `(e.name, e)` and discards the endpoint
+  // (`better-auth/dist/api/index.mjs:210`), so a bare capture arrives with no transaction, URL or
+  // route — which is why FORMBRICKS-183 sat at ~242 events untriageable. Tags don't affect grouping,
+  // so the issue stays one issue with `auth.path` as a facet.
+  Sentry.captureException(cause, {
+    tags: {
+      component: "better-auth",
+      ...(request && { "auth.path": request.path, "http.method": request.method }),
+    },
+    // No `extra`. Forwarding `message` was considered and dropped: `redactEmailsInLogMessage` strips
+    // emails and nothing else, so a plugin logging `error("… <token> …", err)` would put that token in
+    // Sentry verbatim — while the message adds nothing, being either the error's own name or a
+    // sentence accompanying the Error already captured here. Keeping Sentry to `Error`-or-nothing is
+    // what makes the header note above stay true.
+  });
+};
+
+/**
  * Route Better Auth's logger to @formbricks/logger and capture GENUINE internal faults to Sentry in
  * production — replaces auth.ts's placeholder logger (and the route's Sentry.captureException on auth
  * failures).
@@ -313,37 +374,9 @@ export const betterAuthLogger: NonNullable<BetterAuthOptions["logger"]> = {
     const safeMessage = redactEmailsInLogMessage(message);
     if (level === "error") {
       contextLogger.error(safeMessage);
-      if (SENTRY_DSN && IS_PRODUCTION) {
-        // Skip handled rejections: a bare string code (no Error), a client-facing APIError, or a
-        // client/timing-caused OAuth `StateError` (ENG-2471). Capture only genuine internal faults so
-        // Sentry stays actionable (see the reason-split above and UNACTIONABLE_STATE_ERROR_CODES).
-        if (cause && !isAPIError(cause) && !isUnactionableStateError(stateErrorCode)) {
-          // ENG-2259: Better Auth's router logs a non-APIError as `(e.name, e)` and discards the
-          // endpoint (`better-auth/dist/api/index.mjs:210`), so a bare capture arrives with no
-          // transaction, URL or route — which is why FORMBRICKS-183 sat at ~242 events untriageable.
-          // Tags don't affect grouping, so the issue stays one issue with `auth.path` as a facet.
-          Sentry.captureException(cause, {
-            tags: {
-              component: "better-auth",
-              ...(request && { "auth.path": request.path, "http.method": request.method }),
-            },
-            // No `extra`. Forwarding `message` was considered and dropped: `redactEmailsInLogMessage`
-            // strips emails and nothing else, so a plugin logging `error("… <token> …", err)` would
-            // put that token in Sentry verbatim — while the message adds nothing, being either the
-            // error's own name or a sentence accompanying the Error already captured here. Keeping
-            // Sentry to `Error`-or-nothing is what makes the header note above stay true.
-          });
-        }
-      }
+      captureInternalAuthFault(cause, stateErrorCode, request);
     } else if (level === "warn") {
-      if (cause) {
-        contextLogger.warn(
-          getSafeWarningErrorContext(cause),
-          typeof safeMessage === "string" ? safeMessage : "Better Auth warning"
-        );
-      } else {
-        contextLogger.warn(safeMessage);
-      }
+      logWarning(contextLogger, safeMessage, cause);
     } else {
       contextLogger.info(safeMessage);
     }

--- a/apps/web/modules/auth/lib/better-auth-path-label.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-path-label.test.ts
@@ -110,6 +110,34 @@ describe("createAuthPathLabeller — labelling rules", () => {
     expect(label("https://app.formbricks.com/api/auth/sign-in/email//")).toBe("/sign-in/email");
   });
 
+  test("a pathological run of slashes stays linear (no catastrophic backtracking)", () => {
+    // Regression guard for the super-linear `replace(/\/+$/, "")` this file used to trim with: the
+    // greedy `\/+` was unanchored at the start, so on a slash run not followed by end-of-string the
+    // engine retried from every offset — O(N^2) on a value taken straight from the request URL.
+    // At this size the old form took ~2.8s locally against ~0.004ms for the reverse scan, so the
+    // budget below is a >5x margin over the slowest plausible CI machine and nowhere near the
+    // regressed cost.
+    const pathological = `https://app.formbricks.com/api/auth/${"/".repeat(100_000)}x`;
+
+    const startedAt = performance.now();
+    const result = label(pathological);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(result).toBe(UNKNOWN_AUTH_PATH_LABEL);
+    expect(elapsedMs).toBeLessThan(500);
+  });
+
+  test("trailing-slash trimming matches the regex it replaced, including the edge shapes", () => {
+    // The reverse scan has to be exactly `replace(/\/+$/, "")`: same result on no slashes, one, many,
+    // and an all-slash path (where it must not walk past index 0).
+    expect(label("https://app.formbricks.com/api/auth/get-session")).toBe("/get-session");
+    expect(label("https://app.formbricks.com/api/auth/get-session/")).toBe("/get-session");
+    expect(label(`https://app.formbricks.com/api/auth/get-session${"/".repeat(50)}`)).toBe("/get-session");
+    // Path reduces to "" — the loop must stop at index 0 rather than underflow.
+    expect(label("https://app.formbricks.com/api/auth///")).toBe(UNKNOWN_AUTH_PATH_LABEL);
+    expect(label("https://app.formbricks.com/api/auth")).toBe(UNKNOWN_AUTH_PATH_LABEL);
+  });
+
   test("a truncated label never collides with the same-named literal endpoint", () => {
     // `/reset-password` (POST, performs the reset) and `/reset-password/:token` (GET callback) are
     // different endpoints; merging them into one bucket would lose the distinction that matters when

--- a/apps/web/modules/auth/lib/better-auth-path-label.ts
+++ b/apps/web/modules/auth/lib/better-auth-path-label.ts
@@ -42,6 +42,21 @@ export const UNKNOWN_AUTH_PATH_LABEL = "unknown";
 
 const getFirstSegment = (path: string): string | undefined => path.split("/")[1] || undefined;
 
+/**
+ * Linear-time trailing-slash trim.
+ *
+ * Not `replace(/\/+$/, "")`: that pattern is super-linear. The leading `\/+` is greedy and
+ * unanchored at the start, so on a run of N slashes the engine retries from every offset and
+ * backtracks the whole run each time — O(N^2). `pathname` here comes straight off the request URL,
+ * which is attacker-controlled, so `/api/auth` + a few thousand slashes would burn CPU per request.
+ * A single reverse scan does the same job in one pass and one allocation.
+ */
+const trimTrailingSlashes = (path: string): string => {
+  let end = path.length;
+  while (end > 0 && path[end - 1] === "/") end--;
+  return path.slice(0, end);
+};
+
 export const createAuthPathLabeller = (declaredPaths: Iterable<string>): ((url: string) => string) => {
   // Only parameter-free declared paths may be emitted verbatim. Patterns still contribute their first
   // segment, so `/reset-password/<token>` degrades to a recognized `/reset-password/*` rather than to
@@ -72,7 +87,7 @@ export const createAuthPathLabeller = (declaredPaths: Iterable<string>): ((url: 
     // Trailing slashes are trimmed before matching: the declared set holds `/get-session`, so
     // `/api/auth/get-session/` would otherwise miss the exact match and degrade to `/get-session/*`,
     // splitting one endpoint across two facet values for nothing.
-    const authPath = pathname.slice(baseIndex + AUTH_BASE_PATH.length).replace(/\/+$/, "");
+    const authPath = trimTrailingSlashes(pathname.slice(baseIndex + AUTH_BASE_PATH.length));
     if (literalPaths.has(authPath)) return authPath;
 
     // `/<segment>/*`, not a bare segment: the emitted values all land in one Sentry facet, so a mix of

--- a/apps/web/modules/auth/lib/oauth-urls.ts
+++ b/apps/web/modules/auth/lib/oauth-urls.ts
@@ -6,7 +6,15 @@ const AUTH_BASE_PATH = "/api/auth";
 const MCP_RESOURCE_PATH = "/api/mcp";
 const MCP_PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource/api/mcp";
 
-const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, "");
+// A reverse scan, not `replace(/\/+$/, "")`: that pattern is greedy and unanchored at the start, so
+// on a run of N slashes the engine retries from every offset — O(N^2). Only ever fed configured
+// values here (WEBAPP_URL / BETTER_AUTH_URL / NEXTAUTH_URL), so this is not the reachable case that
+// better-auth-path-label.ts fixes — it is the same shape, kept off the codebase for good.
+const trimTrailingSlash = (value: string): string => {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end--;
+  return value.slice(0, end);
+};
 
 const normalizeConfiguredUrl = (value: string | undefined, fallback = DEFAULT_WEBAPP_URL): URL => {
   const configured = value?.trim() || fallback;

--- a/apps/web/modules/ee/license-check/lib/license.test.ts
+++ b/apps/web/modules/ee/license-check/lib/license.test.ts
@@ -259,7 +259,7 @@ describe("License Core Logic", () => {
         const second = await getEnterpriseLicense();
 
         expect(second).toEqual(first);
-        expect(mockCache.get.mock.calls.length).toBe(cacheReadsAfterFirstCall);
+        expect(mockCache.get.mock.calls).toHaveLength(cacheReadsAfterFirstCall);
       } finally {
         envMock.NODE_ENV = "test";
       }

--- a/apps/web/modules/ee/workflows/components/inspector/workflow-email-action-form.tsx
+++ b/apps/web/modules/ee/workflows/components/inspector/workflow-email-action-form.tsx
@@ -38,7 +38,18 @@ interface WorkflowEmailActionFormProps {
 // The internal "default language" slot recall/headline resolution uses when no language is selected.
 const DEFAULT_LANGUAGE_CODE = "default";
 
-const HTML_TAG_PATTERN = /<[a-z][\s\S]*>/i;
+// Index scans, not `/<[a-z][\s\S]*>/i`: that pattern is O(N^2) on a long run of `<a` with no `>`,
+// since the greedy `[\s\S]*` rescans to the end from every one. Identical predicate — `[\s\S]*`
+// matches anything, so the regex holds exactly when some `<` + letter is followed later by any `>`,
+// i.e. when the LAST `>` sits after the FIRST `<letter`.
+const HTML_OPENING_TAG_PATTERN = /<[a-z]/i;
+
+const containsHtmlTag = (value: string): boolean => {
+  const openingTag = HTML_OPENING_TAG_PATTERN.exec(value);
+  if (!openingTag) return false;
+
+  return value.lastIndexOf(">") > openingTag.index + 1;
+};
 
 const escapeHtml = (value: string): string =>
   value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
@@ -49,7 +60,7 @@ const escapeHtml = (value: string): string =>
 // node ("Only element or decorator nodes can be inserted to the root node").
 const toEditorHtml = (body: string): string => {
   if (!body) return "";
-  if (HTML_TAG_PATTERN.test(body)) return body;
+  if (containsHtmlTag(body)) return body;
   return body
     .split(/\n{2,}/)
     .map((paragraph) => `<p>${escapeHtml(paragraph).replaceAll("\n", "<br>")}</p>`)

--- a/apps/web/modules/ee/workflows/components/inspector/workflow-node-config-panel.tsx
+++ b/apps/web/modules/ee/workflows/components/inspector/workflow-node-config-panel.tsx
@@ -81,14 +81,13 @@ export const WorkflowNodeConfigPanel = ({ isEditable }: Readonly<WorkflowNodeCon
   if (!selectedNode || !definition) return null;
 
   const blockedReasonType = getBlockedReason(isEditable, isReadOnly, status);
-  const blockedReason =
-    blockedReasonType === "readOnly"
-      ? t("workspace.workflows.edit_blocked_read_only")
-      : blockedReasonType === "archived"
-        ? t("workspace.workflows.edit_blocked_archived")
-        : blockedReasonType === "active"
-          ? t("workspace.workflows.edit_blocked_active")
-          : null;
+  // Inline literal t() calls so the translation-key scanner detects the keys.
+  const blockedReasonMessages: Record<TBlockedReason, string> = {
+    readOnly: t("workspace.workflows.edit_blocked_read_only"),
+    archived: t("workspace.workflows.edit_blocked_archived"),
+    active: t("workspace.workflows.edit_blocked_active"),
+  };
+  const blockedReason = blockedReasonType ? blockedReasonMessages[blockedReasonType] : null;
 
   const registryEntry = getNodeRegistryEntry(selectedNode);
   const ConfigForm = registryEntry.ConfigForm;

--- a/apps/web/modules/email/lib/preview-email-template-styles.ts
+++ b/apps/web/modules/email/lib/preview-email-template-styles.ts
@@ -79,7 +79,12 @@ const EMAIL_PREVIEW_ACCENT_COLORS = {
 // Attribute runs are length-capped: `<p`/`<li` repeated with no closing `>` otherwise makes the
 // engine rescan to the end from every occurrence (O(N^2) — measured 6.7s on 200k chars). Editor
 // output carries at most a couple of hundred characters of style here, so the cap is far above any
-// real tag; past it the tag keeps its original spacing instead of being normalized.
+// real tag.
+//
+// Past it the behaviour is NOT simply "leave the tag alone": if the over-long attribute run itself
+// contains another `<p`/`<li`, the engine restarts there and normalizes THAT tag instead. Reaching
+// it needs a >4096-character tag containing a second opening tag, which the editor never emits —
+// but it rewrites a different tag rather than none. Tracked in ENG-2789.
 const RICH_TEXT_TAG_ATTRIBUTES_MAX = 4096;
 const RICH_TEXT_PARAGRAPH_TAG_REGEX = new RegExp(
   String.raw`<p\b([^>]{0,${RICH_TEXT_TAG_ATTRIBUTES_MAX}})>`,

--- a/apps/web/modules/email/lib/preview-email-template-styles.ts
+++ b/apps/web/modules/email/lib/preview-email-template-styles.ts
@@ -81,8 +81,14 @@ const EMAIL_PREVIEW_ACCENT_COLORS = {
 // output carries at most a couple of hundred characters of style here, so the cap is far above any
 // real tag; past it the tag keeps its original spacing instead of being normalized.
 const RICH_TEXT_TAG_ATTRIBUTES_MAX = 4096;
-const RICH_TEXT_PARAGRAPH_TAG_REGEX = new RegExp(`<p\\b([^>]{0,${RICH_TEXT_TAG_ATTRIBUTES_MAX}})>`, "gi");
-const RICH_TEXT_LIST_ITEM_TAG_REGEX = new RegExp(`<li\\b([^>]{0,${RICH_TEXT_TAG_ATTRIBUTES_MAX}})>`, "gi");
+const RICH_TEXT_PARAGRAPH_TAG_REGEX = new RegExp(
+  String.raw`<p\b([^>]{0,${RICH_TEXT_TAG_ATTRIBUTES_MAX}})>`,
+  "gi"
+);
+const RICH_TEXT_LIST_ITEM_TAG_REGEX = new RegExp(
+  String.raw`<li\b([^>]{0,${RICH_TEXT_TAG_ATTRIBUTES_MAX}})>`,
+  "gi"
+);
 const RICH_TEXT_STYLE_ATTRIBUTE_REGEX = /\sstyle=(["'])(.*?)\1/i;
 const RICH_TEXT_STYLE_ATTRIBUTE_REPLACE_REGEX = /\sstyle=(["'])(.*?)\1/gi;
 const RICH_TEXT_CLASS_ATTRIBUTE_REGEX = /\sclass=(["'])(.*?)\1/i;

--- a/apps/web/modules/email/lib/preview-email-template-styles.ts
+++ b/apps/web/modules/email/lib/preview-email-template-styles.ts
@@ -2,6 +2,7 @@ import type { CSSProperties } from "react";
 import type { TSurveyStyling } from "@formbricks/types/surveys/types";
 import { COLOR_DEFAULTS, STYLE_DEFAULTS } from "@/lib/styling/constants";
 import { isLight, mixColor } from "@/lib/utils/colors";
+import { replaceOpeningTags } from "@/lib/utils/html-opening-tag";
 import {
   NESTED_LIST_ITEM_CLASS,
   NESTED_LIST_ITEM_MARKER_STYLE,
@@ -76,24 +77,6 @@ const EMAIL_PREVIEW_ACCENT_COLORS = {
   "rose-100": "#ffe4e6",
 } as const;
 
-// Attribute runs are length-capped: `<p`/`<li` repeated with no closing `>` otherwise makes the
-// engine rescan to the end from every occurrence (O(N^2) — measured 6.7s on 200k chars). Editor
-// output carries at most a couple of hundred characters of style here, so the cap is far above any
-// real tag.
-//
-// Past it the behaviour is NOT simply "leave the tag alone": if the over-long attribute run itself
-// contains another `<p`/`<li`, the engine restarts there and normalizes THAT tag instead. Reaching
-// it needs a >4096-character tag containing a second opening tag, which the editor never emits —
-// but it rewrites a different tag rather than none. Tracked in ENG-2789.
-const RICH_TEXT_TAG_ATTRIBUTES_MAX = 4096;
-const RICH_TEXT_PARAGRAPH_TAG_REGEX = new RegExp(
-  String.raw`<p\b([^>]{0,${RICH_TEXT_TAG_ATTRIBUTES_MAX}})>`,
-  "gi"
-);
-const RICH_TEXT_LIST_ITEM_TAG_REGEX = new RegExp(
-  String.raw`<li\b([^>]{0,${RICH_TEXT_TAG_ATTRIBUTES_MAX}})>`,
-  "gi"
-);
 const RICH_TEXT_STYLE_ATTRIBUTE_REGEX = /\sstyle=(["'])(.*?)\1/i;
 const RICH_TEXT_STYLE_ATTRIBUTE_REPLACE_REGEX = /\sstyle=(["'])(.*?)\1/gi;
 const RICH_TEXT_CLASS_ATTRIBUTE_REGEX = /\sclass=(["'])(.*?)\1/i;
@@ -101,7 +84,7 @@ const RICH_TEXT_CLASS_ATTRIBUTE_REGEX = /\sclass=(["'])(.*?)\1/i;
 export const importantStyle = (value: string): string => `${value} !important`;
 
 export const normalizeRichTextSpacing = (html: string): string =>
-  html.replaceAll(RICH_TEXT_PARAGRAPH_TAG_REGEX, (_tag, attributes: string = "") => {
+  replaceOpeningTags(html, "p", (attributes) => {
     if (RICH_TEXT_STYLE_ATTRIBUTE_REGEX.test(attributes)) {
       return `<p${attributes.replaceAll(
         RICH_TEXT_STYLE_ATTRIBUTE_REPLACE_REGEX,
@@ -123,7 +106,7 @@ export const normalizeRichTextSpacing = (html: string): string =>
  * list item (best effort: legacy Outlook's Word engine ignores list-style-type).
  */
 export const suppressNestedListMarkers = (html: string): string =>
-  html.replaceAll(RICH_TEXT_LIST_ITEM_TAG_REGEX, (tag: string, attributes: string = "") => {
+  replaceOpeningTags(html, "li", (attributes, tag) => {
     const classMatch = RICH_TEXT_CLASS_ATTRIBUTE_REGEX.exec(attributes);
     const classNames = classMatch ? classMatch[2].split(/\s+/) : [];
     if (!classNames.includes(NESTED_LIST_ITEM_CLASS)) {

--- a/apps/web/modules/email/lib/preview-email-template-styles.ts
+++ b/apps/web/modules/email/lib/preview-email-template-styles.ts
@@ -76,8 +76,13 @@ const EMAIL_PREVIEW_ACCENT_COLORS = {
   "rose-100": "#ffe4e6",
 } as const;
 
-const RICH_TEXT_PARAGRAPH_TAG_REGEX = /<p\b([^>]*)>/gi;
-const RICH_TEXT_LIST_ITEM_TAG_REGEX = /<li\b([^>]*)>/gi;
+// Attribute runs are length-capped: `<p`/`<li` repeated with no closing `>` otherwise makes the
+// engine rescan to the end from every occurrence (O(N^2) — measured 6.7s on 200k chars). Editor
+// output carries at most a couple of hundred characters of style here, so the cap is far above any
+// real tag; past it the tag keeps its original spacing instead of being normalized.
+const RICH_TEXT_TAG_ATTRIBUTES_MAX = 4096;
+const RICH_TEXT_PARAGRAPH_TAG_REGEX = new RegExp(`<p\\b([^>]{0,${RICH_TEXT_TAG_ATTRIBUTES_MAX}})>`, "gi");
+const RICH_TEXT_LIST_ITEM_TAG_REGEX = new RegExp(`<li\\b([^>]{0,${RICH_TEXT_TAG_ATTRIBUTES_MAX}})>`, "gi");
 const RICH_TEXT_STYLE_ATTRIBUTE_REGEX = /\sstyle=(["'])(.*?)\1/i;
 const RICH_TEXT_STYLE_ATTRIBUTE_REPLACE_REGEX = /\sstyle=(["'])(.*?)\1/gi;
 const RICH_TEXT_CLASS_ATTRIBUTE_REGEX = /\sclass=(["'])(.*?)\1/i;

--- a/apps/web/modules/ui/components/editor/components/auto-link-matchers.test.ts
+++ b/apps/web/modules/ui/components/editor/components/auto-link-matchers.test.ts
@@ -53,5 +53,41 @@ describe("auto-link matchers", () => {
     test("returns null when there is no email address", () => {
       expect(matchEmail("no address in here")).toBeNull();
     });
+
+    // The local part is capped at RFC 5321's 64 so a long run of local-part characters cannot be
+    // rescanned from every start position. A cap on its own is not enough: `\b` also sits between a
+    // word character and `+`, `-`, `%` or `.`, so the match could restart INSIDE an overlong local
+    // part and link a different address than the one written. These pin "no link" rather than
+    // "a link to something else".
+    test.each([
+      ["plus", "a+"],
+      ["dot", "a."],
+      ["hyphen", "a-"],
+      ["percent", "a%"],
+      ["underscore", "a_"],
+    ])("does not link a truncated suffix of an overlong local part (%s)", (_label, unit) => {
+      // 32 repeats + a trailing "a" is a 65-character local part, one over the cap, with an
+      // interior word boundary after every punctuation character.
+      const overlong = `${unit.repeat(32)}a@example.com`;
+
+      expect(matchEmail(overlong)).toBeNull();
+    });
+
+    test("links a local part exactly at the 64-character cap", () => {
+      const atCap = `${"a".repeat(64)}@example.com`;
+
+      expect(matchEmail(atCap)).toMatchObject({ index: 0, text: atCap });
+    });
+
+    test("keeps linking ordinary addresses that contain local-part punctuation", () => {
+      for (const address of [
+        "first.last+tag@sub.example.co.uk",
+        "user_name@example.org",
+        "user-name@example-host.io",
+        "percent%sign@example.com",
+      ]) {
+        expect(matchEmail(address)).toMatchObject({ index: 0, text: address });
+      }
+    });
   });
 });

--- a/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
+++ b/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
@@ -1,15 +1,15 @@
 import type { LinkMatcher } from "@lexical/link";
 
-// Every run below is length-bounded, which is what keeps these linear: an unbounded `+` lets the
-// engine rescan a long non-matching run from every start position (O(N^2) — the email matcher
-// measured 18.2s on 200k characters of `%_-`). The caps follow the RFC 5321/1035 limits already
-// used by `EMAIL_IN_MESSAGE` in better-auth-observability.ts: 64 for a local part, 253 for a
-// domain, 63 for a label. Anything longer is not a deliverable address or a resolvable host, so
-// no autolinkable text loses its link.
+// `{1,256}` already keeps this one linear (measured 27ms on 200k characters), so it is unchanged.
 const URL_MATCHER =
-  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]{0,2048})/;
+  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)/;
 
-const EMAIL_MATCHER = /\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,253}\.[A-Za-z]{2,63}\b/;
+// The local part is capped at RFC 5321's 64, which is the ONE change that matters here: unbounded,
+// the engine rescans a long run of local-part characters from every start position looking for an
+// `@` that never comes (O(N^2) — measured 18.2s on 200k characters of `%_-`, against 20ms capped).
+// Deliberately the only cap added: bounding the domain and TLD as well measured no faster on any
+// pump tried, so it would change what matches while buying nothing.
+const EMAIL_MATCHER = /\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
 
 // Auto-linked URLs must behave like links inserted through the link toolbar, which
 // sets the same attributes: a survey opened in the same tab navigates the respondent

--- a/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
+++ b/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
@@ -1,9 +1,15 @@
 import type { LinkMatcher } from "@lexical/link";
 
+// Every run below is length-bounded, which is what keeps these linear: an unbounded `+` lets the
+// engine rescan a long non-matching run from every start position (O(N^2) — the email matcher
+// measured 18.2s on 200k characters of `%_-`). The caps follow the RFC 5321/1035 limits already
+// used by `EMAIL_IN_MESSAGE` in better-auth-observability.ts: 64 for a local part, 253 for a
+// domain, 63 for a label. Anything longer is not a deliverable address or a resolvable host, so
+// no autolinkable text loses its link.
 const URL_MATCHER =
-  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)/;
+  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]{0,2048})/;
 
-const EMAIL_MATCHER = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
+const EMAIL_MATCHER = /\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,253}\.[A-Za-z]{2,63}\b/;
 
 // Auto-linked URLs must behave like links inserted through the link toolbar, which
 // sets the same attributes: a survey opened in the same tab navigates the respondent

--- a/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
+++ b/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
@@ -4,12 +4,21 @@ import type { LinkMatcher } from "@lexical/link";
 const URL_MATCHER =
   /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)/;
 
-// The local part is capped at RFC 5321's 64, which is the ONE change that matters here: unbounded,
-// the engine rescans a long run of local-part characters from every start position looking for an
-// `@` that never comes (O(N^2) — measured 18.2s on 200k characters of `%_-`, against 20ms capped).
-// Deliberately the only cap added: bounding the domain and TLD as well measured no faster on any
-// pump tried, so it would change what matches while buying nothing.
-const EMAIL_MATCHER = /\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
+// Unbounded, the engine rescans a long run of local-part characters from every start position
+// looking for an `@` that never comes — O(N^2), measured 17s on 200k characters of `%_-`.
+//
+// The lookbehind is what makes this safe, and the cap alone is NOT enough. `\b` also sits between a
+// word character and `+`, `-`, `%` or `.`, so with only a cap the engine can restart *inside* an
+// overlong local part and match its last 64 characters: `("a+".repeat(32) + "a@example.com")` linked
+// `+a+a…@example.com`, a DIFFERENT address from the one written. Refusing to start where a
+// local-part character precedes means an overlong local part matches nowhere at all, so the worst
+// case is no link rather than a link to somewhere else.
+//
+// Together they are also linear (0.5ms on the same 200k input), because the lookbehind lets the
+// engine skip every start position inside a run instead of retrying each one.
+//
+// Bounding the domain and TLD as well measured no faster on any pump tried, so those stay unbounded.
+const EMAIL_MATCHER = /\b(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
 
 // Auto-linked URLs must behave like links inserted through the link toolbar, which
 // sets the same attributes: a survey opened in the same tab navigates the respondent

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
     "@formbricks/js-core": "workspace:*",
     "@formbricks/logger": "workspace:*",
     "@formbricks/storage": "workspace:*",
+    "@formbricks/survey-ui": "workspace:*",
     "@formbricks/surveys": "workspace:*",
     "@formbricks/types": "workspace:*",
     "@formbricks/workflows": "workspace:*",

--- a/apps/web/playwright/utils/helper.ts
+++ b/apps/web/playwright/utils/helper.ts
@@ -441,15 +441,15 @@ export const signupUsingInviteToken = async (page: Page, name: string, email: st
 const RENDER_SETTLE_MS = 150;
 
 const flushRender = async (page: Page): Promise<void> => {
-  await page.evaluate(
-    (settleMs) =>
-      new Promise<void>((resolve) => {
-        setTimeout(() => {
-          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-        }, settleMs);
-      }),
-    RENDER_SETTLE_MS
-  );
+  await page.evaluate(async (settleMs) => {
+    // Sequential awaits rather than nested callbacks: the callback form stacked six functions deep,
+    // and the order it encoded — sleep, then two frames — is what the doc comment above requires.
+    const nextFrame = (): Promise<unknown> => new Promise((resolve) => requestAnimationFrame(resolve));
+
+    await new Promise((resolve) => setTimeout(resolve, settleMs));
+    await nextFrame();
+    await nextFrame();
+  }, RENDER_SETTLE_MS);
 };
 
 /**

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -117,6 +117,16 @@ export const config = {
   matcher: [
     // Keep asset exclusions segment-bound: every dynamic route must traverse Proxy so callers cannot
     // bypass the private client-IP header overwrite by choosing an asset-like route prefix.
-    "/((?!_next/(?:static|image)(?:/|$)|(?:favicon\\.ico|sitemap\\.xml|robots\\.txt)$|(?:js|css|images|fonts|icons|public|animated-bgs)(?:/|$)).*)",
+    //
+    // The `\\.` escapes stay, and S7780's `String.raw` fix must NOT be applied here: Next.js reads this
+    // matcher by statically parsing the file, and its extractor
+    // (`next/dist/build/analysis/extract-const-value.js`, 16.2.11) understands string literals,
+    // template literals, arrays and objects — but not a `TaggedTemplateExpression`. Verified against
+    // Next's own SWC parser: `String.raw` yields `Unsupported node type "TaggedTemplateExpression" at
+    // "config.matcher[0]"`, which throws in dev and, in a production build, only logs an error and
+    // leaves `config` undefined — so `parseMiddlewareConfig` receives nothing and the matcher is
+    // silently DROPPED, running Proxy on every static asset and voiding the exclusions above. A plain
+    // template literal parses, but needs the same `\\.` escapes, so it does not satisfy the rule either.
+    "/((?!_next/(?:static|image)(?:/|$)|(?:favicon\\.ico|sitemap\\.xml|robots\\.txt)$|(?:js|css|images|fonts|icons|public|animated-bgs)(?:/|$)).*)", // NOSONAR(typescript:S7780) -- String.raw breaks Next.js's static matcher extraction; see above
   ],
 };

--- a/packages/survey-ui/package.json
+++ b/packages/survey-ui/package.json
@@ -48,7 +48,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./styles": "./dist/survey-ui.css"
+    "./styles": "./dist/survey-ui.css",
+    "./youtube-id": {
+      "types": "./dist/lib/youtube-id.d.ts",
+      "import": "./dist/lib/youtube-id.js"
+    }
   },
   "scripts": {
     "dev": "vite build --watch --mode dev",

--- a/packages/survey-ui/src/lib/video.test.ts
+++ b/packages/survey-ui/src/lib/video.test.ts
@@ -204,3 +204,31 @@ describe("isSafeMediaUrl", () => {
     }
   );
 });
+
+describe("extractYoutubeId — stored-value denial of service (ENG-2789)", () => {
+  // The pattern list this replaced used `youtube\\.com.*v=(…)`, whose `.*` backtracks once per
+  // `youtube.com`. `ZStorageUrl` is an unbounded `z.string()`, so a value this long persists and
+  // reaches the RESPONDENT renderer, where `element-media.tsx` converts it twice per render.
+  test("a long repeated-host URL resolves fast instead of blocking the thread", () => {
+    const stored = `https://youtube.com/${"youtube.com/".repeat(25_600)}`; // 307,220 characters
+
+    const startedAt = performance.now();
+    const result = convertToEmbedUrl(stored);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(result).toBeUndefined();
+    // ~6700ms per call before, and the renderer calls it twice.
+    expect(elapsedMs).toBeLessThan(200);
+  });
+
+  // Greedy `.*` took the LAST marker on the line and backtracked to an earlier one when the last
+  // had no id after it. Both are load-bearing, so they are pinned rather than left to the corpus.
+  test.each([
+    ["https://www.youtube.com/watch?x=v=FIRST&v=SECOND", "https://www.youtube.com/embed/SECOND"],
+    ["https://youtube.com/embed/abc/embed/def", "https://www.youtube.com/embed/def"],
+    ["https://youtube.com/watch?v=&v=OK", "https://www.youtube.com/embed/OK"],
+    ["https://youtube.com/watch?v=&v=", undefined],
+  ])("resolves %s to %s, as the pattern did", (url, expected) => {
+    expect(convertToEmbedUrl(url)).toBe(expected);
+  });
+});

--- a/packages/survey-ui/src/lib/video.test.ts
+++ b/packages/survey-ui/src/lib/video.test.ts
@@ -217,8 +217,11 @@ describe("extractYoutubeId — stored-value denial of service (ENG-2789)", () =>
     const elapsedMs = performance.now() - startedAt;
 
     expect(result).toBeUndefined();
-    // ~6700ms per call before, and the renderer calls it twice.
-    expect(elapsedMs).toBeLessThan(200);
+    // Budget chosen from measurements, not a round number: the scan costs 6ms uninstrumented but
+    // ~330ms under the coverage run CI uses, which slows tight character loops far more than it
+    // slows a native regex. The pattern this replaced takes ~3300ms on the same input either way,
+    // so 2000ms sits above the instrumented pass and below the regression it guards against.
+    expect(elapsedMs).toBeLessThan(2000);
   });
 
   // Greedy `.*` took the LAST marker on the line and backtracked to an earlier one when the last

--- a/packages/survey-ui/src/lib/video.ts
+++ b/packages/survey-ui/src/lib/video.ts
@@ -56,7 +56,13 @@ export const checkForLoomUrl = (url: string): boolean => {
 const extractYoutubeId = (url: string): string | null => {
   let id = "";
 
-  // Regular expressions for various YouTube URL formats
+  // The `.{0,2048}` caps replace an unbounded `.*`, which rescanned to the end from every start
+  // position (O(N^2) — measured 1.6s on 200k chars). Greedy on purpose: `.*v=` resolves the LAST
+  // `v=`, and a lazy cap would silently switch it to the first.
+  //
+  // The cap is not free: a `v=` more than 2048 characters past `youtube.com`, or a second
+  // `youtube.com` in the string, can make this resolve a different id than the uncapped form did.
+  // No real watch URL is that long, but it is a wrong-id outcome rather than a no-match. ENG-2789.
   const regExpList = [
     /youtu\.be\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtu.be/<id>
     /youtube\.com.{0,2048}v=(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>

--- a/packages/survey-ui/src/lib/video.ts
+++ b/packages/survey-ui/src/lib/video.ts
@@ -53,31 +53,88 @@ export const checkForLoomUrl = (url: string): boolean => {
   }
 };
 
-const extractYoutubeId = (url: string): string | null => {
-  let id = "";
+// `youtube.com` followed later by `v=` or `embed/`, scanned rather than matched with
+// `/youtube\.com.*v=(…)/`. That pattern is quadratic: `.*` runs to the end of the line and
+// backtracks once per `youtube.com`, so a stored value of `"youtube.com/".repeat(25_600)` took
+// 6.7s per call — and `element-media.tsx` calls the converter twice, blocking the RESPONDENT's
+// main thread for ~13s. `ZStorageUrl` is an unbounded `z.string()`, so nothing caps the value on
+// its way into the database (ENG-2789).
+//
+// A length cap was rejected: it would resolve a different id than the pattern did when a marker
+// sits beyond it. This reproduces the pattern exactly instead.
+//
+// The equivalence rests on three properties of the original:
+//   - `.` excludes line terminators, so the marker shares a line with the host it follows.
+//   - `.*` is greedy, so the LAST marker on that line wins, and it backtracks to an earlier one
+//     when the last has no id character after it.
+//   - If the first host on a line has no usable marker, no later host on that line can either —
+//     its search region is a suffix of the first's — so the scan skips the line instead of
+//     retrying every position, which is what makes it linear.
+const YOUTUBE_HOST = "youtube.com";
 
-  // Unbounded `.*` here is quadratic in theory (measured 1.6s on 200k characters), but the input is
-  // a video URL from a form field, so that length cannot occur. A `.{0,2048}` cap was tried and
-  // removed: it bought nothing reachable and could resolve a DIFFERENT id than the uncapped form —
-  // a `v=` beyond the cap, or a second `youtube.com`, shifts which match wins. Exactness matters
-  // more than a bound that never binds. See ENG-2789.
-  const regExpList = [
-    /youtu\.be\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.*v=(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
-    /youtube\.com.*embed\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
-    /youtube-nocookie\.com\/embed\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
-  ];
+const isYoutubeIdCharacter = (character: string | undefined): boolean =>
+  character !== undefined && /[a-zA-Z0-9_-]/.test(character);
 
-  regExpList.some((regExp) => {
-    const match = regExp.exec(url);
-    if (match?.groups?.videoId) {
-      id = match.groups.videoId;
-      return true;
+const isLineTerminator = (character: string): boolean =>
+  character === "\n" || character === "\r" || character === "\u2028" || character === "\u2029";
+
+/** Greedy run of id characters at `start`, or "" when there is none. */
+const readYoutubeId = (url: string, start: number): string => {
+  let end = start;
+  while (end < url.length && isYoutubeIdCharacter(url[end])) end++;
+  return url.slice(start, end);
+};
+
+/**
+ * The id the pattern `youtube\.com.*<marker>([a-zA-Z0-9_-]+)` would capture, or "" when it would
+ * not match.
+ */
+const extractIdAfterHostMarker = (url: string, marker: string): string => {
+  let searchFrom = 0;
+
+  while (searchFrom <= url.length) {
+    const host = url.indexOf(YOUTUBE_HOST, searchFrom);
+    if (host === -1) return "";
+
+    const regionStart = host + YOUTUBE_HOST.length;
+    let lineEnd = regionStart;
+    while (lineEnd < url.length && !isLineTerminator(url[lineEnd])) lineEnd++;
+
+    // Greedy `.*` takes the last usable marker on the line, falling back to earlier ones when the
+    // id run after it is empty.
+    for (let at = lineEnd - marker.length; at >= regionStart; at--) {
+      if (!url.startsWith(marker, at)) continue;
+      const id = readYoutubeId(url, at + marker.length);
+      if (id) return id;
     }
-    return false;
-  });
 
-  return id || null;
+    searchFrom = lineEnd + 1;
+  }
+
+  return "";
+};
+
+const extractYoutubeId = (url: string): string | null => {
+  // Order preserved from the pattern list this replaces: youtu.be, then `v=`, then `embed/`, then
+  // youtube-nocookie. The first and last carry no `.*`, so they stay as regexes.
+  for (const [pattern, marker] of [
+    [/youtu\.be\/(?<videoId>[a-zA-Z0-9_-]+)/, null],
+    [null, "v="],
+    [null, "embed/"],
+    [/youtube-nocookie\.com\/embed\/(?<videoId>[a-zA-Z0-9_-]+)/, null],
+  ] as [RegExp | null, string | null][]) {
+    if (pattern) {
+      const match = pattern.exec(url);
+      const id = match ? (match.groups?.videoId ?? null) : null;
+      if (id) return id;
+      continue;
+    }
+
+    const id = extractIdAfterHostMarker(url, marker as string);
+    if (id) return id;
+  }
+
+  return null;
 };
 
 const extractVimeoId = (url: string): string | null => {

--- a/packages/survey-ui/src/lib/video.ts
+++ b/packages/survey-ui/src/lib/video.ts
@@ -1,3 +1,5 @@
+import { extractIdAfterHostMarker } from "./youtube-id";
+
 export const checkForYoutubeUrl = (url: string): boolean => {
   try {
     const youtubeUrl = new URL(url);
@@ -51,67 +53,6 @@ export const checkForLoomUrl = (url: string): boolean => {
     // invalid URL
     return false;
   }
-};
-
-// `youtube.com` followed later by `v=` or `embed/`, scanned rather than matched with
-// `/youtube\.com.*v=(…)/`. That pattern is quadratic: `.*` runs to the end of the line and
-// backtracks once per `youtube.com`, so a stored value of `"youtube.com/".repeat(25_600)` took
-// 6.7s per call — and `element-media.tsx` calls the converter twice, blocking the RESPONDENT's
-// main thread for ~13s. `ZStorageUrl` is an unbounded `z.string()`, so nothing caps the value on
-// its way into the database (ENG-2789).
-//
-// A length cap was rejected: it would resolve a different id than the pattern did when a marker
-// sits beyond it. This reproduces the pattern exactly instead.
-//
-// The equivalence rests on three properties of the original:
-//   - `.` excludes line terminators, so the marker shares a line with the host it follows.
-//   - `.*` is greedy, so the LAST marker on that line wins, and it backtracks to an earlier one
-//     when the last has no id character after it.
-//   - If the first host on a line has no usable marker, no later host on that line can either —
-//     its search region is a suffix of the first's — so the scan skips the line instead of
-//     retrying every position, which is what makes it linear.
-const YOUTUBE_HOST = "youtube.com";
-
-const isYoutubeIdCharacter = (character: string | undefined): boolean =>
-  character !== undefined && /[a-zA-Z0-9_-]/.test(character);
-
-const isLineTerminator = (character: string): boolean =>
-  character === "\n" || character === "\r" || character === "\u2028" || character === "\u2029";
-
-/** Greedy run of id characters at `start`, or "" when there is none. */
-const readYoutubeId = (url: string, start: number): string => {
-  let end = start;
-  while (end < url.length && isYoutubeIdCharacter(url[end])) end++;
-  return url.slice(start, end);
-};
-
-/**
- * The id the pattern `youtube\.com.*<marker>([a-zA-Z0-9_-]+)` would capture, or "" when it would
- * not match.
- */
-const extractIdAfterHostMarker = (url: string, marker: string): string => {
-  let searchFrom = 0;
-
-  while (searchFrom <= url.length) {
-    const host = url.indexOf(YOUTUBE_HOST, searchFrom);
-    if (host === -1) return "";
-
-    const regionStart = host + YOUTUBE_HOST.length;
-    let lineEnd = regionStart;
-    while (lineEnd < url.length && !isLineTerminator(url[lineEnd])) lineEnd++;
-
-    // Greedy `.*` takes the last usable marker on the line, falling back to earlier ones when the
-    // id run after it is empty.
-    for (let at = lineEnd - marker.length; at >= regionStart; at--) {
-      if (!url.startsWith(marker, at)) continue;
-      const id = readYoutubeId(url, at + marker.length);
-      if (id) return id;
-    }
-
-    searchFrom = lineEnd + 1;
-  }
-
-  return "";
 };
 
 const extractYoutubeId = (url: string): string | null => {

--- a/packages/survey-ui/src/lib/video.ts
+++ b/packages/survey-ui/src/lib/video.ts
@@ -1,4 +1,4 @@
-import { extractIdAfterHostMarker } from "./youtube-id";
+import { extractYoutubeId } from "./youtube-id";
 
 export const checkForYoutubeUrl = (url: string): boolean => {
   try {
@@ -53,29 +53,6 @@ export const checkForLoomUrl = (url: string): boolean => {
     // invalid URL
     return false;
   }
-};
-
-const extractYoutubeId = (url: string): string | null => {
-  // Order preserved from the pattern list this replaces: youtu.be, then `v=`, then `embed/`, then
-  // youtube-nocookie. The first and last carry no `.*`, so they stay as regexes.
-  for (const [pattern, marker] of [
-    [/youtu\.be\/(?<videoId>[a-zA-Z0-9_-]+)/, null],
-    [null, "v="],
-    [null, "embed/"],
-    [/youtube-nocookie\.com\/embed\/(?<videoId>[a-zA-Z0-9_-]+)/, null],
-  ] as [RegExp | null, string | null][]) {
-    if (pattern) {
-      const match = pattern.exec(url);
-      const id = match ? (match.groups?.videoId ?? null) : null;
-      if (id) return id;
-      continue;
-    }
-
-    const id = extractIdAfterHostMarker(url, marker as string);
-    if (id) return id;
-  }
-
-  return null;
 };
 
 const extractVimeoId = (url: string): string | null => {

--- a/packages/survey-ui/src/lib/video.ts
+++ b/packages/survey-ui/src/lib/video.ts
@@ -59,8 +59,8 @@ const extractYoutubeId = (url: string): string | null => {
   // Regular expressions for various YouTube URL formats
   const regExpList = [
     /youtu\.be\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.*v=(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
-    /youtube\.com.*embed\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
+    /youtube\.com.{0,2048}v=(?<videoId>[a-zA-Z0-9_-]{1,64})/, // youtube.com/watch?v=<id>
+    /youtube\.com.{0,2048}embed\/(?<videoId>[a-zA-Z0-9_-]{1,64})/, // youtube.com/embed/<id>
     /youtube-nocookie\.com\/embed\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
   ];
 

--- a/packages/survey-ui/src/lib/video.ts
+++ b/packages/survey-ui/src/lib/video.ts
@@ -56,17 +56,15 @@ export const checkForLoomUrl = (url: string): boolean => {
 const extractYoutubeId = (url: string): string | null => {
   let id = "";
 
-  // The `.{0,2048}` caps replace an unbounded `.*`, which rescanned to the end from every start
-  // position (O(N^2) — measured 1.6s on 200k chars). Greedy on purpose: `.*v=` resolves the LAST
-  // `v=`, and a lazy cap would silently switch it to the first.
-  //
-  // The cap is not free: a `v=` more than 2048 characters past `youtube.com`, or a second
-  // `youtube.com` in the string, can make this resolve a different id than the uncapped form did.
-  // No real watch URL is that long, but it is a wrong-id outcome rather than a no-match. ENG-2789.
+  // Unbounded `.*` here is quadratic in theory (measured 1.6s on 200k characters), but the input is
+  // a video URL from a form field, so that length cannot occur. A `.{0,2048}` cap was tried and
+  // removed: it bought nothing reachable and could resolve a DIFFERENT id than the uncapped form —
+  // a `v=` beyond the cap, or a second `youtube.com`, shifts which match wins. Exactness matters
+  // more than a bound that never binds. See ENG-2789.
   const regExpList = [
     /youtu\.be\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.{0,2048}v=(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
-    /youtube\.com.{0,2048}embed\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
+    /youtube\.com.*v=(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
+    /youtube\.com.*embed\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
     /youtube-nocookie\.com\/embed\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
   ];
 

--- a/packages/survey-ui/src/lib/video.ts
+++ b/packages/survey-ui/src/lib/video.ts
@@ -59,8 +59,8 @@ const extractYoutubeId = (url: string): string | null => {
   // Regular expressions for various YouTube URL formats
   const regExpList = [
     /youtu\.be\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.{0,2048}v=(?<videoId>[a-zA-Z0-9_-]{1,64})/, // youtube.com/watch?v=<id>
-    /youtube\.com.{0,2048}embed\/(?<videoId>[a-zA-Z0-9_-]{1,64})/, // youtube.com/embed/<id>
+    /youtube\.com.{0,2048}v=(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
+    /youtube\.com.{0,2048}embed\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
     /youtube-nocookie\.com\/embed\/(?<videoId>[a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
   ];
 

--- a/packages/survey-ui/src/lib/youtube-id.ts
+++ b/packages/survey-ui/src/lib/youtube-id.ts
@@ -65,3 +65,30 @@ export const extractIdAfterHostMarker = (url: string, marker: string): string =>
 
   return "";
 };
+
+/**
+ * The YouTube video id in `url`, or null.
+ *
+ * Order is preserved from the pattern list this replaces: youtu.be, then `v=`, then `embed/`, then
+ * youtube-nocookie. The first and last carry no `.*`, so they stay regexes; the middle two are the
+ * quadratic ones and go through the scan above.
+ */
+export const extractYoutubeId = (url: string): string | null => {
+  for (const [pattern, marker] of [
+    [/youtu\.be\/([a-zA-Z0-9_-]+)/, null],
+    [null, "v="],
+    [null, "embed/"],
+    [/youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, null],
+  ] as [RegExp | null, string | null][]) {
+    if (pattern) {
+      const match = pattern.exec(url);
+      if (match?.[1]) return match[1];
+      continue;
+    }
+
+    const id = extractIdAfterHostMarker(url, marker as string);
+    if (id) return id;
+  }
+
+  return null;
+};

--- a/packages/survey-ui/src/lib/youtube-id.ts
+++ b/packages/survey-ui/src/lib/youtube-id.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared by all three copies of the video-URL helpers — this package, `@formbricks/surveys`, and
+ * `apps/web`. Those three modules are deliberately parallel (three build targets), but this scan is
+ * subtle enough that three copies would be three chances to get the greedy/backtracking/line
+ * semantics wrong, so it lives here and they import it.
+ */
+
+// `youtube.com` followed later by `v=` or `embed/`, scanned rather than matched with
+// `/youtube\.com.*v=(…)/`. That pattern is quadratic: `.*` runs to the end of the line and
+// backtracks once per `youtube.com`, so a stored value of `"youtube.com/".repeat(25_600)` took
+// 6.7s per call — and `element-media.tsx` calls the converter twice, blocking the RESPONDENT's
+// main thread for ~13s. `ZStorageUrl` is an unbounded `z.string()`, so nothing caps the value on
+// its way into the database (ENG-2789).
+//
+// A length cap was rejected: it would resolve a different id than the pattern did when a marker
+// sits beyond it. This reproduces the pattern exactly instead.
+//
+// The equivalence rests on three properties of the original:
+//   - `.` excludes line terminators, so the marker shares a line with the host it follows.
+//   - `.*` is greedy, so the LAST marker on that line wins, and it backtracks to an earlier one
+//     when the last has no id character after it.
+//   - If the first host on a line has no usable marker, no later host on that line can either —
+//     its search region is a suffix of the first's — so the scan skips the line instead of
+//     retrying every position, which is what makes it linear.
+const YOUTUBE_HOST = "youtube.com";
+
+const isYoutubeIdCharacter = (character: string | undefined): boolean =>
+  character !== undefined && /[a-zA-Z0-9_-]/.test(character);
+
+const isLineTerminator = (character: string): boolean =>
+  character === "\n" || character === "\r" || character === "\u2028" || character === "\u2029";
+
+/** Greedy run of id characters at `start`, or "" when there is none. */
+const readYoutubeId = (url: string, start: number): string => {
+  let end = start;
+  while (end < url.length && isYoutubeIdCharacter(url[end])) end++;
+  return url.slice(start, end);
+};
+
+/**
+ * The id the pattern `youtube\.com.*<marker>([a-zA-Z0-9_-]+)` would capture, or "" when it would
+ * not match.
+ */
+export const extractIdAfterHostMarker = (url: string, marker: string): string => {
+  let searchFrom = 0;
+
+  while (searchFrom <= url.length) {
+    const host = url.indexOf(YOUTUBE_HOST, searchFrom);
+    if (host === -1) return "";
+
+    const regionStart = host + YOUTUBE_HOST.length;
+    let lineEnd = regionStart;
+    while (lineEnd < url.length && !isLineTerminator(url[lineEnd])) lineEnd++;
+
+    // Greedy `.*` takes the last usable marker on the line, falling back to earlier ones when the
+    // id run after it is empty.
+    for (let at = lineEnd - marker.length; at >= regionStart; at--) {
+      if (!url.startsWith(marker, at)) continue;
+      const id = readYoutubeId(url, at + marker.length);
+      if (id) return id;
+    }
+
+    searchFrom = lineEnd + 1;
+  }
+
+  return "";
+};

--- a/packages/surveys/src/lib/recall.ts
+++ b/packages/surveys/src/lib/recall.ts
@@ -11,10 +11,19 @@ const extractId = (text: string): string | null => {
 };
 
 // Extracts the fallback value from a string containing the "fallback" pattern.
+// An index scan, not `/fallback:([^#]*)#/`: that pattern is O(N^2) on a long run of `fallback:`
+// with no `#` after it, because the engine rescans to the end from every occurrence. Identical
+// result — `[^#]*` cannot cross a `#`, so the regex ends at the first `#` after the FIRST
+// `fallback:`, and if none follows that one none follows a later one either.
+const FALLBACK_MARKER = "fallback:";
+
 const extractFallbackValue = (text: string): string => {
-  const pattern = /fallback:([^#]*)#/;
-  const match = text.match(pattern);
-  return match?.[1] ?? "";
+  const markerStart = text.indexOf(FALLBACK_MARKER);
+  if (markerStart === -1) return "";
+
+  const valueStart = markerStart + FALLBACK_MARKER.length;
+  const valueEnd = text.indexOf("#", valueStart);
+  return valueEnd === -1 ? "" : text.slice(valueStart, valueEnd);
 };
 
 // Extracts the complete recall information (ID and fallback) from a headline string.

--- a/packages/surveys/src/lib/video-upload.test.ts
+++ b/packages/surveys/src/lib/video-upload.test.ts
@@ -116,3 +116,34 @@ describe("convertToEmbedUrl", () => {
     });
   });
 });
+
+describe("extractYoutubeId — stored-value denial of service (ENG-2789)", () => {
+  // The pattern list this replaced used `youtube\\.com.*v=(…)`, whose `.*` backtracks once per
+  // `youtube.com`. `ZStorageUrl` is an unbounded `z.string()`, so a value this long persists and
+  // reaches the RESPONDENT renderer, where `element-media.tsx` converts it twice per render.
+  test("a long repeated-host URL resolves fast instead of blocking the thread", () => {
+    const stored = `https://youtube.com/${"youtube.com/".repeat(25_600)}`; // 307,220 characters
+
+    const startedAt = performance.now();
+    const result = extractYoutubeId(stored);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(result).toBeNull();
+    // ~6700ms per call before, and the renderer calls it twice.
+    expect(elapsedMs).toBeLessThan(200);
+  });
+
+  // Greedy `.*` took the LAST marker on the line and backtracked to an earlier one when the last
+  // had no id after it. Both are load-bearing, so they are pinned rather than left to the corpus.
+  test.each([
+    ["https://www.youtube.com/watch?x=v=FIRST&v=SECOND", "SECOND"],
+    ["https://youtube.com/embed/abc/embed/def", "def"],
+    ["https://youtube.com/watch?v=&v=OK", "OK"],
+    ["https://youtube.com/watch?v=&v=", null],
+    // `.` cannot cross a line terminator, so a marker on the next line is not reachable.
+    ["youtube.com\nv=NEXTLINE", null],
+    ["youtube.com v=SAMELINE\nyoutube.com v=SECOND", "SAMELINE"],
+  ])("resolves %s to %s, as the pattern did", (url, expected) => {
+    expect(extractYoutubeId(url)).toBe(expected);
+  });
+});

--- a/packages/surveys/src/lib/video-upload.test.ts
+++ b/packages/surveys/src/lib/video-upload.test.ts
@@ -129,8 +129,11 @@ describe("extractYoutubeId — stored-value denial of service (ENG-2789)", () =>
     const elapsedMs = performance.now() - startedAt;
 
     expect(result).toBeNull();
-    // ~6700ms per call before, and the renderer calls it twice.
-    expect(elapsedMs).toBeLessThan(200);
+    // Budget chosen from measurements, not a round number: the scan costs 6ms uninstrumented but
+    // ~330ms under the coverage run CI uses, which slows tight character loops far more than it
+    // slows a native regex. The pattern this replaced takes ~3300ms on the same input either way,
+    // so 2000ms sits above the instrumented pass and below the regression it guards against.
+    expect(elapsedMs).toBeLessThan(2000);
   });
 
   // Greedy `.*` took the LAST marker on the line and backtracked to an earlier one when the last

--- a/packages/surveys/src/lib/video-upload.ts
+++ b/packages/surveys/src/lib/video-upload.ts
@@ -59,8 +59,8 @@ export const extractYoutubeId = (url: string): string | null => {
   // Regular expressions for various YouTube URL formats
   const regExpList = [
     /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.*v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
-    /youtube\.com.*embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
+    /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]{1,64})/, // youtube.com/watch?v=<id>
+    /youtube\.com.{0,2048}embed\/([a-zA-Z0-9_-]{1,64})/, // youtube.com/embed/<id>
     /youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
   ];
 

--- a/packages/surveys/src/lib/video-upload.ts
+++ b/packages/surveys/src/lib/video-upload.ts
@@ -59,8 +59,8 @@ export const extractYoutubeId = (url: string): string | null => {
   // Regular expressions for various YouTube URL formats
   const regExpList = [
     /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]{1,64})/, // youtube.com/watch?v=<id>
-    /youtube\.com.{0,2048}embed\/([a-zA-Z0-9_-]{1,64})/, // youtube.com/embed/<id>
+    /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
+    /youtube\.com.{0,2048}embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
     /youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
   ];
 

--- a/packages/surveys/src/lib/video-upload.ts
+++ b/packages/surveys/src/lib/video-upload.ts
@@ -56,7 +56,13 @@ export const checkForLoomUrl = (url: string): boolean => {
 export const extractYoutubeId = (url: string): string | null => {
   let id = "";
 
-  // Regular expressions for various YouTube URL formats
+  // The `.{0,2048}` caps replace an unbounded `.*`, which rescanned to the end from every start
+  // position (O(N^2) — measured 1.6s on 200k chars). Greedy on purpose: `.*v=` resolves the LAST
+  // `v=`, and a lazy cap would silently switch it to the first.
+  //
+  // The cap is not free: a `v=` more than 2048 characters past `youtube.com`, or a second
+  // `youtube.com` in the string, can make this resolve a different id than the uncapped form did.
+  // No real watch URL is that long, but it is a wrong-id outcome rather than a no-match. ENG-2789.
   const regExpList = [
     /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
     /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>

--- a/packages/surveys/src/lib/video-upload.ts
+++ b/packages/surveys/src/lib/video-upload.ts
@@ -1,3 +1,5 @@
+import { extractIdAfterHostMarker } from "@formbricks/survey-ui/youtube-id";
+
 export const checkForYoutubeUrl = (url: string): boolean => {
   try {
     const youtubeUrl = new URL(url);
@@ -51,67 +53,6 @@ export const checkForLoomUrl = (url: string): boolean => {
     // invalid URL
     return false;
   }
-};
-
-// `youtube.com` followed later by `v=` or `embed/`, scanned rather than matched with
-// `/youtube\.com.*v=(…)/`. That pattern is quadratic: `.*` runs to the end of the line and
-// backtracks once per `youtube.com`, so a stored value of `"youtube.com/".repeat(25_600)` took
-// 6.7s per call — and `element-media.tsx` calls the converter twice, blocking the RESPONDENT's
-// main thread for ~13s. `ZStorageUrl` is an unbounded `z.string()`, so nothing caps the value on
-// its way into the database (ENG-2789).
-//
-// A length cap was rejected: it would resolve a different id than the pattern did when a marker
-// sits beyond it. This reproduces the pattern exactly instead.
-//
-// The equivalence rests on three properties of the original:
-//   - `.` excludes line terminators, so the marker shares a line with the host it follows.
-//   - `.*` is greedy, so the LAST marker on that line wins, and it backtracks to an earlier one
-//     when the last has no id character after it.
-//   - If the first host on a line has no usable marker, no later host on that line can either —
-//     its search region is a suffix of the first's — so the scan skips the line instead of
-//     retrying every position, which is what makes it linear.
-const YOUTUBE_HOST = "youtube.com";
-
-const isYoutubeIdCharacter = (character: string | undefined): boolean =>
-  character !== undefined && /[a-zA-Z0-9_-]/.test(character);
-
-const isLineTerminator = (character: string): boolean =>
-  character === "\n" || character === "\r" || character === "\u2028" || character === "\u2029";
-
-/** Greedy run of id characters at `start`, or "" when there is none. */
-const readYoutubeId = (url: string, start: number): string => {
-  let end = start;
-  while (end < url.length && isYoutubeIdCharacter(url[end])) end++;
-  return url.slice(start, end);
-};
-
-/**
- * The id the pattern `youtube\.com.*<marker>([a-zA-Z0-9_-]+)` would capture, or "" when it would
- * not match.
- */
-const extractIdAfterHostMarker = (url: string, marker: string): string => {
-  let searchFrom = 0;
-
-  while (searchFrom <= url.length) {
-    const host = url.indexOf(YOUTUBE_HOST, searchFrom);
-    if (host === -1) return "";
-
-    const regionStart = host + YOUTUBE_HOST.length;
-    let lineEnd = regionStart;
-    while (lineEnd < url.length && !isLineTerminator(url[lineEnd])) lineEnd++;
-
-    // Greedy `.*` takes the last usable marker on the line, falling back to earlier ones when the
-    // id run after it is empty.
-    for (let at = lineEnd - marker.length; at >= regionStart; at--) {
-      if (!url.startsWith(marker, at)) continue;
-      const id = readYoutubeId(url, at + marker.length);
-      if (id) return id;
-    }
-
-    searchFrom = lineEnd + 1;
-  }
-
-  return "";
 };
 
 export const extractYoutubeId = (url: string): string | null => {

--- a/packages/surveys/src/lib/video-upload.ts
+++ b/packages/surveys/src/lib/video-upload.ts
@@ -1,4 +1,6 @@
-import { extractIdAfterHostMarker } from "@formbricks/survey-ui/youtube-id";
+import { extractYoutubeId } from "@formbricks/survey-ui/youtube-id";
+
+export { extractYoutubeId };
 
 export const checkForYoutubeUrl = (url: string): boolean => {
   try {
@@ -53,29 +55,6 @@ export const checkForLoomUrl = (url: string): boolean => {
     // invalid URL
     return false;
   }
-};
-
-export const extractYoutubeId = (url: string): string | null => {
-  // Order preserved from the pattern list this replaces: youtu.be, then `v=`, then `embed/`, then
-  // youtube-nocookie. The first and last carry no `.*`, so they stay as regexes.
-  for (const [pattern, marker] of [
-    [/youtu\.be\/([a-zA-Z0-9_-]+)/, null],
-    [null, "v="],
-    [null, "embed/"],
-    [/youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, null],
-  ] as [RegExp | null, string | null][]) {
-    if (pattern) {
-      const match = pattern.exec(url);
-      const id = match ? match[1] : null;
-      if (id) return id;
-      continue;
-    }
-
-    const id = extractIdAfterHostMarker(url, marker as string);
-    if (id) return id;
-  }
-
-  return null;
 };
 
 const extractVimeoId = (url: string): string | null => {

--- a/packages/surveys/src/lib/video-upload.ts
+++ b/packages/surveys/src/lib/video-upload.ts
@@ -56,17 +56,15 @@ export const checkForLoomUrl = (url: string): boolean => {
 export const extractYoutubeId = (url: string): string | null => {
   let id = "";
 
-  // The `.{0,2048}` caps replace an unbounded `.*`, which rescanned to the end from every start
-  // position (O(N^2) — measured 1.6s on 200k chars). Greedy on purpose: `.*v=` resolves the LAST
-  // `v=`, and a lazy cap would silently switch it to the first.
-  //
-  // The cap is not free: a `v=` more than 2048 characters past `youtube.com`, or a second
-  // `youtube.com` in the string, can make this resolve a different id than the uncapped form did.
-  // No real watch URL is that long, but it is a wrong-id outcome rather than a no-match. ENG-2789.
+  // Unbounded `.*` here is quadratic in theory (measured 1.6s on 200k characters), but the input is
+  // a video URL from a form field, so that length cannot occur. A `.{0,2048}` cap was tried and
+  // removed: it bought nothing reachable and could resolve a DIFFERENT id than the uncapped form —
+  // a `v=` beyond the cap, or a second `youtube.com`, shifts which match wins. Exactness matters
+  // more than a bound that never binds. See ENG-2789.
   const regExpList = [
     /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.{0,2048}v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
-    /youtube\.com.{0,2048}embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
+    /youtube\.com.*v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
+    /youtube\.com.*embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
     /youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
   ];
 

--- a/packages/surveys/src/lib/video-upload.ts
+++ b/packages/surveys/src/lib/video-upload.ts
@@ -53,31 +53,88 @@ export const checkForLoomUrl = (url: string): boolean => {
   }
 };
 
-export const extractYoutubeId = (url: string): string | null => {
-  let id = "";
+// `youtube.com` followed later by `v=` or `embed/`, scanned rather than matched with
+// `/youtube\.com.*v=(…)/`. That pattern is quadratic: `.*` runs to the end of the line and
+// backtracks once per `youtube.com`, so a stored value of `"youtube.com/".repeat(25_600)` took
+// 6.7s per call — and `element-media.tsx` calls the converter twice, blocking the RESPONDENT's
+// main thread for ~13s. `ZStorageUrl` is an unbounded `z.string()`, so nothing caps the value on
+// its way into the database (ENG-2789).
+//
+// A length cap was rejected: it would resolve a different id than the pattern did when a marker
+// sits beyond it. This reproduces the pattern exactly instead.
+//
+// The equivalence rests on three properties of the original:
+//   - `.` excludes line terminators, so the marker shares a line with the host it follows.
+//   - `.*` is greedy, so the LAST marker on that line wins, and it backtracks to an earlier one
+//     when the last has no id character after it.
+//   - If the first host on a line has no usable marker, no later host on that line can either —
+//     its search region is a suffix of the first's — so the scan skips the line instead of
+//     retrying every position, which is what makes it linear.
+const YOUTUBE_HOST = "youtube.com";
 
-  // Unbounded `.*` here is quadratic in theory (measured 1.6s on 200k characters), but the input is
-  // a video URL from a form field, so that length cannot occur. A `.{0,2048}` cap was tried and
-  // removed: it bought nothing reachable and could resolve a DIFFERENT id than the uncapped form —
-  // a `v=` beyond the cap, or a second `youtube.com`, shifts which match wins. Exactness matters
-  // more than a bound that never binds. See ENG-2789.
-  const regExpList = [
-    /youtu\.be\/([a-zA-Z0-9_-]+)/, // youtu.be/<id>
-    /youtube\.com.*v=([a-zA-Z0-9_-]+)/, // youtube.com/watch?v=<id>
-    /youtube\.com.*embed\/([a-zA-Z0-9_-]+)/, // youtube.com/embed/<id>
-    /youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, // youtube-nocookie.com/embed/<id>
-  ];
+const isYoutubeIdCharacter = (character: string | undefined): boolean =>
+  character !== undefined && /[a-zA-Z0-9_-]/.test(character);
 
-  regExpList.some((regExp) => {
-    const match = url.match(regExp);
-    if (match && match[1]) {
-      id = match[1];
-      return true;
+const isLineTerminator = (character: string): boolean =>
+  character === "\n" || character === "\r" || character === "\u2028" || character === "\u2029";
+
+/** Greedy run of id characters at `start`, or "" when there is none. */
+const readYoutubeId = (url: string, start: number): string => {
+  let end = start;
+  while (end < url.length && isYoutubeIdCharacter(url[end])) end++;
+  return url.slice(start, end);
+};
+
+/**
+ * The id the pattern `youtube\.com.*<marker>([a-zA-Z0-9_-]+)` would capture, or "" when it would
+ * not match.
+ */
+const extractIdAfterHostMarker = (url: string, marker: string): string => {
+  let searchFrom = 0;
+
+  while (searchFrom <= url.length) {
+    const host = url.indexOf(YOUTUBE_HOST, searchFrom);
+    if (host === -1) return "";
+
+    const regionStart = host + YOUTUBE_HOST.length;
+    let lineEnd = regionStart;
+    while (lineEnd < url.length && !isLineTerminator(url[lineEnd])) lineEnd++;
+
+    // Greedy `.*` takes the last usable marker on the line, falling back to earlier ones when the
+    // id run after it is empty.
+    for (let at = lineEnd - marker.length; at >= regionStart; at--) {
+      if (!url.startsWith(marker, at)) continue;
+      const id = readYoutubeId(url, at + marker.length);
+      if (id) return id;
     }
-    return false;
-  });
 
-  return id || null;
+    searchFrom = lineEnd + 1;
+  }
+
+  return "";
+};
+
+export const extractYoutubeId = (url: string): string | null => {
+  // Order preserved from the pattern list this replaces: youtu.be, then `v=`, then `embed/`, then
+  // youtube-nocookie. The first and last carry no `.*`, so they stay as regexes.
+  for (const [pattern, marker] of [
+    [/youtu\.be\/([a-zA-Z0-9_-]+)/, null],
+    [null, "v="],
+    [null, "embed/"],
+    [/youtube-nocookie\.com\/embed\/([a-zA-Z0-9_-]+)/, null],
+  ] as [RegExp | null, string | null][]) {
+    if (pattern) {
+      const match = pattern.exec(url);
+      const id = match ? match[1] : null;
+      if (id) return id;
+      continue;
+    }
+
+    const id = extractIdAfterHostMarker(url, marker as string);
+    if (id) return id;
+  }
+
+  return null;
 };
 
 const extractVimeoId = (url: string): string | null => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       '@formbricks/storage':
         specifier: workspace:*
         version: link:../../packages/storage
+      '@formbricks/survey-ui':
+        specifier: workspace:*
+        version: link:../../packages/survey-ui
       '@formbricks/surveys':
         specifier: workspace:*
         version: link:../../packages/surveys

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,14 @@ sonar.organization=formbricks
 
 # Sources
 sonar.sources=apps/web,packages/surveys,packages/survey-ui,packages/js-core,packages/cache,packages/storage
-sonar.exclusions=**/node_modules/**,**/.next/**,**/dist/**,**/build/**,**/*.test.*,**/*.spec.*,**/__mocks__/**,packages/survey-ui/**/*.stories.*
+# `**/.env` is a generated file, not source. `apps/web/.env` is a tracked SYMLINK to the repo-root
+# `.env` (which is gitignored) so that Next.js picks the root file up, and CI runs `pnpm dev:setup`
+# before scanning — which writes that file from `.env.example` and fills every secret with a fresh
+# `openssl rand -hex 32` (scripts/setup-dev-env.sh). Sonar then followed the symlink and reported
+# those throwaway runner-local values as hardcoded credentials. Nothing is committed: the template
+# ships the keys empty. `.env.example` itself stays in scope, so a real secret added there is still
+# caught.
+sonar.exclusions=**/node_modules/**,**/.next/**,**/dist/**,**/build/**,**/*.test.*,**/*.spec.*,**/__mocks__/**,packages/survey-ui/**/*.stories.*,**/.env
 
 # Tests
 sonar.tests=apps/web,packages/surveys,packages/survey-ui,packages/js-core,packages/cache,packages/storage


### PR DESCRIPTION
Fixes ENG-2786

## What & why

**Was:** SonarQube reported eight open findings against `main`, one a super-linear regex on an attacker-controlled request path. A sweep found the same shape in nine more places.

**Now:** Seven findings fixed, one suppressed with proof it cannot be applied, and every super-linear regex replaced by a scan that is provably identical to it.

- The Sonar one, `better-auth-path-label`, trimmed with `replace(/\/+$/, "")` — greedy and start-unanchored, so O(N²) on `pathname` off the request URL. 12130ms → 0.06ms at 200k characters.
- A [recheck](https://github.com/makenowjust-labs/recheck) sweep over 1,884 regexes in 314 files found the rest. All quadratic, none exponential.
- Length caps were tried and abandoned: a cap makes an over-long match land on a *later* copy of the pattern, which is wrong output rather than none.

## Where to look

- [html-opening-tag.ts](apps/web/lib/utils/html-opening-tag.ts) — new; replaces four tag regexes with one scan
- [youtube-id.ts](packages/survey-ui/src/lib/youtube-id.ts) — new; the YouTube scan, shared by all three copies
- [auto-link-matchers.ts:21](apps/web/modules/ui/components/editor/components/auto-link-matchers.ts#L21) — the only regex whose language changes
- [proxy.ts:120](apps/web/proxy.ts#L120) — why `String.raw` is refused, not applied
- [sonar-project.properties:13](sonar-project.properties#L13) — the one change that alters what gets scanned

## Breaking changes

- [ ] This PR contains breaking changes

None. Everything is internal to this repo — no API shape, route, env var, config key or SDK export changes, and `proxy.ts`'s matcher string is byte-identical to `main`'s. One regex narrows what it matches: an email local part over RFC 5321's 64 characters no longer autolinks in the editor. That is cosmetic editor behaviour, not a consumer contract.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && vitest run` · `cd packages/surveys && vitest run` · `cd packages/survey-ui && vitest run`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Slash-run path stays linear | unit (red on main) | 3004ms on the old regex vs a 500ms budget; passes now |
| Overlong local part never links a different address | unit (red on main) | 4 of 5 cases red against the cap-only form; underscore green as control |
| Tag scanner matches the four regexes it replaces | unit (guard) | ~80k comparisons incl. cap-breaking shapes, U+0130, astral-plane input |
| Recall split matches the regex it replaces | unit (guard) | 30k inputs incl. a span containing a second opener |
| Stored YouTube URL cannot block the respondent thread | unit (red on main) | 6787ms against a 2000ms budget on the old pattern; ~330ms now |
| Every changed module matches its base version | manual | Real modules, base vs branch, over shared corpora — all identical |
| Autolink boundary behaves as documented | manual | Live: base links 64- and 65-char local parts, branch links only the 64 |

<details>
<summary>The regex sweep — before → after at 200k adversarial characters</summary>

| Site | Before | After | Technique |
| --- | --- | --- | --- |
| `better-auth-path-label.ts` | 12130ms | 0.06ms | reverse scan (exact) |
| `auto-link-matchers.ts` email | 17024ms | 0.5ms | lookbehind + RFC 5321 cap |
| `workflow-email-action-form.tsx` | 6316ms | 0.2ms | index scan (exact) |
| `preview-email-template-styles.ts` `<p>`/`<li>` | 7453 / 5269ms | linear | shared tag scan (exact) |
| `SingleResponseCardBody.tsx` | 4895ms | linear | `splitRecallHighlights` (exact) |
| `emailTemplateFragment.ts` `<body>` / DOCTYPE | 2363 / 1418ms | 0.2ms | shared tag scan (exact) |
| `recall.ts` (web + surveys) | 1681ms | 0.1ms | index scan (exact) |
| `video-upload.ts` / `video.ts` youtube | 6738ms | 6ms | shared scan (exact) |
| `oauth-urls.ts` trim | — | — | reverse scan (exact) |

**Why no caps survive.** A cap does not merely make an over-long match fail. When the over-long run contains another copy of the pattern's prefix, the engine restarts there and matches a different span — `<p` + 4096 characters + `<p style="x">` matched at index 4099 instead of 0. CodeRabbit caught this in the email matcher; it was present in all six caps.

The four tag patterns now share `findOpeningTag` / `findClosingTag` / `replaceOpeningTags`. They are exact because `[^>]*` cannot cross a `>`, so a tag ends at the first one, and because no `>` after the first opening tag means none after a later one either.

**One exception, deliberate.** The email local part keeps its cap, guarded by a negative lookbehind so a match can never begin inside a run.

**The YouTube matcher was a stored DoS, caught in review.** I had left it quadratic, reasoning the input was a bounded form field. It is not: `ZStorageUrl` is a `z.string()` with no `.max()`, the value persists, and `element-media.tsx` converts it twice per render in the **respondent's** browser. A 307,220-character value took 6738ms per pass — about 13.5s of blocked main thread. It is now a linear scan, shared from `packages/survey-ui/src/lib/youtube-id.ts` by all three copies.

**The YouTube wildcard stays greedy.** `.*v=` resolves the last `v=`, and a lazy cap silently switches it to the first. Caught by a realistic-input check on `?x=v=FIRST&v=SECOND`, not by fuzzing.
</details>

<details>
<summary>How equivalence was established</summary>

Every replacement is compared against the **original** regex from `main`, never against an intermediate form:

1. **Differential against the real modules.** The base-commit version of each changed file was placed beside its current version so every alias and relative import resolved identically, then both were driven over a shared corpus and compared export-for-export — `recall`, `video-upload`, `video`, `emailTemplateFragment`, `preview-email-template-styles`, `auto-link-matchers`, `better-auth-path-label`, `client-ip`, `oauth-urls`. All identical.
2. **Fuzzing and boundaries.** 300k random inputs per pair, plus tests pinning where behaviour is intended to differ.
3. **Adversarial shapes.** Every input a cap got wrong, U+0130 (which `toLowerCase` expands to two code units, misaligning an index-based scan), and astral-plane characters.

Live, on a throwaway stack (Postgres + Redis + SpiceDB, seeded tenant): the editor autolinks `first.last+tag@sub.example.co.uk` and `https://www.example.com/a?b=c` as before, and at the boundary the base build links both a 64- and a 65-character local part while this branch links only the 64 — the one intended difference.
</details>

<details>
<summary>Why <code>proxy.ts</code> keeps its escapes (S7780)</summary>

Next.js reads `config.matcher` by statically parsing the file. Its extractor (`next/dist/build/analysis/extract-const-value.js`, 16.2.11) handles string literals, template literals, arrays and objects — but has no `TaggedTemplateExpression` branch. Driving Next's own SWC parser over each candidate:

```
current (escaped string literal)   -> OK   identical to intended pattern: true
String.raw tagged template         -> UNSUPPORTED: Unsupported node type "TaggedTemplateExpression" at "config.matcher[0]"
plain template literal             -> OK   identical to intended pattern: true
```

On `unsupported`, `exportedConfig.config` stays undefined, so `parseMiddlewareConfig` receives nothing and returns `{}` — the matcher is silently dropped and Proxy runs on every static asset. It throws in dev (E1013) and only logs an error during `next build`. A plain template literal parses but needs the same `\\.` escapes, so it does not satisfy the rule either.

`apps/web/.env` was also flagged for credentials. That file is generated in CI by `pnpm dev:setup`, which fills every secret with a fresh `openssl rand -hex 32`; `.env.example` ships the keys empty. It is excluded from the scan rather than "fixed", and `.env.example` stays in scope.
</details>

**Open gaps**

- The email helpers still find tags by scanning rather than parsing. The repo ships eight HTML parsers, but a parser re-serializes and so cannot be proven output-identical here — ENG-2789.
- `apps/web` gains a `@formbricks/survey-ui` workspace dependency so it can import the shared scan. It already had survey-ui in its tree transitively via `@formbricks/surveys`.
- The eleven findings the AuthZed cutover (#9089) added are ENG-2788, not this PR.

**Risks**

- `client-ip.ts` and `better-auth-path-label.ts` sit on security paths. Both are differentially identical to base; re-check IP rate limiting and Sentry's `auth.path` facet if anything looks off.
- `html-opening-tag.ts` is new shared code behind the email preview and the summary email. Its tests compare it against the regexes it replaces, so a future edit that drifts from them fails rather than silently changing rendering.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.
