### PR TITLE
feat(js-core): debug-log the Embedded Data bag's successful writes [ENG-1844]

### DIFF
--- a/packages/js-core/src/lib/survey/embedded-data.ts
+++ b/packages/js-core/src/lib/survey/embedded-data.ts
@@ -59,14 +59,28 @@ export class EmbeddedDataStore {
       return;
     }
 
+    const set: string[] = [];
+    const removed: string[] = [];
+
     for (const [key, value] of Object.entries(data)) {
       if (value === undefined) continue;
       if (value === null) {
         this.data.delete(key);
+        removed.push(key);
         continue;
       }
       this.data.set(key, value);
+      set.push(key);
     }
+
+    // A success trace, because the bag is otherwise invisible: it lives in memory (nothing in
+    // devtools storage) and the API has no getter, so without this line a developer wiring up GTM
+    // gets zero confirmation until a survey happens to display. Debug level: it prints only with
+    // `?formbricksDebug=true`, so respondents' consoles stay clean. Keys only, never values — the
+    // documented use of this bag includes hashed identity fields.
+    Logger.getInstance().debug(
+      `setEmbeddedData: set [${set.join(", ")}]${removed.length > 0 ? `, removed [${removed.join(", ")}]` : ""} — the bag now holds [${[...this.data.keys()].join(", ")}]. Keys land on a response only if the survey declares them as ingested Embedded Data fields.`
+    );
   }
 
   /**
@@ -80,7 +94,9 @@ export class EmbeddedDataStore {
    */
   public clearEmbeddedData(...args: [] | [key: string]): void {
     if (args.length === 0) {
+      const clearedCount = this.data.size;
       this.data.clear();
+      Logger.getInstance().debug(`clearEmbeddedData: cleared the whole bag (${String(clearedCount)} keys)`);
       return;
     }
 
@@ -93,6 +109,9 @@ export class EmbeddedDataStore {
     }
 
     this.data.delete(key);
+    Logger.getInstance().debug(
+      `clearEmbeddedData: removed "${key}" — the bag now holds [${[...this.data.keys()].join(", ")}]`
+    );
   }
 
   /**

--- a/packages/js-core/src/lib/survey/embedded-data.ts
+++ b/packages/js-core/src/lib/survey/embedded-data.ts
@@ -31,6 +31,9 @@ export type TEmbeddedDataInput = Record<string, string | number | boolean | Date
 export class EmbeddedDataStore {
   private static instance: EmbeddedDataStore | undefined;
   private data = new Map<string, string | number | boolean | Date>();
+  // Grabbed once: the Logger is itself a never-replaced singleton, so re-resolving it at every log
+  // site buys nothing. Configuration (the debug level) lands on this same instance later.
+  private readonly logger = Logger.getInstance();
 
   static getInstance(): EmbeddedDataStore {
     EmbeddedDataStore.instance ??= new EmbeddedDataStore();
@@ -53,7 +56,7 @@ export class EmbeddedDataStore {
     // refused too, and so is an array (`typeof [] === "object"`): either would spread into junk
     // numeric keys ({0: "p", 1: "l", …} / {0: "a", 1: "b"}) — `ecommerce.items` is the common array case.
     if (typeof data !== "object" || data === null || Array.isArray(data)) {
-      Logger.getInstance().error(
+      this.logger.error(
         `setEmbeddedData: expected an object, got ${data === null ? "null" : typeof data} — nothing was set`
       );
       return;
@@ -78,7 +81,7 @@ export class EmbeddedDataStore {
     // gets zero confirmation until a survey happens to display. Debug level: it prints only with
     // `?formbricksDebug=true`, so respondents' consoles stay clean. Keys only, never values — the
     // documented use of this bag includes hashed identity fields.
-    Logger.getInstance().debug(
+    this.logger.debug(
       `setEmbeddedData: set [${set.join(", ")}]${removed.length > 0 ? `, removed [${removed.join(", ")}]` : ""} — the bag now holds [${[...this.data.keys()].join(", ")}]. Keys land on a response only if the survey declares them as ingested Embedded Data fields.`
     );
   }
@@ -96,20 +99,20 @@ export class EmbeddedDataStore {
     if (args.length === 0) {
       const clearedCount = this.data.size;
       this.data.clear();
-      Logger.getInstance().debug(`clearEmbeddedData: cleared the whole bag (${String(clearedCount)} keys)`);
+      this.logger.debug(`clearEmbeddedData: cleared the whole bag (${String(clearedCount)} keys)`);
       return;
     }
 
     const [key] = args;
     if (typeof key !== "string") {
-      Logger.getInstance().error(
+      this.logger.error(
         "clearEmbeddedData: expected a field name — nothing was cleared (call with no argument to clear everything)"
       );
       return;
     }
 
     this.data.delete(key);
-    Logger.getInstance().debug(
+    this.logger.debug(
       `clearEmbeddedData: removed "${key}" — the bag now holds [${[...this.data.keys()].join(", ")}]`
     );
   }

--- a/packages/js-core/src/lib/survey/embedded-data.ts
+++ b/packages/js-core/src/lib/survey/embedded-data.ts
@@ -68,8 +68,8 @@ export class EmbeddedDataStore {
     for (const [key, value] of Object.entries(data)) {
       if (value === undefined) continue;
       if (value === null) {
-        this.data.delete(key);
-        removed.push(key);
+        // `Map.delete` says whether the key existed; the trace must report only real removals.
+        if (this.data.delete(key)) removed.push(key);
         continue;
       }
       this.data.set(key, value);
@@ -111,10 +111,17 @@ export class EmbeddedDataStore {
       return;
     }
 
-    this.data.delete(key);
-    this.logger.debug(
-      `clearEmbeddedData: removed "${key}" — the bag now holds [${[...this.data.keys()].join(", ")}]`
-    );
+    // Both outcomes get a line — an absent key saying so is exactly the feedback a developer
+    // debugging "why is/isn't my key here" needs, and silence was this trace's original sin.
+    if (this.data.delete(key)) {
+      this.logger.debug(
+        `clearEmbeddedData: removed "${key}" — the bag now holds [${[...this.data.keys()].join(", ")}]`
+      );
+    } else {
+      this.logger.debug(
+        `clearEmbeddedData: "${key}" was not in the bag — the bag holds [${[...this.data.keys()].join(", ")}]`
+      );
+    }
   }
 
   /**

--- a/packages/js-core/src/lib/survey/embedded-data.ts
+++ b/packages/js-core/src/lib/survey/embedded-data.ts
@@ -81,8 +81,9 @@ export class EmbeddedDataStore {
     // gets zero confirmation until a survey happens to display. Debug level: it prints only with
     // `?formbricksDebug=true`, so respondents' consoles stay clean. Keys only, never values — the
     // documented use of this bag includes hashed identity fields.
+    const removedSegment = removed.length > 0 ? `, removed [${removed.join(", ")}]` : "";
     this.logger.debug(
-      `setEmbeddedData: set [${set.join(", ")}]${removed.length > 0 ? `, removed [${removed.join(", ")}]` : ""} — the bag now holds [${[...this.data.keys()].join(", ")}]. Keys land on a response only if the survey declares them as ingested Embedded Data fields.`
+      `setEmbeddedData: set [${set.join(", ")}]${removedSegment} — the bag now holds [${[...this.data.keys()].join(", ")}]. Keys land on a response only if the survey declares them as ingested Embedded Data fields.`
     );
   }
 

--- a/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
+++ b/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
@@ -2,8 +2,11 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { EmbeddedDataStore, buildDisplayHiddenFields } from "@/lib/survey/embedded-data";
 
 // The guards log through Logger; mocked so refused inputs don't spray the test output.
+const { mockLogger } = vi.hoisted(() => ({ mockLogger: { error: vi.fn(), debug: vi.fn() } }));
+
+// The guards log errors and the success trace logs at debug; a stable instance lets tests assert both.
 vi.mock("@/lib/common/logger", () => ({
-  Logger: { getInstance: vi.fn(() => ({ error: vi.fn(), debug: vi.fn() })) },
+  Logger: { getInstance: vi.fn(() => mockLogger) },
 }));
 
 describe("EmbeddedDataStore", () => {
@@ -166,5 +169,58 @@ describe("buildDisplayHiddenFields", () => {
         typeof buildDisplayHiddenFields
       >[0])
     ).toEqual({ plan: "ambient-pro" });
+  });
+});
+
+describe("the debug success trace — the bag's only success feedback", () => {
+  beforeEach(() => {
+    EmbeddedDataStore.getInstance().clearEmbeddedData();
+    mockLogger.debug.mockClear();
+  });
+
+  test("a successful set logs the keys it set and what the bag now holds — keys only, never values", () => {
+    EmbeddedDataStore.getInstance().setEmbeddedData({ plan: "pro", hashed_email: "s3cret-hash" });
+
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+    const message = mockLogger.debug.mock.calls[0][0] as string;
+    expect(message).toContain("set [plan, hashed_email]");
+    expect(message).toContain("the bag now holds [plan, hashed_email]");
+    // The bag's documented use includes hashed identity fields; values must never reach a log line.
+    expect(message).not.toContain("pro");
+    expect(message).not.toContain("s3cret-hash");
+  });
+
+  test("a null removal shows up in the trace as removed, not set", () => {
+    EmbeddedDataStore.getInstance().setEmbeddedData({ plan: "pro" });
+    mockLogger.debug.mockClear();
+
+    EmbeddedDataStore.getInstance().setEmbeddedData({ plan: null, pageType: "product" });
+
+    const message = mockLogger.debug.mock.calls[0][0] as string;
+    expect(message).toContain("set [pageType]");
+    expect(message).toContain("removed [plan]");
+    expect(message).toContain("the bag now holds [pageType]");
+  });
+
+  test("clearEmbeddedData traces both forms", () => {
+    EmbeddedDataStore.getInstance().setEmbeddedData({ plan: "pro", pageType: "product" });
+    mockLogger.debug.mockClear();
+
+    EmbeddedDataStore.getInstance().clearEmbeddedData("plan");
+    expect(mockLogger.debug.mock.calls[0][0]).toContain('removed "plan"');
+
+    EmbeddedDataStore.getInstance().clearEmbeddedData();
+    expect(mockLogger.debug.mock.calls[1][0]).toContain("cleared the whole bag (1 keys)");
+  });
+
+  test("a refused input logs an error and no success trace", () => {
+    mockLogger.error.mockClear();
+
+    EmbeddedDataStore.getInstance().setEmbeddedData(
+      null as unknown as Parameters<EmbeddedDataStore["setEmbeddedData"]>[0]
+    );
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.debug).not.toHaveBeenCalled();
   });
 });

--- a/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
+++ b/packages/js-core/src/lib/survey/tests/embedded-data.test.ts
@@ -213,6 +213,28 @@ describe("the debug success trace — the bag's only success feedback", () => {
     expect(mockLogger.debug.mock.calls[1][0]).toContain("cleared the whole bag (1 keys)");
   });
 
+  test("a null for an ABSENT key is not reported as removed — the trace records only real removals", () => {
+    EmbeddedDataStore.getInstance().setEmbeddedData({ plan: "pro" });
+    mockLogger.debug.mockClear();
+
+    EmbeddedDataStore.getInstance().setEmbeddedData({ missing: null, pageType: "product" });
+
+    const message = mockLogger.debug.mock.calls[0][0] as string;
+    expect(message).toContain("set [pageType]");
+    expect(message).not.toContain("removed");
+  });
+
+  test("clearing an absent key says so instead of claiming a removal", () => {
+    EmbeddedDataStore.getInstance().setEmbeddedData({ plan: "pro" });
+    mockLogger.debug.mockClear();
+
+    EmbeddedDataStore.getInstance().clearEmbeddedData("missing");
+
+    const message = mockLogger.debug.mock.calls[0][0] as string;
+    expect(message).toContain('"missing" was not in the bag');
+    expect(message).not.toContain('removed "missing"');
+  });
+
   test("a refused input logs an error and no success trace", () => {
     mockLogger.error.mockClear();
 


### PR DESCRIPTION
## What & why

`setEmbeddedData` succeeds in total silence, and the bag is otherwise invisible — it lives in memory (nothing in devtools storage) and the API has no getter. A developer wiring it up gets zero confirmation until a survey happens to display, which came up immediately in manual testing of the mobile ports: "it works, but there is no log, which is kinda confusing as a dev."

This adds a success trace at **debug level** (prints only with `?formbricksDebug=true`, so respondents' consoles stay clean):

```
setEmbeddedData: set [plan, pageType] — the bag now holds [plan, pageType, cookie_id]. Keys land on a response only if the survey declares them as ingested Embedded Data fields.
clearEmbeddedData: removed "plan" — the bag now holds [pageType, cookie_id]
clearEmbeddedData: cleared the whole bag (2 keys)
```

**Keys only, never values** — the bag's documented use includes hashed identity fields, and values must not reach log lines. The trailing sentence pre-empts the next confusion ("set succeeded" ≠ "will appear on the response" — the renderer's allow-list decides that at display).

The four mobile SDK parity PRs (react-native#77, ios#54, android#58, flutter#44) ported the same silence; they're getting review comments pointing at this as the pattern, each via its own debug-gated logger.

## Linear ticket

Follow-up to ENG-1844 — https://linear.app/formbricks/issue/ENG-1844/sdk-setembeddeddata-clearembeddeddata-app-surveys (the DX gap was flagged on #8989's review as "the bag is invisible"; this is the cheap half of the fix, a debug getter/log being the alternative considered).

## How this was tested

- `@formbricks/js-core` ✅ 320 tests · `turbo run typecheck lint` ✅ · prettier ✅
- Tests added: set-trace carries set/removed keys and the bag's key list **and no values** (asserted against a `hashed_email` value string); null-removal shows under `removed`; both clear forms trace; a refused input logs an error and **no** success trace. The keys-only test checked to **fail with the trace removed**.
- The test file's logger mock became a stable `vi.hoisted` instance so debug calls are assertable — previously each `getInstance()` returned a fresh object.

## Breaking changes

None — debug-level logging only.

## QA / Test Plan

**How to test**

- [ ] App survey page with `?formbricksDebug=true`: `formbricks.setEmbeddedData({ plan: "pro" })` → console shows `setEmbeddedData: set [plan] — the bag now holds [plan]…`.
- [ ] Without the debug flag → no output (respondent consoles stay clean).
- [ ] `formbricks.setEmbeddedData({ plan: null })` → trace shows `removed [plan]`.
- [ ] `formbricks.clearEmbeddedData()` → `cleared the whole bag (N keys)`.
- [ ] Values never appear in any of the lines, only key names.

**Preconditions / test data**

- Any page with the JS SDK set up; no survey needed — that's the point.

**Risks & regressions**

- None beyond log noise in debug mode; the trace is keys-only by design — re-check no value ever leaks into it if the message is edited.

**Migrations / env / cutover**

- none
