### PR TITLE
fix(workflows): make the rich-text editor look disabled when read-only

### DIFF
--- a/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
@@ -45,7 +45,7 @@ export const RichTextTranslationInput = ({
   }, [value]);
 
   return (
-    <div className={disabled ? "cursor-not-allowed rounded-md opacity-60" : "rounded-md"}>
+    <div className="rounded-md">
       <Editor
         key={`${path}-${editorKey}`}
         disableLists

--- a/apps/web/modules/ui/components/editor/components/editor.tsx
+++ b/apps/web/modules/ui/components/editor/components/editor.tsx
@@ -117,12 +117,18 @@ export const Editor = (props: TextEditorProps) => {
 
   return (
     <>
-      <div className="editor cursor-text rounded-md">
+      <div className={cn("editor rounded-md", editable ? "cursor-text" : "cursor-not-allowed")}>
         <LexicalComposer initialConfig={{ ...editorConfig, editable }}>
           <SyncEditablePlugin editable={editable} />
           <div
             ref={editorContainerRef}
-            className={cn("editor-container rounded-md p-0", props.isInvalid && "border! border-red-500!")}>
+            className={cn(
+              "editor-container rounded-md p-0",
+              // Defined in styles-editor.css — see the comment there for why this state can't be
+              // expressed as Tailwind utilities.
+              !editable && "editor-container-disabled",
+              props.isInvalid && "border! border-red-500!"
+            )}>
             <ToolbarPlugin
               getText={props.getText}
               setText={props.setText}
@@ -142,9 +148,7 @@ export const Editor = (props: TextEditorProps) => {
               isExternalUrlsAllowed={props.isExternalUrlsAllowed}
             />
             {props.onEmptyChange ? <EditorContentChecker onEmptyChange={props.onEmptyChange} /> : null}
-            <div
-              className={cn("editor-inner scroll-bar", !editable && "bg-muted")}
-              style={{ height: props.height }}>
+            <div className="editor-inner scroll-bar" style={{ height: props.height }}>
               <RichTextPlugin
                 contentEditable={
                   <ContentEditable

--- a/apps/web/modules/ui/components/editor/styles-editor.css
+++ b/apps/web/modules/ui/components/editor/styles-editor.css
@@ -22,6 +22,32 @@
   border-color: var(--color-brand-dark);
 }
 
+/*
+ * Read-only mode (`editable={false}`): the same `disabled:opacity-50` treatment `Input` and
+ * `Textarea` carry, plus dropping the resize grip — nothing inside the editor is a native disabled
+ * control, so there is no `:disabled` for those utilities to hook onto and the state is painted on
+ * the wrapper instead.
+ *
+ * It lives here rather than in Tailwind classes on the component because `.editor-inner` sets
+ * `resize` in this stylesheet, which Next.js emits unlayered — that beats any `resize-none` from
+ * `@layer utilities` no matter the specificity, so the grip would survive.
+ *
+ * The toolbar's buttons opt out of the fade: they already carry their own `disabled:opacity-50`,
+ * and compounding the two washes the icons out to 25%. At full opacity inside this 50% wrapper they
+ * composite to the same 50% a disabled button shows anywhere else.
+ */
+.editor-container-disabled {
+  opacity: 0.5;
+}
+
+.editor-container-disabled .editor-inner {
+  resize: none;
+}
+
+.editor-container-disabled button:disabled {
+  opacity: 1;
+}
+
 .editor-inner {
   background: var(--cal-bg);
   position: relative;


### PR DESCRIPTION
Fixes ENG-2598

## What & why

**Was:** In a workflow the user cannot edit, the email Body kept black text, a white box and its resize grip — the one control in the inspector that still looked editable.

**Now:** It carries the `opacity-50` + `cursor-not-allowed` treatment of the disabled Subject input beside it, and the resize grip is gone.

- `bg-muted`, the class meant to convey that state, emits nothing: `--color-muted` is not in the theme.
- The state is painted on the wrapper because nothing inside the editor is a native disabled control.

## Where to look

- [styles-editor.css](https://github.com/formbricks/formbricks/blob/claude/textarea-disabled-read-only-d30kd2/apps/web/modules/ui/components/editor/styles-editor.css), lines 26-49 — why these rules cannot be Tailwind utilities
- `rich-text-translation-input.tsx` line 48 — its own fade would now apply twice, so it goes

## Breaking changes

- [ ] This PR contains breaking changes

None. Styling internal to this repo; no API, SDK, route, env var or config key changes.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm db:up && pnpm dev`, then open a `send_email` node in an enabled workflow — `/workspaces/{workspaceId}/workflows/{workflowId}?node=send-email`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Body editor reads as disabled when the workflow is not editable | manual | Fades to match the Subject input, resize grip gone, not-allowed cursor |
| Editable inspector is untouched | manual | Same seed shot on both sides of the change: the PNGs are byte-identical |
| Toolbar icons do not fade twice | manual | Identical across the pair below — the `button:disabled` reset holds |

Screenshots — inspector on an enabled workflow (not editable):

| Before | After |
| --- | --- |
| ![Body text at full strength on white with a resize grip in the corner](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2598/read-only-before.png) | ![Body text faded to match the disabled Subject input, no resize grip](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2598/read-only-after.png) |

The same inspector on a draft workflow (editable) is [unchanged](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2598/editable-unchanged.png) — shot from the same seeded workflow on both sides of the change, and the two files hash identically.

**Open gaps**

- Multi-language translation input not re-shot: its `disabled` is the transient AI-translating state.

**Risks**

- Every `editable={false}` Editor now fades; the two call sites above are the only ones.

---

**AI model used** — `claude-opus-5`, reasoning effort `max`.
