### PR TITLE
fix(api): stop 500 on partial response updates that omit data

### DIFF
--- a/apps/web/app/api/v1/management/responses/[responseId]/route.ts
+++ b/apps/web/app/api/v1/management/responses/[responseId]/route.ts
@@ -16,7 +16,8 @@ import { resolveStorageUrlsInObject, validateClientFileUploads } from "@/modules
 import { updateResponseWithQuotaEvaluation } from "./lib/response";
 
 type TUncheckedResponseUpdate = Record<string, unknown> & {
-  data: TResponseData;
+  // Both optional: the body is unchecked here, and ZResponseUpdateInput allows partial updates.
+  data?: TResponseData;
   language?: string;
 };
 

--- a/apps/web/lib/response/service.test.ts
+++ b/apps/web/lib/response/service.test.ts
@@ -343,6 +343,32 @@ describe("updateResponse", () => {
         })
       );
     });
+
+    test("preserves stored data and language when the input omits them", async () => {
+      // The management API accepts partial bodies (e.g. `{ "finished": true }`), so `data` and
+      // `language` can both be absent. Absent must mean "leave the stored column alone" — never
+      // overwrite it with an empty value (ENG-2425).
+      const currentResponse = createMockCurrentResponse({
+        data: { question1: "answer1" },
+        language: "de-DE",
+      }) as unknown as NonNullable<Awaited<ReturnType<typeof prisma.response.findUnique>>>;
+
+      vi.mocked(prisma.response.findUnique).mockResolvedValue(currentResponse);
+      vi.mocked(prisma.response.update).mockResolvedValue(currentResponse);
+
+      await updateResponse(mockResponseId, { finished: true });
+
+      expect(prisma.response.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            finished: true,
+            data: { question1: "answer1" },
+            // undefined is a Prisma no-op; null or "" would wipe the stored language
+            language: undefined,
+          }),
+        })
+      );
+    });
   });
 
   describe("variables merging behavior", () => {

--- a/apps/web/modules/api/lib/validation.test.ts
+++ b/apps/web/modules/api/lib/validation.test.ts
@@ -116,6 +116,16 @@ describe("validateResponseData", () => {
     expect(validateResponseData(undefined, mockResponseData, "en", null)).toBeNull();
   });
 
+  test("should return null when responseData is absent", () => {
+    // Partial API updates (e.g. `{ "finished": true }` on PUT /api/v1/management/responses/:id) omit
+    // `data` entirely, so the helper must treat it as "nothing to validate" (ENG-2425).
+    mockGetElementsFromBlocks.mockReturnValue(mockElements);
+
+    expect(validateResponseData(mockBlocks, undefined, "en")).toBeNull();
+    expect(validateResponseData(mockBlocks, null, "en")).toBeNull();
+    expect(mockValidateBlockResponses).not.toHaveBeenCalled();
+  });
+
   test("should use default language code", () => {
     mockGetElementsFromBlocks.mockReturnValue(mockElements);
     mockValidateBlockResponses.mockReturnValue({});

--- a/apps/web/modules/api/lib/validation.ts
+++ b/apps/web/modules/api/lib/validation.ts
@@ -14,17 +14,22 @@ import { ApiErrorDetails } from "@/modules/api/v2/types/api-error";
  * all survey elements regardless of completion status.
  *
  * @param blocks - Survey blocks containing elements with validation rules (preferred)
- * @param responseData - Response data to validate (keyed by element ID)
+ * @param responseData - Response data to validate (keyed by element ID); absent on partial updates
  * @param languageCode - Language code for error messages (defaults to "en")
  * @param questions - Survey questions (legacy format, used as fallback if blocks are empty)
  * @returns Validation error map keyed by element ID, or null if validation passes
  */
 export const validateResponseData = (
   blocks: unknown[] | undefined | null,
-  responseData: TResponseData,
+  responseData: TResponseData | undefined | null,
   languageCode: string = "en",
   questions?: TSurveyQuestion[] | undefined | null
 ): TValidationErrorMap | null => {
+  // Partial updates omit `data` entirely (e.g. `{ "finished": true }`), so there is nothing to
+  // validate. Matches the sibling validators on this path (validateClientFileUploads,
+  // validateOtherOptionLengthForMultipleChoice), which both early-return on absent data.
+  if (!responseData) return null;
+
   // Use blocks if available, otherwise transform questions to blocks
   let blocksToUse: TSurveyBlock[] = [];
 


### PR DESCRIPTION
Fixes ENG-2425

## What & why

**Was:** `PUT /api/v1/management/responses/:responseId` returned a 500 for any partial body that omitted `data` — `{ "finished": true }`, `{ "language": "de" }`.

**Now:** the partial update applies and returns the updated response.

- The route validates before parsing, and `validateResponseData` read `Object.keys(responseData)` unguarded while `data` is optional.
- The guard sits in the helper, not the route: its two sibling validators here already early-return on absent data, and one guard covers all seven callers.

## Where to look

- [validation.ts](apps/web/modules/api/lib/validation.ts) — the guard
- [route.ts](apps/web/app/api/v1/management/responses/[responseId]/route.ts) — unchecked-body type now says `data?`

## Breaking changes

- [ ] This PR contains breaking changes

None. A request that used to 500 now succeeds; nothing changes for a request that already worked.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && npx vitest run modules/api/lib/validation.test.ts lib/response/service.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Absent `data` no longer throws | unit (red on main) | `validation.test.ts` "should return null when responseData is absent": red with the production `TypeError`, green after |
| Absent `data` validates nothing | unit (red on main) | Same test — `validateBlockResponses` not called |
| Partial update keeps stored `data`/`language` | unit (mutation) | `service.test.ts` "preserves stored data and language when the input omits them"; red at `lib/response/service.ts:588` (`?? null`) and `:573` (drop merge) |
| Six other `validateResponseData` callers | unit (guard) | 145 tests green across the v1/v2 management and client response suites |

<details>
<summary>Red-on-main check</summary>

```
git stash push -- apps/web/modules/api/lib/validation.ts 'apps/web/app/api/v1/management/responses/[responseId]/route.ts'
cd apps/web && npx vitest run modules/api/lib/validation.test.ts
```

```
× should return null when responseData is absent
TypeError: Cannot convert undefined or null to object
 ❯ modules/api/lib/validation.ts:45:69
```

</details>

**Open gaps**

- Not run against a live instance; the throw and the fix are both at the helper.
- Six unrelated suites fail to load locally (`@authzed/authzed-node` missing); same on `main`.

**Risks**

- The six other callers now accept absent data instead of throwing. All parse `data` as required first, so the guard is unreachable there.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code 2.1.251), reasoning effort `xhigh`.
