### PR TITLE
docs: replace untrusted self-hosting minimum with real v6 sizing

### DIFF
--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -10,11 +10,15 @@ Formbricks is not a single container. The v6 baseline runs the Formbricks app, F
 worker), Cube, PostgreSQL, Redis/Valkey, and SpiceDB, so size the host for the whole stack rather than for
 the app alone.
 
-| Deployment                                                       | CPU                     | Memory                | Disk               |
-| ---------------------------------------------------------------- | ----------------------- | --------------------- | ------------------ |
-| Evaluation on a single server ([Docker](/self-hosting/setup/docker), [one-click](/self-hosting/setup/one-click)) | 2 vCPU                  | 4 GB                  | 20 GB SSD          |
-| Small production on a single server                              | 4 vCPU                  | 8 GB                  | 50 GB SSD          |
-| [Minimal enterprise setup](#minimal-enterprise-setup) (Kubernetes) | 6 vCPU across the nodes | 12 GB across the nodes | managed services   |
+| Deployment                        | CPU          | Memory      | Disk       |
+| --------------------------------- | ------------ | ----------- | ---------- |
+| Single server, evaluation         | 2 vCPU       | 4 GB        | 20 GB SSD  |
+| Single server, small production   | 4 vCPU       | 8 GB        | 50 GB SSD  |
+| Kubernetes, minimal enterprise    | 6 vCPU total | 12 GB total | managed    |
+
+The single-server rows apply to the [Docker](/self-hosting/setup/docker) and
+[one-click](/self-hosting/setup/one-click) installs. The Kubernetes row is spread across a node pool and
+assumes managed data services — see [Minimal Enterprise Setup](#minimal-enterprise-setup).
 
 <Info>
   **HTTPS Required**: Ensure your server runs with a valid HTTPS certificate.
@@ -30,31 +34,33 @@ the app alone.
 These are the defaults the Helm chart ships, and they are the most precise sizing statement we can give.
 A Docker Compose install runs the same services without enforced limits.
 
-| Component                | Replicas | CPU request | Memory request | Memory limit |
-| ------------------------ | -------- | ----------- | -------------- | ------------ |
-| Formbricks app           | 1        | 1000m       | 1 Gi           | 2 Gi         |
-| Formbricks Hub API       | 1        | 100m        | 256 Mi         | 512 Mi       |
-| Formbricks Hub worker    | 1        | 100m        | 256 Mi         | 512 Mi       |
-| Cube                     | 1        | 250m        | 512 Mi         | 1 Gi         |
-| PostgreSQL (bundled)     | 1        | 250m        | 512 Mi         | 1 Gi         |
-| Redis/Valkey (bundled)   | 1        | 100m        | 128 Mi         | 192 Mi       |
-| SpiceDB                  | 2        | 100m each   | 256 Mi each    | 512 Mi each  |
-| **Total**                |          | **2 vCPU**  | **3.2 GiB**    | **6.2 GiB**  |
+| Component              | CPU request | Memory request | Memory limit |
+| ---------------------- | ----------- | -------------- | ------------ |
+| Formbricks app         | 1000m       | 1 Gi           | 2 Gi         |
+| Hub API                | 100m        | 256 Mi         | 512 Mi       |
+| Hub worker             | 100m        | 256 Mi         | 512 Mi       |
+| Cube                   | 250m        | 512 Mi         | 1 Gi         |
+| PostgreSQL (bundled)   | 250m        | 512 Mi         | 1 Gi         |
+| Redis/Valkey (bundled) | 100m        | 128 Mi         | 192 Mi       |
+| SpiceDB (2 replicas)   | 200m        | 512 Mi         | 1 Gi         |
+| **Total**              | **2 vCPU**  | **3.2 GiB**    | **6.2 GiB**  |
 
 Migration Jobs run alongside this on install and upgrade, and Kubernetes itself takes roughly 0.5 vCPU and
-1 GB per node before any of it is schedulable.
+1 GB per node before any of it is schedulable. The two bundled rows drop out when you use managed
+PostgreSQL and Redis.
 
 ### Optional Services Are Much Heavier
 
-Everything below is disabled by default. Budget for it separately, and prefer an external endpoint over
-self-hosting the model if you only need the AI features occasionally.
+The [AI features](/self-hosting/advanced/enterprise-features/ai-features) below are all disabled by default.
+Budget for them separately, and prefer an external endpoint over self-hosting the model if you only need
+them occasionally.
 
-| Component                                                        | CPU request | Memory request | Notes                        |
-| ---------------------------------------------------------------- | ----------- | -------------- | ---------------------------- |
-| Hub embeddings (TEI)                                             | 8 vCPU      | 8 Gi           | plus a 10 Gi model cache     |
-| Hub background embeddings pool                                   | 4 vCPU      | 8 Gi           | plus a 10 Gi model cache     |
-| [AI taxonomy](/self-hosting/advanced/enterprise-features/ai-features) | 1 vCPU      | 2 Gi           | 4 Gi limit                   |
-| Bundled Qwen/vLLM                                                | 400m router | 1 Gi router    | requires GPU-capable nodes   |
+| Component            | CPU request | Memory request | Notes               |
+| -------------------- | ----------- | -------------- | ------------------- |
+| Hub embeddings (TEI) | 8 vCPU      | 8 Gi           | + 10 Gi model cache |
+| Background embeddings pool | 4 vCPU | 8 Gi          | + 10 Gi model cache |
+| AI taxonomy          | 1 vCPU      | 2 Gi           | 4 Gi limit          |
+| Qwen/vLLM router     | 400m        | 1 Gi           | needs GPU nodes     |
 
 ## Minimal Enterprise Setup
 

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -4,21 +4,120 @@ description: "Learn how to self-host Formbricks."
 icon: "server"
 ---
 
-### System Requirements
+## System Requirements
 
-<Info>
-  **Minimum Setup**: 1 vCPU, 2 GB RAM, 8 GB SSD.
-</Info>
+Formbricks is not a single container. The v6 baseline runs the Formbricks app, Formbricks Hub (API and
+worker), Cube, PostgreSQL, Redis/Valkey, and SpiceDB, so size the host for the whole stack rather than for
+the app alone.
+
+| Deployment                                                       | CPU                     | Memory                | Disk               |
+| ---------------------------------------------------------------- | ----------------------- | --------------------- | ------------------ |
+| Evaluation on a single server ([Docker](/self-hosting/setup/docker), [one-click](/self-hosting/setup/one-click)) | 2 vCPU                  | 4 GB                  | 20 GB SSD          |
+| Small production on a single server                              | 4 vCPU                  | 8 GB                  | 50 GB SSD          |
+| [Minimal enterprise setup](#minimal-enterprise-setup) (Kubernetes) | 6 vCPU across the nodes | 12 GB across the nodes | managed services   |
 
 <Info>
   **HTTPS Required**: Ensure your server runs with a valid HTTPS certificate.
 </Info>
 
-#### **Self-Hosting Options**
+<Warning>
+  4 GB is a floor, not a comfortable target. It leaves no headroom for a large response import, a survey
+  bundle rebuild, or any of the optional AI services below.
+</Warning>
+
+### Where The Memory Goes
+
+These are the defaults the Helm chart ships, and they are the most precise sizing statement we can give.
+A Docker Compose install runs the same services without enforced limits.
+
+| Component                | Replicas | CPU request | Memory request | Memory limit |
+| ------------------------ | -------- | ----------- | -------------- | ------------ |
+| Formbricks app           | 1        | 1000m       | 1 Gi           | 2 Gi         |
+| Formbricks Hub API       | 1        | 100m        | 256 Mi         | 512 Mi       |
+| Formbricks Hub worker    | 1        | 100m        | 256 Mi         | 512 Mi       |
+| Cube                     | 1        | 250m        | 512 Mi         | 1 Gi         |
+| PostgreSQL (bundled)     | 1        | 250m        | 512 Mi         | 1 Gi         |
+| Redis/Valkey (bundled)   | 1        | 100m        | 128 Mi         | 192 Mi       |
+| SpiceDB                  | 2        | 100m each   | 256 Mi each    | 512 Mi each  |
+| **Total**                |          | **2 vCPU**  | **3.2 GiB**    | **6.2 GiB**  |
+
+Migration Jobs run alongside this on install and upgrade, and Kubernetes itself takes roughly 0.5 vCPU and
+1 GB per node before any of it is schedulable.
+
+### Optional Services Are Much Heavier
+
+Everything below is disabled by default. Budget for it separately, and prefer an external endpoint over
+self-hosting the model if you only need the AI features occasionally.
+
+| Component                                                        | CPU request | Memory request | Notes                        |
+| ---------------------------------------------------------------- | ----------- | -------------- | ---------------------------- |
+| Hub embeddings (TEI)                                             | 8 vCPU      | 8 Gi           | plus a 10 Gi model cache     |
+| Hub background embeddings pool                                   | 4 vCPU      | 8 Gi           | plus a 10 Gi model cache     |
+| [AI taxonomy](/self-hosting/advanced/enterprise-features/ai-features) | 1 vCPU      | 2 Gi           | 4 Gi limit                   |
+| Bundled Qwen/vLLM                                                | 400m router | 1 Gi router    | requires GPU-capable nodes   |
+
+## Minimal Enterprise Setup
+
+This is the smallest deployment we consider production-grade: a managed Kubernetes cluster with managed
+data services, sized for a modest steady load and left free to autoscale into peaks. It is the same shape as
+a large deployment, just narrower — nothing here has to be re-architected when traffic grows.
+
+### Cluster
+
+| Resource       | Minimum                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| Node pool      | 3 nodes × 2 vCPU / 4 GB (Azure `Standard_B2s`, AWS `t3.medium`, GCP `e2-medium`) |
+| Autoscaling    | Cluster autoscaler 3 → 5 nodes; app HPA `minReplicas: 2`                 |
+| Control plane  | The free/standard managed tier is sufficient at this size                |
+| Edge           | A load balancer plus [Envoy or an equivalent edge rate limiter](/self-hosting/advanced/rate-limiting) |
+
+Two app replicas are the reason for the third node. One replica cannot be evicted without downtime, which
+makes node drains and rolling upgrades disruptive — see the
+[Kubernetes deployment guide](/self-hosting/setup/kubernetes) for the replica and PodDisruptionBudget
+settings.
+
+### Managed Data Services
+
+Run these outside the cluster. They hold the state, and a managed service gives you backups and failover
+that the bundled charts do not.
+
+| Service        | Minimum                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| PostgreSQL     | 2 vCores burstable, 64 GB SSD, `pgvector` available, PITR backups enabled |
+| SpiceDB store  | A separate database and login on the same PostgreSQL server              |
+| Redis/Valkey   | 250 MB managed cache; 1 GB once you enable Envoy rate limiting           |
+| Object storage | ~50 GB S3-compatible or Azure Blob for [file uploads](/self-hosting/configuration/file-uploads) |
+| Registry       | A basic private registry, if you mirror the Formbricks images            |
+
+Moving PostgreSQL and Redis out of the cluster frees roughly 350m CPU and 640 Mi of memory per node pool,
+which is what makes three small nodes workable.
+
+<Note>
+  Budget for data egress separately. Survey traffic is served to end users, so egress scales with responses
+  rather than with cluster size.
+</Note>
+
+### What This Sizing Assumes
+
+- No AI features. Self-hosted embeddings or an in-cluster LLM change the node pool completely — use an
+  external endpoint at this size.
+- A single region and no cross-region replication.
+- Peaks handled by autoscaling rather than by permanently provisioned capacity.
+
+### What To Scale First
+
+1. **App replicas**, via the HPA — the app is stateless and this is the cheapest lever.
+2. **PostgreSQL vCores**, once response writes or dashboard queries start queuing.
+3. **Redis**, which becomes the dominant cost at high request rates. If that matters more than the
+   operational simplicity of a managed cache, run Valkey in-cluster instead.
+
+## **Self-Hosting Options**
 
 * [**One-Click Setup**](/self-hosting/setup/one-click)**:** Set up Formbricks on Ubuntu in minutes with our shell script.
 
 * [**Docker Setup**](/self-hosting/setup/docker)**:** Use our pre-built Docker image for an effortless start.
+
+* [**Kubernetes Deployment**](/self-hosting/setup/kubernetes)**:** Deploy the full stack with the official Helm chart.
 
 * [**Migration Guide**](/self-hosting/advanced/migration)**:** Upgrade your existing Formbricks instance smoothly.
 
@@ -28,7 +127,7 @@ icon: "server"
 
 * [**Licensing**](/self-hosting/advanced/license)**:**  Learn more about our AGPL Formbricks Core and its open-source license & Unlock advanced features tailored for larger teams and enterprises with the EE License.
 
-### **Hosting Options**
+## **Hosting Options**
 
 * **Cloud Hosting:** Hassle-free managed deployment at [app.formbricks.com](https://app.formbricks.com).
 
@@ -36,7 +135,7 @@ icon: "server"
 
 * **Self-Hosting with EE License:** Unlock advanced features for large teams or enterprises.
 
-### **Licensing Options Comparison**:
+## **Licensing Options Comparison**:
 
 For Self Hosting, our core product is free however certain advanced features are a part of our Enterprise License offering. Please refer this table to understand if you want the features that are a part of it and then we’ll reach out to you!
 

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -133,7 +133,7 @@ that the bundled charts do not.
 | -------------- | ----------------------------------------------------------- |
 | PostgreSQL     | 2 vCores burstable, 64 GB SSD, `pgvector`, PITR backups     |
 | SpiceDB store  | A separate database and login on the same PostgreSQL server |
-| Redis/Valkey   | 250 MB managed cache; 1 GB once Envoy rate limiting is on   |
+| Redis/Valkey   | 250 MB; 1 GB with Envoy rate limiting; more for backlogs    |
 | Object storage | ~50 GB, S3-compatible                                       |
 | Registry       | A basic private registry, if you mirror Formbricks images   |
 
@@ -166,16 +166,22 @@ multi-page survey can be several jobs per response. Size Redis for that queue, n
 
 Consumer capacity is `web replicas × BULLMQ_WORKER_COUNT × BULLMQ_WORKER_CONCURRENCY`, all three of which
 default to `1`. That is a count of jobs in flight, not a rate: throughput also depends on how long the
-average `response-pipeline.process` job takes on your instance. A queue that grows faster than it drains
-backs up in Redis rather than failing. Raising `BULLMQ_WORKER_COUNT` or `BULLMQ_WORKER_CONCURRENCY` adds no
-pods, but the work still lands on the same pod's CPU and memory and on Redis and Postgres behind it, so
-measure before raising either. See [job runner](/self-hosting/configuration/job-runner).
+average `response-pipeline.process` job takes on your instance. Raising `BULLMQ_WORKER_COUNT` or
+`BULLMQ_WORKER_CONCURRENCY` adds no pods, but the work still lands on the same pod's CPU and memory and on
+Redis and Postgres behind it, so measure before raising either. See
+[job runner](/self-hosting/configuration/job-runner).
 
 <Warning>
   The app HPA scales on CPU and memory utilization only. Queue depth is not one of its metrics, so a
   backlog can grow while both targets sit under their thresholds and no replica is added. Backlog-driven
   scaling needs a queue-depth metric published to the metrics API and added to the HPA yourself.
 </Warning>
+
+Redis is the hard limit on that backlog. The chart pins `maxmemory-policy noeviction` so BullMQ cannot
+silently lose jobs, which means a full Redis refuses writes rather than evicting. Enqueue errors are not
+swallowed: the response row is already committed to Postgres, so no answer is lost, but the client still
+gets an error. Retention settings only trim completed and failed jobs — they do not make the queue
+unbounded. Size Redis for the deepest backlog you expect, not for the steady state.
 
 **50,000 contacts.** This is storage and index growth, not throughput. Contact attributes are one row per
 attribute per contact, so 50,000 contacts with 10 attributes each is 500,000 attribute rows before a single

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -4,21 +4,23 @@ description: "Learn how to self-host Formbricks."
 icon: "server"
 ---
 
-## System Requirements
+## System requirements
 
 Formbricks is not a single container. The v6 baseline runs the Formbricks app, Formbricks Hub (API and
-worker), Cube, PostgreSQL, Redis/Valkey, and SpiceDB, so size the host for the whole stack rather than for
-the app alone.
+worker), Cube, PostgreSQL, Redis/Valkey, SpiceDB and the SpiceDB operator, so size the host for the whole
+stack rather than for the app alone.
 
-| Deployment                        | CPU          | Memory      | Disk       |
-| --------------------------------- | ------------ | ----------- | ---------- |
-| Single server, evaluation         | 2 vCPU       | 4 GB        | 20 GB SSD  |
-| Single server, small production   | 4 vCPU       | 8 GB        | 50 GB SSD  |
-| Kubernetes, minimal enterprise    | 6 vCPU total | 12 GB total | managed    |
+| Deployment                | CPU       | Memory    | Disk      |
+| ------------------------- | --------- | --------- | --------- |
+| Single server, evaluation | 2 vCPU    | 4 GB      | 20 GB SSD |
+| Single server, low load   | 4 vCPU    | 8 GB      | 50 GB SSD |
+| Kubernetes, production    | see below | see below | managed   |
 
 The single-server rows apply to the [Docker](/self-hosting/setup/docker) and
-[one-click](/self-hosting/setup/one-click) installs. The Kubernetes row is spread across a node pool and
-assumes managed data services — see [Minimal Enterprise Setup](#minimal-enterprise-setup).
+[one-click](/self-hosting/setup/one-click) installs. Both run every service on one host, so a host reboot or
+a Formbricks upgrade is downtime. At low load that is usually an acceptable trade and not a reason to reach
+for Kubernetes. Choose [Kubernetes](/self-hosting/setup/kubernetes) when you need to survive a node failure
+or carry an uptime SLA, and size it from [Kubernetes production setup](#kubernetes-production-setup).
 
 <Info>
   **HTTPS Required**: Ensure your server runs with a valid HTTPS certificate.
@@ -29,92 +31,165 @@ assumes managed data services — see [Minimal Enterprise Setup](#minimal-enterp
   bundle rebuild, or any of the optional AI services below.
 </Warning>
 
-### Where The Memory Goes
+### Where the memory goes
 
 These are the defaults the Helm chart ships, and they are the most precise sizing statement we can give.
 A Docker Compose install runs the same services without enforced limits.
 
-| Component              | CPU request | Memory request | Memory limit |
-| ---------------------- | ----------- | -------------- | ------------ |
-| Formbricks app         | 1000m       | 1 Gi           | 2 Gi         |
-| Hub API                | 100m        | 256 Mi         | 512 Mi       |
-| Hub worker             | 100m        | 256 Mi         | 512 Mi       |
-| Cube                   | 250m        | 512 Mi         | 1 Gi         |
-| PostgreSQL (bundled)   | 250m        | 512 Mi         | 1 Gi         |
-| Redis/Valkey (bundled) | 100m        | 128 Mi         | 192 Mi       |
-| SpiceDB (2 replicas)   | 200m        | 512 Mi         | 1 Gi         |
-| **Total**              | **2 vCPU**  | **3.2 GiB**    | **6.2 GiB**  |
+| Component              | CPU request  | Memory request | Memory limit |
+| ---------------------- | ------------ | -------------- | ------------ |
+| Formbricks app         | 1000m        | 1 Gi           | 2 Gi         |
+| Hub API                | not set      | not set        | not set      |
+| Hub worker             | 100m         | 256 Mi         | 512 Mi       |
+| Cube                   | 250m         | 512 Mi         | 1 Gi         |
+| PostgreSQL (bundled)   | 250m         | 512 Mi         | 1 Gi         |
+| Redis/Valkey (bundled) | 100m         | 128 Mi         | 192 Mi       |
+| SpiceDB (2 replicas)   | 200m         | 512 Mi         | 1 Gi         |
+| SpiceDB operator       | 20m          | 64 Mi          | 160 Mi       |
+| **Total**              | **1.9 vCPU** | **2.9 GiB**    | **5.8 GiB**  |
 
-Migration Jobs run alongside this on install and upgrade, and Kubernetes itself takes roughly 0.5 vCPU and
-1 GB per node before any of it is schedulable. The two bundled rows drop out when you use managed
-PostgreSQL and Redis.
+The chart sets neither requests nor limits on the Hub API, so it is scheduled best-effort and is not in that
+total — leave headroom for it. Migration Jobs run alongside this on install and upgrade, and Kubernetes
+itself takes roughly 0.5 vCPU and 1 GB per node before any of it is schedulable. The two bundled data rows
+drop out when you use managed PostgreSQL and Redis.
 
-### Optional Services Are Much Heavier
+### Optional services are much heavier
 
-The [AI features](/self-hosting/advanced/enterprise-features/ai-features) below are all disabled by default.
-Budget for them separately, and prefer an external endpoint over self-hosting the model if you only need
-them occasionally.
+<Note>
+  AI features are an Enterprise feature. Configure your
+  [Enterprise license](/self-hosting/advanced/license) before enabling them.
+</Note>
 
-| Component            | CPU request | Memory request | Notes               |
-| -------------------- | ----------- | -------------- | ------------------- |
-| Hub embeddings (TEI) | 8 vCPU      | 8 Gi           | + 10 Gi model cache |
-| Background embeddings pool | 4 vCPU | 8 Gi          | + 10 Gi model cache |
-| AI taxonomy          | 1 vCPU      | 2 Gi           | 4 Gi limit          |
-| Qwen/vLLM router     | 400m        | 1 Gi           | needs GPU nodes     |
+Everything in this table is disabled by default. Budget for it separately, and prefer an external endpoint
+over self-hosting the model if you only need it occasionally. Setup lives in
+[AI features](/self-hosting/advanced/enterprise-features/ai-features).
 
-## Minimal Enterprise Setup
+| Component              | CPU request | Memory request | Notes               |
+| ---------------------- | ----------- | -------------- | ------------------- |
+| Hub embeddings (TEI)   | 4 vCPU      | 8 Gi           | + 10 Gi model cache |
+| Worker embeddings pool | 8 vCPU      | 8 Gi           | + 10 Gi model cache |
+| AI taxonomy            | 1 vCPU      | 2 Gi           | 4 Gi limit          |
+| Qwen/vLLM router       | 400m        | 1 Gi           | needs GPU nodes     |
 
-This is the smallest deployment we consider production-grade: a managed Kubernetes cluster with managed
-data services, sized for a modest steady load and left free to autoscale into peaks. It is the same shape as
-a large deployment, just narrower — nothing here has to be re-architected when traffic grows.
+The worker-only pool (`hub.embeddings.background`) is the expensive one — 8 vCPU per replica, with its own
+HPA ceiling of 6. Enable it only when the foreground runtime cannot keep up with backfill.
+
+## Kubernetes production setup
+
+A managed Kubernetes cluster with managed data services, sized for a modest steady load and left free to
+autoscale into peaks. It is the same shape as a large deployment, just narrower — nothing here has to be
+re-architected when traffic grows.
+
+<Warning>
+  Chart defaults make the **app** tier highly available and leave everything else a singleton:
+  `hub.replicas`, `hub.worker.replicas` and `cube.replicas` all ship as `1`. Cube cannot simply be raised —
+  the chart refuses to render more than one replica against its default in-memory cache driver, so multiple
+  Cube replicas need Cube Store. Raise the Hub replica counts and plan Cube Store before promising an SLA
+  that covers Hub and analytics, not just survey delivery.
+</Warning>
 
 ### Cluster
 
-| Resource       | Minimum                                                                  |
-| -------------- | ------------------------------------------------------------------------ |
-| Node pool      | 3 nodes × 2 vCPU / 4 GB (Azure `Standard_B2s`, AWS `t3.medium`, GCP `e2-medium`) |
-| Autoscaling    | Cluster autoscaler 3 → 5 nodes; app HPA `minReplicas: 2`                 |
-| Control plane  | The free/standard managed tier is sufficient at this size                |
-| Edge           | A load balancer plus [Envoy or an equivalent edge rate limiter](/self-hosting/advanced/rate-limiting) |
+| Resource      | Minimum                                                  |
+| ------------- | -------------------------------------------------------- |
+| Node pool     | 3 nodes, at least 4 vCPU and 8 GB each                    |
+| Autoscaling   | Cluster autoscaler 3 → 6 nodes; app HPA `minReplicas: 2` |
+| Control plane | A paid tier that carries an uptime SLA                   |
+| Edge          | A load balancer plus an edge rate limiter                |
+
+Capacity is given provider-neutrally on purpose. A 2 vCPU node cannot hold the app's 1 vCPU request
+alongside the platform reserve and the singletons, and some managed services exclude burstable instance
+families from system node pools entirely — check your provider's supported node types before picking an
+instance size. Free control-plane tiers are positioned for development and testing and carry no financially
+backed uptime SLA, so treat the production tier as part of the cost of the SLA rather than an upsell.
 
 Two app replicas are the reason for the third node. One replica cannot be evicted without downtime, which
 makes node drains and rolling upgrades disruptive — see the
 [Kubernetes deployment guide](/self-hosting/setup/kubernetes) for the replica and PodDisruptionBudget
-settings.
+settings. The edge rate limiter is not optional either: since v5 several public routes are no longer
+throttled by the application server. See [rate limiting](/self-hosting/advanced/rate-limiting).
 
-### Managed Data Services
+#### Match the HPA ceiling to the node pool
+
+The chart ships `autoscaling.maxReplicas: 10` against a 1 vCPU request per app pod, so the HPA can ask for
+10 vCPU of app alone. A pool that cannot supply that leaves the extra replicas `Pending` — an HPA does not
+lower its own ceiling. Size the two together:
+
+- Allocatable CPU is roughly `(node vCPU − 0.5) × nodes`.
+- Subtract about 0.6 vCPU for Hub worker, Cube, SpiceDB and its operator.
+- Subtract headroom for the Hub API, which has no request and still uses CPU.
+- What is left, divided by 1 vCPU, is the highest `maxReplicas` the pool can honor.
+
+Six 4-vCPU nodes clear the shipped ceiling of 10, which is why the autoscaler maximum above is 6. A pool
+that stops lower needs `autoscaling.maxReplicas` lowered to match it.
+
+### Managed data services
 
 Run these outside the cluster. They hold the state, and a managed service gives you backups and failover
 that the bundled charts do not.
 
-| Service        | Minimum                                                                  |
-| -------------- | ------------------------------------------------------------------------ |
-| PostgreSQL     | 2 vCores burstable, 64 GB SSD, `pgvector` available, PITR backups enabled |
-| SpiceDB store  | A separate database and login on the same PostgreSQL server              |
-| Redis/Valkey   | 250 MB managed cache; 1 GB once you enable Envoy rate limiting           |
-| Object storage | ~50 GB S3-compatible or Azure Blob for [file uploads](/self-hosting/configuration/file-uploads) |
-| Registry       | A basic private registry, if you mirror the Formbricks images            |
+| Service        | Minimum                                                     |
+| -------------- | ----------------------------------------------------------- |
+| PostgreSQL     | 2 vCores burstable, 64 GB SSD, `pgvector`, PITR backups     |
+| SpiceDB store  | A separate database and login on the same PostgreSQL server |
+| Redis/Valkey   | 250 MB managed cache; 1 GB once Envoy rate limiting is on   |
+| Object storage | ~50 GB, S3-compatible                                       |
+| Registry       | A basic private registry, if you mirror Formbricks images   |
 
-Moving PostgreSQL and Redis out of the cluster frees roughly 350m CPU and 640 Mi of memory per node pool,
-which is what makes three small nodes workable.
+Formbricks speaks the S3 API only, so object storage has to be S3-compatible — AWS S3, DigitalOcean Spaces,
+Wasabi, StorJ or a self-hosted equivalent. A service without an S3 API, such as Azure Blob Storage, needs an
+S3-compatible gateway in front of it. See [file uploads](/self-hosting/configuration/file-uploads).
+
+Moving PostgreSQL and Redis out of the cluster frees roughly 350m CPU and 640 Mi of memory across the node
+pool, which is what makes a small pool workable.
 
 <Note>
   Budget for data egress separately. Survey traffic is served to end users, so egress scales with responses
   rather than with cluster size.
 </Note>
 
-### What This Sizing Assumes
+### Sizing for a specific load
+
+Two questions come up more than any others, and neither is answered by the tables above, because both are
+about rate and volume rather than about the resting stack.
+
+**25,000 responses arriving at once.** Spread over an hour that is roughly 7 writes a second; compressed
+into ten minutes, roughly 42. The per-IP limit of 100 requests a minute on the public response route does
+not throttle a burst like that, because a campaign burst arrives from thousands of distinct IPs. The job
+runner does: every response enqueues a `response-pipeline.process` job, and a completed one enqueues two —
+`responseCreated` and `responseFinished`. Every app replica ships a single worker at a concurrency of one,
+so drain rate is `replicas × BULLMQ_WORKER_CONCURRENCY`, and 25,000 finished responses is 50,000 jobs. A
+burst that outruns the drain rate backs up in Redis rather than failing. Raise
+`BULLMQ_WORKER_CONCURRENCY` first — it costs no pods — then let the HPA add replicas, and give Redis room
+for the queue. See [job runner](/self-hosting/configuration/job-runner).
+
+**50,000 contacts.** This is storage and index growth, not throughput. Contact attributes are one row per
+attribute per contact, so 50,000 contacts with 10 attributes each is 500,000 attribute rows before a single
+response is stored. Size PostgreSQL storage from that plus your response retention, and add vCores when
+segment evaluation or dashboard queries start queuing.
+
+<Warning>
+  We do not publish a responses-per-second figure per replica. We have not load-tested one, and it would not
+  transfer: a 40-question survey with file uploads is not the same write as a one-question NPS. Use the
+  levers above to size the queue and the storage, then watch HPA CPU utilization and job-queue depth through
+  your first real campaign.
+</Warning>
+
+### What this sizing assumes
 
 - No AI features. Self-hosted embeddings or an in-cluster LLM change the node pool completely — use an
   external endpoint at this size.
 - A single region and no cross-region replication.
 - Peaks handled by autoscaling rather than by permanently provisioned capacity.
+- Object storage outside the cluster, not a bundled in-cluster S3 service.
 
-### What To Scale First
+### What to scale first
 
-1. **App replicas**, via the HPA — the app is stateless and this is the cheapest lever.
-2. **PostgreSQL vCores**, once response writes or dashboard queries start queuing.
-3. **Redis**, which becomes the dominant cost at high request rates. If that matters more than the
+1. **Job concurrency**, via `BULLMQ_WORKER_CONCURRENCY` — the only lever here that costs no capacity.
+2. **App replicas**, via the HPA — the app is stateless, so this is the cheapest capacity lever. Check the
+   ceiling still fits the node pool.
+3. **PostgreSQL vCores**, once response writes or dashboard queries start queuing.
+4. **Redis**, which becomes the dominant cost at high request rates. If that matters more than the
    operational simplicity of a managed cache, run Valkey in-cluster instead.
 
 ## **Self-Hosting Options**

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -77,14 +77,15 @@ HPA ceiling of 6. Enable it only when the foreground runtime cannot keep up with
 ## Kubernetes production setup
 
 A managed Kubernetes cluster with managed data services, sized for a modest steady load and left free to
-autoscale into peaks. It is the same shape as a large deployment, just narrower — nothing here has to be
-re-architected when traffic grows.
+autoscale into peaks. The app tier grows by adding replicas and needs no redesign; raising availability
+beyond it, or scaling analytics, does change the topology — see the warning below.
 
 <Warning>
-  Chart defaults make the **app** tier highly available and leave everything else a singleton:
-  `hub.replicas`, `hub.worker.replicas` and `cube.replicas` all ship as `1`. Cube cannot simply be raised —
-  the chart refuses to render more than one replica against its default in-memory cache driver, so multiple
-  Cube replicas need Cube Store. Raise the Hub replica counts and plan Cube Store before promising an SLA
+  Every replica count in the chart ships as `1`, including `autoscaling.minReplicas` for the app. The
+  `minReplicas: 2` in the table below is a required override, not a default. `hub.replicas`,
+  `hub.worker.replicas` and `cube.replicas` stay singletons until you raise them, and Cube cannot simply be
+  raised — the chart refuses to render more than one replica against its default in-memory cache driver, so
+  multiple Cube replicas need Cube Store. Raise the Hub counts and plan Cube Store before promising an SLA
   that covers Hub and analytics, not just survey delivery.
 </Warning>
 
@@ -155,25 +156,38 @@ about rate and volume rather than about the resting stack.
 
 **25,000 responses arriving at once.** Spread over an hour that is roughly 7 writes a second; compressed
 into ten minutes, roughly 42. The per-IP limit of 100 requests a minute on the public response route does
-not throttle a burst like that, because a campaign burst arrives from thousands of distinct IPs. The job
-runner does: every response enqueues a `response-pipeline.process` job, and a completed one enqueues two —
-`responseCreated` and `responseFinished`. Every app replica ships a single worker at a concurrency of one,
-so drain rate is `replicas × BULLMQ_WORKER_CONCURRENCY`, and 25,000 finished responses is 50,000 jobs. A
-burst that outruns the drain rate backs up in Redis rather than failing. Raise
-`BULLMQ_WORKER_CONCURRENCY` first — it costs no pods — then let the HPA add replicas, and give Redis room
-for the queue. See [job runner](/self-hosting/configuration/job-runner).
+not throttle a burst like that, because a campaign burst arrives from thousands of distinct IPs. Plan for
+the job queue behind it instead.
+
+A response enqueues several `response-pipeline.process` jobs, not one: `responseCreated` on the initial
+write, one `responseUpdated` each time the SDK saves progress, and `responseFinished` on submission. So the
+job count scales with how many times a respondent's answers are saved, not with the response count — a
+multi-page survey can be several jobs per response. Size Redis for that queue, not for 25,000 entries.
+
+Consumer capacity is `web replicas × BULLMQ_WORKER_COUNT × BULLMQ_WORKER_CONCURRENCY`, all three of which
+default to `1`. That is a count of jobs in flight, not a rate: throughput also depends on how long the
+average `response-pipeline.process` job takes on your instance. A queue that grows faster than it drains
+backs up in Redis rather than failing. Raising `BULLMQ_WORKER_COUNT` or `BULLMQ_WORKER_CONCURRENCY` adds no
+pods, but the work still lands on the same pod's CPU and memory and on Redis and Postgres behind it, so
+measure before raising either. See [job runner](/self-hosting/configuration/job-runner).
+
+<Warning>
+  The app HPA scales on CPU and memory utilization only. Queue depth is not one of its metrics, so a
+  backlog can grow while both targets sit under their thresholds and no replica is added. Backlog-driven
+  scaling needs a queue-depth metric published to the metrics API and added to the HPA yourself.
+</Warning>
 
 **50,000 contacts.** This is storage and index growth, not throughput. Contact attributes are one row per
 attribute per contact, so 50,000 contacts with 10 attributes each is 500,000 attribute rows before a single
 response is stored. Size PostgreSQL storage from that plus your response retention, and add vCores when
 segment evaluation or dashboard queries start queuing.
 
-<Warning>
+<Note>
   We do not publish a responses-per-second figure per replica. We have not load-tested one, and it would not
   transfer: a 40-question survey with file uploads is not the same write as a one-question NPS. Use the
-  levers above to size the queue and the storage, then watch HPA CPU utilization and job-queue depth through
-  your first real campaign.
-</Warning>
+  levers above to size the queue and the storage, then watch both pod CPU and queue depth through your first
+  real campaign — they move independently.
+</Note>
 
 ### What this sizing assumes
 
@@ -185,14 +199,15 @@ segment evaluation or dashboard queries start queuing.
 
 ### What to scale first
 
-1. **Job concurrency**, via `BULLMQ_WORKER_CONCURRENCY` — the only lever here that costs no capacity.
+1. **Job concurrency**, via `BULLMQ_WORKER_COUNT` and `BULLMQ_WORKER_CONCURRENCY` — no extra pods, but it
+   spends the pod's own CPU and memory, so raise it against a measurement.
 2. **App replicas**, via the HPA — the app is stateless, so this is the cheapest capacity lever. Check the
    ceiling still fits the node pool.
 3. **PostgreSQL vCores**, once response writes or dashboard queries start queuing.
 4. **Redis**, which becomes the dominant cost at high request rates. If that matters more than the
    operational simplicity of a managed cache, run Valkey in-cluster instead.
 
-## **Self-Hosting Options**
+## **Self-hosting options**
 
 * [**One-Click Setup**](/self-hosting/setup/one-click)**:** Set up Formbricks on Ubuntu in minutes with our shell script.
 
@@ -208,7 +223,7 @@ segment evaluation or dashboard queries start queuing.
 
 * [**Licensing**](/self-hosting/advanced/license)**:**  Learn more about our AGPL Formbricks Core and its open-source license & Unlock advanced features tailored for larger teams and enterprises with the EE License.
 
-## **Hosting Options**
+## **Hosting options**
 
 * **Cloud Hosting:** Hassle-free managed deployment at [app.formbricks.com](https://app.formbricks.com).
 
@@ -216,7 +231,7 @@ segment evaluation or dashboard queries start queuing.
 
 * **Self-Hosting with EE License:** Unlock advanced features for large teams or enterprises.
 
-## **Licensing Options Comparison**:
+## **Licensing options comparison**
 
 For Self Hosting, our core product is free however certain advanced features are a part of our Enterprise License offering. Please refer this table to understand if you want the features that are a part of it and then we’ll reach out to you!
 

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -16,8 +16,10 @@ host for the whole stack rather than for the app alone.
 | Single server, low load   | 4 vCPU    | 8 GB      | 50 GB SSD |
 | Kubernetes, production    | see below | see below | managed   |
 
-Chart defaults request 1.9 vCPU and 2.9 GiB across those services, before the roughly 0.5 vCPU and 1 GB
-that Kubernetes reserves per node. `charts/formbricks/values.yaml` is the source for every figure here.
+Chart defaults request 1.9 vCPU and 2.9 GiB across those services — see `charts/formbricks/values.yaml`,
+plus `charts/spicedb-operator/values.yaml` for the operator. On Kubernetes, add whatever your provider
+reserves per node on top, typically around 0.5 vCPU and 1 GB. The single-server rows are derived from those
+totals rather than load-tested.
 
 <Info>
   **HTTPS Required**: Ensure your server runs with a valid HTTPS certificate.

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -6,9 +6,9 @@ icon: "server"
 
 ## System requirements
 
-Formbricks is not a single container. The v6 baseline runs the Formbricks app, Formbricks Hub (API and
-worker), Cube, PostgreSQL, Redis/Valkey, SpiceDB and the SpiceDB operator, so size the host for the whole
-stack rather than for the app alone.
+Formbricks is not a single container. The v6 baseline runs eight long-running services — the app,
+Formbricks Hub (API and worker), Cube, PostgreSQL, Redis/Valkey, SpiceDB and its operator — so size the
+host for the whole stack rather than for the app alone.
 
 | Deployment                | CPU       | Memory    | Disk      |
 | ------------------------- | --------- | --------- | --------- |
@@ -16,11 +16,8 @@ stack rather than for the app alone.
 | Single server, low load   | 4 vCPU    | 8 GB      | 50 GB SSD |
 | Kubernetes, production    | see below | see below | managed   |
 
-The single-server rows apply to the [Docker](/self-hosting/setup/docker) and
-[one-click](/self-hosting/setup/one-click) installs. Both run every service on one host, so a host reboot or
-a Formbricks upgrade is downtime. At low load that is usually an acceptable trade and not a reason to reach
-for Kubernetes. Choose [Kubernetes](/self-hosting/setup/kubernetes) when you need to survive a node failure
-or carry an uptime SLA, and size it from [Kubernetes production setup](#kubernetes-production-setup).
+Chart defaults request 1.9 vCPU and 2.9 GiB across those services, before the roughly 0.5 vCPU and 1 GB
+that Kubernetes reserves per node. `charts/formbricks/values.yaml` is the source for every figure here.
 
 <Info>
   **HTTPS Required**: Ensure your server runs with a valid HTTPS certificate.
@@ -28,190 +25,53 @@ or carry an uptime SLA, and size it from [Kubernetes production setup](#kubernet
 
 <Warning>
   4 GB is a floor, not a comfortable target. It leaves no headroom for a large response import, a survey
-  bundle rebuild, or any of the optional AI services below.
+  bundle rebuild, or any of the optional AI services.
 </Warning>
 
-### Where the memory goes
+### Single server or Kubernetes
 
-These are the defaults the Helm chart ships, and they are the most precise sizing statement we can give.
-A Docker Compose install runs the same services without enforced limits.
+The single-server rows cover the [Docker](/self-hosting/setup/docker) and
+[one-click](/self-hosting/setup/one-click) installs. Both run every service on one host, so a reboot or an
+upgrade means downtime — usually an acceptable trade at low load, and not on its own a reason to reach for
+Kubernetes. Choose [Kubernetes](/self-hosting/setup/kubernetes) when you need to survive a node failure or
+carry an uptime SLA.
 
-| Component              | CPU request  | Memory request | Memory limit |
-| ---------------------- | ------------ | -------------- | ------------ |
-| Formbricks app         | 1000m        | 1 Gi           | 2 Gi         |
-| Hub API                | not set      | not set        | not set      |
-| Hub worker             | 100m         | 256 Mi         | 512 Mi       |
-| Cube                   | 250m         | 512 Mi         | 1 Gi         |
-| PostgreSQL (bundled)   | 250m         | 512 Mi         | 1 Gi         |
-| Redis/Valkey (bundled) | 100m         | 128 Mi         | 192 Mi       |
-| SpiceDB (2 replicas)   | 200m         | 512 Mi         | 1 Gi         |
-| SpiceDB operator       | 20m          | 64 Mi          | 160 Mi       |
-| **Total**              | **1.9 vCPU** | **2.9 GiB**    | **5.8 GiB**  |
+For Kubernetes, start at 3 nodes of at least 4 vCPU and 8 GB, autoscaling to 6, with PostgreSQL, Redis and
+object storage as managed services outside the cluster. Capacity is deliberately provider-neutral: a 2 vCPU
+node cannot hold the app's 1 vCPU request alongside the platform reserve, some providers exclude burstable
+instance families from system node pools, and a free control-plane tier carries no uptime SLA. Nothing is
+highly available out of the box — every replica count in the chart ships as `1`. Object storage must speak
+the S3 API, so a service without one, such as Azure Blob Storage, needs an
+[S3-compatible gateway](/self-hosting/configuration/file-uploads) in front of it. The
+[Kubernetes deployment guide](/self-hosting/setup/kubernetes) has the replica, autoscaling and
+managed-service settings.
 
-The chart sets neither requests nor limits on the Hub API, so it is scheduled best-effort and is not in that
-total — leave headroom for it. Migration Jobs run alongside this on install and upgrade, and Kubernetes
-itself takes roughly 0.5 vCPU and 1 GB per node before any of it is schedulable. The two bundled data rows
-drop out when you use managed PostgreSQL and Redis.
+### AI services are much heavier
 
-### Optional services are much heavier
+Self-hosted AI is off by default and is a different order of magnitude: Hub embeddings alone request 4 vCPU
+and 8 Gi for the foreground runtime, and 8 vCPU for the worker pool. Prefer an external endpoint unless you
+need them constantly.
 
 <Note>
   AI features are an Enterprise feature. Configure your
   [Enterprise license](/self-hosting/advanced/license) before enabling them.
 </Note>
 
-Everything in this table is disabled by default. Budget for it separately, and prefer an external endpoint
-over self-hosting the model if you only need it occasionally. Setup lives in
-[AI features](/self-hosting/advanced/enterprise-features/ai-features).
-
-| Component              | CPU request | Memory request | Notes               |
-| ---------------------- | ----------- | -------------- | ------------------- |
-| Hub embeddings (TEI)   | 4 vCPU      | 8 Gi           | + 10 Gi model cache |
-| Worker embeddings pool | 8 vCPU      | 8 Gi           | + 10 Gi model cache |
-| AI taxonomy            | 1 vCPU      | 2 Gi           | 4 Gi limit          |
-| Qwen/vLLM router       | 400m        | 1 Gi           | needs GPU nodes     |
-
-The worker-only pool (`hub.embeddings.background`) is the expensive one — 8 vCPU per replica, with its own
-HPA ceiling of 6. Enable it only when the foreground runtime cannot keep up with backfill.
-
-## Kubernetes production setup
-
-A managed Kubernetes cluster with managed data services, sized for a modest steady load and left free to
-autoscale into peaks. The app tier grows by adding replicas and needs no redesign; raising availability
-beyond it, or scaling analytics, does change the topology — see the warning below.
-
-<Warning>
-  Every replica count in the chart ships as `1`, including `autoscaling.minReplicas` for the app. The
-  `minReplicas: 2` in the table below is a required override, not a default. `hub.replicas`,
-  `hub.worker.replicas` and `cube.replicas` stay singletons until you raise them, and Cube cannot simply be
-  raised — the chart refuses to render more than one replica against its default in-memory cache driver, so
-  multiple Cube replicas need Cube Store. Raise the Hub counts and plan Cube Store before promising an SLA
-  that covers Hub and analytics, not just survey delivery.
-</Warning>
-
-### Cluster
-
-| Resource      | Minimum                                                  |
-| ------------- | -------------------------------------------------------- |
-| Node pool     | 3 nodes, at least 4 vCPU and 8 GB each                    |
-| Autoscaling   | Cluster autoscaler 3 → 6 nodes; app HPA `minReplicas: 2` |
-| Control plane | A paid tier that carries an uptime SLA                   |
-| Edge          | A load balancer plus an edge rate limiter                |
-
-Capacity is given provider-neutrally on purpose. A 2 vCPU node cannot hold the app's 1 vCPU request
-alongside the platform reserve and the singletons, and some managed services exclude burstable instance
-families from system node pools entirely — check your provider's supported node types before picking an
-instance size. Free control-plane tiers are positioned for development and testing and carry no financially
-backed uptime SLA, so treat the production tier as part of the cost of the SLA rather than an upsell.
-
-Two app replicas are the reason for the third node. One replica cannot be evicted without downtime, which
-makes node drains and rolling upgrades disruptive — see the
-[Kubernetes deployment guide](/self-hosting/setup/kubernetes) for the replica and PodDisruptionBudget
-settings. The edge rate limiter is not optional either: since v5 several public routes are no longer
-throttled by the application server. See [rate limiting](/self-hosting/advanced/rate-limiting).
-
-#### Match the HPA ceiling to the node pool
-
-The chart ships `autoscaling.maxReplicas: 10` against a 1 vCPU request per app pod, so the HPA can ask for
-10 vCPU of app alone. A pool that cannot supply that leaves the extra replicas `Pending` — an HPA does not
-lower its own ceiling. Size the two together:
-
-- Allocatable CPU is roughly `(node vCPU − 0.5) × nodes`.
-- Subtract about 0.6 vCPU for Hub worker, Cube, SpiceDB and its operator.
-- Subtract headroom for the Hub API, which has no request and still uses CPU.
-- What is left, divided by 1 vCPU, is the highest `maxReplicas` the pool can honor.
-
-Six 4-vCPU nodes clear the shipped ceiling of 10, which is why the autoscaler maximum above is 6. A pool
-that stops lower needs `autoscaling.maxReplicas` lowered to match it.
-
-### Managed data services
-
-Run these outside the cluster. They hold the state, and a managed service gives you backups and failover
-that the bundled charts do not.
-
-| Service        | Minimum                                                     |
-| -------------- | ----------------------------------------------------------- |
-| PostgreSQL     | 2 vCores burstable, 64 GB SSD, `pgvector`, PITR backups     |
-| SpiceDB store  | A separate database and login on the same PostgreSQL server |
-| Redis/Valkey   | 250 MB; 1 GB with Envoy rate limiting; more for backlogs    |
-| Object storage | ~50 GB, S3-compatible                                       |
-| Registry       | A basic private registry, if you mirror Formbricks images   |
-
-Formbricks speaks the S3 API only, so object storage has to be S3-compatible — AWS S3, DigitalOcean Spaces,
-Wasabi, StorJ or a self-hosted equivalent. A service without an S3 API, such as Azure Blob Storage, needs an
-S3-compatible gateway in front of it. See [file uploads](/self-hosting/configuration/file-uploads).
-
-Moving PostgreSQL and Redis out of the cluster frees roughly 350m CPU and 640 Mi of memory across the node
-pool, which is what makes a small pool workable.
-
-<Note>
-  Budget for data egress separately. Survey traffic is served to end users, so egress scales with responses
-  rather than with cluster size.
-</Note>
-
 ### Sizing for a specific load
 
-Two questions come up more than any others, and neither is answered by the tables above, because both are
-about rate and volume rather than about the resting stack.
-
-**25,000 responses arriving at once.** Spread over an hour that is roughly 7 writes a second; compressed
-into ten minutes, roughly 42. The per-IP limit of 100 requests a minute on the public response route does
-not throttle a burst like that, because a campaign burst arrives from thousands of distinct IPs. Plan for
-the job queue behind it instead.
-
-A response enqueues several `response-pipeline.process` jobs, not one: `responseCreated` on the initial
-write, one `responseUpdated` each time the SDK saves progress, and `responseFinished` on submission. So the
-job count scales with how many times a respondent's answers are saved, not with the response count — a
-multi-page survey can be several jobs per response. Size Redis for that queue, not for 25,000 entries.
-
-Consumer capacity is `web replicas × BULLMQ_WORKER_COUNT × BULLMQ_WORKER_CONCURRENCY`, all three of which
-default to `1`. That is a count of jobs in flight, not a rate: throughput also depends on how long the
-average `response-pipeline.process` job takes on your instance. Raising `BULLMQ_WORKER_COUNT` or
-`BULLMQ_WORKER_CONCURRENCY` adds no pods, but the work still lands on the same pod's CPU and memory and on
-Redis and Postgres behind it, so measure before raising either. See
+**A burst of responses** is a queue question rather than a request-rate one. Each response enqueues several
+`response-pipeline.process` jobs — `responseCreated`, one `responseUpdated` per progress save, then
+`responseFinished` — so the count scales with how often answers are saved, and consumers default to one job
+in flight per app replica. Size Redis for the deepest backlog you expect: the chart pins
+`maxmemory-policy noeviction`, so a full Redis refuses writes rather than dropping jobs. See
 [job runner](/self-hosting/configuration/job-runner).
 
-<Warning>
-  The app HPA scales on CPU and memory utilization only. Queue depth is not one of its metrics, so a
-  backlog can grow while both targets sit under their thresholds and no replica is added. Backlog-driven
-  scaling needs a queue-depth metric published to the metrics API and added to the HPA yourself.
-</Warning>
+**A large contact list** is storage rather than throughput. Contact attributes are one row per attribute per
+contact, so 50,000 contacts with 10 attributes each is 500,000 rows before a single response is stored.
 
-Redis is the hard limit on that backlog. The chart pins `maxmemory-policy noeviction` so BullMQ cannot
-silently lose jobs, which means a full Redis refuses writes rather than evicting. Enqueue errors are not
-swallowed: the response row is already committed to Postgres, so no answer is lost, but the client still
-gets an error. Retention settings only trim completed and failed jobs — they do not make the queue
-unbounded. Size Redis for the deepest backlog you expect, not for the steady state.
-
-**50,000 contacts.** This is storage and index growth, not throughput. Contact attributes are one row per
-attribute per contact, so 50,000 contacts with 10 attributes each is 500,000 attribute rows before a single
-response is stored. Size PostgreSQL storage from that plus your response retention, and add vCores when
-segment evaluation or dashboard queries start queuing.
-
-<Note>
-  We do not publish a responses-per-second figure per replica. We have not load-tested one, and it would not
-  transfer: a 40-question survey with file uploads is not the same write as a one-question NPS. Use the
-  levers above to size the queue and the storage, then watch both pod CPU and queue depth through your first
-  real campaign — they move independently.
-</Note>
-
-### What this sizing assumes
-
-- No AI features. Self-hosted embeddings or an in-cluster LLM change the node pool completely — use an
-  external endpoint at this size.
-- A single region and no cross-region replication.
-- Peaks handled by autoscaling rather than by permanently provisioned capacity.
-- Object storage outside the cluster, not a bundled in-cluster S3 service.
-
-### What to scale first
-
-1. **Job concurrency**, via `BULLMQ_WORKER_COUNT` and `BULLMQ_WORKER_CONCURRENCY` — no extra pods, but it
-   spends the pod's own CPU and memory, so raise it against a measurement.
-2. **App replicas**, via the HPA — the app is stateless, so this is the cheapest capacity lever. Check the
-   ceiling still fits the node pool.
-3. **PostgreSQL vCores**, once response writes or dashboard queries start queuing.
-4. **Redis**, which becomes the dominant cost at high request rates. If that matters more than the
-   operational simplicity of a managed cache, run Valkey in-cluster instead.
+We publish no responses-per-second figure per replica: it is not load-tested, and a 40-question survey with
+file uploads is not the same write as a one-question NPS. Watch pod CPU and queue depth separately through
+your first campaign — they move independently.
 
 ## **Self-hosting options**
 

--- a/docs/self-hosting/setup/kubernetes.mdx
+++ b/docs/self-hosting/setup/kubernetes.mdx
@@ -213,6 +213,15 @@ If you intentionally run a single app replica, either disable the PDB or use `ma
 `minAvailable` and accept downtime during the eviction. Never set both fields; set the unused field to `null` in
 your values file.
 
+Two autoscaling defaults are easy to miss:
+
+- **`maxReplicas: 10` can exceed what the node pool can hold.** Each app pod requests 1 vCPU, so the ceiling
+  needs about 10 allocatable vCPU for the app alone, on top of the platform reserve and the Hub, Cube and
+  SpiceDB pods. A smaller pool leaves the extra replicas `Pending` — an HPA does not lower its own ceiling.
+- **The HPA scales on CPU and memory utilization only.** Queue depth is not one of its metrics, so a job
+  backlog can grow while both targets sit under their thresholds and no replica is added. Backlog-driven
+  scaling needs a queue-depth metric published to the metrics API and added to the HPA yourself.
+
 ### Cube
 
 Cube is part of the baseline Formbricks v5 stack and is bundled with the chart by default


### PR DESCRIPTION
No ticket — docs correction raised from a customer infra planning review.

## What & why

**Was:** The overview advertised a 1 vCPU / 2 GB / 8 GB SSD minimum — about a third of a v6 install, so a reader following it gets an OOM.

**Now:** Sizing is derived from the Helm chart's defaults and kept to intro length, with the deeper Kubernetes detail on the pages that already cover it.

- Chart defaults request 1.9 vCPU / 2.9 GiB across eight services, not 1 vCPU / 2 GB.
- Capacity is provider-neutral — no VM SKUs, no cloud named.
- Two undocumented autoscaling traps move to the Kubernetes guide's replica section.

## Where to look

- [overview.mdx:13](docs/self-hosting/overview.mdx#L13) — the numbers, vs. `charts/formbricks/values.yaml`
- [overview.mdx:63](docs/self-hosting/overview.mdx#L63) — load scenarios
- [kubernetes.mdx:201](docs/self-hosting/setup/kubernetes.mdx#L201) — the two HPA traps

[Preview](https://formbricks-claude-formbricks-enterprise-resources-e37b17.mintlify.site/self-hosting/overview)

## Breaking changes

- [ ] This PR contains breaking changes

None. Documentation only.

## Migrations & env

- none

## How this was tested

Rerun: `npx prettier --check docs/self-hosting/overview.mdx docs/self-hosting/setup/kubernetes.mdx`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Numbers match chart defaults | manual | Re-derived from `values.yaml`; invented Hub API row dropped |
| Embeddings figures name the right pool | manual | Foreground 4 vCPU, `background` 8 vCPU |
| Storage guidance matches the S3 contract | manual | Azure Blob removed; gateway requirement stated |
| Load scenarios rest on shipped defaults | manual | Job count traced through `sendToPipeline` callers |
| Cut content covered elsewhere, not lost | manual | Managed PG/Redis, replicas, Cube, `pgvector` already documented |
| Renders unclipped, anchors resolve | manual | All tables `scrollWidth == clientWidth` on the preview |

**Open gaps**

- No responses-per-second per replica — no load test exists, so the page says so.
- Single-server rows are derived from chart totals, not load-tested.
- Table widths measured at the preview's 640px well only.

**Risks**

- Figures drift if chart defaults change; the page names `values.yaml` to re-derive.

<details>
<summary>Review feedback addressed</summary>

Six factual corrections from @BhagyaAmarasinghe, each answered in its own thread:

1. Embeddings CPU rows were reversed between the foreground runtime and the worker pool.
2. `Standard_B2s` is not valid for an AKS system node pool — all VM SKUs are gone, capacity is provider-neutral.
3. The shipped `maxReplicas: 10` could not be honoured by a 5 × 2-vCPU pool.
4. Free control-plane tiers carry no financially backed SLA.
5. Azure Blob Storage has no S3 API and cannot back file uploads directly.
6. "Production-grade" overstated HA: every replica count in the chart ships as `1`.

Found while re-deriving: the old Hub API row (100m / 256 Mi / 512 Mi) was invented — the chart sets no requests or limits on it.

From CodeRabbit, eight findings. Seven accepted: heading casing, the Enterprise note block, the `minReplicas: 1` default, the `BULLMQ_WORKER_COUNT` term missing from the capacity formula, concurrency described as free, the HPA scaling on CPU and memory only, and Redis refusing writes under `maxmemory-policy noeviction` rather than absorbing an unbounded backlog. One rejected on its arithmetic: `responseCreated` and `responseFinished` enqueue the same job name with a different payload, so a finished response is two jobs, not three — but it pointed at a real miss, `put-response-handler.ts:247`, which enqueues `responseUpdated` on every progress save.

</details>

<details>
<summary>What was cut, and where it lives now</summary>

The page had grown to ~200 lines of capacity planning on the first page a self-hoster reads. Cut back to the corrected numbers, the single-server vs. Kubernetes choice, and two short load scenarios.

The per-component table, cluster table, managed-service table, HPA arithmetic, and the assumptions and scale-first lists are gone. Most of it duplicated existing pages: `Using Managed PostgreSQL And Redis`, `Production Replicas And Disruption Budgets` and `Cube` on the Kubernetes guide, `pgvector` on cluster-setup and migration, worker tuning on job-runner. The two facts documented nowhere else — the HPA ceiling exceeding the node pool, and the HPA scaling on CPU and memory only — moved to the Kubernetes guide's replica section.

</details>

<details>
<summary>Cost figures from the source planning doc were deliberately left out</summary>

The sizing was derived from a customer-specific Azure infra plan. The resource shape is published; the monthly cost tables are not, since they are engagement- and Azure-specific. Naming no cloud at all also removes the AKS-validity problem the SKU row created.

</details>

<details>
<summary>Mintlify: the 🔴 Failed comment above is stale</summary>

The `mintlify[bot]` comment reflects the very first pushed commit, which was force-pushed away before review — the failure there was Mintlify's transient "Failed to get OpenApi files", unrelated to the MDX. Every commit since has deployed green: `Mintlify Deployment | Deployment Succeeded` and `link-rot` green on each, and the preview URL serves the current page. Mintlify's GitHub App does not refresh that comment after a force-push, so the check runs are the signal, not the table.

</details>

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.
