### PR TITLE
fix: map P2002 with unrecoverable fields to 409 on client response create

### DIFF
--- a/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.test.ts
+++ b/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.test.ts
@@ -24,6 +24,30 @@ describe("handleClientResponseCreateError", () => {
     );
   });
 
+  // ENG-2251: adapter-pg parses the column list out of the Postgres error DETAIL; when that line is
+  // absent or unparseable it emits `constraint: undefined`, so no field check can match. A P2002
+  // must still be a conflict (409), never fall through to DatabaseError (500).
+  test("maps a P2002 without recoverable fields to UniqueConstraintError", () => {
+    const error = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "test",
+      meta: { driverAdapterError: { cause: { kind: "UniqueConstraintViolation" } } },
+    });
+    expect(() => handleClientResponseCreateError(error)).toThrow(
+      new UniqueConstraintError("Response already exists")
+    );
+  });
+
+  test("maps a P2002 without any meta to UniqueConstraintError", () => {
+    const error = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "test",
+    });
+    expect(() => handleClientResponseCreateError(error)).toThrow(
+      new UniqueConstraintError("Response already exists")
+    );
+  });
+
   test("maps any other known Prisma error to DatabaseError carrying its message", () => {
     const error = new Prisma.PrismaClientKnownRequestError("boom", { code: "P2025", clientVersion: "test" });
     expect(() => handleClientResponseCreateError(error)).toThrow(new DatabaseError("boom"));

--- a/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.ts
+++ b/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.ts
@@ -19,13 +19,21 @@ export const isDisplayIdUniqueConstraintError = (error: PrismaClientKnownRequest
  */
 export const handleClientResponseCreateError = (error: unknown, displayId?: string | null): never => {
   if (isPrismaKnownRequestError(error)) {
+    // Captured before the P2002 guards: their negative branches narrow `error` to `never`.
+    const { message } = error;
     if (isDisplayIdUniqueConstraintError(error)) {
       throw new InvalidInputError(`Display ${displayId} is already linked to a response`);
     }
     if (isSingleUseIdUniqueConstraintError(error)) {
       throw new UniqueConstraintError("Response already submitted for this single-use link");
     }
-    throw new DatabaseError(error.message);
+    if (isUniqueConstraintError(error)) {
+      // The adapter recovers the column list by parsing the Postgres error DETAIL, which can be
+      // absent or unparseable (redacted detail, non-English lc_messages). A P2002 is still a
+      // duplicate either way, so it must stay a conflict — never fall through to a 500.
+      throw new UniqueConstraintError("Response already exists");
+    }
+    throw new DatabaseError(message);
   }
   throw error;
 };

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
@@ -163,7 +163,7 @@ describe("createResponse", () => {
 
   test("should throw DatabaseError on Prisma known request error", async () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Test Prisma Error", {
-      code: "P2002",
+      code: "P2025",
       clientVersion: "test",
     });
     vi.mocked(prisma.response.create).mockRejectedValue(prismaError);

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
@@ -202,7 +202,9 @@ describe("createResponse V2", () => {
     ).rejects.toThrow(UniqueConstraintError);
   });
 
-  test("should throw DatabaseError on P2002 without singleUseId or displayId target", async () => {
+  // ENG-2251: a P2002 on this create can only be one of the response table's unique constraints,
+  // so an unmatched (or unrecoverable) target is still a duplicate — a 409, never a 500.
+  test("should throw UniqueConstraintError on P2002 without singleUseId or displayId target", async () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
       clientVersion: "test",
@@ -211,7 +213,7 @@ describe("createResponse V2", () => {
     vi.mocked(mockTx.response.create).mockRejectedValue(prismaError);
     await expect(
       createResponse(mockResponseInput, mockTx as unknown as Prisma.TransactionClient)
-    ).rejects.toThrow(DatabaseError);
+    ).rejects.toThrow(UniqueConstraintError);
   });
 
   test("should throw InvalidInputError on P2002 with displayId target (race condition)", async () => {


### PR DESCRIPTION
Fixes ENG-2251

## What & why

**Was:** a duplicate single-use response whose P2002 column list the driver adapter couldn't recover fell through to `DatabaseError` — a 500 plus a Sentry event, instead of the documented 409.

**Now:** any P2002 on the client response create maps to a 409 conflict; only genuinely unknown errors reach the 500 path.

- The production incident's main shape (quoted column names) was already fixed by #8743; this covers the remaining shape where `@prisma/adapter-pg` recovers no fields at all (Postgres DETAIL absent or unparseable — redacted detail, non-English `lc_messages`).
- A P2002 is a duplicate regardless of whether we can name the columns, so the field-specific branches now sit above a generic conflict fallback (same pattern as the org users create).

## Where to look

- [response-error.ts:30-35](https://github.com/formbricks/formbricks/blob/fix/ENG-2251_p2002-conflict-fallback/apps/web/app/api/client/%5BworkspaceId%5D/responses/lib/response-error.ts#L30-L35) — the new P2002 fallback

## Breaking changes

- [ ] This PR contains breaking changes

None — this changes a status code (500 → 409), but only for the degraded P2002 shape on the v1/v2 client response creates, where 409 is already the documented duplicate status (and what production returns for the common shape since #8743). A client coded to the contract keeps working unchanged; the 500 was the bug, so documenting it as a migration step would invent an action nobody has to take.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && pnpm vitest run "app/api/client/[workspaceId]/responses/lib/response-error.test.ts"`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| P2002 with `constraint: undefined` (adapter shape when DETAIL is unparseable) → 409 | unit (red on main) | throws `UniqueConstraintError`; on main it threw `DatabaseError` (500) |
| P2002 with no `meta` at all → 409 | unit (red on main) | throws `UniqueConstraintError`; on main it threw `DatabaseError` (500) |
| Real duplicate `(surveyId, singleUseId)` / `displayId` against real Postgres still 409 / 400 | unit (guard) | `response-error.integration.test.ts`, 2/2 green against Prisma 7 + adapter-pg |
| P2002 with fields matching neither constraint → 409 | unit (guard) | v1/v2 `response.test.ts` updated: these asserted the old 500 mapping |
| Non-P2002 Prisma errors still map to `DatabaseError` | unit (guard) | existing test unchanged, green |

**Open gaps**

- A healthy Postgres always emits a parseable DETAIL, so the no-fields shape can't be driven end-to-end; the unit fixtures mirror `mapDriverError` in `@prisma/adapter-pg` (verified against the installed adapter source), which emits `constraint: undefined` exactly then.

**Risks**

- A `displayId` duplicate with unrecoverable fields now returns 409 instead of the field-specific 400 — previously it was a 500, so callers only gain a usable status.

---

> [!NOTE]
> **AI model used** — `claude-fable-5`, reasoning effort `unknown`.
