### PR TITLE
fix(contacts): order attribute upserts and retry on deadlock in the identify path

### DIFF
--- a/apps/web/lib/utils/prisma-deadlock.test.ts
+++ b/apps/web/lib/utils/prisma-deadlock.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from "vitest";
+import { Prisma } from "@formbricks/database/prisma";
+import { isDeadlockError, retryOnDeadlock } from "./prisma-deadlock";
+
+const p2034 = new Prisma.PrismaClientKnownRequestError("deadlock", {
+  code: "P2034",
+  clientVersion: "0.0.1",
+});
+
+describe("isDeadlockError", () => {
+  test("matches a Prisma P2034 known request error", () => {
+    expect(isDeadlockError(p2034)).toBe(true);
+  });
+
+  test("matches the driver-adapter shape by message (the ENG-2038 / ENG-2252 Sentry shape)", () => {
+    expect(isDeadlockError(new Error("deadlock detected"))).toBe(true);
+    expect(isDeadlockError(new Error("SQLSTATE 40P01"))).toBe(true);
+  });
+
+  test("does not match other errors or non-errors", () => {
+    expect(isDeadlockError(new Error("boom"))).toBe(false);
+    expect(
+      isDeadlockError(
+        new Prisma.PrismaClientKnownRequestError("dup", { code: "P2002", clientVersion: "0.0.1" })
+      )
+    ).toBe(false);
+    expect(isDeadlockError("deadlock detected")).toBe(false);
+    expect(isDeadlockError(undefined)).toBe(false);
+  });
+});
+
+describe("retryOnDeadlock", () => {
+  test("returns the result without retrying when the operation succeeds", async () => {
+    const operation = vi.fn().mockResolvedValue("ok");
+
+    await expect(retryOnDeadlock(operation)).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries a deadlock and returns the next attempt's result", async () => {
+    const operation = vi.fn().mockRejectedValueOnce(p2034).mockResolvedValueOnce("ok");
+
+    await expect(retryOnDeadlock(operation)).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  test("gives up after the max attempts when the deadlock persists", async () => {
+    const operation = vi.fn().mockRejectedValue(new Error("deadlock detected"));
+
+    await expect(retryOnDeadlock(operation)).rejects.toThrow("deadlock detected");
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  test("does not retry a non-deadlock error", async () => {
+    const operation = vi.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(retryOnDeadlock(operation)).rejects.toThrow("boom");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/utils/prisma-deadlock.test.ts
+++ b/apps/web/lib/utils/prisma-deadlock.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { Prisma } from "@formbricks/database/prisma";
+import { logger } from "@formbricks/logger";
 import { isDeadlockError, retryOnDeadlock } from "./prisma-deadlock";
+
+const context = { operation: "test.operation" };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const p2034 = new Prisma.PrismaClientKnownRequestError("deadlock", {
   code: "P2034",
@@ -33,28 +40,49 @@ describe("retryOnDeadlock", () => {
   test("returns the result without retrying when the operation succeeds", async () => {
     const operation = vi.fn().mockResolvedValue("ok");
 
-    await expect(retryOnDeadlock(operation)).resolves.toBe("ok");
+    await expect(retryOnDeadlock(operation, context)).resolves.toBe("ok");
     expect(operation).toHaveBeenCalledTimes(1);
   });
 
   test("retries a deadlock and returns the next attempt's result", async () => {
     const operation = vi.fn().mockRejectedValueOnce(p2034).mockResolvedValueOnce("ok");
 
-    await expect(retryOnDeadlock(operation)).resolves.toBe("ok");
+    await expect(retryOnDeadlock(operation, context)).resolves.toBe("ok");
     expect(operation).toHaveBeenCalledTimes(2);
   });
 
   test("gives up after the max attempts when the deadlock persists", async () => {
     const operation = vi.fn().mockRejectedValue(new Error("deadlock detected"));
 
-    await expect(retryOnDeadlock(operation)).rejects.toThrow("deadlock detected");
+    await expect(retryOnDeadlock(operation, context)).rejects.toThrow("deadlock detected");
     expect(operation).toHaveBeenCalledTimes(3);
   });
 
   test("does not retry a non-deadlock error", async () => {
     const operation = vi.fn().mockRejectedValue(new Error("boom"));
 
-    await expect(retryOnDeadlock(operation)).rejects.toThrow("boom");
+    await expect(retryOnDeadlock(operation, context)).rejects.toThrow("boom");
     expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  test("logs each retry with the caller's context, so a swallowed deadlock stays visible", async () => {
+    const warn = vi.spyOn(logger, "warn");
+    const operation = vi.fn().mockRejectedValueOnce(p2034).mockResolvedValueOnce("ok");
+
+    await retryOnDeadlock(operation, { operation: "updateAttributes.existingAttributes", contactId: "c1" });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      { operation: "updateAttributes.existingAttributes", contactId: "c1", attempt: 1 },
+      "Retrying transaction after Postgres deadlock"
+    );
+  });
+
+  test("does not log when the operation succeeds first time", async () => {
+    const warn = vi.spyOn(logger, "warn");
+
+    await retryOnDeadlock(vi.fn().mockResolvedValue("ok"), context);
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/utils/prisma-deadlock.ts
+++ b/apps/web/lib/utils/prisma-deadlock.ts
@@ -1,0 +1,39 @@
+import { isPrismaKnownRequestError } from "@/lib/utils/prisma-error";
+
+/**
+ * A Postgres deadlock aborts ONE transaction in the cycle (SQLSTATE 40P01) and is safe to retry.
+ * Prisma reports it as P2034 on interactive transactions; the pg driver adapter can also surface it
+ * as a DriverAdapterError whose message carries "deadlock detected" — the shape seen in Sentry for
+ * ENG-2038 (login path) and ENG-2252 (contact identify path).
+ */
+export const isDeadlockError = (error: unknown): boolean => {
+  if (isPrismaKnownRequestError(error) && error.code === "P2034") {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : "";
+  return /deadlock detected/i.test(message) || message.includes("40P01");
+};
+
+const DEADLOCK_MAX_ATTEMPTS = 3;
+
+/**
+ * Retry a DB operation a bounded number of times when it fails with a deadlock, with a short linear
+ * backoff so retried transactions don't re-collide in lockstep. Non-deadlock errors propagate on the
+ * first attempt. The caller must be idempotent: a deadlock rolls the whole transaction back, so
+ * re-running it must be safe.
+ *
+ * Retry is the second line of defense — the first is acquiring locks in a deterministic order so no
+ * cycle can form in the first place (see updateAttributes in modules/ee/contacts/lib/attributes.ts).
+ */
+export const retryOnDeadlock = async <T>(operation: () => Promise<T>): Promise<T> => {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= DEADLOCK_MAX_ATTEMPTS || !isDeadlockError(error)) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, attempt * 25));
+    }
+  }
+};

--- a/apps/web/lib/utils/prisma-deadlock.ts
+++ b/apps/web/lib/utils/prisma-deadlock.ts
@@ -1,3 +1,4 @@
+import { logger } from "@formbricks/logger";
 import { isPrismaKnownRequestError } from "@/lib/utils/prisma-error";
 
 /**
@@ -24,8 +25,16 @@ const DEADLOCK_MAX_ATTEMPTS = 3;
  *
  * Retry is the second line of defense — the first is acquiring locks in a deterministic order so no
  * cycle can form in the first place (see updateAttributes in modules/ee/contacts/lib/attributes.ts).
+ *
+ * `context` identifies the caller in the retry log. A swallowed deadlock is otherwise invisible —
+ * the request succeeds and nothing reaches Sentry — which would leave "no longer deadlocking" and
+ * "deadlocking but recovering" indistinguishable in production. Pass ids only: this runs on paths
+ * carrying contact attributes and user emails, and none of that belongs in a log line.
  */
-export const retryOnDeadlock = async <T>(operation: () => Promise<T>): Promise<T> => {
+export const retryOnDeadlock = async <T>(
+  operation: () => Promise<T>,
+  context: { operation: string } & Record<string, unknown>
+): Promise<T> => {
   for (let attempt = 1; ; attempt++) {
     try {
       return await operation();
@@ -33,6 +42,7 @@ export const retryOnDeadlock = async <T>(operation: () => Promise<T>): Promise<T
       if (attempt >= DEADLOCK_MAX_ATTEMPTS || !isDeadlockError(error)) {
         throw error;
       }
+      logger.warn({ ...context, attempt }, "Retrying transaction after Postgres deadlock");
       await new Promise((resolve) => setTimeout(resolve, attempt * 25));
     }
   }

--- a/apps/web/modules/auth/lib/user.ts
+++ b/apps/web/modules/auth/lib/user.ts
@@ -45,36 +45,39 @@ export const updateUserLastLoginAt = async (email: string) => {
   try {
     // Retry on a transient deadlock (40P01): the last-login bump is idempotent, so a bounded retry
     // clears rare cross-transaction contention on the hot login path instead of surfacing a 500.
-    return await retryOnDeadlock(() =>
-      prisma.$transaction(async (tx) => {
-        // FOR NO KEY UPDATE (not FOR UPDATE): this serializes concurrent same-user updates of
-        // lastLoginAt, but — unlike FOR UPDATE — does NOT conflict with the FOR KEY SHARE lock that a
-        // concurrent Session→User FK insert takes on this row during sign-in. FOR UPDATE here was
-        // stronger than the subsequent UPDATE needs and created a deadlock cycle on the login path
-        // (ENG-2038). The row is only read to return the previous lastLoginAt for a login analytics flag.
-        const lockedUsers = await tx.$queryRaw<Array<{ id: string; lastLoginAt: Date | null }>>`
+    // No identifier in the log context: the only one in scope here is the email.
+    return await retryOnDeadlock(
+      () =>
+        prisma.$transaction(async (tx) => {
+          // FOR NO KEY UPDATE (not FOR UPDATE): this serializes concurrent same-user updates of
+          // lastLoginAt, but — unlike FOR UPDATE — does NOT conflict with the FOR KEY SHARE lock that a
+          // concurrent Session→User FK insert takes on this row during sign-in. FOR UPDATE here was
+          // stronger than the subsequent UPDATE needs and created a deadlock cycle on the login path
+          // (ENG-2038). The row is only read to return the previous lastLoginAt for a login analytics flag.
+          const lockedUsers = await tx.$queryRaw<Array<{ id: string; lastLoginAt: Date | null }>>`
         SELECT "id", "lastLoginAt"
         FROM "User"
         WHERE "email" = ${email}
         FOR NO KEY UPDATE
       `;
-        const lockedUser = lockedUsers[0];
+          const lockedUser = lockedUsers[0];
 
-        if (!lockedUser) {
-          throw new ResourceNotFoundError("email", email);
-        }
+          if (!lockedUser) {
+            throw new ResourceNotFoundError("email", email);
+          }
 
-        await tx.user.update({
-          where: {
-            id: lockedUser.id,
-          },
-          data: {
-            lastLoginAt: new Date(),
-          },
-        });
+          await tx.user.update({
+            where: {
+              id: lockedUser.id,
+            },
+            data: {
+              lastLoginAt: new Date(),
+            },
+          });
 
-        return lockedUser.lastLoginAt;
-      })
+          return lockedUser.lastLoginAt;
+        }),
+      { operation: "updateUserLastLoginAt" }
     );
   } catch (error) {
     if (error instanceof ResourceNotFoundError) {

--- a/apps/web/modules/auth/lib/user.ts
+++ b/apps/web/modules/auth/lib/user.ts
@@ -5,43 +5,13 @@ import { PrismaErrorType } from "@formbricks/database/types/error";
 import { ZId } from "@formbricks/types/common";
 import { DatabaseError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TUserCreateInput, TUserUpdateInput, ZUserEmail, ZUserUpdateInput } from "@formbricks/types/user";
+import { retryOnDeadlock } from "@/lib/utils/prisma-deadlock";
 import { isPrismaKnownRequestError, isUniqueConstraintError } from "@/lib/utils/prisma-error";
 import { validateInputs } from "@/lib/utils/validate";
 
 type TUserDbClient = PrismaClient | Prisma.TransactionClient;
 
 const getDbClient = (tx?: Prisma.TransactionClient): TUserDbClient => tx ?? prisma;
-
-// A Postgres deadlock aborts ONE transaction in the cycle (SQLSTATE 40P01) and is safe to retry.
-// Prisma reports it as P2034 on interactive transactions; the pg driver adapter can also surface it as
-// a DriverAdapterError whose message carries "deadlock detected" (the shape seen in Sentry for ENG-2038).
-const isDeadlockError = (error: unknown): boolean => {
-  if (isPrismaKnownRequestError(error) && error.code === "P2034") {
-    return true;
-  }
-  const message = error instanceof Error ? error.message : "";
-  return /deadlock detected/i.test(message) || message.includes("40P01");
-};
-
-const DEADLOCK_MAX_ATTEMPTS = 3;
-
-/**
- * Retry a DB operation a bounded number of times when it fails with a deadlock, with a short linear
- * backoff so retried transactions don't re-collide in lockstep. Non-deadlock errors propagate on the
- * first attempt. Defense-in-depth for the login write path (ENG-2038); the caller must be idempotent.
- */
-const retryOnDeadlock = async <T>(operation: () => Promise<T>): Promise<T> => {
-  for (let attempt = 1; ; attempt++) {
-    try {
-      return await operation();
-    } catch (error) {
-      if (attempt >= DEADLOCK_MAX_ATTEMPTS || !isDeadlockError(error)) {
-        throw error;
-      }
-      await new Promise((resolve) => setTimeout(resolve, attempt * 25));
-    }
-  }
-};
 
 export const updateUser = async (id: string, data: TUserUpdateInput, tx?: Prisma.TransactionClient) => {
   validateInputs([id, ZId], [data, ZUserUpdateInput.partial()]);

--- a/apps/web/modules/ee/contacts/lib/attributes.integration.test.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.integration.test.ts
@@ -46,6 +46,26 @@ const createGate = (): { wait: Promise<void>; open: () => void } => {
   return { wait, open };
 };
 
+/**
+ * Block until Postgres reports a lock request that has not been granted — i.e. our identify
+ * transaction is genuinely waiting on the row the competitor holds. Polling the real lock state
+ * replaces "sleep and hope": on a loaded machine a fixed delay lets the competitor take its second
+ * row before we ever block, no cycle forms, and the test silently stops proving anything.
+ */
+const waitForBlockedLock = async (timeoutMs = 15_000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const [{ blocked }] = await prisma.$queryRaw<Array<{ blocked: number }>>`
+      SELECT count(*)::int AS blocked FROM pg_locks WHERE NOT granted
+    `;
+    if (blocked > 0) return;
+    if (Date.now() > deadline) {
+      throw new Error("timed out waiting for a blocked lock — the intended deadlock never set up");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+};
+
 const seedContactWithAttributes = async (
   keys: string[]
 ): Promise<{ workspaceId: string; contactId: string; attributeKeyIdsSorted: string[] }> => {
@@ -214,9 +234,9 @@ describe("updateAttributes under concurrent identify calls (ENG-2252)", () => {
       attr_a: "recovered",
       attr_b: "recovered",
     });
-    // Let the identify transaction take the first row and start waiting on the last one, so the
-    // competitor's request for the first row closes the cycle rather than merely queueing.
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    // Wait until the identify transaction actually holds the first row and is blocked on the last,
+    // so the competitor's request for the first row closes the cycle rather than merely queueing.
+    await waitForBlockedLock();
     identifyIsInFlight.open();
 
     const [identifyResult] = await Promise.all([identify, competingWriter]);

--- a/apps/web/modules/ee/contacts/lib/attributes.integration.test.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.integration.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
 import { resetDb } from "@/integration/reset-db";
 import { updateAttributes } from "@/modules/ee/contacts/lib/attributes";
 
@@ -31,6 +32,55 @@ const USER_ID = "eng-2252-user";
 beforeEach(async () => {
   await resetDb();
 });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** A promise plus its resolver, for stepping two transactions through an interleaving. */
+const createGate = (): { wait: Promise<void>; open: () => void } => {
+  let open!: () => void;
+  const wait = new Promise<void>((resolve) => {
+    open = () => resolve();
+  });
+  return { wait, open };
+};
+
+const seedContactWithAttributes = async (
+  keys: string[]
+): Promise<{ workspaceId: string; contactId: string; attributeKeyIdsSorted: string[] }> => {
+  const organization = await prisma.organization.create({ data: { name: "ENG-2252 org" } });
+  const workspace = await prisma.workspace.create({
+    data: { name: "ENG-2252 workspace", organizationId: organization.id },
+  });
+  const contact = await prisma.contact.create({ data: { workspaceId: workspace.id } });
+
+  await prisma.contactAttributeKey.createMany({
+    data: keys.map((key) => ({
+      key,
+      name: key,
+      type: key === "userId" ? "default" : "custom",
+      workspaceId: workspace.id,
+    })),
+  });
+  const attributeKeys = await prisma.contactAttributeKey.findMany({
+    where: { workspaceId: workspace.id },
+  });
+  await prisma.contactAttribute.createMany({
+    data: attributeKeys.map((attributeKey) => ({
+      contactId: contact.id,
+      attributeKeyId: attributeKey.id,
+      value: attributeKey.key === "userId" ? USER_ID : "initial",
+    })),
+  });
+
+  return {
+    workspaceId: workspace.id,
+    contactId: contact.id,
+    // The order updateAttributes now locks in.
+    attributeKeyIdsSorted: attributeKeys.map((k) => k.id).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+  };
+};
 
 describe("updateAttributes under concurrent identify calls (ENG-2252)", () => {
   test("concurrent updates of one contact with differently-ordered payloads all succeed", async () => {
@@ -107,4 +157,83 @@ describe("updateAttributes under concurrent identify calls (ENG-2252)", () => {
       expect(attribute.value).toBe(expected);
     }
   });
+
+  /**
+   * The retry is the second line of defense, and deterministic ordering means the test above no
+   * longer reaches it — so it would ship unproven against a real database. The unit tests reject a
+   * synthetic error from a mocked `$transaction`, which cannot show that a REAL driver-adapter 40P01
+   * is classified as a deadlock, nor that re-running a batch `$transaction` (fresh PrismaPromises on
+   * the second attempt) actually recovers.
+   *
+   * This forces a cycle that ordering cannot prevent — a competing writer taking the same two rows in
+   * the opposite order — and makes OUR transaction the victim: Postgres aborts whichever backend
+   * detects the cycle, and a backend detects it once its lock wait exceeds its own `deadlock_timeout`.
+   * Raising that to 20s on the competing session (SET LOCAL, so it dies with the transaction) leaves
+   * our session, on the 1s default, as the detector — and therefore the one aborted with 40P01.
+   */
+  test("recovers when a competing writer forces a real 40P01 that ordering cannot prevent", async () => {
+    const { workspaceId, contactId, attributeKeyIdsSorted } = await seedContactWithAttributes([
+      "userId",
+      "attr_a",
+      "attr_b",
+    ]);
+    const firstLocked = attributeKeyIdsSorted[0];
+    const lastLocked = attributeKeyIdsSorted[attributeKeyIdsSorted.length - 1];
+
+    const warn = vi.spyOn(logger, "warn");
+    const competitorHoldsLastRow = createGate();
+    const identifyIsInFlight = createGate();
+
+    // Competing writer: takes the LAST row in our lock order first, then the first — the reverse
+    // order, which is what ordering alone cannot defend against.
+    const competingWriter = prisma.$transaction(
+      async (tx) => {
+        await tx.$executeRawUnsafe("SET LOCAL deadlock_timeout = '20s'");
+        await tx.$queryRaw`
+          SELECT "id" FROM "ContactAttribute"
+          WHERE "contactId" = ${contactId} AND "attributeKeyId" = ${lastLocked}
+          FOR UPDATE
+        `;
+        competitorHoldsLastRow.open();
+
+        await identifyIsInFlight.wait;
+        // Blocks until our aborted transaction rolls back and releases this row, then commits
+        // immediately — so our retry finds both rows free.
+        await tx.$queryRaw`
+          SELECT "id" FROM "ContactAttribute"
+          WHERE "contactId" = ${contactId} AND "attributeKeyId" = ${firstLocked}
+          FOR UPDATE
+        `;
+      },
+      { timeout: 25_000, maxWait: 25_000 }
+    );
+
+    await competitorHoldsLastRow.wait;
+    const identify = updateAttributes(contactId, USER_ID, workspaceId, {
+      userId: USER_ID,
+      attr_a: "recovered",
+      attr_b: "recovered",
+    });
+    // Let the identify transaction take the first row and start waiting on the last one, so the
+    // competitor's request for the first row closes the cycle rather than merely queueing.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    identifyIsInFlight.open();
+
+    const [identifyResult] = await Promise.all([identify, competingWriter]);
+
+    expect(identifyResult.success).toBe(true);
+    // The retry ran: a real driver-adapter 40P01 was classified as a deadlock and re-attempted.
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ operation: "updateAttributes.existingAttributes", attempt: 1 }),
+      "Retrying transaction after Postgres deadlock"
+    );
+    // ...and the retried batch committed, so the writes are not silently lost.
+    const values = await prisma.contactAttribute.findMany({
+      where: { contactId, attributeKeyId: { not: attributeKeyIdsSorted[0] } },
+      select: { value: true, attributeKey: { select: { key: true } } },
+    });
+    for (const attribute of values.filter((v) => v.attributeKey.key.startsWith("attr_"))) {
+      expect(attribute.value).toBe("recovered");
+    }
+  }, 40_000);
 });

--- a/apps/web/modules/ee/contacts/lib/attributes.integration.test.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.integration.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { resetDb } from "@/integration/reset-db";
+import { updateAttributes } from "@/modules/ee/contacts/lib/attributes";
+
+/**
+ * ENG-2252: concurrent identify calls (`POST /api/v2/client/{environmentId}/user`) for the SAME
+ * contact deadlock when their payloads carry the same attribute keys in different orders.
+ *
+ * `updateAttributes` runs one upsert per attribute inside a single `$transaction`, in
+ * `Object.entries(...)` order — i.e. caller-supplied key order. Two concurrent transactions that
+ * touch the same `ContactAttribute` rows in opposite orders acquire the row locks in opposite
+ * orders, form a lock cycle, and Postgres aborts one of them with SQLSTATE 40P01 ("deadlock
+ * detected") — which the client API surfaces as a 500. The failure lives in real DB locking, not in
+ * any mockable layer, so this drives the real prisma client against real Postgres (same rationale
+ * as prisma-constraint.integration.test.ts).
+ *
+ * Deadlock mechanics make the repro all-but-deterministic rather than strictly guaranteed: each
+ * round races callers whose payloads are exact reverses of each other across enough rows (21) that
+ * two overlapping transactions must cross somewhere in the middle, and runs several rounds. On the
+ * unfixed code this fails reliably; a fix that orders the upserts deterministically (and/or retries
+ * on 40P01) makes it pass deterministically.
+ */
+
+const ATTRIBUTE_COUNT = 20;
+const ROUNDS = 5;
+const CALLERS_PER_ORDER = 2;
+
+const USER_ID = "eng-2252-user";
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("updateAttributes under concurrent identify calls (ENG-2252)", () => {
+  test("concurrent updates of one contact with differently-ordered payloads all succeed", async () => {
+    const organization = await prisma.organization.create({ data: { name: "ENG-2252 org" } });
+    const workspace = await prisma.workspace.create({
+      data: { name: "ENG-2252 workspace", organizationId: organization.id },
+    });
+    const contact = await prisma.contact.create({ data: { workspaceId: workspace.id } });
+
+    // "userId" plus 20 custom keys. Zero-padded so ascending name order is unambiguous.
+    const keys = [
+      "userId",
+      ...Array.from({ length: ATTRIBUTE_COUNT }, (_, i) => `attr_${String(i).padStart(2, "0")}`),
+    ];
+    await prisma.contactAttributeKey.createMany({
+      data: keys.map((key) => ({
+        key,
+        name: key,
+        type: key === "userId" ? "default" : "custom",
+        workspaceId: workspace.id,
+      })),
+    });
+    const attributeKeys = await prisma.contactAttributeKey.findMany({
+      where: { workspaceId: workspace.id },
+    });
+
+    // Pre-create one row per key so every payload entry takes the existing-attribute upsert path —
+    // the shape of a repeat identify call for a known contact, where the deadlock occurs.
+    await prisma.contactAttribute.createMany({
+      data: attributeKeys.map((attributeKey) => ({
+        contactId: contact.id,
+        attributeKeyId: attributeKey.id,
+        value: attributeKey.key === "userId" ? USER_ID : "initial",
+      })),
+    });
+
+    // Same key set, opposite insertion order — Object.entries() preserves it, so the two payload
+    // shapes upsert (and lock) the same rows in opposite orders.
+    const buildPayload = (round: number, reversed: boolean): Record<string, string> => {
+      const orderedKeys = reversed ? [...keys].reverse() : keys;
+      return Object.fromEntries(
+        orderedKeys.map((key) => [key, key === "userId" ? USER_ID : `round-${round}`])
+      );
+    };
+
+    for (let round = 0; round < ROUNDS; round++) {
+      const calls = Array.from({ length: CALLERS_PER_ORDER * 2 }, (_, i) =>
+        updateAttributes(contact.id, USER_ID, workspace.id, buildPayload(round, i % 2 === 1))
+      );
+
+      const results = await Promise.allSettled(calls);
+
+      const failures = results
+        .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+        .map((failure) => String(failure.reason));
+      expect(failures, `round ${round}: concurrent identify calls must not fail`).toEqual([]);
+
+      for (const result of results) {
+        if (result.status === "fulfilled") {
+          expect(result.value.success).toBe(true);
+        }
+      }
+    }
+
+    // Whichever caller committed last, every attribute row must hold a value from the final round —
+    // no row may be left behind by an aborted transaction.
+    const finalAttributes = await prisma.contactAttribute.findMany({
+      where: { contactId: contact.id },
+      select: { value: true, attributeKey: { select: { key: true } } },
+    });
+    expect(finalAttributes).toHaveLength(keys.length);
+    for (const attribute of finalAttributes) {
+      const expected = attribute.attributeKey.key === "userId" ? USER_ID : `round-${ROUNDS - 1}`;
+      expect(attribute.value).toBe(expected);
+    }
+  });
+});

--- a/apps/web/modules/ee/contacts/lib/attributes.test.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.test.ts
@@ -490,6 +490,57 @@ describe("updateAttributes", () => {
     // Both name (coerced from boolean) and email should be upserted
     expect(transactionCall).toHaveLength(2);
   });
+
+  describe("concurrent-identify deadlock protection (ENG-2252)", () => {
+    test("upserts existing attributes in attributeKeyId order regardless of payload key order", async () => {
+      vi.mocked(getContactAttributeKeys).mockResolvedValue(attributeKeys);
+      vi.mocked(getContactAttributes).mockResolvedValue({ name: "Jane", email: "jane@example.com" });
+      vi.mocked(hasEmailAttribute).mockResolvedValue(false);
+
+      // Payload in the exact reverse of attributeKeyId order — the ordering that deadlocks against a
+      // concurrent ascending payload when upserts lock rows in caller order.
+      const attributes = { customAttr: "c", email: "john@example.com", name: "John" };
+      const result = await updateAttributes(contactId, userId, workspaceId, attributes);
+
+      expect(result.success).toBe(true);
+      const upsertedKeyIds = vi
+        .mocked(prisma.contactAttribute.upsert)
+        .mock.calls.map(([args]) => args.where.contactId_attributeKeyId?.attributeKeyId);
+      expect(upsertedKeyIds).toEqual(["key-1", "key-2", "key-3"]);
+    });
+
+    test("retries the upsert transaction once when it deadlocks, and succeeds", async () => {
+      vi.mocked(getContactAttributeKeys).mockResolvedValue(attributeKeys);
+      vi.mocked(getContactAttributes).mockResolvedValue({ name: "Jane", email: "jane@example.com" });
+      vi.mocked(hasEmailAttribute).mockResolvedValue(false);
+      // The driver-adapter deadlock shape seen in Sentry (FORMBRICKS-19P).
+      vi.mocked(prisma.$transaction)
+        .mockRejectedValueOnce(new Error("deadlock detected"))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await updateAttributes(contactId, userId, workspaceId, {
+        name: "John",
+        email: "john@example.com",
+      });
+
+      expect(result.success).toBe(true);
+      expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    });
+
+    test("creates new attribute keys in key order regardless of payload key order", async () => {
+      vi.mocked(getContactAttributeKeys).mockResolvedValue([]);
+      vi.mocked(getContactAttributes).mockResolvedValue({});
+      vi.mocked(prisma.contactAttributeKey.create).mockResolvedValue(undefined as never);
+
+      const result = await updateAttributes(contactId, userId, workspaceId, { zeta: "1", alpha: "2" });
+
+      expect(result.success).toBe(true);
+      const createdKeys = vi
+        .mocked(prisma.contactAttributeKey.create)
+        .mock.calls.map(([args]) => args.data.key);
+      expect(createdKeys).toEqual(["alpha", "zeta"]);
+    });
+  });
 });
 
 describe("formatAttributeMessage", () => {

--- a/apps/web/modules/ee/contacts/lib/attributes.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.ts
@@ -4,6 +4,7 @@ import { ZId, ZString } from "@formbricks/types/common";
 import { TContactAttributesInput, ZContactAttributesInput } from "@formbricks/types/contact-attribute";
 import { TContactAttributeKey } from "@formbricks/types/contact-attribute-key";
 import { MAX_ATTRIBUTE_CLASSES_PER_ENVIRONMENT } from "@/lib/constants";
+import { retryOnDeadlock } from "@/lib/utils/prisma-deadlock";
 import { formatSnakeCaseToTitleCase, isSafeIdentifier } from "@/lib/utils/safe-identifier";
 import { validateInputs } from "@/lib/utils/validate";
 import {
@@ -277,30 +278,44 @@ export const updateAttributes = async (
     messages.push({ code: "userid_already_exists", params: {} });
   }
 
-  // Update all existing attributes with typed column values
+  // Update all existing attributes with typed column values.
+  //
+  // Lock in a deterministic order (ENG-2252): concurrent identify calls for the same contact send the
+  // same keys in whatever order the caller's payload carries, and the upserts acquire the
+  // ContactAttribute row locks in exactly that order — so two payloads with opposite key order form a
+  // lock cycle and Postgres aborts one with SQLSTATE 40P01 ("deadlock detected"). Sorting by
+  // attributeKeyId (the locked rows' identity — contactId is constant here) makes every transaction
+  // take the locks in the same order, so no cycle can form between identify calls. The bounded retry
+  // covers what ordering can't: collisions with other write paths touching the same rows. Both are
+  // safe because a deadlock rolls the whole transaction back and the upserts are idempotent.
   if (existingAttributes.length > 0) {
-    await prisma.$transaction(
-      existingAttributes.map(({ attributeKeyId, columns }) =>
-        prisma.contactAttribute.upsert({
-          where: {
-            contactId_attributeKeyId: {
+    const orderedExistingAttributes = [...existingAttributes].sort((a, b) =>
+      a.attributeKeyId < b.attributeKeyId ? -1 : a.attributeKeyId > b.attributeKeyId ? 1 : 0
+    );
+    await retryOnDeadlock(() =>
+      prisma.$transaction(
+        orderedExistingAttributes.map(({ attributeKeyId, columns }) =>
+          prisma.contactAttribute.upsert({
+            where: {
+              contactId_attributeKeyId: {
+                contactId,
+                attributeKeyId,
+              },
+            },
+            update: {
+              value: columns.value,
+              valueNumber: columns.valueNumber,
+              valueDate: columns.valueDate,
+            },
+            create: {
               contactId,
               attributeKeyId,
+              value: columns.value,
+              valueNumber: columns.valueNumber,
+              valueDate: columns.valueDate,
             },
-          },
-          update: {
-            value: columns.value,
-            valueNumber: columns.valueNumber,
-            valueDate: columns.valueDate,
-          },
-          create: {
-            contactId,
-            attributeKeyId,
-            value: columns.value,
-            valueNumber: columns.valueNumber,
-            valueDate: columns.valueDate,
-          },
-        })
+          })
+        )
       )
     );
   }
@@ -370,26 +385,34 @@ export const updateAttributes = async (
           messages.push({ code: "new_attribute_created", params: { key, dataType } });
         }
 
-        // Create new attributes since we're under the limit
-        await prisma.$transaction(
-          preparedNewAttributes.map(({ key, dataType, columns }) =>
-            prisma.contactAttributeKey.create({
-              data: {
-                key,
-                name: formatSnakeCaseToTitleCase(key),
-                type: "custom",
-                dataType,
-                workspaceId,
-                attributes: {
-                  create: {
-                    contactId,
-                    value: columns.value,
-                    valueNumber: columns.valueNumber,
-                    valueDate: columns.valueDate,
+        // Create new attributes since we're under the limit. Same discipline as the upsert
+        // transaction above (ENG-2252): a deterministic order — key is the identity the
+        // (key, workspaceId) unique index locks on — plus a bounded deadlock retry. A deadlock rolls
+        // the whole batch back, so re-running it is safe.
+        const orderedNewAttributes = [...preparedNewAttributes].sort((a, b) =>
+          a.key < b.key ? -1 : a.key > b.key ? 1 : 0
+        );
+        await retryOnDeadlock(() =>
+          prisma.$transaction(
+            orderedNewAttributes.map(({ key, dataType, columns }) =>
+              prisma.contactAttributeKey.create({
+                data: {
+                  key,
+                  name: formatSnakeCaseToTitleCase(key),
+                  type: "custom",
+                  dataType,
+                  workspaceId,
+                  attributes: {
+                    create: {
+                      contactId,
+                      value: columns.value,
+                      valueNumber: columns.valueNumber,
+                      valueDate: columns.valueDate,
+                    },
                   },
                 },
-              },
-            })
+              })
+            )
           )
         );
       }

--- a/apps/web/modules/ee/contacts/lib/attributes.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.ts
@@ -62,6 +62,20 @@ export const formatAttributeMessage = (msg: TAttributeUpdateMessage): string => 
   return template;
 };
 
+/**
+ * Total, locale-independent ordering of two strings by code unit.
+ *
+ * Deliberately NOT `localeCompare` (ENG-2252): this decides the order in which the attribute
+ * transactions below take their row locks, and that order must be byte-identical on every server in
+ * the fleet. `localeCompare` varies with the runtime's locale, so two pods could sort the same keys
+ * differently, take locks in opposite orders, and reintroduce the deadlock this ordering prevents.
+ */
+const compareCodeUnits = (a: string, b: string): number => {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+};
+
 // Default/system attributes that should not be deleted even if missing from payload
 const DEFAULT_ATTRIBUTES = new Set(["email", "userId", "firstName", "lastName"]);
 
@@ -290,7 +304,7 @@ export const updateAttributes = async (
   // safe because a deadlock rolls the whole transaction back and the upserts are idempotent.
   if (existingAttributes.length > 0) {
     const orderedExistingAttributes = [...existingAttributes].sort((a, b) =>
-      a.attributeKeyId < b.attributeKeyId ? -1 : a.attributeKeyId > b.attributeKeyId ? 1 : 0
+      compareCodeUnits(a.attributeKeyId, b.attributeKeyId)
     );
     await retryOnDeadlock(
       () =>
@@ -392,7 +406,7 @@ export const updateAttributes = async (
         // (key, workspaceId) unique index locks on — plus a bounded deadlock retry. A deadlock rolls
         // the whole batch back, so re-running it is safe.
         const orderedNewAttributes = [...preparedNewAttributes].sort((a, b) =>
-          a.key < b.key ? -1 : a.key > b.key ? 1 : 0
+          compareCodeUnits(a.key, b.key)
         );
         await retryOnDeadlock(
           () =>

--- a/apps/web/modules/ee/contacts/lib/attributes.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.ts
@@ -292,31 +292,33 @@ export const updateAttributes = async (
     const orderedExistingAttributes = [...existingAttributes].sort((a, b) =>
       a.attributeKeyId < b.attributeKeyId ? -1 : a.attributeKeyId > b.attributeKeyId ? 1 : 0
     );
-    await retryOnDeadlock(() =>
-      prisma.$transaction(
-        orderedExistingAttributes.map(({ attributeKeyId, columns }) =>
-          prisma.contactAttribute.upsert({
-            where: {
-              contactId_attributeKeyId: {
+    await retryOnDeadlock(
+      () =>
+        prisma.$transaction(
+          orderedExistingAttributes.map(({ attributeKeyId, columns }) =>
+            prisma.contactAttribute.upsert({
+              where: {
+                contactId_attributeKeyId: {
+                  contactId,
+                  attributeKeyId,
+                },
+              },
+              update: {
+                value: columns.value,
+                valueNumber: columns.valueNumber,
+                valueDate: columns.valueDate,
+              },
+              create: {
                 contactId,
                 attributeKeyId,
+                value: columns.value,
+                valueNumber: columns.valueNumber,
+                valueDate: columns.valueDate,
               },
-            },
-            update: {
-              value: columns.value,
-              valueNumber: columns.valueNumber,
-              valueDate: columns.valueDate,
-            },
-            create: {
-              contactId,
-              attributeKeyId,
-              value: columns.value,
-              valueNumber: columns.valueNumber,
-              valueDate: columns.valueDate,
-            },
-          })
-        )
-      )
+            })
+          )
+        ),
+      { operation: "updateAttributes.existingAttributes", contactId, workspaceId }
     );
   }
 
@@ -392,28 +394,30 @@ export const updateAttributes = async (
         const orderedNewAttributes = [...preparedNewAttributes].sort((a, b) =>
           a.key < b.key ? -1 : a.key > b.key ? 1 : 0
         );
-        await retryOnDeadlock(() =>
-          prisma.$transaction(
-            orderedNewAttributes.map(({ key, dataType, columns }) =>
-              prisma.contactAttributeKey.create({
-                data: {
-                  key,
-                  name: formatSnakeCaseToTitleCase(key),
-                  type: "custom",
-                  dataType,
-                  workspaceId,
-                  attributes: {
-                    create: {
-                      contactId,
-                      value: columns.value,
-                      valueNumber: columns.valueNumber,
-                      valueDate: columns.valueDate,
+        await retryOnDeadlock(
+          () =>
+            prisma.$transaction(
+              orderedNewAttributes.map(({ key, dataType, columns }) =>
+                prisma.contactAttributeKey.create({
+                  data: {
+                    key,
+                    name: formatSnakeCaseToTitleCase(key),
+                    type: "custom",
+                    dataType,
+                    workspaceId,
+                    attributes: {
+                      create: {
+                        contactId,
+                        value: columns.value,
+                        valueNumber: columns.valueNumber,
+                        valueDate: columns.valueDate,
+                      },
                     },
                   },
-                },
-              })
-            )
-          )
+                })
+              )
+            ),
+          { operation: "updateAttributes.newAttributeKeys", contactId, workspaceId }
         );
       }
     }


### PR DESCRIPTION
Fixes ENG-2252

## What & why

**Was:** Concurrent identify calls for one contact deadlocked in Postgres and the loser 500’d — 213 events on `POST /api/v2/client/{id}/user` in 90 days.

**Now:** The attribute upserts always take row locks in the same order, so concurrent calls queue instead of forming a cycle.

- Ordering is the fix; the bounded retry catches cycles with other writers.
- Sorts on `attributeKeyId` / `key` — what the unique indexes lock on.
- Retries log, separating "recovering" from "gone".

## Where to look

- [attributes.ts#L306-L335](https://github.com/formbricks/formbricks/blob/fix/ENG-2252_contact-identify-deadlock/apps/web/modules/ee/contacts/lib/attributes.ts#L306-L335) — sort then retry, upsert path
- [prisma-deadlock.ts](https://github.com/formbricks/formbricks/blob/fix/ENG-2252_contact-identify-deadlock/apps/web/lib/utils/prisma-deadlock.ts) — helper lifted from `user.ts`
- [attributes.integration.test.ts#L194](https://github.com/formbricks/formbricks/blob/fix/ENG-2252_contact-identify-deadlock/apps/web/modules/ee/contacts/lib/attributes.integration.test.ts#L194) — forced real 40P01

## Breaking changes

- [ ] This PR contains breaking changes

None — internal only: status codes, response shapes, env and the SDK surface are untouched. Message ordering still follows the payload (both sorts copy first).

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web test && pnpm --filter @formbricks/web test:integration`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Reversed-order payloads racing one contact | unit (red on main) | 20 rows × 5 rounds clean |
| Real 40P01 ordering cannot prevent | unit (mutation) | Recovers; red with `prisma-deadlock.ts:18` set to 1 |
| Upserts locked in `attributeKeyId` order | unit (red on main) | Reversed payload upserts key-1, key-2, key-3 |
| New keys created in `key` order | unit (red on main) | `{zeta, alpha}` creates alpha first |
| Retry logs once, ids only | unit (guard) | `prisma-deadlock.test.ts`; no PII in the line |
| Login path unaffected by extraction | unit (guard) | `user.test.ts` + `auth-email-password` integration |

<details>
<summary>Local prerequisites and stability runs</summary>

The integration suite needs Postgres + Redis; CI provisions them. Locally I ran it against throwaway containers via `TEST_DB_CONTAINER` / `TEST_REDIS_CONTAINER` / `TEST_DATABASE_URL` / `TEST_REDIS_URL`.

Both concurrency tests ran 10 consecutive times green. The forced-deadlock test waits on `pg_locks` for an ungranted lock rather than sleeping, so a loaded runner cannot let the competitor finish early and quietly stop proving anything.

Full unit suite: 723 files pass. Two files fail on this machine (`widget-view`, `authzed-entrypoints`) — identical with this branch stashed, so pre-existing.
</details>

**Open gaps**

- HTTP status mapping unverified — the route wrapper needs a Next request scope.
- Adjacent failures here are ticketed, not fixed: ENG-2802, ENG-2803, ENG-749.

**Risks**

- Retry triples worst-case DB work under contention; ordering should make it rare.
- A switch to `localeCompare` in either sort reintroduces the bug.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.
