### PR TITLE
feat: filter responses by embedded data + reserved fields as typed filters [ENG-1848]

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/actions.ts
@@ -105,11 +105,15 @@ export const getSurveyFilterDataAction = authenticatedActionClient
 
     const workspaceId = await getWorkspaceIdFromSurveyId(parsedInput.surveyId);
 
-    const [tags, { contactAttributes: attributes, meta, hiddenFields }, quotas = []] = await Promise.all([
+    const [
+      tags,
+      { contactAttributes: attributes, meta, hiddenFields, reservedValues, variableValues },
+      quotas = [],
+    ] = await Promise.all([
       getTagsByWorkspaceId(workspaceId),
       getResponseFilteringValues(parsedInput.surveyId),
       isQuotasAllowed ? getQuotas(parsedInput.surveyId) : [],
     ]);
 
-    return { environmentTags: tags, attributes, meta, hiddenFields, quotas };
+    return { environmentTags: tags, attributes, meta, hiddenFields, reservedValues, variableValues, quotas };
   });

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementFilterComboBox.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementFilterComboBox.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { ChevronDown, ChevronUp, X } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { TEmbeddedDataType } from "@formbricks/types/embedded-data";
 import { TI18nString } from "@formbricks/types/i18n";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { OptionsType } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementsComboBox";
@@ -46,7 +47,22 @@ type ElementFilterComboBoxProps = {
   handleRemoveMultiSelect: (value: string[]) => void;
   disabled?: boolean;
   fieldId?: string;
+  /** Embedded Data / reserved fields: picks the value input (number/date/free text) per dataType. */
+  fieldDataType?: TEmbeddedDataType;
 };
+
+// Operators whose value is free text rather than a pick from observed values.
+const TEXT_FAMILY_OPERATORS = [
+  "Contains",
+  "Does not contain",
+  "Starts with",
+  "Does not start with",
+  "Ends with",
+  "Does not end with",
+];
+
+// Operators that take no value at all; the value box is disabled while one is selected.
+const NO_VALUE_OPERATORS = ["Is set", "Is not set"];
 
 // Helper function to check if multiple selection is allowed
 const checkIsMultiple = (
@@ -82,6 +98,7 @@ export const ElementFilterComboBox = ({
   handleRemoveMultiSelect,
   disabled = false,
   fieldId,
+  fieldDataType,
 }: ElementFilterComboBoxProps) => {
   const [open, setOpen] = useState(false);
   const commandRef = useRef(null);
@@ -102,10 +119,20 @@ export const ElementFilterComboBox = ({
     });
   }, [isMultiple, filterComboBoxOptions, filterComboBoxValue]);
 
-  const isDisabledComboBox = checkIsDisabledComboBox(type, filterValue);
+  const isNoValueOperator = NO_VALUE_OPERATORS.includes(filterValue ?? "");
+  const isDisabledComboBox = checkIsDisabledComboBox(type, filterValue) || isNoValueOperator;
 
