### PR TITLE
feat: export reserved + embedded data fields as stable typed columns [ENG-1847]

### DIFF
--- a/apps/web/lib/response/utils.test.ts
+++ b/apps/web/lib/response/utils.test.ts
@@ -6,7 +6,6 @@ import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import {
   calculateTtcTotal,
-  extracMetadataKeys,
   extractChoiceIdsFromResponse,
   extractSurveyDetails,
   generateAllPermutationsOfSubsets,
@@ -539,27 +538,6 @@ describe("Response Utils", () => {
     });
   });
 
-  describe("extracMetadataKeys", () => {
-    test("should extract metadata keys correctly", () => {
-      const meta = {
-        userAgent: { browser: "Chrome", os: "Windows", device: "Desktop" },
-        country: "US",
-        source: "direct",
-      };
-      const result = extracMetadataKeys(meta);
-      expect(result).toContain("userAgent - browser");
-      expect(result).toContain("userAgent - os");
-      expect(result).toContain("userAgent - device");
-      expect(result).toContain("country");
-      expect(result).toContain("source");
-    });
-
-    test("should handle empty metadata", () => {
-      const result = extracMetadataKeys({});
-      expect(result).toEqual([]);
-    });
-  });
-
   // TODO: Fix this test after the survey editor poc is merged
   describe("extractSurveyDetails", () => {
     const mockSurvey: Partial<TSurvey> = asRead({
@@ -627,10 +605,76 @@ describe("Response Utils", () => {
 
     test("should extract survey details correctly", () => {
       const result = extractSurveyDetails(mockSurvey as TSurvey, mockResponses as TResponse[]);
-      expect(result.metaDataFields).toContain("userAgent - browser");
+      // Catalog-derived, not first-response-derived: the header exists whatever any response holds.
+      expect(result.metaDataFields).toContain("Browser");
+      expect(result.metaDataFields).toContain("Utm Source");
+      expect(result.metaDataFields).not.toContain("userAgent - browser");
       expect(result.elements).toHaveLength(2); // 1 regular question + 2 matrix rows
       expect(result.hiddenFields).toContain("hidden1");
       expect(result.userAttributes).toContain("email");
+    });
+
+    // ENG-1847: the reserved column set is catalog-derived and stable — the four decisions below
+    // (stability, shadowing, anonymize, basics dedupe) are each a rule reused from elsewhere, pinned
+    // here so the export cannot drift from the response table.
+    describe("reserved export columns (ENG-1847)", () => {
+      test("columns are stable: a first response with NO meta still yields every catalog header", () => {
+        // The old derivation read the FIRST response's meta keys, so this exact input produced zero
+        // meta columns — red under that implementation.
+        const bareResponse = { ...mockResponses[0], meta: {} } as TResponse;
+        const result = extractSurveyDetails(mockSurvey as TSurvey, [bareResponse]);
+
+        expect(result.metaDataFields).toContain("Utm Source");
+        expect(result.metaDataFields).toContain("Page Path");
+        expect(result.metaDataFields).toContain("Locale");
+      });
+
+      test("a survey declaring `url` does not get the reserved Url column — declared owns the name", () => {
+        const shadowedSurvey = asRead({
+          ...mockSurvey,
+          hiddenFields: { enabled: true, fieldIds: ["url", "hidden1"] },
+        }) as TSurvey;
+
+        const result = extractSurveyDetails(shadowedSurvey, mockResponses as TResponse[]);
+
+        expect(result.metaDataFields).not.toContain("Url");
+        expect(result.hiddenFields).toContain("url");
+      });
+
+      test("an anonymized survey omits the privacy-drop columns and keeps the rest", () => {
+        const anonymizedSurvey = {
+          ...(mockSurvey as TSurvey),
+          isAnonymizeResponsesEnabled: true,
+        } as TSurvey;
+
+        const result = extractSurveyDetails(anonymizedSurvey, mockResponses as TResponse[]);
+
+        expect(result.metaDataFields).not.toContain("Country");
+        expect(result.metaDataFields).toContain("Utm Source");
+      });
+
+      test("facts the fixed basic columns already carry never become reserved columns", () => {
+        const result = extractSurveyDetails(mockSurvey as TSurvey, mockResponses as TResponse[]);
+
+        for (const doubled of ["Response Id", "Survey Id", "Finished", "Started At"]) {
+          expect(result.metaDataFields).not.toContain(doubled);
+        }
+        // finishedAt/durationSeconds are NOT basics-covered — they must be columns.
+        expect(result.metaDataFields).toContain("Finished At");
+        expect(result.metaDataFields).toContain("Duration Seconds");
+      });
+
+      test("ipAddress is a column only when the survey captures it", () => {
+        const withIp = { ...(mockSurvey as TSurvey), isCaptureIpEnabled: true } as TSurvey;
+        const withoutIp = { ...(mockSurvey as TSurvey), isCaptureIpEnabled: false } as TSurvey;
+
+        expect(extractSurveyDetails(withIp, mockResponses as TResponse[]).metaDataFields).toContain(
+          "Ip Address"
+        );
+        expect(extractSurveyDetails(withoutIp, mockResponses as TResponse[]).metaDataFields).not.toContain(
+          "Ip Address"
+        );
+      });
     });
 
     test("should collect contact attributes for link surveys too", () => {
@@ -774,9 +818,55 @@ describe("Response Utils", () => {
         false
       );
       expect(result[0]["Response ID"]).toBe("response1");
-      expect(result[0]["userAgent - browser"]).toBe("Chrome");
+      expect(result[0]["Browser"]).toBe("Chrome");
       expect(result[0]["1. Question 1"]).toBe("answer1");
       expect(result[0]["person.email"]).toBe("test@example.com");
+    });
+
+    test("reserved values are typed and projected: duration numeric, finishedAt ISO, url query redacted, absent empty", () => {
+      const finishedAtDate = new Date("2026-08-30T10:00:00.000Z");
+      const richResponse = {
+        ...mockResponses[0],
+        updatedAt: finishedAtDate,
+        ttc: { _total: 12500 },
+        meta: {
+          ...mockResponses[0].meta,
+          url: "https://example.com/pricing?email=leak@example.com",
+        },
+      } as unknown as TResponse;
+
+      const result = getResponsesJson(
+        mockSurvey as TSurvey,
+        [richResponse] as TResponse[],
+        [["1. Question 1"]],
+        [],
+        [],
+        false
+      );
+
+      // number cell, seconds not milliseconds — real numeric in XLSX, not text
+      expect(result[0]["Duration Seconds"]).toBe(13);
+      expect(result[0]["Finished At"]).toBe("2026-08-30T10:00:00.000Z");
+      // redactQuery is honoured on the export projection like every other projection
+      expect(result[0]["Url"]).toBe("https://example.com/pricing");
+      expect(String(result[0]["Url"])).not.toContain("leak@example.com");
+      // a column whose value this response never captured is an empty cell, not a missing key
+      expect(result[0]["Utm Source"]).toBe("");
+    });
+
+    test("an ingested number stays a number in the cell", () => {
+      const surveyWithNumberField = asRead({
+        ...mockSurvey,
+        hiddenFields: { enabled: true, fieldIds: ["seats"] },
+      }) as TSurvey;
+      const response = {
+        ...mockResponses[0],
+        data: { ...mockResponses[0].data, seats: 12 },
+      } as unknown as TResponse;
+
+      const result = getResponsesJson(surveyWithNumberField, [response], [], [], ["seats"], false);
+
+      expect(result[0]["seats"]).toBe(12);
     });
 
     test("a computed field the response never captured leaves an empty cell", () => {

--- a/apps/web/lib/response/utils.ts
+++ b/apps/web/lib/response/utils.ts
@@ -1,5 +1,14 @@
 import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
-import { getComputedEmbeddedFields, getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
+import {
+  RESERVED_FIELD_CATALOG,
+  type TReservedFieldCatalogEntry,
+  dropShadowedReservedEntries,
+  getComputedEmbeddedFields,
+  getIngestedStorageKeys,
+  getSurveyEmbeddedFields,
+  listShadowingNames,
+  projectReservedValues,
+} from "@formbricks/types/embedded-data-resolver";
 import {
   TResponse,
   TResponseDataValue,
@@ -9,6 +18,7 @@ import {
   TSurveyContactAttributes,
   TSurveyMetaFieldFilter,
 } from "@formbricks/types/responses";
+import { formatFieldNameToTitleCase } from "@formbricks/types/safe-identifier";
 import {
   TSurveyElement,
   TSurveyMultipleChoiceElement,
@@ -120,24 +130,52 @@ export const getResponsesFileName = (surveyName: string, extension: string) => {
   return `export-${sanitizedSurveyName.split(" ").join("-")}-${formattedDateString}.${extension}`.toLocaleLowerCase();
 };
 
-export const extracMetadataKeys = (obj: TResponse["meta"]) => {
-  let keys: string[] = [];
+/**
+ * The four catalog entries whose values the export's fixed basic columns already carry — "Response
+ * ID", "Survey ID", "Finished" and "Timestamp" (`createdAt`, which is what `startedAt` reads).
+ * Skipped from the reserved column set so one fact never gets two columns.
+ */
+const EXPORT_BASICS_COVERED_RESERVED_NAMES = new Set(["responseId", "surveyId", "finished", "startedAt"]);
 
-  Object.entries(obj ?? {}).forEach(([key, value]) => {
-    if (typeof value === "object" && value !== null) {
-      Object.entries(value).forEach(([subKey]) => {
-        keys.push(key + " - " + subKey);
-      });
-    } else {
-      keys.push(key);
-    }
+/**
+ * The reserved fields one survey's export carries as columns — the catalog, minus what cannot or
+ * must not appear (ENG-1847).
+ *
+ * Catalog-derived on purpose: the previous column set was the FIRST response's `meta` keys, so a
+ * first response missing `utmSource` meant no column at all, however many later responses carried
+ * it — and headers came out as raw key paths (`userAgent - browser`). This set is stable per
+ * survey, whatever any individual response holds.
+ *
+ * The filters, each a decision already made elsewhere and reused here:
+ * - shadowed entries drop (`dropShadowedReservedEntries`) — a survey declaring `url` keeps its
+ *   declared column and never gets the reserved one, same rule as the renderer and response table;
+ * - the four facts the fixed basic columns already carry are skipped (one column per fact);
+ * - on an anonymized survey, `privacy: "drop"` entries are never captured, so their always-empty
+ *   columns are omitted;
+ * - `ipAddress` is only a column when the survey captures it (`isCaptureIpEnabled`).
+ */
+export const getReservedExportEntries = (survey: TSurvey): TReservedFieldCatalogEntry[] => {
+  const elementIds = getElementsFromBlocks(survey.blocks).map((element) => element.id);
+  const shadowingNames = listShadowingNames(getSurveyEmbeddedFields(survey), elementIds);
+
+  return dropShadowedReservedEntries(RESERVED_FIELD_CATALOG, shadowingNames).filter((entry) => {
+    if (EXPORT_BASICS_COVERED_RESERVED_NAMES.has(entry.name)) return false;
+    if (survey.isAnonymizeResponsesEnabled && entry.privacy === "drop") return false;
+    if (entry.name === "ipAddress" && !survey.isCaptureIpEnabled) return false;
+    return true;
   });
-
-  return keys;
 };
 
+/**
+ * The export header for a reserved column. `formatFieldNameToTitleCase` rather than the localized
+ * `getReservedFieldLabel`: export headers are a machine-facing contract, and localizing them would
+ * make the column names depend on whichever operator happened to click download.
+ */
+export const getReservedExportHeader = (entry: TReservedFieldCatalogEntry): string =>
+  formatFieldNameToTitleCase(entry.name);
+
 export const extractSurveyDetails = (survey: TSurvey, responses: TResponse[]) => {
-  const metaDataFields = responses.length > 0 ? extracMetadataKeys(responses[0].meta) : [];
+  const metaDataFields = getReservedExportEntries(survey).map(getReservedExportHeader);
   const modifiedSurvey = replaceHeadlineRecall(survey, "default");
 
   const modifiedElements = getElementsFromBlocks(modifiedSurvey.blocks);
@@ -179,6 +217,7 @@ export const getResponsesJson = (
   isQuotasAllowed: boolean = false
 ): Record<string, string | number>[] => {
   const jsonData: Record<string, string | number>[] = [];
+  const reservedEntries = getReservedExportEntries(survey);
 
   responses.forEach((response, idx) => {
     // basic response details
@@ -197,15 +236,12 @@ export const getResponsesJson = (
       jsonData[idx]["Quotas"] = response.quotas?.map((quota) => quota.name).join(", ") || "";
     }
 
-    // meta details
-    Object.entries(response.meta ?? {}).forEach(([key, value]) => {
-      if (typeof value === "object" && value !== null) {
-        Object.entries(value).forEach(([subKey, subValue]) => {
-          jsonData[idx][key + " - " + subKey] = subValue;
-        });
-      } else {
-        jsonData[idx][key] = value;
-      }
+    // Reserved fields, through the same projection recall/logic read (coercion to the declared
+    // dataType, booleans stringified, `redactQuery` honoured). Every column gets a cell — absent
+    // values as "" — so rows stay aligned with the stable header set.
+    const reservedValues = projectReservedValues(reservedEntries, response);
+    reservedEntries.forEach((entry) => {
+      jsonData[idx][getReservedExportHeader(entry)] = reservedValues[entry.name] ?? "";
     });
 
     // survey response data
@@ -261,11 +297,14 @@ export const getResponsesJson = (
       jsonData[idx][`person.${attribute}`] = response.contactAttributes?.[attribute] || "";
     });
 
-    // hidden fields
+    // hidden fields — a number stays a number (the ingest contract stores coerced values, so a
+    // `dataType: "number"` field holds a real number and the XLSX cell should be numeric, not text)
     hiddenFields.forEach((field) => {
       const value = response.data[field];
       if (Array.isArray(value)) {
         jsonData[idx][field] = value.join("; ");
+      } else if (typeof value === "number") {
+        jsonData[idx][field] = value;
       } else {
         jsonData[idx][field] = processResponseData(value);
       }

--- a/apps/web/playwright/response-export.spec.ts
+++ b/apps/web/playwright/response-export.spec.ts
@@ -77,7 +77,10 @@ const submitAnswer = async (page: Page, answer: string): Promise<void> => {
 };
 
 test.describe("Response export columns @slow", () => {
-  test("exports reserved fields as stable, titlecased, redacted columns", async ({ page, users }) => {
+  test("exports reserved fields as stable, titlecased, redacted columns", async ({
+    page,
+    users,
+  }, testInfo) => {
     const owner = await users.create({ skipSurveySeed: true });
     if (!owner.workspaceId) throw new Error("users.create() did not return a workspaceId");
     const surveyId = await seedSurvey(owner.workspaceId, owner.id);
@@ -110,7 +113,10 @@ test.describe("Response export columns @slow", () => {
     await page.getByTestId("fb__custom-filter-download-all-csv").click();
     const download = await downloadPromise;
 
-    const csvPath = await download.path();
+    // saveAs, not download.path(): CI runs this suite against Azure's remote browsers
+    // (playwright.service.config.ts), where path() throws — saveAs transfers the artifact.
+    const csvPath = testInfo.outputPath(download.suggestedFilename());
+    await download.saveAs(csvPath);
     const csv = await readFile(csvPath, "utf-8");
     const [headerLine] = csv.split("\n");
 

--- a/apps/web/playwright/response-export.spec.ts
+++ b/apps/web/playwright/response-export.spec.ts
@@ -1,0 +1,143 @@
+import { createId } from "@paralleldrive/cuid2";
+import { type Page, expect } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { type TSurveyEnding } from "@formbricks/types/surveys/types";
+import { transformQuestionsToBlocks } from "@/app/lib/api/survey-transformation";
+import { test } from "./lib/fixtures";
+
+/**
+ * **Response export columns, end to end (ENG-1847).**
+ *
+ * The unit suite (apps/web/lib/response/utils.test.ts) pins every rule of the catalog-derived
+ * export on its own. This walks the one seam none of them reach — the real download: a browser
+ * submits → Postgres → the owner clicks Download → the CSV Playwright catches has the columns.
+ *
+ * The scenario is the regression that motivated the ticket. The export used to derive its meta
+ * columns from the first fetched response (`Object.keys(responses[0].meta)`), and responses are
+ * fetched newest-first. So: submit a campaign response first, then a bare one. On the old code the
+ * bare (newest) response dictated the header set and the campaign columns vanished from the whole
+ * file — silently, rows and all.
+ */
+type I18n = { default: string };
+const i18nValue = (value: string): I18n => ({ default: value });
+
+type TLegacyQuestions = Parameters<typeof transformQuestionsToBlocks>[0];
+
+const QUESTION = "How did you hear about us?";
+const ENDING_HEADLINE = "Thanks!";
+
+const UTM_QUERY = "utm_source=newsletter&utm_medium=email";
+
+const seedSurvey = async (workspaceId: string, createdBy: string): Promise<string> => {
+  const endings = [
+    { id: createId(), type: "endScreen" as const, headline: i18nValue(ENDING_HEADLINE) },
+  ] as unknown as TSurveyEnding[];
+
+  const questions = [
+    {
+      id: createId(),
+      type: "openText",
+      headline: i18nValue(QUESTION),
+      required: true,
+      inputType: "text",
+      placeholder: i18nValue("Type your answer here..."),
+      charLimit: { enabled: false },
+    },
+  ];
+
+  const survey = await prisma.survey.create({
+    data: {
+      workspaceId,
+      createdBy,
+      name: "Response export survey",
+      type: "link",
+      status: "inProgress",
+      welcomeCard: { enabled: false, timeToFinish: false, showResponseCount: false },
+      blocks: transformQuestionsToBlocks(
+        questions as unknown as TLegacyQuestions,
+        endings
+      ) as unknown as Prisma.InputJsonValue[],
+      endings: endings as unknown as Prisma.InputJsonValue[],
+    },
+    select: { id: true },
+  });
+
+  return survey.id;
+};
+
+const submitAnswer = async (page: Page, answer: string): Promise<void> => {
+  await expect(page.getByText(QUESTION)).toBeVisible();
+  await page.getByPlaceholder("Type your answer here...").fill(answer);
+  await page.getByRole("button", { name: "Finish" }).click();
+  // The ending card only renders once the ingest POST resolves; the first submission of a run can
+  // take longer than the default 5s, so wait for the real signal.
+  await expect(page.getByText(ENDING_HEADLINE)).toBeVisible({ timeout: 60000 });
+};
+
+test.describe("Response export columns @slow", () => {
+  test("exports reserved fields as stable, titlecased, redacted columns", async ({ page, users }) => {
+    const owner = await users.create({ skipSurveySeed: true });
+    if (!owner.workspaceId) throw new Error("users.create() did not return a workspaceId");
+    const surveyId = await seedSurvey(owner.workspaceId, owner.id);
+
+    // Respondent 1 arrives through a campaign link, so their response carries the utm fields —
+    // and a page URL whose query string must NOT survive into the export (`redactQuery`).
+    await page.goto(`/s/${surveyId}?${UTM_QUERY}`);
+    await submitAnswer(page, "From the newsletter");
+
+    // Respondent 2 uses the bare link. Submitted second, so this response is the NEWEST — the one
+    // the old first-response derivation would have taken the header set from, erasing every
+    // campaign column. localStorage is cleared so the renderer treats this as a fresh respondent.
+    await page.evaluate(() => window.localStorage.clear());
+    await page.goto(`/s/${surveyId}`);
+    await submitAnswer(page, "Found it myself");
+
+    // Both rows are written asynchronously after submit; poll rather than race the second insert.
+    await expect
+      .poll(async () => prisma.response.count({ where: { surveyId } }), {
+        timeout: 20000,
+        message: "Both submitted responses should be stored",
+      })
+      .toBe(2);
+
+    await owner.login();
+    await page.goto(`/workspaces/${owner.workspaceId}/surveys/${surveyId}/responses`);
+
+    await page.getByRole("button", { name: "Download" }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByTestId("fb__custom-filter-download-all-csv").click();
+    const download = await downloadPromise;
+
+    const csvPath = await download.path();
+    const csv = await readFile(csvPath, "utf-8");
+    const [headerLine] = csv.split("\n");
+
+    // Stability: the campaign columns are there even though the newest response never had them,
+    // and they carry the catalog's titlecased names, not raw meta keys.
+    expect(headerLine).toContain("Utm Source");
+    expect(headerLine).toContain("Utm Medium");
+    expect(headerLine).toContain("Browser");
+    expect(headerLine).not.toContain("userAgent - browser");
+
+    // Typed catalog columns that raw response meta never carried.
+    expect(headerLine).toContain("Duration Seconds");
+    expect(headerLine).toContain("Finished At");
+
+    // Dedupe: the export's basic "Timestamp" column already covers startedAt, so the catalog copy
+    // must not re-appear beside it.
+    expect(headerLine).not.toContain("Started At");
+
+    // The campaign row's value made it into a cell of its own. Quoted, because the answer text
+    // "From the newsletter" would otherwise match too.
+    expect(csv).toContain('"newsletter"');
+
+    // Redaction: the survey was answered at a URL carrying the query string, and `redactQuery`
+    // strips it from the exported Url — so the raw query must appear nowhere in the file.
+    expect(csv).not.toContain("utm_source=");
+
+    // Header plus both response rows.
+    expect(csv.trim().split("\n")).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## What & why

The response export (CSV/XLSX) derived its metadata columns from whichever response happened to be fetched first: `Object.keys(responses[0].meta)`. Responses are fetched newest-first, so the column set changed depending on the latest response — if the newest respondent arrived without a campaign link, every `utm*` column silently vanished from the whole file, rows included. Headers were raw meta keys (`utmSource`, `userAgent - browser`), the `url` cell leaked the full query string, and typed fields like duration or finish time were not exported at all.

This PR derives the export columns from the reserved-field catalog instead, so they are stable regardless of the data:

- **Headers** come from the catalog, titlecased via `formatFieldNameToTitleCase` (`Utm Source`, `Browser`) — deliberately not localized, since export headers are machine-facing.
- **Values** come from the shared typed projection (`projectReservedValues`) — the same rules recall/logic use: `Duration Seconds` as a number, `Finished At` as ISO, `Url` with the query string stripped (`redactQuery`), absent values as empty cells.
- **Gates**: declared fields shadow their reserved namesake; anonymized surveys drop `privacy: "drop"` fields (Country, Ip Address, …); `Ip Address` only with IP capture enabled; `responseId`/`surveyId`/`finished`/`startedAt` are skipped because the export's basic columns already carry them.
- Ingested number fields stay numeric in XLSX instead of being stringified.
- `extracMetadataKeys` is deleted; it had no other consumer.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1847

## How this was tested

- `apps/web/lib/response/utils.test.ts`: 72/72 ✅ — 7 new tests pinning column stability, shadowing, anonymize/IP gating, basics dedupe, typed values (duration, ISO, redacted Url, empty cell), and numeric ingested cells. Three mutation fail-checks verified each new test goes red without its rule.
- New e2e `apps/web/playwright/response-export.spec.ts`: submits a campaign response then a bare one (newest), downloads the real CSV, asserts the campaign columns survive, headers are titlecased, and the query string is redacted. **Red on the old code** — the failure shows the exact bug (header set taken from the bare newest response, no utm columns) — green on this branch.
- Full `apps/web` unit suite: 7807 passed ✅; `turbo typecheck` ✅; lint ✅.

<details>
<summary>Export columns, before / after (same seeded survey: one campaign response, one bare response — bare is newest)</summary>

**Before** — raw keys from the newest response's meta: no utm columns at all (the campaign data is visibly stuck inside the `url` cell), query string leaked:

![Old export: raw meta-key headers, no utm columns, url cell carrying the full query string](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1847/export-columns-before.png)

**After** — stable titlecased catalog columns: `Utm Source`/`Utm Medium` present with the campaign row filled, `Url` query-free, typed `Duration Seconds` and `Finished At`:

![New export: titlecased catalog headers, utm columns present, redacted Url, typed duration and finish time](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1847/export-columns-after.png)

</details>

## Breaking changes

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| Metadata column headers in the response CSV/XLSX export | Raw meta keys (`utmSource`, `userAgent - browser`, `url`), present only when the newest exported response carried the field | Stable titlecased names (`Utm Source`, `Browser`, `Url`), always present; new columns `Duration Seconds`, `Finished At` | Anyone parsing export files by header downstream | Update header mappings to the new names |
| `Url` column value in exports | Full page URL including query string | Query string stripped | Downstream consumers reading query params from the exported URL | Read campaign params from the dedicated `Utm *` columns instead |

## QA / Test Plan

**How to test**

- [ ] Create a link survey with one question. Open its link with `?utm_source=newsletter&utm_medium=email` appended and submit; then open the bare link (fresh browser/incognito) and submit → both stored.
- [ ] Responses tab → Download → All responses (CSV) → the file has `Utm Source` and `Utm Medium` columns; the campaign row carries the values, the bare row has empty cells.
- [ ] In the same file, the `Url` column shows the survey URL **without** the query string; `Duration Seconds` and `Finished At` columns are present.
- [ ] Download as Excel → `Duration Seconds` is a real number cell (right-aligned, summable).
- [ ] Survey settings → enable "Anonymize responses" → re-export → `Country` and `Ip Address` columns are gone; `Utm Source` remains.
- [ ] Export a survey with zero responses → the header row still contains the full column set.
- [ ] Headers contain `Timestamp` but no separate `Started At` column (no duplicate).

**Preconditions / test data**

- Any workspace; a link survey with at least one question. No flags or entitlements involved.

**Risks & regressions**

- Response table UI and summary page are untouched (they read their own paths); only the download file changes.
- Downstream CSV parsers keyed on old header names will need remapping (see Breaking changes).

**Migrations / env / cutover**

- none
