### PR TITLE
fix(nav): restrict trial upgrade banner to owner/manager roles

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -530,6 +530,7 @@ export const MainNavigation = ({
 
                 {/* Trial Days Remaining */}
                 {!isCollapsed &&
+                  isOwnerOrManager &&
                   isFormbricksCloud &&
                   trialDaysRemaining !== null &&
                   (newTrialBannerVariant === "test" ? (


### PR DESCRIPTION
No ticket — small role-gating fix requested directly, not tracked in Linear.

## What & why

**Was:** The trial "upgrade" banner in the workspace sidebar rendered for every organization
member — including `member` and `billing` roles, who cannot act on billing.

**Now:** The banner only renders for `owner` and `manager` roles, matching the "New Version
Available" banner right above it in the same sidebar.

## Where to look

- [MainNavigation.tsx:531-551](apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx#L531-L551) — added `isOwnerOrManager` to the existing render condition

## Breaking changes

- [ ] This PR contains breaking changes

None — purely restricts an internal UI element to a narrower set of roles; no API/SDK surface touched.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm lint apps/web`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Banner hidden for `member`/`billing` roles, shown for `owner`/`manager` | manual (code reasoning) | New condition reuses the same `isOwnerOrManager` flag already gating the "New Version Available" banner immediately above it in the same component |

**Open gaps**

- Not visually verified in a live session: the banner only renders for `isFormbricksCloud` orgs with an active Stripe trial, a state not reproducible in this local worktree.

**Risks**

- none

---

> [!NOTE]
> **AI model used** — `claude-sonnet-5`, reasoning effort `xhigh`.