-  // Check if this is a text input field (URL meta field)
-  const isTextInputField = type === OptionsType.META && fieldId === "url";
+  // Free-form value input instead of the observed-values combobox: the URL meta field (its value
+  // set is deliberately not enumerated), any text-family operator, number/date typed fields, and a
+  // typed field with no observed values to offer.
+  const isTextInputField =
+    !isNoValueOperator &&
+    ((type === OptionsType.META && fieldId === "url") ||
+      TEXT_FAMILY_OPERATORS.includes(filterValue ?? "") ||
+      (fieldDataType !== undefined && fieldDataType !== "boolean" && fieldDataType !== "string") ||
+      (fieldDataType !== undefined && (!filterComboBoxOptions || filterComboBoxOptions.length === 0)));
+
+  const textInputType = fieldDataType === "number" ? "number" : fieldDataType === "date" ? "date" : "text";
 
   // Filter options based on search query
   const filteredOptions = useMemo(
@@ -243,11 +270,11 @@ export const ElementFilterComboBox = ({
 
       {isTextInputField ? (
         <Input
-          type="text"
+          type={textInputType}
           value={typeof filterComboBoxValue === "string" ? filterComboBoxValue : ""}
           onChange={(e) => onChangeFilterComboBoxValue(e.target.value)}
           disabled={isComboBoxDisabled}
-          placeholder={t("common.enter_url")}
+          placeholder={type === OptionsType.META && fieldId === "url" ? t("common.enter_url") : undefined}
           className="h-9 rounded-l-none border-none bg-white text-sm focus:ring-offset-0"
         />
       ) : (

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementFilterComboBox.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementFilterComboBox.tsx
@@ -52,17 +52,44 @@ type ElementFilterComboBoxProps = {
 };
 
 // Operators whose value is free text rather than a pick from observed values.
-const TEXT_FAMILY_OPERATORS = [
+const TEXT_FAMILY_OPERATORS = new Set([
   "Contains",
   "Does not contain",
   "Starts with",
   "Does not start with",
   "Ends with",
   "Does not end with",
-];
+]);
 
 // Operators that take no value at all; the value box is disabled while one is selected.
-const NO_VALUE_OPERATORS = ["Is set", "Is not set"];
+const NO_VALUE_OPERATORS = new Set(["Is set", "Is not set"]);
+
+const getFreeTextInputType = (fieldDataType?: TEmbeddedDataType): "number" | "date" | "text" => {
+  if (fieldDataType === "number") return "number";
+  if (fieldDataType === "date") return "date";
+  return "text";
+};
+
+/**
+ * Free-form value input instead of the observed-values combobox: the URL meta field (its value set
+ * is deliberately not enumerated), any text-family operator, number/date typed fields, and a typed
+ * field with no observed values to offer.
+ */
+const checkIsFreeTextValueInput = (params: {
+  type?: TSurveyElementTypeEnum | Omit<OptionsType, OptionsType.ELEMENTS>;
+  fieldId?: string;
+  fieldDataType?: TEmbeddedDataType;
+  filterValue?: string;
+  hasComboBoxOptions: boolean;
+  isNoValueOperator: boolean;
+}): boolean => {
+  if (params.isNoValueOperator) return false;
+  if (params.type === OptionsType.META && params.fieldId === "url") return true;
+  if (TEXT_FAMILY_OPERATORS.has(params.filterValue ?? "")) return true;
+  if (params.fieldDataType === undefined) return false;
+  if (params.fieldDataType !== "boolean" && params.fieldDataType !== "string") return true;
+  return !params.hasComboBoxOptions;
+};
 
 // Helper function to check if multiple selection is allowed
 const checkIsMultiple = (
@@ -119,20 +146,19 @@ export const ElementFilterComboBox = ({
     });
   }, [isMultiple, filterComboBoxOptions, filterComboBoxValue]);
 
-  const isNoValueOperator = NO_VALUE_OPERATORS.includes(filterValue ?? "");
+  const isNoValueOperator = NO_VALUE_OPERATORS.has(filterValue ?? "");
   const isDisabledComboBox = checkIsDisabledComboBox(type, filterValue) || isNoValueOperator;
 
-  // Free-form value input instead of the observed-values combobox: the URL meta field (its value
-  // set is deliberately not enumerated), any text-family operator, number/date typed fields, and a
-  // typed field with no observed values to offer.
-  const isTextInputField =
-    !isNoValueOperator &&
-    ((type === OptionsType.META && fieldId === "url") ||
-      TEXT_FAMILY_OPERATORS.includes(filterValue ?? "") ||
-      (fieldDataType !== undefined && fieldDataType !== "boolean" && fieldDataType !== "string") ||
-      (fieldDataType !== undefined && (!filterComboBoxOptions || filterComboBoxOptions.length === 0)));
+  const isTextInputField = checkIsFreeTextValueInput({
+    type,
+    fieldId,
+    fieldDataType,
+    filterValue,
+    hasComboBoxOptions: (filterComboBoxOptions?.length ?? 0) > 0,
+    isNoValueOperator,
+  });
 
-  const textInputType = fieldDataType === "number" ? "number" : fieldDataType === "date" ? "date" : "text";
+  const textInputType = getFreeTextInputType(fieldDataType);
 
   // Filter options based on search query
   const filteredOptions = useMemo(

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementsComboBox.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementsComboBox.tsx
@@ -28,6 +28,7 @@ import {
   Rows3Icon,
   SmartphoneIcon,
   SmilePlusIcon,
+  SquareFunctionIcon,
   StarIcon,
   User,
 } from "lucide-react";
@@ -36,6 +37,7 @@ import { useTranslation } from "react-i18next";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { getLocalizedValue } from "@/lib/i18n/utils";
 import { useClickOutside } from "@/lib/utils/hooks/useClickOutside";
+import { RESERVED_FIELD_ICONS } from "@/modules/analysis/lib/reserved-field-display";
 import { Button } from "@/modules/ui/components/button";
 import {
   Command,
@@ -54,6 +56,7 @@ export enum OptionsType {
   OTHERS = "Other Filters",
   META = "Meta",
   HIDDEN_FIELDS = "Hidden Fields",
+  VARIABLES = "Variables",
   QUOTAS = "Quotas",
 }
 
@@ -71,6 +74,8 @@ const getOptionsTypeTranslationKey = (type: OptionsType, t: TFunction): string =
       return t("common.meta");
     case OptionsType.HIDDEN_FIELDS:
       return t("common.hidden_fields");
+    case OptionsType.VARIABLES:
+      return t("common.variables");
     case OptionsType.QUOTAS:
       return t("common.quotas");
   }
@@ -116,7 +121,11 @@ const elementIcons = {
   // hidden fields
   [OptionsType.HIDDEN_FIELDS]: EyeOff,
 
-  // meta
+  // variables (computed embedded fields)
+  [OptionsType.VARIABLES]: SquareFunctionIcon,
+
+  // meta — reserved fields resolve through RESERVED_FIELD_ICONS by catalog name (see getDisplayIcon);
+  // these stay as fallbacks for ids the shared map has no icon for.
   device: SmartphoneIcon,
   os: AirplayIcon,
   browser: GlobeIcon,
@@ -158,12 +167,19 @@ const getLabelClassName = (type: OptionsType | string, label?: string): string =
   return label === "os" || label === "url" ? "uppercase" : "capitalize";
 };
 
-export const SelectedCommandItem = ({ label, elementType, type }: Partial<ElementOption>) => {
+export const SelectedCommandItem = ({ label, elementType, type, id }: Partial<ElementOption>) => {
   const getDisplayIcon = () => {
     if (!type) return null;
     if (type === OptionsType.ELEMENTS && elementType) return getIcon(elementType);
     if (type === OptionsType.ATTRIBUTES) return getIcon(OptionsType.ATTRIBUTES);
     if (type === OptionsType.HIDDEN_FIELDS) return getIcon(OptionsType.HIDDEN_FIELDS);
+    if (type === OptionsType.VARIABLES) return getIcon(OptionsType.VARIABLES);
+    if (type === OptionsType.META && id) {
+      // Reserved fields share the response table's icon map, keyed by catalog name.
+      const ReservedIcon = RESERVED_FIELD_ICONS[id];
+      if (ReservedIcon) return <ReservedIcon className="size-5" strokeWidth={1.5} />;
+      return getIcon(id);
+    }
     if ([OptionsType.META, OptionsType.OTHERS].includes(type) && label) return getIcon(label);
     if (type === OptionsType.TAGS) return getIcon(OptionsType.TAGS);
     if (type === OptionsType.QUOTAS) return getIcon(OptionsType.QUOTAS);

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ResponseFilter.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ResponseFilter.tsx
@@ -4,6 +4,7 @@ import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { ChevronDown, ChevronUp, Plus, TrashIcon } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { TEmbeddedDataType } from "@formbricks/types/embedded-data";
 import { TI18nString } from "@formbricks/types/i18n";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -14,7 +15,7 @@ import {
 } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/components/response-filter-context";
 import { getSurveyFilterDataAction } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/actions";
 import { ElementFilterComboBox } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementFilterComboBox";
-import { generateElementAndFilterOptions } from "@/app/lib/surveys/surveys";
+import { NO_VALUE_FILTER_OPERATORS, generateElementAndFilterOptions } from "@/app/lib/surveys/surveys";
 import { getLocalizedValue } from "@/lib/i18n/utils";
 import { Button } from "@/modules/ui/components/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/modules/ui/components/popover";
@@ -36,9 +37,12 @@ export type ElementFilterOptions = {
     | "Quotas"
     | "Hidden Fields"
     | "Meta"
+    | "Variables"
     | OptionsType.OTHERS;
   filterOptions: (string | TI18nString)[];
   filterComboBoxOptions: (string | TI18nString)[];
+  /** For Embedded Data / reserved fields: drives the operator set and the value input type. */
+  fieldDataType?: TEmbeddedDataType;
   id: string;
 };
 
@@ -103,20 +107,23 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
 
       if (!surveyFilterData?.data) return;
 
-      const { attributes, meta, environmentTags, hiddenFields, quotas } = surveyFilterData.data;
-      const { elementFilterOptions, elementOptions } = generateElementAndFilterOptions(
+      const { attributes, environmentTags, hiddenFields, reservedValues, variableValues, quotas } =
+        surveyFilterData.data;
+      const { elementFilterOptions, elementOptions } = generateElementAndFilterOptions({
         survey,
         environmentTags,
         attributes,
-        meta,
+        reservedValues,
         hiddenFields,
-        quotas
-      );
+        variableValues,
+        quotas,
+        t,
+      });
       setSelectedOptions({ elementFilterOptions: elementFilterOptions, elementOptions: elementOptions });
     };
 
     handleInitialData();
-  }, [isOpen, setSelectedOptions]);
+  }, [isOpen, setSelectedOptions, t]);
 
   const handleOnChangeElementComboBoxValue = (value: ElementOption, index: number) => {
     const matchingFilterOption = selectedOptions.elementFilterOptions.find(
@@ -149,8 +156,13 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
   const clearItem = () => {
     setFilterValue({
       filter: filterValue.filter.filter((s) => {
-        // keep the filter if elementType is selected and filterComboBoxValue is selected
-        return s.elementType.hasOwnProperty("label") && s.filterType.filterComboBoxValue?.length;
+        // keep the filter if elementType is selected and a value is selected — or the chosen
+        // operator needs no value at all (Is set / Is not set)
+        return (
+          s.elementType.hasOwnProperty("label") &&
+          (s.filterType.filterComboBoxValue?.length ||
+            NO_VALUE_FILTER_OPERATORS.includes(s.filterType.filterValue ?? ""))
+        );
       }),
       responseStatus: filterValue.responseStatus,
     });
@@ -307,6 +319,13 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
                           (q.type === s.elementType.elementType || q.type === s.elementType.type) &&
                           q.id === s.elementType.id
                       )?.filterComboBoxOptions
+                    }
+                    fieldDataType={
+                      selectedOptions.elementFilterOptions.find(
+                        (q) =>
+                          (q.type === s.elementType.elementType || q.type === s.elementType.type) &&
+                          q.id === s.elementType.id
+                      )?.fieldDataType
                     }
                     filterValue={filterValue.filter[i].filterType.filterValue}
                     filterComboBoxValue={filterValue.filter[i].filterType.filterComboBoxValue}

--- a/apps/web/app/lib/surveys/surveys.test.ts
+++ b/apps/web/app/lib/surveys/surveys.test.ts
@@ -1,6 +1,8 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
+import { TFunction } from "i18next";
 import { afterEach, describe, expect, test } from "vitest";
+import { deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
 import { type TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyLanguage } from "@formbricks/types/surveys/types";
 import { TTag } from "@formbricks/types/tags";
@@ -11,6 +13,28 @@ import {
 } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/components/response-filter-context";
 import { OptionsType } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementsComboBox";
 import { generateElementAndFilterOptions, getFormattedFilters, getTodayDate } from "./surveys";
+
+const t = ((key: string) => key) as TFunction;
+
+/** A survey as readers receive it: EmbeddedData rows inlined from the legacy columns (ENG-2412). */
+const asRead = (survey: TSurvey): TSurvey =>
+  ({ ...survey, embeddedFields: deriveLegacyEmbeddedData(survey) }) as TSurvey;
+
+const genOptions = (
+  survey: TSurvey,
+  extra: Partial<Parameters<typeof generateElementAndFilterOptions>[0]> = {}
+) =>
+  generateElementAndFilterOptions({
+    survey: asRead(survey),
+    environmentTags: undefined,
+    attributes: {},
+    reservedValues: {},
+    hiddenFields: {},
+    variableValues: {},
+    quotas: [],
+    t,
+    ...extra,
+  });
 
 describe("surveys", () => {
   afterEach(() => {
@@ -44,12 +68,13 @@ describe("surveys", () => {
         status: "draft",
       } as unknown as TSurvey;
 
-      const result = generateElementAndFilterOptions(survey, undefined, {}, {}, {}, []);
+      const result = genOptions(survey);
 
       expect(result.elementOptions.length).toBeGreaterThan(0);
       expect(result.elementOptions[0].header).toBe(OptionsType.ELEMENTS);
-      expect(result.elementFilterOptions.length).toBe(1);
-      expect(result.elementFilterOptions[0].id).toBe("q1");
+      const elementRows = result.elementFilterOptions.filter((o) => o.type !== "Meta");
+      expect(elementRows.length).toBe(1);
+      expect(elementRows[0].id).toBe("q1");
     });
 
     test("should include tags in options when provided", () => {
@@ -67,7 +92,7 @@ describe("surveys", () => {
         { id: "tag1", name: "Tag 1", workspaceId: "env1", createdAt: new Date(), updatedAt: new Date() },
       ];
 
-      const result = generateElementAndFilterOptions(survey, tags, {}, {}, {}, []);
+      const result = genOptions(survey, { environmentTags: tags });
 
       const tagsHeader = result.elementOptions.find((opt) => opt.header === OptionsType.TAGS);
       expect(tagsHeader).toBeDefined();
@@ -90,7 +115,7 @@ describe("surveys", () => {
         role: ["admin", "user"],
       };
 
-      const result = generateElementAndFilterOptions(survey, undefined, attributes, {}, {}, []);
+      const result = genOptions(survey, { attributes });
 
       const attributesHeader = result.elementOptions.find((opt) => opt.header === OptionsType.ATTRIBUTES);
       expect(attributesHeader).toBeDefined();
@@ -98,7 +123,7 @@ describe("surveys", () => {
       expect(attributesHeader?.option[0].label).toBe("role");
     });
 
-    test("should include meta in options when provided", () => {
+    test("meta options are catalog-driven, not derived from observed response values (ENG-1848)", () => {
       const survey = {
         id: "survey1",
         name: "Test Survey",
@@ -107,43 +132,107 @@ describe("surveys", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         status: "draft",
+        isCaptureIpEnabled: true,
       } as unknown as TSurvey;
 
-      const meta = {
-        source: ["web", "mobile"],
-      };
-
-      const result = generateElementAndFilterOptions(survey, undefined, {}, meta, {}, []);
+      // No observed values passed at all — the fields must still be offered.
+      const result = genOptions(survey);
 
       const metaHeader = result.elementOptions.find((opt) => opt.header === OptionsType.META);
       expect(metaHeader).toBeDefined();
-      expect(metaHeader?.option.length).toBe(1);
-      expect(metaHeader?.option[0].label).toBe("source");
+      const ids = metaHeader?.option.map((o) => o.id) ?? [];
+      expect(ids).toContain("utmSource");
+      expect(ids).toContain("browser");
+      expect(ids).toContain("durationSeconds");
+      // Covered elsewhere (response status, date range) or meaningless as user filters.
+      for (const excluded of ["responseId", "surveyId", "finished", "startedAt", "language"]) {
+        expect(ids).not.toContain(excluded);
+      }
+
+      // Observed values feed the combobox when provided.
+      const withValues = genOptions(survey, { reservedValues: { utmSource: ["newsletter", "ads"] } });
+      const utmSource = withValues.elementFilterOptions.find((o) => o.id === "utmSource");
+      expect(utmSource?.filterComboBoxOptions).toEqual(["newsletter", "ads"]);
+      expect(utmSource?.fieldDataType).toBe("string");
     });
 
-    test("should include hidden fields in options when provided", () => {
+    test("reserved options drop shadowed names and respect the IP capture toggle", () => {
       const survey = {
         id: "survey1",
         name: "Test Survey",
         blocks: [],
         questions: [],
+        hiddenFields: { enabled: true, fieldIds: ["url"] },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        status: "draft",
+        isCaptureIpEnabled: false,
+      } as unknown as TSurvey;
+
+      const result = genOptions(survey);
+
+      const metaIds =
+        result.elementOptions.find((opt) => opt.header === OptionsType.META)?.option.map((o) => o.id) ?? [];
+      expect(metaIds).not.toContain("url"); // the declared field owns the name
+      expect(metaIds).not.toContain("ipAddress");
+      expect(metaIds).toContain("pagePath");
+    });
+
+    test("hidden fields enumerate from the survey's declared ingested fields", () => {
+      const survey = {
+        id: "survey1",
+        name: "Test Survey",
+        blocks: [],
+        questions: [],
+        hiddenFields: { enabled: true, fieldIds: ["segment"] },
         createdAt: new Date(),
         updatedAt: new Date(),
         status: "draft",
       } as unknown as TSurvey;
 
-      const hiddenFields = {
-        segment: ["free", "paid"],
-      };
+      // A declared field is filterable even before observed values exist.
+      const bare = genOptions(survey);
+      const bareHeader = bare.elementOptions.find((opt) => opt.header === OptionsType.HIDDEN_FIELDS);
+      expect(bareHeader?.option.length).toBe(1);
+      expect(bareHeader?.option[0].label).toBe("segment");
 
-      const result = generateElementAndFilterOptions(survey, undefined, {}, {}, hiddenFields, []);
-
-      const hiddenFieldsHeader = result.elementOptions.find(
-        (opt) => opt.header === OptionsType.HIDDEN_FIELDS
+      const result = genOptions(survey, { hiddenFields: { segment: ["free", "paid"] } });
+      const segment = result.elementFilterOptions.find(
+        (o) => o.type === "Hidden Fields" && o.id === "segment"
       );
-      expect(hiddenFieldsHeader).toBeDefined();
-      expect(hiddenFieldsHeader?.option.length).toBe(1);
-      expect(hiddenFieldsHeader?.option[0].label).toBe("segment");
+      expect(segment?.filterComboBoxOptions).toEqual(["free", "paid"]);
+      expect(segment?.filterOptions).toContain("Contains");
+      expect(segment?.filterOptions).toContain("Is set");
+    });
+
+    test("variables enumerate from the survey's computed fields, keyed by storageKey", () => {
+      const survey = {
+        id: "survey1",
+        name: "Test Survey",
+        blocks: [],
+        questions: [],
+        variables: [{ id: "var_score", name: "score", type: "number", value: 0 }],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        status: "draft",
+      } as unknown as TSurvey;
+
+      const result = genOptions(survey);
+
+      const variablesHeader = result.elementOptions.find((opt) => opt.header === OptionsType.VARIABLES);
+      expect(variablesHeader?.option).toEqual([
+        { label: "score", type: OptionsType.VARIABLES, id: "var_score" },
+      ]);
+      const score = result.elementFilterOptions.find((o) => o.type === "Variables" && o.id === "var_score");
+      expect(score?.fieldDataType).toBe("number");
+      expect(score?.filterOptions).toEqual([
+        "Equals",
+        "Not equals",
+        "Is greater than",
+        "Is less than",
+        "Is set",
+        "Is not set",
+      ]);
     });
 
     test("should include language options when survey has languages", () => {
@@ -158,7 +247,7 @@ describe("surveys", () => {
         languages: [{ language: { code: "en" } as unknown as TLanguage } as unknown as TSurveyLanguage],
       } as unknown as TSurvey;
 
-      const result = generateElementAndFilterOptions(survey, undefined, {}, {}, {}, []);
+      const result = genOptions(survey);
 
       const othersHeader = result.elementOptions.find((opt) => opt.header === OptionsType.OTHERS);
       expect(othersHeader).toBeDefined();
@@ -255,16 +344,16 @@ describe("surveys", () => {
         status: "draft",
       } as unknown as TSurvey;
 
-      const result = generateElementAndFilterOptions(survey, undefined, {}, {}, {}, []);
+      const result = genOptions(survey);
 
-      expect(result.elementFilterOptions.length).toBe(8);
+      expect(result.elementFilterOptions.filter((o) => o.type !== "Meta").length).toBe(8);
       expect(result.elementFilterOptions.some((o) => o.id === "q1")).toBeTruthy();
       expect(result.elementFilterOptions.some((o) => o.id === "q2")).toBeTruthy();
       expect(result.elementFilterOptions.some((o) => o.id === "q7")).toBeTruthy();
       expect(result.elementFilterOptions.some((o) => o.id === "q8")).toBeTruthy();
     });
 
-    test("should provide extended filter options for URL meta field", () => {
+    test("reserved fields get operators per dataType (ENG-1848)", () => {
       const survey = {
         id: "survey1",
         name: "Test Survey",
@@ -275,17 +364,9 @@ describe("surveys", () => {
         status: "draft",
       } as unknown as TSurvey;
 
-      const meta = {
-        url: ["https://example.com", "https://test.com"],
-        source: ["web", "mobile"],
-      };
+      const result = genOptions(survey);
 
-      const result = generateElementAndFilterOptions(survey, undefined, {}, meta, {}, []);
-
-      const urlFilterOption = result.elementFilterOptions.find((o) => o.id === "url");
-      const sourceFilterOption = result.elementFilterOptions.find((o) => o.id === "source");
-
-      expect(urlFilterOption).toBeDefined();
+      const urlFilterOption = result.elementFilterOptions.find((o) => o.type === "Meta" && o.id === "url");
       expect(urlFilterOption?.filterOptions).toEqual([
         "Equals",
         "Not equals",
@@ -295,10 +376,22 @@ describe("surveys", () => {
         "Does not start with",
         "Ends with",
         "Does not end with",
+        "Is set",
+        "Is not set",
       ]);
 
-      expect(sourceFilterOption).toBeDefined();
-      expect(sourceFilterOption?.filterOptions).toEqual(["Equals", "Not equals"]);
+      const screenWidthOption = result.elementFilterOptions.find(
+        (o) => o.type === "Meta" && o.id === "screenWidth"
+      );
+      expect(screenWidthOption?.fieldDataType).toBe("number");
+      expect(screenWidthOption?.filterOptions).toEqual([
+        "Equals",
+        "Not equals",
+        "Is greater than",
+        "Is less than",
+        "Is set",
+        "Is not set",
+      ]);
     });
 
     test("should include quota options in filter options when quotas are provided", () => {
@@ -313,7 +406,7 @@ describe("surveys", () => {
 
       const quotas = [{ id: "quota1" }];
 
-      const result = generateElementAndFilterOptions(survey, undefined, {}, {}, {}, quotas as any);
+      const result = genOptions(survey, { quotas: quotas as any });
 
       const quotaFilterOption = result.elementFilterOptions.find((o) => o.id === "quota1");
       expect(quotaFilterOption).toBeDefined();
@@ -338,7 +431,7 @@ describe("surveys", () => {
 
       const quotas = [{ id: "quota1" }, { id: "quota2" }];
 
-      const result = generateElementAndFilterOptions(survey, undefined, {}, {}, {}, quotas as any);
+      const result = genOptions(survey, { quotas: quotas as any });
 
       const quota1 = result.elementFilterOptions.find((o) => o.id === "quota1");
       const quota2 = result.elementFilterOptions.find((o) => o.id === "quota2");
@@ -359,7 +452,7 @@ describe("surveys", () => {
   });
 
   describe("getFormattedFilters", () => {
-    const survey = {
+    const survey = asRead({
       id: "survey1",
       name: "Test Survey",
       blocks: [
@@ -477,10 +570,12 @@ describe("surveys", () => {
         },
       ],
       questions: [],
+      hiddenFields: { enabled: true, fieldIds: ["plan"] },
+      variables: [{ id: "var_score", name: "score", type: "number", value: 0 }],
       createdAt: new Date(),
       updatedAt: new Date(),
       status: "draft",
-    } as unknown as TSurvey;
+    } as unknown as TSurvey);
 
     const dateRange: DateRange = {
       from: new Date("2023-01-01"),
@@ -843,12 +938,12 @@ describe("surveys", () => {
       expect(result.others?.Language).toEqual({ op: "equals", value: "en" });
     });
 
-    test("should filter by meta fields", () => {
+    test("reserved fields land in the reserved group, keyed by catalog name (ENG-1848)", () => {
       const selectedFilter: SelectedFilterValue = {
         responseStatus: "all",
         filter: [
           {
-            elementType: { type: "Meta", label: "source", id: "source" },
+            elementType: { type: "Meta", label: "Source", id: "source" },
             filterType: { filterValue: "Not equals", filterComboBoxValue: "web" },
           },
         ],
@@ -856,7 +951,77 @@ describe("surveys", () => {
 
       const result = getFormattedFilters(survey, selectedFilter, {} as any);
 
-      expect(result.meta?.source).toEqual({ op: "notEquals", value: "web" });
+      expect(result.reserved?.source).toEqual({ op: "notEquals", value: "web" });
+      expect(result.meta).toBeUndefined();
+    });
+
+    test("number-typed reserved values are sent as numbers, presence ops carry no value", () => {
+      const selectedFilter: SelectedFilterValue = {
+        responseStatus: "all",
+        filter: [
+          {
+            elementType: { type: "Meta", label: "Screen Width", id: "screenWidth" },
+            filterType: { filterValue: "Is greater than", filterComboBoxValue: "1000" },
+          },
+          {
+            elementType: { type: "Meta", label: "UTM Source", id: "utmSource" },
+            filterType: { filterValue: "Is set", filterComboBoxValue: undefined },
+          },
+        ],
+      } as any;
+
+      const result = getFormattedFilters(survey, selectedFilter, {} as any);
+
+      expect(result.reserved?.screenWidth).toEqual({ op: "greaterThan", value: 1000 });
+      expect(result.reserved?.utmSource).toEqual({ op: "isSet" });
+    });
+
+    test("fails closed: an unknown or shadowed reserved id emits nothing", () => {
+      const selectedFilter: SelectedFilterValue = {
+        responseStatus: "all",
+        filter: [
+          {
+            elementType: { type: "Meta", label: "Nope", id: "notInCatalog" },
+            filterType: { filterValue: "Equals", filterComboBoxValue: "x" },
+          },
+        ],
+      } as any;
+
+      const result = getFormattedFilters(survey, selectedFilter, {} as any);
+
+      expect(result.reserved).toBeUndefined();
+    });
+
+    test("variables land in the variables group keyed by storageKey, coerced to their dataType", () => {
+      const selectedFilter: SelectedFilterValue = {
+        responseStatus: "all",
+        filter: [
+          {
+            elementType: { type: "Variables", label: "score", id: "var_score" },
+            filterType: { filterValue: "Is less than", filterComboBoxValue: "5" },
+          },
+        ],
+      } as any;
+
+      const result = getFormattedFilters(survey, selectedFilter, {} as any);
+
+      expect(result.variables?.var_score).toEqual({ op: "lessThan", value: 5 });
+    });
+
+    test("ingested presence maps onto the data group's submitted/skipped vocabulary", () => {
+      const selectedFilter: SelectedFilterValue = {
+        responseStatus: "all",
+        filter: [
+          {
+            elementType: { type: "Hidden Fields", label: "plan", id: "plan" },
+            filterType: { filterValue: "Is not set", filterComboBoxValue: undefined },
+          },
+        ],
+      } as any;
+
+      const result = getFormattedFilters(survey, selectedFilter, {} as any);
+
+      expect(result.data?.plan).toEqual({ op: "skipped" });
     });
 
     test("should handle multiple filters together", () => {
@@ -900,7 +1065,7 @@ describe("surveys", () => {
 
       const result = getFormattedFilters(survey, selectedFilter, dateRange);
 
-      expect(result.meta?.url).toEqual({ op: "contains", value: "example.com" });
+      expect(result.reserved?.url).toEqual({ op: "contains", value: "example.com" });
     });
 
     test("should format URL meta filters with all supported string operations", () => {
@@ -927,7 +1092,7 @@ describe("surveys", () => {
         } as any;
 
         const result = getFormattedFilters(survey, selectedFilter, dateRange);
-        expect(result.meta?.url).toEqual(expected);
+        expect(result.reserved?.url).toEqual(expected);
       });
     });
 
@@ -944,7 +1109,7 @@ describe("surveys", () => {
 
       const result = getFormattedFilters(survey, selectedFilter, dateRange);
 
-      expect(result.meta?.url).toBeUndefined();
+      expect(result.reserved?.url).toBeUndefined();
     });
 
     test("should handle URL meta filters with whitespace-only values", () => {
@@ -960,7 +1125,8 @@ describe("surveys", () => {
 
       const result = getFormattedFilters(survey, selectedFilter, dateRange);
 
-      expect(result.meta?.url).toEqual({ op: "contains", value: "" });
+      // A whitespace-only value cannot form a condition; the row drops instead of matching nothing.
+      expect(result.reserved?.url).toBeUndefined();
     });
 
     test("should still handle existing meta filters with array values", () => {
@@ -976,7 +1142,7 @@ describe("surveys", () => {
 
       const result = getFormattedFilters(survey, selectedFilter, dateRange);
 
-      expect(result.meta?.source).toEqual({ op: "equals", value: "google" });
+      expect(result.reserved?.source).toEqual({ op: "equals", value: "google" });
     });
 
     test("should handle mixed URL and traditional meta filters", () => {
@@ -996,8 +1162,8 @@ describe("surveys", () => {
 
       const result = getFormattedFilters(survey, selectedFilter, dateRange);
 
-      expect(result.meta?.url).toEqual({ op: "contains", value: "formbricks.com" });
-      expect(result.meta?.source).toEqual({ op: "equals", value: "newsletter" });
+      expect(result.reserved?.url).toEqual({ op: "contains", value: "formbricks.com" });
+      expect(result.reserved?.source).toEqual({ op: "equals", value: "newsletter" });
     });
 
     test("should filter by quota with screened in status", () => {

--- a/apps/web/app/lib/surveys/surveys.test.ts
+++ b/apps/web/app/lib/surveys/surveys.test.ts
@@ -73,7 +73,7 @@ describe("surveys", () => {
       expect(result.elementOptions.length).toBeGreaterThan(0);
       expect(result.elementOptions[0].header).toBe(OptionsType.ELEMENTS);
       const elementRows = result.elementFilterOptions.filter((o) => o.type !== "Meta");
-      expect(elementRows.length).toBe(1);
+      expect(elementRows).toHaveLength(1);
       expect(elementRows[0].id).toBe("q1");
     });
 
@@ -346,7 +346,7 @@ describe("surveys", () => {
 
       const result = genOptions(survey);
 
-      expect(result.elementFilterOptions.filter((o) => o.type !== "Meta").length).toBe(8);
+      expect(result.elementFilterOptions.filter((o) => o.type !== "Meta")).toHaveLength(8);
       expect(result.elementFilterOptions.some((o) => o.id === "q1")).toBeTruthy();
       expect(result.elementFilterOptions.some((o) => o.id === "q2")).toBeTruthy();
       expect(result.elementFilterOptions.some((o) => o.id === "q7")).toBeTruthy();
@@ -1081,6 +1081,22 @@ describe("surveys", () => {
         {} as any
       );
       expect(boolContains.data?.is_pro).toBeUndefined();
+
+      // Only the exact literals are booleans — "yes" must drop, not coerce to false.
+      const boolGarbage = getFormattedFilters(
+        typedSurvey,
+        {
+          responseStatus: "all",
+          filter: [
+            {
+              elementType: { type: "Hidden Fields", label: "is_pro", id: "is_pro" },
+              filterType: { filterValue: "Equals", filterComboBoxValue: "yes" },
+            },
+          ],
+        } as any,
+        {} as any
+      );
+      expect(boolGarbage.data?.is_pro).toBeUndefined();
     });
 
     test("ingested presence maps onto the data group's submitted/skipped vocabulary", () => {

--- a/apps/web/app/lib/surveys/surveys.test.ts
+++ b/apps/web/app/lib/surveys/surveys.test.ts
@@ -1008,6 +1008,81 @@ describe("surveys", () => {
       expect(result.variables?.var_score).toEqual({ op: "lessThan", value: 5 });
     });
 
+    test("boolean and date ingested fields coerce per dataType; invalid numbers drop the row", () => {
+      // Legacy-derived fields are all string-typed, so craft the typed rows directly.
+      const typedSurvey = {
+        ...survey,
+        embeddedFields: [
+          ...(survey.embeddedFields ?? []),
+          {
+            field: {
+              name: "is_pro",
+              source: "ingested",
+              dataType: "boolean",
+              defaultValue: null,
+              locked: false,
+            },
+            link: { storageKey: "is_pro" },
+          },
+          {
+            field: {
+              name: "signup_date",
+              source: "ingested",
+              dataType: "date",
+              defaultValue: null,
+              locked: false,
+            },
+            link: { storageKey: "signup_date" },
+          },
+        ],
+      } as TSurvey;
+
+      const result = getFormattedFilters(
+        typedSurvey,
+        {
+          responseStatus: "all",
+          filter: [
+            {
+              elementType: { type: "Hidden Fields", label: "is_pro", id: "is_pro" },
+              filterType: { filterValue: "Equals", filterComboBoxValue: "true" },
+            },
+            {
+              elementType: { type: "Hidden Fields", label: "signup_date", id: "signup_date" },
+              filterType: { filterValue: "Is before", filterComboBoxValue: "2026-01-01" },
+            },
+            {
+              elementType: { type: "Variables", label: "score", id: "var_score" },
+              filterType: { filterValue: "Is less than", filterComboBoxValue: "abc" },
+            },
+          ],
+        } as any,
+        {} as any
+      );
+
+      // Booleans are stored as real jsonb booleans, so the filter value must be one too.
+      expect(result.data?.is_pro).toEqual({ op: "equals", value: true });
+      // Dates ride the comparison ops with the ISO string.
+      expect(result.data?.signup_date).toEqual({ op: "lessThan", value: "2026-01-01" });
+      // A non-numeric value for a number field cannot form a condition — the row drops.
+      expect(result.variables).toBeUndefined();
+
+      // A text op makes no sense on a boolean — dropped rather than matching wrongly.
+      const boolContains = getFormattedFilters(
+        typedSurvey,
+        {
+          responseStatus: "all",
+          filter: [
+            {
+              elementType: { type: "Hidden Fields", label: "is_pro", id: "is_pro" },
+              filterType: { filterValue: "Contains", filterComboBoxValue: "tru" },
+            },
+          ],
+        } as any,
+        {} as any
+      );
+      expect(boolContains.data?.is_pro).toBeUndefined();
+    });
+
     test("ingested presence maps onto the data group's submitted/skipped vocabulary", () => {
       const selectedFilter: SelectedFilterValue = {
         responseStatus: "all",

--- a/apps/web/app/lib/surveys/surveys.ts
+++ b/apps/web/app/lib/surveys/surveys.ts
@@ -192,6 +192,7 @@ const buildTypedFieldCondition = (
   }
   if (dataType === "boolean") {
     if (op !== "equals" && op !== "notEquals") return null;
+    if (value !== "true" && value !== "false") return null;
     return { op, value: value === "true" } as TTypedFieldFilterCondition;
   }
   return { op, value } as TTypedFieldFilterCondition;

--- a/apps/web/app/lib/surveys/surveys.ts
+++ b/apps/web/app/lib/surveys/surveys.ts
@@ -1,3 +1,9 @@
+import { TFunction } from "i18next";
+import { TEmbeddedDataType } from "@formbricks/types/embedded-data";
+import {
+  getComputedEmbeddedFields,
+  getIngestedEmbeddedFields,
+} from "@formbricks/types/embedded-data-resolver";
 import { TSurveyQuota } from "@formbricks/types/quota";
 import {
   TResponseFilterCriteria,
@@ -21,7 +27,9 @@ import {
 } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ElementsComboBox";
 import { ElementFilterOptions } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ResponseFilter";
 import { getLocalizedValue } from "@/lib/i18n/utils";
+import { getReservedFilterEntries } from "@/lib/response/utils";
 import { recallToHeadline } from "@/lib/utils/recall";
+import { getReservedFieldLabel } from "@/modules/analysis/lib/reserved-field-display";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 
 const conditionOptions: Record<string, string[]> = {
@@ -114,14 +122,100 @@ const META_OP_MAP = {
   "Does not end with": "doesNotEndWith",
 } as const;
 
-export const generateElementAndFilterOptions = (
-  survey: TSurvey,
-  environmentTags: TTag[] | undefined,
-  attributes: TSurveyContactAttributes,
-  meta: TSurveyMetaFieldFilter,
-  hiddenFields: TResponseHiddenFieldsFilter,
-  quotas: TSurveyQuota[]
-): {
+/** Operators that take no right-hand value; rows carrying them must survive the empty-value cleanup. */
+export const NO_VALUE_FILTER_OPERATORS = ["Is set", "Is not set"];
+
+// Operator menus per Embedded Data / reserved field dataType (ENG-1848) — the editor's
+// logic-builder model: string → equality + text ops, number → comparisons, date → before/after,
+// boolean → equality; every family can also match on absence.
+const TEXT_FIELD_OPERATORS = [...Object.keys(META_OP_MAP), ...NO_VALUE_FILTER_OPERATORS];
+const NUMBER_FIELD_OPERATORS = [
+  "Equals",
+  "Not equals",
+  "Is greater than",
+  "Is less than",
+  ...NO_VALUE_FILTER_OPERATORS,
+];
+const DATE_FIELD_OPERATORS = ["Equals", "Not equals", "Is before", "Is after", ...NO_VALUE_FILTER_OPERATORS];
+const BOOLEAN_FIELD_OPERATORS = ["Equals", "Not equals", ...NO_VALUE_FILTER_OPERATORS];
+
+const getTypedFieldOperators = (dataType: TEmbeddedDataType): string[] => {
+  switch (dataType) {
+    case "number":
+      return NUMBER_FIELD_OPERATORS;
+    case "date":
+      return DATE_FIELD_OPERATORS;
+    case "boolean":
+      return BOOLEAN_FIELD_OPERATORS;
+    default:
+      return TEXT_FIELD_OPERATORS;
+  }
+};
+
+// Operator label → criteria op for the typed field groups. "Is before"/"Is after" reuse the
+// comparison ops: jsonb compares same-format ISO strings lexicographically, i.e. chronologically.
+const TYPED_FIELD_OP_MAP: Record<string, string> = {
+  ...META_OP_MAP,
+  "Is greater than": "greaterThan",
+  "Is less than": "lessThan",
+  "Is before": "lessThan",
+  "Is after": "greaterThan",
+  "Is set": "isSet",
+  "Is not set": "isNotSet",
+};
+
+type TTypedFieldFilterCondition = NonNullable<TResponseFilterCriteria["reserved"]>[string];
+
+/**
+ * One filter row → one typed condition, coerced to the field's dataType (a number field must send a
+ * real number — a string-typed `equals` never matches a jsonb number). Returns null when the row
+ * cannot form a valid condition, so half-filled rows drop instead of matching wrongly.
+ */
+const buildTypedFieldCondition = (
+  filterType: FilterValue["filterType"],
+  dataType: TEmbeddedDataType
+): TTypedFieldFilterCondition | null => {
+  const op = TYPED_FIELD_OP_MAP[filterType.filterValue ?? ""];
+  if (!op) return null;
+  if (op === "isSet" || op === "isNotSet") return { op };
+
+  const raw = Array.isArray(filterType.filterComboBoxValue)
+    ? filterType.filterComboBoxValue[0]
+    : filterType.filterComboBoxValue;
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  const value = raw.trim();
+
+  if (dataType === "number") {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return null;
+    return { op, value: numeric } as TTypedFieldFilterCondition;
+  }
+  if (dataType === "boolean") {
+    if (op !== "equals" && op !== "notEquals") return null;
+    return { op, value: value === "true" } as TTypedFieldFilterCondition;
+  }
+  return { op, value } as TTypedFieldFilterCondition;
+};
+
+export const generateElementAndFilterOptions = ({
+  survey,
+  environmentTags,
+  attributes,
+  reservedValues,
+  hiddenFields,
+  variableValues,
+  quotas,
+  t,
+}: {
+  survey: TSurvey;
+  environmentTags: TTag[] | undefined;
+  attributes: TSurveyContactAttributes;
+  reservedValues: TSurveyMetaFieldFilter;
+  hiddenFields: TResponseHiddenFieldsFilter;
+  variableValues: TSurveyMetaFieldFilter;
+  quotas: TSurveyQuota[];
+  t: TFunction;
+}): {
   elementOptions: ElementOptions[];
   elementFilterOptions: ElementFilterOptions[];
 } => {
@@ -186,42 +280,77 @@ export const generateElementAndFilterOptions = (
     });
   }
 
-  if (meta) {
+  // Reserved fields, catalog-driven (ENG-1848): the same per-survey list the response table shows
+  // (shadowed / anonymized / uncaptured entries gated out by getReservedFilterEntries), with the
+  // table's localized labels and operators per dataType — no longer whatever meta keys the stored
+  // responses happened to hold.
+  const reservedEntries = getReservedFilterEntries(survey);
+  if (reservedEntries.length > 0) {
     elementOptions = [
       ...elementOptions,
       {
         header: OptionsType.META,
-        option: Object.keys(meta).map((m) => {
-          return { label: m, type: OptionsType.META, id: m };
+        option: reservedEntries.map((entry) => {
+          return { label: getReservedFieldLabel(entry.name, t), type: OptionsType.META, id: entry.name };
         }),
       },
     ];
-    Object.keys(meta).forEach((m) => {
+    reservedEntries.forEach((entry) => {
       elementFilterOptions.push({
         type: "Meta",
-        filterOptions: m === "url" ? Object.keys(META_OP_MAP) : ["Equals", "Not equals"],
-        filterComboBoxOptions: meta[m],
-        id: m,
+        filterOptions: getTypedFieldOperators(entry.dataType),
+        filterComboBoxOptions: reservedValues[entry.name] ?? [],
+        fieldDataType: entry.dataType,
+        id: entry.name,
       });
     });
   }
 
-  if (hiddenFields) {
+  // Ingested embedded fields enumerate from the survey's rows, not from observed response values —
+  // a declared field is filterable before its first response. Values live at data[storageKey].
+  const ingestedFields = getIngestedEmbeddedFields(survey);
+  if (ingestedFields.length > 0) {
     elementOptions = [
       ...elementOptions,
       {
         header: OptionsType.HIDDEN_FIELDS,
-        option: Object.keys(hiddenFields).map((hiddenField) => {
-          return { label: hiddenField, type: OptionsType.HIDDEN_FIELDS, id: hiddenField };
+        option: ingestedFields.map(({ field, link }) => {
+          return { label: field.name, type: OptionsType.HIDDEN_FIELDS, id: link.storageKey };
         }),
       },
     ];
-    Object.keys(hiddenFields).forEach((hiddenField) => {
+    ingestedFields.forEach(({ field, link }) => {
       elementFilterOptions.push({
         type: "Hidden Fields",
-        filterOptions: ["Equals", "Not equals"],
-        filterComboBoxOptions: hiddenFields[hiddenField],
-        id: hiddenField,
+        filterOptions: getTypedFieldOperators(field.dataType),
+        filterComboBoxOptions:
+          field.dataType === "boolean" ? ["true", "false"] : (hiddenFields[link.storageKey] ?? []),
+        fieldDataType: field.dataType,
+        id: link.storageKey,
+      });
+    });
+  }
+
+  // Computed embedded fields (variables), keyed by storageKey (ENG-1848).
+  const computedFields = getComputedEmbeddedFields(survey);
+  if (computedFields.length > 0) {
+    elementOptions = [
+      ...elementOptions,
+      {
+        header: OptionsType.VARIABLES,
+        option: computedFields.map(({ field, link }) => {
+          return { label: field.name, type: OptionsType.VARIABLES, id: link.storageKey };
+        }),
+      },
+    ];
+    computedFields.forEach(({ field, link }) => {
+      elementFilterOptions.push({
+        type: "Variables",
+        filterOptions: getTypedFieldOperators(field.dataType),
+        filterComboBoxOptions:
+          field.dataType === "boolean" ? ["true", "false"] : (variableValues[link.storageKey] ?? []),
+        fieldDataType: field.dataType,
+        id: link.storageKey,
       });
     });
   }
@@ -460,23 +589,16 @@ const processElementFilters = (
   });
 };
 
-// Helper function to process equals/not equals filters (for hiddenFields, attributes, others)
+// Helper function to process equals/not equals filters (for attributes, others)
 const processEqualsNotEqualsFilter = (
   filterType: FilterValue["filterType"],
   label: string | undefined,
   filters: TResponseFilterCriteria,
-  targetKey: "data" | "contactAttributes" | "others"
+  targetKey: "contactAttributes" | "others"
 ) => {
   if (!filterType.filterComboBoxValue) return;
 
-  if (targetKey === "data") {
-    filters.data = filters.data || {};
-    if (filterType.filterValue === "Equals") {
-      filters.data[label ?? ""] = { op: "equals", value: filterType.filterComboBoxValue as string };
-    } else if (filterType.filterValue === "Not equals") {
-      filters.data[label ?? ""] = { op: "notEquals", value: filterType.filterComboBoxValue as string };
-    }
-  } else if (targetKey === "contactAttributes") {
+  if (targetKey === "contactAttributes") {
     filters.contactAttributes = filters.contactAttributes || {};
     if (filterType.filterValue === "Equals") {
       filters.contactAttributes[label ?? ""] = {
@@ -499,32 +621,77 @@ const processEqualsNotEqualsFilter = (
   }
 };
 
-// Helper function to process meta filters
-const processMetaFilters = (meta: FilterValue[], filters: TResponseFilterCriteria) => {
-  if (!meta.length) return;
+// Reserved-field filter rows → the `reserved` criteria group, keyed by catalog name (ENG-1848).
+const processReservedFilters = (
+  reserved: FilterValue[],
+  survey: TSurvey,
+  filters: TResponseFilterCriteria
+) => {
+  if (!reserved.length) return;
 
-  filters.meta = filters.meta || {};
+  const entriesByName = new Map(getReservedFilterEntries(survey).map((entry) => [entry.name, entry]));
 
-  meta.forEach(({ filterType, elementType }) => {
-    const label = elementType.label ?? "";
-    const metaFilters = filters.meta!; // Safe because we initialized it above
+  reserved.forEach(({ filterType, elementType }) => {
+    const entry = entriesByName.get(elementType.id ?? "");
+    if (!entry) return; // fail closed: shadowed/gated names never emit a reserved condition
 
-    // For text input cases (URL filtering)
-    if (typeof filterType.filterComboBoxValue === "string" && filterType.filterComboBoxValue.length > 0) {
-      const value = filterType.filterComboBoxValue.trim();
-      const op = META_OP_MAP[filterType.filterValue as keyof typeof META_OP_MAP];
-      if (op) {
-        metaFilters[label] = { op, value };
-      }
-    }
-    // For dropdown/select cases (existing metadata fields)
-    else if (Array.isArray(filterType.filterComboBoxValue) && filterType.filterComboBoxValue.length > 0) {
-      const value = filterType.filterComboBoxValue[0];
-      if (filterType.filterValue === "Equals") {
-        metaFilters[label] = { op: "equals", value };
-      } else if (filterType.filterValue === "Not equals") {
-        metaFilters[label] = { op: "notEquals", value };
-      }
+    const condition = buildTypedFieldCondition(filterType, entry.dataType);
+    if (!condition) return;
+    filters.reserved = filters.reserved || {};
+    filters.reserved[entry.name] = condition;
+  });
+};
+
+// Computed-field filter rows → the `variables` criteria group, keyed by storageKey (ENG-1848).
+const processVariableFilters = (
+  variables: FilterValue[],
+  survey: TSurvey,
+  filters: TResponseFilterCriteria
+) => {
+  if (!variables.length) return;
+
+  const fieldsByKey = new Map(
+    getComputedEmbeddedFields(survey).map((field) => [field.link.storageKey, field])
+  );
+
+  variables.forEach(({ filterType, elementType }) => {
+    const field = fieldsByKey.get(elementType.id ?? "");
+    if (!field) return;
+
+    const condition = buildTypedFieldCondition(filterType, field.field.dataType);
+    if (!condition) return;
+    filters.variables = filters.variables || {};
+    filters.variables[field.link.storageKey] = condition;
+  });
+};
+
+// Ingested-field filter rows → the `data` group under the storageKey. Presence maps onto the data
+// group's own vocabulary: submitted (key present) / skipped (absent or empty), matching isSet's
+// treatment of "" as not set.
+const processIngestedFilters = (
+  hiddenFields: FilterValue[],
+  survey: TSurvey,
+  filters: TResponseFilterCriteria
+) => {
+  if (!hiddenFields.length) return;
+
+  const fieldsByKey = new Map(
+    getIngestedEmbeddedFields(survey).map((field) => [field.link.storageKey, field])
+  );
+
+  hiddenFields.forEach(({ filterType, elementType }) => {
+    const field = fieldsByKey.get(elementType.id ?? "");
+    if (!field) return;
+
+    const condition = buildTypedFieldCondition(filterType, field.field.dataType);
+    if (!condition) return;
+    filters.data = filters.data || {};
+    if (condition.op === "isSet") {
+      filters.data[field.link.storageKey] = { op: "submitted" };
+    } else if (condition.op === "isNotSet") {
+      filters.data[field.link.storageKey] = { op: "skipped" };
+    } else {
+      filters.data[field.link.storageKey] = condition;
     }
   });
 };
@@ -564,6 +731,7 @@ export const getFormattedFilters = (
   const others: FilterValue[] = [];
   const meta: FilterValue[] = [];
   const hiddenFields: FilterValue[] = [];
+  const variables: FilterValue[] = [];
   const quotas: FilterValue[] = [];
 
   selectedFilter.filter.forEach((filter) => {
@@ -579,6 +747,8 @@ export const getFormattedFilters = (
       meta.push(filter);
     } else if (filter.elementType?.type === "Hidden Fields") {
       hiddenFields.push(filter);
+    } else if (filter.elementType?.type === "Variables") {
+      variables.push(filter);
     } else if (filter.elementType?.type === "Quotas") {
       quotas.push(filter);
     }
@@ -615,14 +785,8 @@ export const getFormattedFilters = (
   }
 
   processElementFilters(elements, survey, filters);
-
-  // for hidden fields
-  if (hiddenFields.length) {
-    filters.data = filters.data || {};
-    hiddenFields.forEach(({ filterType, elementType }) => {
-      processEqualsNotEqualsFilter(filterType, elementType.label, filters, "data");
-    });
-  }
+  processIngestedFilters(hiddenFields, survey, filters);
+  processVariableFilters(variables, survey, filters);
 
   // for attributes
   if (attributes.length) {
@@ -640,7 +804,7 @@ export const getFormattedFilters = (
     });
   }
 
-  processMetaFilters(meta, filters);
+  processReservedFilters(meta, survey, filters);
   processQuotaFilters(quotas, filters);
 
   return filters;

--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -7,6 +7,7 @@ import { PrismaErrorType } from "@formbricks/database/types/error";
 import { logger } from "@formbricks/logger";
 import { ZId, ZOptionalNumber, ZString } from "@formbricks/types/common";
 import { type TIngestFlag, mergeIngestFlags } from "@formbricks/types/embedded-data-ingest";
+import { type TEmbeddedValueResponse } from "@formbricks/types/embedded-data-resolver";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import {
   TResponse,
@@ -38,6 +39,8 @@ import {
   getResponseContactAttributes,
   getResponseHiddenFields,
   getResponseMeta,
+  getResponseReservedFilterValues,
+  getResponseVariableFilterValues,
   getResponsesFileName,
   getResponsesJson,
   normalizeResponseLanguage,
@@ -295,17 +298,30 @@ export const getResponseFilteringValues = reactCache(async (surveyId: string) =>
         surveyId,
       },
       select: {
+        // The full TEmbeddedValueResponse shape, so reserved values run through the shared
+        // projection (redactQuery, type coercion) instead of raw meta reads (ENG-1848).
+        id: true,
+        surveyId: true,
+        createdAt: true,
+        updatedAt: true,
+        finished: true,
+        language: true,
         data: true,
+        variables: true,
+        ttc: true,
         meta: true,
         contactAttributes: true,
       },
     });
 
+    const embeddedValueResponses = responses as unknown as TEmbeddedValueResponse[];
     const contactAttributes = getResponseContactAttributes(responses);
     const meta = getResponseMeta(responses);
     const hiddenFields = getResponseHiddenFields(survey, responses);
+    const reservedValues = getResponseReservedFilterValues(survey, embeddedValueResponses);
+    const variableValues = getResponseVariableFilterValues(survey, embeddedValueResponses);
 
-    return { contactAttributes, meta, hiddenFields };
+    return { contactAttributes, meta, hiddenFields, reservedValues, variableValues };
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       throw new DatabaseError(error.message);

--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -284,6 +284,24 @@ export const getResponseSnapshotForPipeline = async (responseId: string): Promis
   }
 };
 
+// The full TEmbeddedValueResponse shape, so reserved values run through the shared projection
+// (redactQuery, type coercion) instead of raw meta reads (ENG-1848). Kept as a named selection so
+// the row type stays checked against TEmbeddedValueResponse — a field added there without being
+// selected here must fail the build, not read undefined at runtime.
+const filteringValuesSelection = {
+  id: true,
+  surveyId: true,
+  createdAt: true,
+  updatedAt: true,
+  finished: true,
+  language: true,
+  data: true,
+  variables: true,
+  ttc: true,
+  meta: true,
+  contactAttributes: true,
+} satisfies Prisma.ResponseSelect;
+
 export const getResponseFilteringValues = reactCache(async (surveyId: string) => {
   validateInputs([surveyId, ZId]);
 
@@ -297,24 +315,10 @@ export const getResponseFilteringValues = reactCache(async (surveyId: string) =>
       where: {
         surveyId,
       },
-      select: {
-        // The full TEmbeddedValueResponse shape, so reserved values run through the shared
-        // projection (redactQuery, type coercion) instead of raw meta reads (ENG-1848).
-        id: true,
-        surveyId: true,
-        createdAt: true,
-        updatedAt: true,
-        finished: true,
-        language: true,
-        data: true,
-        variables: true,
-        ttc: true,
-        meta: true,
-        contactAttributes: true,
-      },
+      select: filteringValuesSelection,
     });
 
-    const embeddedValueResponses = responses as unknown as TEmbeddedValueResponse[];
+    const embeddedValueResponses: TEmbeddedValueResponse[] = responses;
     const contactAttributes = getResponseContactAttributes(responses);
     const meta = getResponseMeta(responses);
     const hiddenFields = getResponseHiddenFields(survey, responses);

--- a/apps/web/lib/response/utils.test.ts
+++ b/apps/web/lib/response/utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { Prisma } from "@formbricks/database/prisma";
-import { RESERVED_FIELD_CATALOG, deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
+import {
+  RESERVED_FIELD_CATALOG,
+  type TEmbeddedValueResponse,
+  deriveLegacyEmbeddedData,
+} from "@formbricks/types/embedded-data-resolver";
 import { TResponse } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -13,6 +17,8 @@ import {
   getResponseContactAttributes,
   getResponseHiddenFields,
   getResponseMeta,
+  getResponseReservedFilterValues,
+  getResponseVariableFilterValues,
   getResponsesFileName,
   getResponsesJson,
 } from "./utils";
@@ -645,6 +651,97 @@ describe("Response Utils", () => {
       expect(mismatched.AND).toContainEqual({ AND: [] });
     });
 
+    test("every comparison and text-op arm translates one-to-one", () => {
+      const cases: Array<[object, object]> = [
+        [
+          { screenWidth: { op: "lessThan" as const, value: 800 } },
+          { meta: { path: ["screenWidth"], lt: 800 } },
+        ],
+        [
+          { screenWidth: { op: "lessEqual" as const, value: 800 } },
+          { meta: { path: ["screenWidth"], lte: 800 } },
+        ],
+        [
+          { screenWidth: { op: "greaterEqual" as const, value: 800 } },
+          { meta: { path: ["screenWidth"], gte: 800 } },
+        ],
+        [
+          { pagePath: { op: "contains" as const, value: "/checkout" } },
+          { meta: { path: ["pagePath"], string_contains: "/checkout" } },
+        ],
+        [
+          { pagePath: { op: "startsWith" as const, value: "/app" } },
+          { meta: { path: ["pagePath"], string_starts_with: "/app" } },
+        ],
+        [
+          { pagePath: { op: "doesNotStartWith" as const, value: "/app" } },
+          { NOT: { meta: { path: ["pagePath"], string_starts_with: "/app" } } },
+        ],
+        [
+          { pagePath: { op: "endsWith" as const, value: "/done" } },
+          { meta: { path: ["pagePath"], string_ends_with: "/done" } },
+        ],
+        [
+          { pagePath: { op: "doesNotEndWith" as const, value: "/done" } },
+          { NOT: { meta: { path: ["pagePath"], string_ends_with: "/done" } } },
+        ],
+      ];
+      for (const [reserved, expected] of cases) {
+        const result = buildWhereClause(reservedSurvey, { reserved } as never);
+        expect(result.AND).toContainEqual({ AND: [expected] });
+      }
+    });
+
+    test("duration bounds stay consistent with the projection at every boundary", () => {
+      const lessEqual = buildWhereClause(reservedSurvey, {
+        reserved: { durationSeconds: { op: "lessEqual", value: 60 } },
+      });
+      expect(lessEqual.AND).toContainEqual({ AND: [{ ttc: { path: ["_total"], lt: 60500 } }] });
+
+      const greaterEqual = buildWhereClause(reservedSurvey, {
+        reserved: { durationSeconds: { op: "greaterEqual", value: 60 } },
+      });
+      expect(greaterEqual.AND).toContainEqual({ AND: [{ ttc: { path: ["_total"], gte: 59500 } }] });
+
+      const notEquals = buildWhereClause(reservedSurvey, {
+        reserved: { durationSeconds: { op: "notEquals", value: 13 } },
+      });
+      expect(JSON.stringify(notEquals.AND)).toMatch(
+        /"OR":\[\{"ttc":\{"path":\["_total"\],"lt":12500\}\},\{"ttc":\{"path":\["_total"\],"gte":13500\}\},\{"ttc":\{"path":\["_total"\],"equals":\{\}\}\}\]/
+      );
+
+      // A non-numeric value cannot form a window — nothing is emitted.
+      const notANumber = buildWhereClause(reservedSurvey, {
+        reserved: { durationSeconds: { op: "equals", value: "abc" } },
+      });
+      expect(notANumber.AND).toContainEqual({ AND: [] });
+    });
+
+    test("data text ops: remaining arms translate one-to-one", () => {
+      const cases: Array<[object, object]> = [
+        [
+          { plan: { op: "doesNotContain" as const, value: "trial" } },
+          { NOT: { data: { path: ["plan"], string_contains: "trial" } } },
+        ],
+        [
+          { plan: { op: "startsWith" as const, value: "gold" } },
+          { data: { path: ["plan"], string_starts_with: "gold" } },
+        ],
+        [
+          { plan: { op: "doesNotStartWith" as const, value: "gold" } },
+          { NOT: { data: { path: ["plan"], string_starts_with: "gold" } } },
+        ],
+        [
+          { plan: { op: "endsWith" as const, value: "-v2" } },
+          { data: { path: ["plan"], string_ends_with: "-v2" } },
+        ],
+      ];
+      for (const [data, expected] of cases) {
+        const result = buildWhereClause(reservedSurvey, { data } as never);
+        expect(result.AND).toContainEqual({ AND: [expected] });
+      }
+    });
+
     test("variables filter by computed storageKey, unknown keys emit nothing", () => {
       const known = buildWhereClause(reservedSurvey, {
         variables: { var_score: { op: "greaterEqual", value: 5 } },
@@ -739,6 +836,76 @@ describe("Response Utils", () => {
       } as TSurvey).map((entry) => entry.name);
       expect(ipOff).not.toContain("ipAddress");
       expect(ipOff).toContain("country");
+    });
+  });
+
+  describe("filter value helpers (ENG-1848)", () => {
+    const valueSurvey = asRead({
+      id: "s5",
+      name: "FilterValuesSurvey",
+      blocks: [],
+      questions: [],
+      type: "link",
+      hiddenFields: { enabled: true, fieldIds: [] },
+      variables: [
+        { id: "var_plan", name: "plan_name", type: "text" as const, value: "" },
+        { id: "var_score", name: "score", type: "number" as const, value: 0 },
+      ],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      workspaceId: "e5",
+      createdBy: "u5",
+      status: "inProgress",
+    }) as TSurvey;
+
+    const mkResponse = (over: Record<string, unknown>): TEmbeddedValueResponse =>
+      ({
+        id: "r1",
+        surveyId: "s5",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        finished: true,
+        language: null,
+        data: {},
+        variables: {},
+        ttc: {},
+        meta: {},
+        ...over,
+      }) as unknown as TEmbeddedValueResponse;
+
+    test("reserved values: distinct strings by catalog name, projected (url query-stripped), numbers skipped", () => {
+      const values = getResponseReservedFilterValues(valueSurvey, [
+        mkResponse({ meta: { utmSource: "newsletter", url: "https://x.test/p?email=leak@x.test" } }),
+        mkResponse({ meta: { utmSource: "newsletter", screenWidth: 1280 } }),
+        mkResponse({ meta: { utmSource: "ads" } }),
+      ]);
+
+      expect(values.utmSource).toEqual(["newsletter", "ads"]);
+      // The dropdown gets the projected value, so the query string never leaks into filter options.
+      expect(values.url).toEqual(["https://x.test/p"]);
+      // Number-typed entries get a numeric input, not an options list.
+      expect(values.screenWidth).toBeUndefined();
+    });
+
+    test("reserved values respect the per-survey gates", () => {
+      const anonymized = { ...valueSurvey, isAnonymizeResponsesEnabled: true } as TSurvey;
+      const values = getResponseReservedFilterValues(anonymized, [
+        mkResponse({ meta: { country: "DE", utmSource: "ads" } }),
+      ]);
+      expect(values.country).toBeUndefined();
+      expect(values.utmSource).toEqual(["ads"]);
+    });
+
+    test("variable values: distinct strings keyed by storageKey, non-string fields and empties skipped", () => {
+      const values = getResponseVariableFilterValues(valueSurvey, [
+        mkResponse({ variables: { var_plan: "gold", var_score: 5 } }),
+        mkResponse({ variables: { var_plan: "gold" } }),
+        mkResponse({ variables: { var_plan: "" } }),
+        mkResponse({ variables: { var_plan: "silver" } }),
+      ]);
+
+      expect(values.var_plan).toEqual(["gold", "silver"]);
+      expect(values.var_score).toBeUndefined();
     });
   });
 

--- a/apps/web/lib/response/utils.test.ts
+++ b/apps/web/lib/response/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { Prisma } from "@formbricks/database/prisma";
-import { deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
+import { RESERVED_FIELD_CATALOG, deriveLegacyEmbeddedData } from "@formbricks/types/embedded-data-resolver";
 import { TResponse } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -9,13 +9,14 @@ import {
   extractChoiceIdsFromResponse,
   extractSurveyDetails,
   generateAllPermutationsOfSubsets,
+  getReservedFilterEntries,
   getResponseContactAttributes,
   getResponseHiddenFields,
   getResponseMeta,
   getResponsesFileName,
   getResponsesJson,
 } from "./utils";
-import { buildWhereClause } from "./where-clause";
+import { RESERVED_FILTER_LOCATORS, buildWhereClause } from "./where-clause";
 
 /**
  * A survey as a reader actually receives it: `transformPrismaSurvey` inlines the EmbeddedData rows
@@ -526,6 +527,218 @@ describe("Response Utils", () => {
           ],
         },
       ]);
+    });
+  });
+
+  describe("buildWhereClause – reserved + variables filters (ENG-1848)", () => {
+    const reservedSurvey = asRead({
+      id: "s3",
+      name: "ReservedSurvey",
+      blocks: [],
+      questions: [],
+      type: "link",
+      hiddenFields: { enabled: true, fieldIds: [] },
+      variables: [{ id: "var_score", name: "score", type: "number" as const, value: 0 }],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      workspaceId: "e3",
+      createdBy: "u3",
+      status: "inProgress",
+    }) as TSurvey;
+
+    test("reserved string field filters its meta path with the catalog name", () => {
+      const result = buildWhereClause(reservedSurvey, {
+        reserved: { utmSource: { op: "equals", value: "newsletter" } },
+      });
+      expect(result.AND).toContainEqual({
+        AND: [{ meta: { path: ["utmSource"], equals: "newsletter" } }],
+      });
+    });
+
+    test("deviceType remaps to the stored userAgent.device path", () => {
+      const result = buildWhereClause(reservedSurvey, {
+        reserved: { deviceType: { op: "equals", value: "desktop" } },
+      });
+      expect(result.AND).toContainEqual({
+        AND: [{ meta: { path: ["userAgent", "device"], equals: "desktop" } }],
+      });
+    });
+
+    test("number-typed reserved field compares numerically", () => {
+      const result = buildWhereClause(reservedSurvey, {
+        reserved: { screenWidth: { op: "greaterThan", value: 1000 } },
+      });
+      expect(result.AND).toContainEqual({
+        AND: [{ meta: { path: ["screenWidth"], gt: 1000 } }],
+      });
+    });
+
+    test("negated text ops wrap in NOT, and notEquals also matches absent values", () => {
+      const contains = buildWhereClause(reservedSurvey, {
+        reserved: { pagePath: { op: "doesNotContain", value: "/checkout" } },
+      });
+      expect(contains.AND).toContainEqual({
+        AND: [{ NOT: { meta: { path: ["pagePath"], string_contains: "/checkout" } } }],
+      });
+
+      const notEquals = buildWhereClause(reservedSurvey, {
+        reserved: { country: { op: "notEquals", value: "DE" } },
+      });
+      // Prisma.DbNull stringifies to {}, hence the regex assertion (same trick as notUploaded above).
+      expect(JSON.stringify(notEquals.AND)).toMatch(
+        /"OR":\[\{"meta":\{"path":\["country"\],"not":"DE"\}\},\{"meta":\{"path":\["country"\],"equals":\{\}\}\}\]/
+      );
+    });
+
+    test("isSet / isNotSet match presence via DbNull", () => {
+      const isSet = buildWhereClause(reservedSurvey, { reserved: { utmSource: { op: "isSet" } } });
+      expect(JSON.stringify(isSet.AND)).toMatch(/"meta":\{"path":\["utmSource"\],"not":\{\}\}/);
+
+      const isNotSet = buildWhereClause(reservedSurvey, { reserved: { utmSource: { op: "isNotSet" } } });
+      expect(JSON.stringify(isNotSet.AND)).toMatch(/"meta":\{"path":\["utmSource"\],"equals":\{\}\}/);
+    });
+
+    test("durationSeconds filters ttc._total milliseconds through Math.round windows", () => {
+      const equals = buildWhereClause(reservedSurvey, {
+        reserved: { durationSeconds: { op: "equals", value: 13 } },
+      });
+      expect(equals.AND).toContainEqual({
+        AND: [
+          {
+            AND: [{ ttc: { path: ["_total"], gte: 12500 } }, { ttc: { path: ["_total"], lt: 13500 } }],
+          },
+        ],
+      });
+
+      // rounded > 60 starts at 60500ms (60499 rounds DOWN to 60), rounded < 60 ends below 59500.
+      const greaterThan = buildWhereClause(reservedSurvey, {
+        reserved: { durationSeconds: { op: "greaterThan", value: 60 } },
+      });
+      expect(greaterThan.AND).toContainEqual({ AND: [{ ttc: { path: ["_total"], gte: 60500 } }] });
+
+      const lessThan = buildWhereClause(reservedSurvey, {
+        reserved: { durationSeconds: { op: "lessThan", value: 60 } },
+      });
+      expect(lessThan.AND).toContainEqual({ AND: [{ ttc: { path: ["_total"], lt: 59500 } }] });
+    });
+
+    test("fails closed: shadowed, unknown, and type-mismatched conditions emit nothing", () => {
+      // `url` is declared as an ingested field here, so the reserved read must never be queried.
+      const shadowingSurvey = asRead({
+        ...reservedSurvey,
+        hiddenFields: { enabled: true, fieldIds: ["url"] },
+      }) as TSurvey;
+      const shadowed = buildWhereClause(shadowingSurvey, {
+        reserved: { url: { op: "equals", value: "https://x.test" } },
+      });
+      expect(shadowed.AND).toContainEqual({ AND: [] });
+
+      const unknown = buildWhereClause(reservedSurvey, {
+        reserved: { notInCatalog: { op: "equals", value: "x" } },
+      });
+      expect(unknown.AND).toContainEqual({ AND: [] });
+
+      // A text op on the number-typed duration entry has no meaningful translation.
+      const mismatched = buildWhereClause(reservedSurvey, {
+        reserved: { durationSeconds: { op: "contains", value: "6" } },
+      });
+      expect(mismatched.AND).toContainEqual({ AND: [] });
+    });
+
+    test("variables filter by computed storageKey, unknown keys emit nothing", () => {
+      const known = buildWhereClause(reservedSurvey, {
+        variables: { var_score: { op: "greaterEqual", value: 5 } },
+      });
+      expect(known.AND).toContainEqual({
+        AND: [{ variables: { path: ["var_score"], gte: 5 } }],
+      });
+
+      const unknown = buildWhereClause(reservedSurvey, {
+        variables: { not_a_variable: { op: "equals", value: 5 } },
+      });
+      expect(unknown.AND).toContainEqual({ AND: [] });
+    });
+
+    test("ingested string fields get text ops through the data group", () => {
+      const result = buildWhereClause(reservedSurvey, {
+        data: { plan: { op: "contains", value: "gold" } },
+      });
+      expect(result.AND).toContainEqual({
+        AND: [{ data: { path: ["plan"], string_contains: "gold" } }],
+      });
+
+      const negated = buildWhereClause(reservedSurvey, {
+        data: { plan: { op: "doesNotEndWith", value: "-trial" } },
+      });
+      expect(negated.AND).toContainEqual({
+        AND: [{ NOT: { data: { path: ["plan"], string_ends_with: "-trial" } } }],
+      });
+    });
+
+    test("anti-drift: every filterable catalog entry has a storage locator", () => {
+      const filterableNames = RESERVED_FIELD_CATALOG.filter(
+        (entry) => entry.display !== "none" || entry.name === "durationSeconds"
+      ).map((entry) => entry.name);
+      expect(filterableNames.length).toBeGreaterThan(0);
+      for (const name of filterableNames) {
+        expect(RESERVED_FILTER_LOCATORS[name], `catalog entry "${name}" has no filter locator`).toBeDefined();
+      }
+    });
+  });
+
+  describe("getReservedFilterEntries (ENG-1848)", () => {
+    const baseSurvey = asRead({
+      id: "s4",
+      name: "FilterEntriesSurvey",
+      blocks: [],
+      questions: [],
+      type: "link",
+      hiddenFields: { enabled: true, fieldIds: [] },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      workspaceId: "e4",
+      createdBy: "u4",
+      status: "inProgress",
+      isAnonymizeResponsesEnabled: false,
+      isCaptureIpEnabled: true,
+    }) as TSurvey;
+
+    test("offers the table's display entries plus durationSeconds, never ids or startedAt", () => {
+      const names = getReservedFilterEntries(baseSurvey).map((entry) => entry.name);
+      expect(names).toContain("utmSource");
+      expect(names).toContain("browser");
+      expect(names).toContain("durationSeconds");
+      for (const excluded of ["responseId", "surveyId", "finished", "startedAt", "finishedAt", "language"]) {
+        expect(names).not.toContain(excluded);
+      }
+    });
+
+    test("a declared field owns its name — the reserved entry is dropped", () => {
+      const shadowingSurvey = asRead({
+        ...baseSurvey,
+        hiddenFields: { enabled: true, fieldIds: ["url"] },
+      }) as TSurvey;
+      const names = getReservedFilterEntries(shadowingSurvey).map((entry) => entry.name);
+      expect(names).not.toContain("url");
+      expect(names).toContain("pagePath");
+    });
+
+    test("anonymized surveys drop never-captured fields; ipAddress follows its capture toggle", () => {
+      const anonymized = getReservedFilterEntries({
+        ...baseSurvey,
+        isAnonymizeResponsesEnabled: true,
+      } as TSurvey).map((entry) => entry.name);
+      for (const dropped of ["country", "browser", "os", "deviceType", "ipAddress"]) {
+        expect(anonymized).not.toContain(dropped);
+      }
+      expect(anonymized).toContain("utmSource");
+
+      const ipOff = getReservedFilterEntries({
+        ...baseSurvey,
+        isCaptureIpEnabled: false,
+      } as TSurvey).map((entry) => entry.name);
+      expect(ipOff).not.toContain("ipAddress");
+      expect(ipOff).toContain("country");
     });
   });
 

--- a/apps/web/lib/response/utils.test.ts
+++ b/apps/web/lib/response/utils.test.ts
@@ -649,6 +649,22 @@ describe("Response Utils", () => {
         reserved: { durationSeconds: { op: "contains", value: "6" } },
       });
       expect(mismatched.AND).toContainEqual({ AND: [] });
+
+      // Same for a text op on a number-typed meta entry: no filter that its value can never match.
+      const textOnNumber = buildWhereClause(reservedSurvey, {
+        reserved: { screenWidth: { op: "contains", value: "1" } },
+      });
+      expect(textOnNumber.AND).toContainEqual({ AND: [] });
+    });
+
+    test("prototype-chain keys never resolve a locator", () => {
+      // z.record keys are unrestricted, so a crafted criteria can carry these; a plain index lookup
+      // would resolve them through Object.prototype and hand Prisma an undefined path.
+      const crafted = JSON.parse(
+        '{"__proto__":{"op":"equals","value":"x"},"constructor":{"op":"equals","value":"x"},"hasOwnProperty":{"op":"isSet"}}'
+      );
+      const result = buildWhereClause(reservedSurvey, { reserved: crafted });
+      expect(result.AND).toContainEqual({ AND: [] });
     });
 
     test("every comparison and text-op arm translates one-to-one", () => {
@@ -773,10 +789,18 @@ describe("Response Utils", () => {
     });
 
     test("anti-drift: every filterable catalog entry has a storage locator", () => {
-      const filterableNames = RESERVED_FIELD_CATALOG.filter(
-        (entry) => entry.display !== "none" || entry.name === "durationSeconds"
-      ).map((entry) => entry.name);
-      expect(filterableNames.length).toBeGreaterThan(0);
+      // The most permissive survey (nothing shadowed, nothing anonymized, IP captured) offers the
+      // full filterable set — derived from the real function, so the rule lives in one place.
+      const permissiveSurvey = {
+        ...reservedSurvey,
+        hiddenFields: { enabled: true, fieldIds: [] },
+        variables: [],
+        embeddedFields: [],
+        isAnonymizeResponsesEnabled: false,
+        isCaptureIpEnabled: true,
+      } as TSurvey;
+      const filterableNames = getReservedFilterEntries(permissiveSurvey).map((entry) => entry.name);
+      expect(filterableNames.length).toBeGreaterThan(20);
       for (const name of filterableNames) {
         expect(RESERVED_FILTER_LOCATORS[name], `catalog entry "${name}" has no filter locator`).toBeDefined();
       }
@@ -894,6 +918,14 @@ describe("Response Utils", () => {
       ]);
       expect(values.country).toBeUndefined();
       expect(values.utmSource).toEqual(["ads"]);
+    });
+
+    test("high-cardinality fields are capped instead of shipping every distinct value", () => {
+      const responses = Array.from({ length: 60 }, (_, i) =>
+        mkResponse({ meta: { pagePath: `/product/${i}` } })
+      );
+      const values = getResponseReservedFilterValues(valueSurvey, responses);
+      expect(values.pagePath).toHaveLength(50);
     });
 
     test("variable values: distinct strings keyed by storageKey, non-string fields and empties skipped", () => {

--- a/apps/web/lib/response/utils.ts
+++ b/apps/web/lib/response/utils.ts
@@ -1,6 +1,7 @@
 import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import {
   RESERVED_FIELD_CATALOG,
+  type TEmbeddedValueResponse,
   type TReservedFieldCatalogEntry,
   dropShadowedReservedEntries,
   getComputedEmbeddedFields,
@@ -173,6 +174,72 @@ export const getReservedExportEntries = (survey: TSurvey): TReservedFieldCatalog
  */
 export const getReservedExportHeader = (entry: TReservedFieldCatalogEntry): string =>
   formatFieldNameToTitleCase(entry.name);
+
+/**
+ * The reserved fields one survey's response filter may offer (ENG-1848) — the same list the
+ * response table shows (`display !== "none"`), plus `durationSeconds`, whose `ttc._total` path the
+ * ticket names explicitly even though the table hides it. The gates:
+ * - shadowed entries drop — filters fail closed on a name the survey's declared fields own
+ *   (`buildWhereClause` enforces the same rule server-side against crafted criteria);
+ * - on an anonymized survey, `privacy: "drop"` entries are never captured, and `ipAddress` is only
+ *   captured when `isCaptureIpEnabled` — offering either would let users build always-empty filters.
+ */
+export const getReservedFilterEntries = (survey: TSurvey): TReservedFieldCatalogEntry[] => {
+  const elementIds = getElementsFromBlocks(survey.blocks).map((element) => element.id);
+  const shadowingNames = listShadowingNames(getSurveyEmbeddedFields(survey), elementIds);
+
+  return dropShadowedReservedEntries(RESERVED_FIELD_CATALOG, shadowingNames).filter((entry) => {
+    if (entry.display === "none" && entry.name !== "durationSeconds") return false;
+    if (survey.isAnonymizeResponsesEnabled && entry.privacy === "drop") return false;
+    if (entry.name === "ipAddress" && !survey.isCaptureIpEnabled) return false;
+    return true;
+  });
+};
+
+/**
+ * Observed values for the string-typed reserved filter fields, through the shared projection — so
+ * `redactQuery` entries (url, pageReferrer) never leak query strings into the filter dropdown.
+ * Number-typed entries are skipped: they get a numeric input, not an options list.
+ */
+export const getResponseReservedFilterValues = (
+  survey: TSurvey,
+  responses: TEmbeddedValueResponse[]
+): TSurveyMetaFieldFilter => {
+  const entries = getReservedFilterEntries(survey).filter((entry) => entry.dataType === "string");
+  const values: Record<string, Set<string>> = {};
+
+  responses.forEach((response) => {
+    const projected = projectReservedValues(entries, response);
+    entries.forEach((entry) => {
+      const value = projected[entry.name];
+      if (typeof value !== "string" || value.length === 0) return;
+      values[entry.name] ??= new Set();
+      values[entry.name].add(value);
+    });
+  });
+
+  return Object.fromEntries(Object.entries(values).map(([name, set]) => [name, Array.from(set)]));
+};
+
+/** Observed values for string-typed computed embedded fields, keyed by storageKey (ENG-1848). */
+export const getResponseVariableFilterValues = (
+  survey: TSurvey,
+  responses: Pick<TResponse, "variables">[]
+): TSurveyMetaFieldFilter => {
+  const stringFields = getComputedEmbeddedFields(survey).filter(({ field }) => field.dataType === "string");
+  const values: Record<string, Set<string>> = {};
+
+  responses.forEach((response) => {
+    stringFields.forEach(({ link }) => {
+      const value = response.variables?.[link.storageKey];
+      if (typeof value !== "string" || value.length === 0) return;
+      values[link.storageKey] ??= new Set();
+      values[link.storageKey].add(value);
+    });
+  });
+
+  return Object.fromEntries(Object.entries(values).map(([key, set]) => [key, Array.from(set)]));
+};
 
 export const extractSurveyDetails = (survey: TSurvey, responses: TResponse[]) => {
   const metaDataFields = getReservedExportEntries(survey).map(getReservedExportHeader);

--- a/apps/web/lib/response/utils.ts
+++ b/apps/web/lib/response/utils.ts
@@ -155,17 +155,28 @@ const EXPORT_BASICS_COVERED_RESERVED_NAMES = new Set(["responseId", "surveyId", 
  *   columns are omitted;
  * - `ipAddress` is only a column when the survey captures it (`isCaptureIpEnabled`).
  */
-export const getReservedExportEntries = (survey: TSurvey): TReservedFieldCatalogEntry[] => {
+/**
+ * The gates every reserved-entry consumer shares: shadowed entries drop (a declared field owns its
+ * name), anonymized surveys drop `privacy: "drop"` entries (never captured), and `ipAddress` needs
+ * its capture toggle. What differs per surface is only which entries are eligible at all.
+ */
+const gateReservedEntries = (
+  survey: TSurvey,
+  isEligible: (entry: TReservedFieldCatalogEntry) => boolean
+): TReservedFieldCatalogEntry[] => {
   const elementIds = getElementsFromBlocks(survey.blocks).map((element) => element.id);
   const shadowingNames = listShadowingNames(getSurveyEmbeddedFields(survey), elementIds);
 
   return dropShadowedReservedEntries(RESERVED_FIELD_CATALOG, shadowingNames).filter((entry) => {
-    if (EXPORT_BASICS_COVERED_RESERVED_NAMES.has(entry.name)) return false;
+    if (!isEligible(entry)) return false;
     if (survey.isAnonymizeResponsesEnabled && entry.privacy === "drop") return false;
     if (entry.name === "ipAddress" && !survey.isCaptureIpEnabled) return false;
     return true;
   });
 };
+
+export const getReservedExportEntries = (survey: TSurvey): TReservedFieldCatalogEntry[] =>
+  gateReservedEntries(survey, (entry) => !EXPORT_BASICS_COVERED_RESERVED_NAMES.has(entry.name));
 
 /**
  * The export header for a reserved column. `formatFieldNameToTitleCase` rather than the localized
@@ -184,16 +195,20 @@ export const getReservedExportHeader = (entry: TReservedFieldCatalogEntry): stri
  * - on an anonymized survey, `privacy: "drop"` entries are never captured, and `ipAddress` is only
  *   captured when `isCaptureIpEnabled` — offering either would let users build always-empty filters.
  */
-export const getReservedFilterEntries = (survey: TSurvey): TReservedFieldCatalogEntry[] => {
-  const elementIds = getElementsFromBlocks(survey.blocks).map((element) => element.id);
-  const shadowingNames = listShadowingNames(getSurveyEmbeddedFields(survey), elementIds);
+export const getReservedFilterEntries = (survey: TSurvey): TReservedFieldCatalogEntry[] =>
+  gateReservedEntries(survey, (entry) => entry.display !== "none" || entry.name === "durationSeconds");
 
-  return dropShadowedReservedEntries(RESERVED_FIELD_CATALOG, shadowingNames).filter((entry) => {
-    if (entry.display === "none" && entry.name !== "durationSeconds") return false;
-    if (survey.isAnonymizeResponsesEnabled && entry.privacy === "drop") return false;
-    if (entry.name === "ipAddress" && !survey.isCaptureIpEnabled) return false;
-    return true;
-  });
+/**
+ * Upper bound on distinct dropdown options collected per field. Free-text fields like `url` or
+ * `pageReferrer` are unbounded in practice, and the whole record ships to the client when the
+ * filter opens; past this many options a dropdown is no better than the free-text input anyway.
+ */
+const MAX_FILTER_VALUE_OPTIONS = 50;
+
+const addBoundedValue = (values: Record<string, Set<string>>, key: string, value: string): void => {
+  values[key] ??= new Set();
+  if (values[key].size >= MAX_FILTER_VALUE_OPTIONS) return;
+  values[key].add(value);
 };
 
 /**
@@ -213,8 +228,7 @@ export const getResponseReservedFilterValues = (
     entries.forEach((entry) => {
       const value = projected[entry.name];
       if (typeof value !== "string" || value.length === 0) return;
-      values[entry.name] ??= new Set();
-      values[entry.name].add(value);
+      addBoundedValue(values, entry.name, value);
     });
   });
 
@@ -233,8 +247,7 @@ export const getResponseVariableFilterValues = (
     stringFields.forEach(({ link }) => {
       const value = response.variables?.[link.storageKey];
       if (typeof value !== "string" || value.length === 0) return;
-      values[link.storageKey] ??= new Set();
-      values[link.storageKey].add(value);
+      addBoundedValue(values, link.storageKey, value);
     });
   });
 

--- a/apps/web/lib/response/where-clause.ts
+++ b/apps/web/lib/response/where-clause.ts
@@ -157,6 +157,57 @@ const buildDurationSecondsCondition = (val: TTypedFieldFilterCondition): Prisma.
   }
 };
 
+/**
+ * The `reserved` criteria group → conditions. Fails closed (ENG-1848): a name the survey's declared
+ * fields or element ids shadow filters the declared value elsewhere, never the reserved read — and
+ * an unknown name emits nothing. `Object.hasOwn` because the keys come from a z.record: a crafted
+ * `__proto__`/`constructor` key must not resolve a locator through the prototype chain.
+ */
+const buildReservedConditions = (
+  survey: TSurvey,
+  reserved: NonNullable<TResponseFilterCriteria["reserved"]>
+): Prisma.ResponseWhereInput[] => {
+  const elementIds = getElementsFromBlocks(survey.blocks).map((element) => element.id);
+  const shadowed = new Set(listShadowingNames(getSurveyEmbeddedFields(survey), elementIds));
+  const catalogEntriesByName = new Map(RESERVED_FIELD_CATALOG.map((entry) => [entry.name, entry]));
+  const conditions: Prisma.ResponseWhereInput[] = [];
+
+  Object.entries(reserved).forEach(([name, val]) => {
+    if (shadowed.has(name)) return;
+    if (!Object.hasOwn(RESERVED_FILTER_LOCATORS, name)) return;
+    const entry = catalogEntriesByName.get(name);
+    if (!entry) return;
+    const locator = RESERVED_FILTER_LOCATORS[name];
+    const condition =
+      locator.kind === "ttcTotalMs"
+        ? buildDurationSecondsCondition(val)
+        : buildJsonPathCondition("meta", locator.path, val, entry.dataType);
+    if (condition) conditions.push(condition);
+  });
+
+  return conditions;
+};
+
+/** The `variables` group → conditions. Keys are computed-field storageKeys; anything else emits nothing. */
+const buildVariableConditions = (
+  survey: TSurvey,
+  variables: NonNullable<TResponseFilterCriteria["variables"]>
+): Prisma.ResponseWhereInput[] => {
+  const computedFieldsByKey = new Map(
+    getComputedEmbeddedFields(survey).map((field) => [field.link.storageKey, field])
+  );
+  const conditions: Prisma.ResponseWhereInput[] = [];
+
+  Object.entries(variables).forEach(([storageKey, val]) => {
+    const field = computedFieldsByKey.get(storageKey);
+    if (!field) return;
+    const condition = buildJsonPathCondition("variables", [storageKey], val, field.field.dataType);
+    if (condition) conditions.push(condition);
+  });
+
+  return conditions;
+};
+
 const createFilterTags = (tags: TResponseFilterCriteria["tags"]) => {
   if (!tags) return [];
 
@@ -368,49 +419,14 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
   }
 
   if (filterCriteria?.reserved) {
-    // Fail closed (ENG-1848): a name the survey's declared fields or element ids shadow filters the
-    // declared value elsewhere, never the reserved read — and an unknown name emits nothing.
-    // `Object.hasOwn` because the keys come from a z.record: a crafted `__proto__`/`constructor`
-    // key must not resolve a locator through the prototype chain.
-    const elementIds = getElementsFromBlocks(survey.blocks).map((element) => element.id);
-    const shadowed = new Set(listShadowingNames(getSurveyEmbeddedFields(survey), elementIds));
-    const catalogEntriesByName = new Map(RESERVED_FIELD_CATALOG.map((entry) => [entry.name, entry]));
-    const reserved: Prisma.ResponseWhereInput[] = [];
-
-    Object.entries(filterCriteria.reserved).forEach(([name, val]) => {
-      if (shadowed.has(name)) return;
-      if (!Object.hasOwn(RESERVED_FILTER_LOCATORS, name)) return;
-      const entry = catalogEntriesByName.get(name);
-      if (!entry) return;
-      const locator = RESERVED_FILTER_LOCATORS[name];
-      const condition =
-        locator.kind === "ttcTotalMs"
-          ? buildDurationSecondsCondition(val)
-          : buildJsonPathCondition("meta", locator.path, val, entry.dataType);
-      if (condition) reserved.push(condition);
-    });
-
     whereClause.push({
-      AND: reserved,
+      AND: buildReservedConditions(survey, filterCriteria.reserved),
     });
   }
 
   if (filterCriteria?.variables) {
-    // Keys are storageKeys of the survey's computed embedded fields; anything else emits nothing.
-    const computedFieldsByKey = new Map(
-      getComputedEmbeddedFields(survey).map((field) => [field.link.storageKey, field])
-    );
-    const variables: Prisma.ResponseWhereInput[] = [];
-
-    Object.entries(filterCriteria.variables).forEach(([storageKey, val]) => {
-      const field = computedFieldsByKey.get(storageKey);
-      if (!field) return;
-      const condition = buildJsonPathCondition("variables", [storageKey], val, field.field.dataType);
-      if (condition) variables.push(condition);
-    });
-
     whereClause.push({
-      AND: variables,
+      AND: buildVariableConditions(survey, filterCriteria.variables),
     });
   }
 

--- a/apps/web/lib/response/where-clause.ts
+++ b/apps/web/lib/response/where-clause.ts
@@ -208,6 +208,27 @@ const buildVariableConditions = (
   return conditions;
 };
 
+/**
+ * The ENG-1848 criteria groups as ready-to-push clauses. Both branches live here rather than in
+ * `buildWhereClause`, which sat exactly at the cognitive-complexity limit before this feature —
+ * even two plain `if`s there tip it over.
+ */
+const buildEmbeddedDataFilterClauses = (
+  survey: TSurvey,
+  filterCriteria?: TResponseFilterCriteria
+): Prisma.ResponseWhereInput[] => {
+  const clauses: Prisma.ResponseWhereInput[] = [];
+
+  if (filterCriteria?.reserved) {
+    clauses.push({ AND: buildReservedConditions(survey, filterCriteria.reserved) });
+  }
+  if (filterCriteria?.variables) {
+    clauses.push({ AND: buildVariableConditions(survey, filterCriteria.variables) });
+  }
+
+  return clauses;
+};
+
 const createFilterTags = (tags: TResponseFilterCriteria["tags"]) => {
   if (!tags) return [];
 
@@ -418,17 +439,7 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
     });
   }
 
-  if (filterCriteria?.reserved) {
-    whereClause.push({
-      AND: buildReservedConditions(survey, filterCriteria.reserved),
-    });
-  }
-
-  if (filterCriteria?.variables) {
-    whereClause.push({
-      AND: buildVariableConditions(survey, filterCriteria.variables),
-    });
-  }
+  whereClause.push(...buildEmbeddedDataFilterClauses(survey, filterCriteria));
 
   if (filterCriteria?.data) {
     const data: Prisma.ResponseWhereInput[] = [];

--- a/apps/web/lib/response/where-clause.ts
+++ b/apps/web/lib/response/where-clause.ts
@@ -1,6 +1,8 @@
 import "server-only";
 import { Prisma } from "@formbricks/database/prisma";
+import { TEmbeddedDataType } from "@formbricks/types/embedded-data";
 import {
+  RESERVED_FIELD_CATALOG,
   getComputedEmbeddedFields,
   getSurveyEmbeddedFields,
   listShadowingNames,
@@ -52,53 +54,68 @@ const mkJsonColumnFilter = (
   filter: Prisma.ResponseWhereInput["meta"]
 ): Prisma.ResponseWhereInput => (column === "meta" ? { meta: filter } : { variables: filter });
 
+// Negated text ops share their Prisma key with the positive op and wrap in NOT.
+const TEXT_OP_TO_PRISMA: Record<string, { key: string; negated: boolean }> = {
+  contains: { key: "string_contains", negated: false },
+  doesNotContain: { key: "string_contains", negated: true },
+  startsWith: { key: "string_starts_with", negated: false },
+  doesNotStartWith: { key: "string_starts_with", negated: true },
+  endsWith: { key: "string_ends_with", negated: false },
+  doesNotEndWith: { key: "string_ends_with", negated: true },
+};
+
+const COMPARISON_OP_TO_PRISMA: Record<string, string> = {
+  lessThan: "lt",
+  lessEqual: "lte",
+  greaterThan: "gt",
+  greaterEqual: "gte",
+};
+
 /**
  * One typed condition → one Prisma JSON-path filter on `meta` or `variables`. `notEquals` and
- * `isNotSet` treat an absent value as a match (same stance as the `data` branch below); ops that
- * don't fit the column's value (e.g. text ops sent for a number field) emit nothing — fail closed.
+ * `isNotSet` treat an absent value as a match (same stance as the `data` branch below). Ops that
+ * don't fit the field's dataType — text ops on anything but a string, comparisons on a boolean or
+ * string — emit nothing: fail closed rather than querying a shape the value can never have.
  */
 const buildJsonPathCondition = (
   column: "meta" | "variables",
   path: string[],
-  val: TTypedFieldFilterCondition
+  val: TTypedFieldFilterCondition,
+  dataType: TEmbeddedDataType
 ): Prisma.ResponseWhereInput | null => {
-  switch (val.op) {
-    case "equals":
-      return mkJsonColumnFilter(column, { path, equals: val.value });
-    case "notEquals":
-      return {
-        OR: [
-          mkJsonColumnFilter(column, { path, not: val.value }),
-          mkJsonColumnFilter(column, { path, equals: Prisma.DbNull }),
-        ],
-      };
-    case "contains":
-      return mkJsonColumnFilter(column, { path, string_contains: val.value });
-    case "doesNotContain":
-      return { NOT: mkJsonColumnFilter(column, { path, string_contains: val.value }) };
-    case "startsWith":
-      return mkJsonColumnFilter(column, { path, string_starts_with: val.value });
-    case "doesNotStartWith":
-      return { NOT: mkJsonColumnFilter(column, { path, string_starts_with: val.value }) };
-    case "endsWith":
-      return mkJsonColumnFilter(column, { path, string_ends_with: val.value });
-    case "doesNotEndWith":
-      return { NOT: mkJsonColumnFilter(column, { path, string_ends_with: val.value }) };
-    case "lessThan":
-      return mkJsonColumnFilter(column, { path, lt: val.value });
-    case "lessEqual":
-      return mkJsonColumnFilter(column, { path, lte: val.value });
-    case "greaterThan":
-      return mkJsonColumnFilter(column, { path, gt: val.value });
-    case "greaterEqual":
-      return mkJsonColumnFilter(column, { path, gte: val.value });
-    case "isSet":
-      return mkJsonColumnFilter(column, { path, not: Prisma.DbNull });
-    case "isNotSet":
-      return mkJsonColumnFilter(column, { path, equals: Prisma.DbNull });
-    default:
-      return null;
+  if (val.op === "isSet") return mkJsonColumnFilter(column, { path, not: Prisma.DbNull });
+  if (val.op === "isNotSet") return mkJsonColumnFilter(column, { path, equals: Prisma.DbNull });
+  if (val.op === "equals") return mkJsonColumnFilter(column, { path, equals: val.value });
+  if (val.op === "notEquals") {
+    return {
+      OR: [
+        mkJsonColumnFilter(column, { path, not: val.value }),
+        mkJsonColumnFilter(column, { path, equals: Prisma.DbNull }),
+      ],
+    };
   }
+
+  const textOp = TEXT_OP_TO_PRISMA[val.op];
+  if (textOp && "value" in val) {
+    if (dataType !== "string") return null;
+    // The dynamic Prisma key needs one cast; the three keys above are all valid string filters.
+    const filter = mkJsonColumnFilter(column, {
+      path,
+      [textOp.key]: val.value,
+    } as Prisma.ResponseWhereInput["meta"]);
+    return textOp.negated ? { NOT: filter } : filter;
+  }
+
+  const comparisonKey = COMPARISON_OP_TO_PRISMA[val.op];
+  if (comparisonKey && "value" in val) {
+    if (dataType !== "number" && dataType !== "date") return null;
+    return mkJsonColumnFilter(column, {
+      path,
+      [comparisonKey]: val.value,
+    } as Prisma.ResponseWhereInput["meta"]);
+  }
+
+  return null;
 };
 
 /**
@@ -353,18 +370,23 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
   if (filterCriteria?.reserved) {
     // Fail closed (ENG-1848): a name the survey's declared fields or element ids shadow filters the
     // declared value elsewhere, never the reserved read — and an unknown name emits nothing.
+    // `Object.hasOwn` because the keys come from a z.record: a crafted `__proto__`/`constructor`
+    // key must not resolve a locator through the prototype chain.
     const elementIds = getElementsFromBlocks(survey.blocks).map((element) => element.id);
     const shadowed = new Set(listShadowingNames(getSurveyEmbeddedFields(survey), elementIds));
+    const catalogEntriesByName = new Map(RESERVED_FIELD_CATALOG.map((entry) => [entry.name, entry]));
     const reserved: Prisma.ResponseWhereInput[] = [];
 
     Object.entries(filterCriteria.reserved).forEach(([name, val]) => {
       if (shadowed.has(name)) return;
+      if (!Object.hasOwn(RESERVED_FILTER_LOCATORS, name)) return;
+      const entry = catalogEntriesByName.get(name);
+      if (!entry) return;
       const locator = RESERVED_FILTER_LOCATORS[name];
-      if (!locator) return;
       const condition =
         locator.kind === "ttcTotalMs"
           ? buildDurationSecondsCondition(val)
-          : buildJsonPathCondition("meta", locator.path, val);
+          : buildJsonPathCondition("meta", locator.path, val, entry.dataType);
       if (condition) reserved.push(condition);
     });
 
@@ -375,12 +397,15 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
 
   if (filterCriteria?.variables) {
     // Keys are storageKeys of the survey's computed embedded fields; anything else emits nothing.
-    const computedKeys = new Set(getComputedEmbeddedFields(survey).map(({ link }) => link.storageKey));
+    const computedFieldsByKey = new Map(
+      getComputedEmbeddedFields(survey).map((field) => [field.link.storageKey, field])
+    );
     const variables: Prisma.ResponseWhereInput[] = [];
 
     Object.entries(filterCriteria.variables).forEach(([storageKey, val]) => {
-      if (!computedKeys.has(storageKey)) return;
-      const condition = buildJsonPathCondition("variables", [storageKey], val);
+      const field = computedFieldsByKey.get(storageKey);
+      if (!field) return;
+      const condition = buildJsonPathCondition("variables", [storageKey], val, field.field.dataType);
       if (condition) variables.push(condition);
     });
 

--- a/apps/web/lib/response/where-clause.ts
+++ b/apps/web/lib/response/where-clause.ts
@@ -1,9 +1,144 @@
 import "server-only";
 import { Prisma } from "@formbricks/database/prisma";
+import {
+  getComputedEmbeddedFields,
+  getSurveyEmbeddedFields,
+  listShadowingNames,
+} from "@formbricks/types/embedded-data-resolver";
 import { TResponseFilterCriteria } from "@formbricks/types/responses";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { generateAllPermutationsOfSubsets } from "./utils";
+
+type TTypedFieldFilterCondition = NonNullable<TResponseFilterCriteria["reserved"]>[string];
+
+type TReservedFilterLocator = { kind: "meta"; path: string[] } | { kind: "ttcTotalMs" };
+
+/**
+ * Where each filterable reserved field physically lives on the Response row. The catalog carries
+ * typed `read` accessors instead of path strings on purpose (see the rationale in
+ * embedded-data-resolver.ts), so the DB layer owns this map; the anti-drift test in utils.test.ts
+ * pins that every entry `getReservedFilterEntries` can offer has a locator. `durationSeconds` is
+ * the one computed entry — it filters the stored `ttc._total` milliseconds through windows that
+ * reproduce the read seam's `Math.round(ms / 1000)` projection exactly.
+ */
+export const RESERVED_FILTER_LOCATORS: Record<string, TReservedFilterLocator> = {
+  source: { kind: "meta", path: ["source"] },
+  url: { kind: "meta", path: ["url"] },
+  country: { kind: "meta", path: ["country"] },
+  action: { kind: "meta", path: ["action"] },
+  browser: { kind: "meta", path: ["userAgent", "browser"] },
+  os: { kind: "meta", path: ["userAgent", "os"] },
+  deviceType: { kind: "meta", path: ["userAgent", "device"] },
+  ipAddress: { kind: "meta", path: ["ipAddress"] },
+  pagePath: { kind: "meta", path: ["pagePath"] },
+  pageReferrer: { kind: "meta", path: ["pageReferrer"] },
+  utmSource: { kind: "meta", path: ["utmSource"] },
+  utmMedium: { kind: "meta", path: ["utmMedium"] },
+  utmCampaign: { kind: "meta", path: ["utmCampaign"] },
+  utmTerm: { kind: "meta", path: ["utmTerm"] },
+  utmContent: { kind: "meta", path: ["utmContent"] },
+  screenWidth: { kind: "meta", path: ["screenWidth"] },
+  screenHeight: { kind: "meta", path: ["screenHeight"] },
+  viewportWidth: { kind: "meta", path: ["viewportWidth"] },
+  viewportHeight: { kind: "meta", path: ["viewportHeight"] },
+  timezone: { kind: "meta", path: ["timezone"] },
+  locale: { kind: "meta", path: ["locale"] },
+  durationSeconds: { kind: "ttcTotalMs" },
+};
+
+const mkJsonColumnFilter = (
+  column: "meta" | "variables",
+  filter: Prisma.ResponseWhereInput["meta"]
+): Prisma.ResponseWhereInput => (column === "meta" ? { meta: filter } : { variables: filter });
+
+/**
+ * One typed condition → one Prisma JSON-path filter on `meta` or `variables`. `notEquals` and
+ * `isNotSet` treat an absent value as a match (same stance as the `data` branch below); ops that
+ * don't fit the column's value (e.g. text ops sent for a number field) emit nothing — fail closed.
+ */
+const buildJsonPathCondition = (
+  column: "meta" | "variables",
+  path: string[],
+  val: TTypedFieldFilterCondition
+): Prisma.ResponseWhereInput | null => {
+  switch (val.op) {
+    case "equals":
+      return mkJsonColumnFilter(column, { path, equals: val.value });
+    case "notEquals":
+      return {
+        OR: [
+          mkJsonColumnFilter(column, { path, not: val.value }),
+          mkJsonColumnFilter(column, { path, equals: Prisma.DbNull }),
+        ],
+      };
+    case "contains":
+      return mkJsonColumnFilter(column, { path, string_contains: val.value });
+    case "doesNotContain":
+      return { NOT: mkJsonColumnFilter(column, { path, string_contains: val.value }) };
+    case "startsWith":
+      return mkJsonColumnFilter(column, { path, string_starts_with: val.value });
+    case "doesNotStartWith":
+      return { NOT: mkJsonColumnFilter(column, { path, string_starts_with: val.value }) };
+    case "endsWith":
+      return mkJsonColumnFilter(column, { path, string_ends_with: val.value });
+    case "doesNotEndWith":
+      return { NOT: mkJsonColumnFilter(column, { path, string_ends_with: val.value }) };
+    case "lessThan":
+      return mkJsonColumnFilter(column, { path, lt: val.value });
+    case "lessEqual":
+      return mkJsonColumnFilter(column, { path, lte: val.value });
+    case "greaterThan":
+      return mkJsonColumnFilter(column, { path, gt: val.value });
+    case "greaterEqual":
+      return mkJsonColumnFilter(column, { path, gte: val.value });
+    case "isSet":
+      return mkJsonColumnFilter(column, { path, not: Prisma.DbNull });
+    case "isNotSet":
+      return mkJsonColumnFilter(column, { path, equals: Prisma.DbNull });
+    default:
+      return null;
+  }
+};
+
+/**
+ * `durationSeconds` filters in seconds against `ttc._total`, which stores milliseconds. The read
+ * seam projects `Math.round(ms / 1000)`, so second `s` covers ms in [s*1000-500, s*1000+500) — the
+ * windows below make DB filtering agree with the projected value at every boundary. `ttc._total`
+ * only exists on finished responses, so partials never match (except via `isNotSet`).
+ */
+const buildDurationSecondsCondition = (val: TTypedFieldFilterCondition): Prisma.ResponseWhereInput | null => {
+  const path = ["_total"];
+  if (val.op === "isSet") return { ttc: { path, not: Prisma.DbNull } };
+  if (val.op === "isNotSet") return { ttc: { path, equals: Prisma.DbNull } };
+  if (!("value" in val)) return null;
+  const seconds = Number(val.value);
+  if (!Number.isFinite(seconds)) return null;
+  const lower = seconds * 1000 - 500;
+  const upper = seconds * 1000 + 500;
+  switch (val.op) {
+    case "equals":
+      return { AND: [{ ttc: { path, gte: lower } }, { ttc: { path, lt: upper } }] };
+    case "notEquals":
+      return {
+        OR: [
+          { ttc: { path, lt: lower } },
+          { ttc: { path, gte: upper } },
+          { ttc: { path, equals: Prisma.DbNull } },
+        ],
+      };
+    case "greaterThan":
+      return { ttc: { path, gte: upper } };
+    case "greaterEqual":
+      return { ttc: { path, gte: lower } };
+    case "lessThan":
+      return { ttc: { path, lt: lower } };
+    case "lessEqual":
+      return { ttc: { path, lt: upper } };
+    default:
+      return null;
+  }
+};
 
 const createFilterTags = (tags: TResponseFilterCriteria["tags"]) => {
   if (!tags) return [];
@@ -212,6 +347,45 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
     });
     whereClause.push({
       AND: others,
+    });
+  }
+
+  if (filterCriteria?.reserved) {
+    // Fail closed (ENG-1848): a name the survey's declared fields or element ids shadow filters the
+    // declared value elsewhere, never the reserved read — and an unknown name emits nothing.
+    const elementIds = getElementsFromBlocks(survey.blocks).map((element) => element.id);
+    const shadowed = new Set(listShadowingNames(getSurveyEmbeddedFields(survey), elementIds));
+    const reserved: Prisma.ResponseWhereInput[] = [];
+
+    Object.entries(filterCriteria.reserved).forEach(([name, val]) => {
+      if (shadowed.has(name)) return;
+      const locator = RESERVED_FILTER_LOCATORS[name];
+      if (!locator) return;
+      const condition =
+        locator.kind === "ttcTotalMs"
+          ? buildDurationSecondsCondition(val)
+          : buildJsonPathCondition("meta", locator.path, val);
+      if (condition) reserved.push(condition);
+    });
+
+    whereClause.push({
+      AND: reserved,
+    });
+  }
+
+  if (filterCriteria?.variables) {
+    // Keys are storageKeys of the survey's computed embedded fields; anything else emits nothing.
+    const computedKeys = new Set(getComputedEmbeddedFields(survey).map(({ link }) => link.storageKey));
+    const variables: Prisma.ResponseWhereInput[] = [];
+
+    Object.entries(filterCriteria.variables).forEach(([storageKey, val]) => {
+      if (!computedKeys.has(storageKey)) return;
+      const condition = buildJsonPathCondition("variables", [storageKey], val);
+      if (condition) variables.push(condition);
+    });
+
+    whereClause.push({
+      AND: variables,
     });
   }
 
@@ -458,6 +632,61 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
           });
           break;
         }
+        // Text ops for string-typed ingested Embedded Data fields (ENG-1848).
+        case "contains":
+          data.push({
+            data: {
+              path: [key],
+              string_contains: val.value,
+            },
+          });
+          break;
+        case "doesNotContain":
+          data.push({
+            NOT: {
+              data: {
+                path: [key],
+                string_contains: val.value,
+              },
+            },
+          });
+          break;
+        case "startsWith":
+          data.push({
+            data: {
+              path: [key],
+              string_starts_with: val.value,
+            },
+          });
+          break;
+        case "doesNotStartWith":
+          data.push({
+            NOT: {
+              data: {
+                path: [key],
+                string_starts_with: val.value,
+              },
+            },
+          });
+          break;
+        case "endsWith":
+          data.push({
+            data: {
+              path: [key],
+              string_ends_with: val.value,
+            },
+          });
+          break;
+        case "doesNotEndWith":
+          data.push({
+            NOT: {
+              data: {
+                path: [key],
+                string_ends_with: val.value,
+              },
+            },
+          });
+          break;
       }
     });
 

--- a/apps/web/modules/analysis/lib/reserved-field-display.ts
+++ b/apps/web/modules/analysis/lib/reserved-field-display.ts
@@ -13,6 +13,7 @@ import {
   MousePointerClickIcon,
   ShieldIcon,
   SmartphoneIcon,
+  TimerIcon,
 } from "lucide-react";
 import { formatFieldNameToTitleCase } from "@formbricks/types/safe-identifier";
 
@@ -96,6 +97,8 @@ export const RESERVED_FIELD_ICONS: Record<string, LucideIcon> = {
   browser: GlobeIcon,
   country: FlagIcon,
   deviceType: SmartphoneIcon,
+  // Not displayed by the table (display: "none") but offered by the response filter (ENG-1848).
+  durationSeconds: TimerIcon,
   ipAddress: ShieldIcon,
   locale: LanguagesIcon,
   os: AirplayIcon,

--- a/apps/web/playwright/response-filter.spec.ts
+++ b/apps/web/playwright/response-filter.spec.ts
@@ -1,0 +1,126 @@
+import { createId } from "@paralleldrive/cuid2";
+import { type Page, expect } from "@playwright/test";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { type TSurveyEnding } from "@formbricks/types/surveys/types";
+import { transformQuestionsToBlocks } from "@/app/lib/api/survey-transformation";
+import { test } from "./lib/fixtures";
+
+/**
+ * **Filtering responses by a reserved field, end to end (ENG-1848).**
+ *
+ * The unit suites pin every layer on its own: enumeration and gating (getReservedFilterEntries),
+ * the criteria mapping (getFormattedFilters), and the Prisma translation (buildWhereClause). This
+ * walks the seam none of them reach — the real page: the filter dropdown offers the catalog field,
+ * the observed value is pickable, Apply narrows the table through the real query, and the
+ * no-value "Is not set" operator inverts it.
+ */
+type I18n = { default: string };
+const i18nValue = (value: string): I18n => ({ default: value });
+
+type TLegacyQuestions = Parameters<typeof transformQuestionsToBlocks>[0];
+
+const QUESTION = "How did you hear about us?";
+const ENDING_HEADLINE = "Thanks!";
+const CAMPAIGN_ANSWER = "From the newsletter";
+const BARE_ANSWER = "Found it myself";
+
+const seedSurvey = async (workspaceId: string, createdBy: string): Promise<string> => {
+  const endings = [
+    { id: createId(), type: "endScreen" as const, headline: i18nValue(ENDING_HEADLINE) },
+  ] as unknown as TSurveyEnding[];
+
+  const questions = [
+    {
+      id: createId(),
+      type: "openText",
+      headline: i18nValue(QUESTION),
+      required: true,
+      inputType: "text",
+      placeholder: i18nValue("Type your answer here..."),
+      charLimit: { enabled: false },
+    },
+  ];
+
+  const survey = await prisma.survey.create({
+    data: {
+      workspaceId,
+      createdBy,
+      name: "Response filter survey",
+      type: "link",
+      status: "inProgress",
+      welcomeCard: { enabled: false, timeToFinish: false, showResponseCount: false },
+      blocks: transformQuestionsToBlocks(
+        questions as unknown as TLegacyQuestions,
+        endings
+      ) as unknown as Prisma.InputJsonValue[],
+      endings: endings as unknown as Prisma.InputJsonValue[],
+    },
+    select: { id: true },
+  });
+
+  return survey.id;
+};
+
+const submitAnswer = async (page: Page, answer: string): Promise<void> => {
+  await expect(page.getByText(QUESTION)).toBeVisible();
+  await page.getByPlaceholder("Type your answer here...").fill(answer);
+  await page.getByRole("button", { name: "Finish" }).click();
+  await expect(page.getByText(ENDING_HEADLINE)).toBeVisible({ timeout: 60000 });
+};
+
+test.describe("Response filtering by reserved fields @slow", () => {
+  test("filters the table by UTM Source, including the no-value Is-set family", async ({ page, users }) => {
+    const owner = await users.create({ skipSurveySeed: true });
+    if (!owner.workspaceId) throw new Error("users.create() did not return a workspaceId");
+    const surveyId = await seedSurvey(owner.workspaceId, owner.id);
+
+    await page.goto(`/s/${surveyId}?utm_source=newsletter`);
+    await submitAnswer(page, CAMPAIGN_ANSWER);
+    await page.evaluate(() => window.localStorage.clear());
+    await page.goto(`/s/${surveyId}`);
+    await submitAnswer(page, BARE_ANSWER);
+    await expect
+      .poll(async () => prisma.response.count({ where: { surveyId } }), {
+        timeout: 20000,
+        message: "Both submitted responses should be stored",
+      })
+      .toBe(2);
+
+    await owner.login();
+    await page.goto(`/workspaces/${owner.workspaceId}/surveys/${surveyId}/responses`);
+    // The table renders an answer in more than one span, so assert via first()/count.
+    await expect(page.getByText(CAMPAIGN_ANSWER).first()).toBeVisible({ timeout: 60000 });
+    await expect(page.getByText(BARE_ANSWER).first()).toBeVisible();
+
+    await test.step("UTM Source equals newsletter → only the campaign response remains", async () => {
+      await page.getByRole("button", { name: /^Filter/ }).click();
+      await page.getByRole("button", { name: "Add filter" }).click();
+
+      // The field dropdown offers the catalog entry even though only one response carries it.
+      // The option list only renders after the combobox is clicked open.
+      await page.getByPlaceholder("Select filter").click();
+      await page.getByPlaceholder("Search...").fill("UTM Source");
+      await page.getByRole("option", { name: "UTM Source" }).click();
+
+      // Default operator is Equals; the observed value is offered in the combobox.
+      await page.getByText("Select...", { exact: true }).click();
+      await page.getByRole("option", { name: "newsletter" }).click();
+      await page.getByRole("button", { name: "Apply filters" }).click();
+
+      await expect(page.getByText(BARE_ANSWER)).toHaveCount(0);
+      await expect(page.getByText(CAMPAIGN_ANSWER).first()).toBeVisible();
+    });
+
+    await test.step("UTM Source is not set → only the bare response remains", async () => {
+      await page.getByRole("button", { name: /^Filter/ }).click();
+      // Switch the operator on the existing row; "Is not set" needs no value at all.
+      await page.getByRole("button", { name: "Equals" }).click();
+      await page.getByRole("menuitem", { name: "Is not set" }).click();
+      await page.getByRole("button", { name: "Apply filters" }).click();
+
+      await expect(page.getByText(CAMPAIGN_ANSWER)).toHaveCount(0);
+      await expect(page.getByText(BARE_ANSWER).first()).toBeVisible();
+    });
+  });
+});

--- a/apps/web/playwright/response-filter.spec.ts
+++ b/apps/web/playwright/response-filter.spec.ts
@@ -108,8 +108,10 @@ test.describe("Response filtering by reserved fields @slow", () => {
       await page.getByRole("option", { name: "newsletter" }).click();
       await page.getByRole("button", { name: "Apply filters" }).click();
 
-      await expect(page.getByText(BARE_ANSWER)).toHaveCount(0);
+      // Positive first: once the expected row has re-rendered, the absence check is meaningful
+      // (an empty still-loading table would satisfy toHaveCount(0) immediately).
       await expect(page.getByText(CAMPAIGN_ANSWER).first()).toBeVisible();
+      await expect(page.getByText(BARE_ANSWER)).toHaveCount(0);
     });
 
     await test.step("UTM Source is not set → only the bare response remains", async () => {
@@ -119,8 +121,8 @@ test.describe("Response filtering by reserved fields @slow", () => {
       await page.getByRole("menuitem", { name: "Is not set" }).click();
       await page.getByRole("button", { name: "Apply filters" }).click();
 
-      await expect(page.getByText(CAMPAIGN_ANSWER)).toHaveCount(0);
       await expect(page.getByText(BARE_ANSWER).first()).toBeVisible();
+      await expect(page.getByText(CAMPAIGN_ANSWER)).toHaveCount(0);
     });
   });
 });

--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -84,24 +84,26 @@ export const ZResponseHiddenFieldsFilter = z.record(z.string(), z.array(z.string
 
 export type TResponseHiddenFieldsFilter = z.infer<typeof ZResponseHiddenFieldsFilter>;
 
+// Comparison values are numbers for number-typed fields, ISO-8601 strings for date-typed ones —
+// jsonb compares same-format ISO strings lexicographically, which is chronological (ENG-1848).
 const ZResponseFilterCriteriaDataLessThan = z.object({
   op: z.literal(ZResponseFilterCondition.enum.lessThan),
-  value: z.number(),
+  value: z.union([z.number(), z.string()]),
 });
 
 const ZResponseFilterCriteriaDataLessEqual = z.object({
   op: z.literal(ZResponseFilterCondition.enum.lessEqual),
-  value: z.number(),
+  value: z.union([z.number(), z.string()]),
 });
 
 const ZResponseFilterCriteriaDataGreaterEqual = z.object({
   op: z.literal(ZResponseFilterCondition.enum.greaterEqual),
-  value: z.number(),
+  value: z.union([z.number(), z.string()]),
 });
 
 const ZResponseFilterCriteriaDataGreaterThan = z.object({
   op: z.literal(ZResponseFilterCondition.enum.greaterThan),
-  value: z.number(),
+  value: z.union([z.number(), z.string()]),
 });
 
 const ZResponseFilterCriteriaDataIncludesOne = z.object({
@@ -114,14 +116,16 @@ const ZResponseFilterCriteriaDataIncludesAll = z.object({
   value: z.array(z.string()),
 });
 
+// Booleans belong to boolean-typed Embedded Data fields, whose stored values are real jsonb
+// booleans — a string "true" would never match them (ENG-1848).
 const ZResponseFilterCriteriaDataEquals = z.object({
   op: z.literal(ZResponseFilterCondition.enum.equals),
-  value: z.union([z.string(), z.number()]),
+  value: z.union([z.string(), z.number(), z.boolean()]),
 });
 
 const ZResponseFilterCriteriaDataNotEquals = z.object({
   op: z.literal(ZResponseFilterCondition.enum.notEquals),
-  value: z.union([z.string(), z.number()]),
+  value: z.union([z.string(), z.number(), z.boolean()]),
 });
 
 const ZResponseFilterCriteriaDataAccepted = z.object({
@@ -204,6 +208,37 @@ const ZResponseFilterCriteriaFilledOut = z.object({
   op: z.literal("filledOut"),
 });
 
+const ZResponseFilterCriteriaIsSet = z.object({
+  op: z.literal("isSet"),
+});
+
+const ZResponseFilterCriteriaIsNotSet = z.object({
+  op: z.literal("isNotSet"),
+});
+
+/**
+ * Condition grammar for the typed Embedded Data + reserved-field filter groups (ENG-1848). One
+ * union serves both groups: which subset a field actually offers is decided by its `dataType` at
+ * the UI (string → equality + text ops, number → equality + comparisons, date → equality +
+ * before/after via lessThan/greaterThan on ISO strings), and `buildWhereClause` only translates.
+ */
+const ZTypedFieldFilterCondition = z.union([
+  ZResponseFilterCriteriaDataEquals,
+  ZResponseFilterCriteriaDataNotEquals,
+  ZResponseFilterCriteriaContains,
+  ZResponseFilterCriteriaDoesNotContain,
+  ZResponseFilterCriteriaStartsWith,
+  ZResponseFilterCriteriaDoesNotStartWith,
+  ZResponseFilterCriteriaEndsWith,
+  ZResponseFilterCriteriaDoesNotEndWith,
+  ZResponseFilterCriteriaDataLessThan,
+  ZResponseFilterCriteriaDataLessEqual,
+  ZResponseFilterCriteriaDataGreaterEqual,
+  ZResponseFilterCriteriaDataGreaterThan,
+  ZResponseFilterCriteriaIsSet,
+  ZResponseFilterCriteriaIsNotSet,
+]);
+
 const ZQuotasFilterCriteriaScreenedIn = z.object({
   op: z.literal("screenedIn"),
 });
@@ -260,9 +295,27 @@ export const ZResponseFilterCriteria = z.object({
         ZResponseFilterCriteriaIsNotEmpty,
         ZResponseFilterCriteriaIsAnyOf,
         ZResponseFilterCriteriaFilledOut,
+        // Text ops for string-typed ingested Embedded Data fields, which filter through `data`
+        // under their storage key (ENG-1848).
+        ZResponseFilterCriteriaContains,
+        ZResponseFilterCriteriaDoesNotContain,
+        ZResponseFilterCriteriaStartsWith,
+        ZResponseFilterCriteriaDoesNotStartWith,
+        ZResponseFilterCriteriaEndsWith,
+        ZResponseFilterCriteriaDoesNotEndWith,
       ])
     )
     .optional(),
+
+  /**
+   * Typed filters on Embedded Data + reserved fields (ENG-1848).
+   * - `variables`: computed embedded fields, keyed by storageKey (values live in `Response.variables`).
+   * - `reserved`: reserved catalog fields, keyed by catalog entry name (`utmSource`, `deviceType`, …).
+   *   The name→storage-path mapping is owned by `buildWhereClause`, which also drops names the
+   *   survey's declared fields shadow — filters fail closed, consistent with recall/logic.
+   */
+  variables: z.record(z.string(), ZTypedFieldFilterCondition).optional(),
+  reserved: z.record(z.string(), ZTypedFieldFilterCondition).optional(),
 
   tags: z
     .object({


### PR DESCRIPTION
## What & why

Response filtering could not reach Embedded Data or reserved fields. The "Meta" filter category listed whatever string keys the stored responses happened to hold (raw camelCase, no number fields, empty on a fresh survey), hidden fields only offered equals/not-equals, and computed fields (variables) were not filterable at all — no criteria key, no query branch, no UI. This is Renata's hard requirement: stakeholders must slice by brand, country, page type.

This PR makes the whole pipeline typed and catalog-driven:

- **Filter dropdown** enumerates reserved fields from the catalog (same list, localized labels, and icons as the response table), ingested fields from the survey's declared rows (filterable before the first response), and a new **Variables** group for computed fields.
- **Operators per dataType**, following the editor's logic-builder model: string → equality + contains/starts/ends (+negations), number → comparisons, date → before/after, boolean → is — and **Is set / Is not set** on every family (the value box disables).
- **Criteria schema** gains `reserved` (catalog-name keyed) and `variables` (storageKey keyed) groups; the `data` group gains text ops for string ingested fields. Values are coerced to the field's dataType (a jsonb number never matches a string `"12"`).
- **`buildWhereClause`** gains a reserved-name → storage-path locator map (`deviceType` → `["userAgent","device"]`, `durationSeconds` → `ttc._total` with `Math.round`-window math so DB filtering agrees with the projected seconds at every boundary) and a `variables` branch. **Filters fail closed** on shadowed names — a survey declaring `url` filters its own field, never the reserved read — enforced at enumeration *and* server-side against crafted criteria; unknown names and type-mismatched ops emit nothing.
- Gates match the export (ENG-1847): anonymized surveys don't offer never-captured fields, `ipAddress` follows its capture toggle — no always-empty filters.
- Observed dropdown values run through the shared projection, so `url` values appear query-stripped.

Date before/after ships on `lessThan`/`greaterThan` with ISO strings — verified empirically that Prisma passes string comparisons to jsonb, which orders same-format ISO strings chronologically.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1848

## How this was tested

- Unit: `apps/web` **7826/7826** ✅, `packages/types` **372/372** ✅; typecheck ✅; lint ✅.
  - `utils.test.ts`: 13 new tests (locator paths incl. the `deviceType` remap, duration windows, presence via DbNull, shadowed/unknown/type-mismatch fail-closed, variables keying, data text ops, enumeration gates) + an anti-drift test pinning that every filterable catalog entry has a locator.
  - `surveys.test.ts`: catalog-driven options, per-dataType operator menus, declared-field enumeration, criteria bucketing (reserved/variables/data), number coercion, presence remap.
  - **Seven mutation fail-checks** verified each rule's test goes red without it (shadow-skip, deviceType remap, duration window, duration inclusion, number coercion, presence remap, reserved fail-closed).
- New e2e `apps/web/playwright/response-filter.spec.ts`: campaign + bare response → filter "UTM Source equals newsletter" narrows the table → switch to "Is not set" inverts it. Green; **red with the old `buildWhereClause`** (revert check).
- Query plan (`EXPLAIN`, local): reserved meta-path and `ttc._total` filters run as `surveyId`-scoped scans — identical shape to every existing JSON filter (no GIN indexes exist on Response JSON columns); no new index in v1.

<details>
<summary>Screenshots — filter dropdown before / after</summary>

**Field list** — before: raw keys observed from stored responses (blank icons, nothing on a fresh survey); after: catalog-driven with the table's labels and icons:

| Before | After |
| --- | --- |
| ![Old dropdown: raw meta keys like PagePath and Locale with missing icons](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1848/filter-fields-before.png) | ![New dropdown: catalog-driven labels Source, URL, Country, Action with icons](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1848/filter-fields-after.png) |

**End of the list** — before: no Variables group, raw `UtmSource`; after: number fields (Screen/Viewport), Hidden fields, and the new Variables group:

| Before | After |
| --- | --- |
| ![Old list end: UtmSource raw key, hidden fields, no Variables group](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1848/filter-groups-bottom-before.png) | ![New list end: screen and viewport fields, hidden fields, Variables group with score](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1848/filter-groups-bottom-after.png) |

**Operators for UTM Source** — before: Equals / Not equals only; after: the full string family plus Is set / Is not set:

| Before | After |
| --- | --- |
| ![Old operator menu: only Equals and Not equals](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1848/filter-operators-before.png) | ![New operator menu: text operator family plus Is set and Is not set](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1848/filter-operators-after.png) |

</details>

## Breaking changes

None — the criteria schema changes are additive (the old `meta` group is still accepted and translated), filter state is session-only, and the widened action response keeps its existing keys.

## QA / Test Plan

**How to test**

- [ ] Create a link survey with one question, a hidden field `plan`, and a number variable `score`. Submit one response via `?utm_source=newsletter&plan=gold` and one via the bare link (incognito).
- [ ] Responses tab → Filter → Add filter → the dropdown shows the Meta group (UTM Source, Browser, Duration Seconds, …), `plan` under Hidden fields, and `score` under Variables — **also on a brand-new survey with zero responses** (previously Meta was empty until responses existed).
- [ ] UTM Source → Equals → "newsletter" offered in the value dropdown → Apply → only the campaign response remains.
- [ ] UTM Source → Is not set → value box disabled → Apply → only the bare response remains. Close and reopen the popover → the row is still there.
- [ ] Page Path → Contains → free-text input appears → `/s/` matches both responses.
- [ ] Screen Width → Is greater than → numeric input; `plan` → Contains "gol"; `score` → Is less than 5.
- [ ] URL field → observed values in the dropdown show **without** query strings.
- [ ] Enable "Anonymize responses" → Country/Browser/OS/Device/IP Address disappear from the dropdown; disable IP capture → only IP Address disappears.
- [ ] A survey with a declared field named `url` (pre-existing/grandfathered) → Meta group has no URL entry; the declared field filters its own values.
- [ ] Apply a filter, then Download → Filtered responses (CSV) → the file honors the same filter. The Summary tab honors it too.
- [ ] Regression: question, tag, attribute, and Language filters behave as before.

**Preconditions / test data**

- Any workspace; a link survey with a hidden field and a number variable (see first step). No flags or entitlements.

**Risks & regressions**

- Duration Seconds only exists on finished responses — partials never match it (except via "Is not set"). Expected, not a bug.
- "Not equals" also matches responses where the field is absent (consistent with existing question filters).
- Typing a non-number into a number filter silently matches everything (the condition is dropped) — fail-closed by design.
- Date filters compare date-only input against stored ISO values: before/after are correct; exact equals won't match a stored datetime.

**Migrations / env / cutover**

- none
