### PR TITLE
feat: pipe response and survey context into feedback record metadata

### DIFF
--- a/apps/web/app/api/v3/feedbackRecords/lib/schemas.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/schemas.ts
@@ -386,15 +386,16 @@ export const ZV3FeedbackRecordCreateBodyFields = z.object({
     // one is the expensive one to learn late: an agent that assumes `metadata` is queryable will
     // promise a breakdown it cannot produce.
     .describe(
-      "Arbitrary context stored with the record and returned verbatim: the dimensions you want to " +
+      "Arbitrary context stored with the record and returned with equivalent values (key order and " +
+        "number formatting are normalized): the dimensions you want to " +
         "group or segment by later, such as channel, device, browser, OS, country, referrer, " +
         "campaign, plan or tags. Values may be strings, numbers, booleans, null, or nested objects " +
         "and arrays. Use snake_case keys and keep them stable across records, since the key is what " +
         "a chart groups by. NOT filterable or searchable through this API — metadata is read back " +
         "with a record, so narrowing by a metadata value means fetching and filtering client-side. " +
         "On update the whole object is REPLACED, not merged, so send every key you want to keep. " +
-        "Avoid personal data: it is stored unredacted, and it is repeated on every record belonging " +
-        "to the same submission."
+        "Avoid personal data: it is stored unredacted (and the Formbricks survey pipeline repeats " +
+        "its own metadata on every record of a submission)."
     ),
 });
 

--- a/apps/web/app/api/v3/feedbackRecords/lib/schemas.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/schemas.ts
@@ -381,7 +381,21 @@ export const ZV3FeedbackRecordCreateBodyFields = z.object({
       message: `must serialize to at most ${MAX_METADATA_BYTES} bytes`,
     })
     .optional()
-    .describe("Additional context (device, tags, etc.)."),
+    // This one description is the whole story for three MCP tools (create, batch create, update),
+    // which inherit it from here, so it has to carry the traps as well as the shape. The filtering
+    // one is the expensive one to learn late: an agent that assumes `metadata` is queryable will
+    // promise a breakdown it cannot produce.
+    .describe(
+      "Arbitrary context stored with the record and returned verbatim: the dimensions you want to " +
+        "group or segment by later, such as channel, device, browser, OS, country, referrer, " +
+        "campaign, plan or tags. Values may be strings, numbers, booleans, null, or nested objects " +
+        "and arrays. Use snake_case keys and keep them stable across records, since the key is what " +
+        "a chart groups by. NOT filterable or searchable through this API — metadata is read back " +
+        "with a record, so narrowing by a metadata value means fetching and filtering client-side. " +
+        "On update the whole object is REPLACED, not merged, so send every key you want to keep. " +
+        "Avoid personal data: it is stored unredacted, and it is repeated on every record belonging " +
+        "to the same submission."
+    ),
 });
 
 /**

--- a/apps/web/lib/feedback-source/pipeline-handler.ts
+++ b/apps/web/lib/feedback-source/pipeline-handler.ts
@@ -34,7 +34,7 @@ const logFailedRecords = (feedbackSourceId: string, failures: TReconcileFailure[
 const processFeedbackSource = async (
   feedbackSource: TFeedbackSourceWithMappings,
   response: TResponse,
-  survey: Pick<TSurvey, "id" | "name" | "blocks" | "languages">,
+  survey: Pick<TSurvey, "id" | "name" | "type" | "blocks" | "languages">,
   workspaceId: string
 ): Promise<void> => {
   const feedbackRecords = transformResponseToFeedbackRecords(
@@ -106,7 +106,7 @@ const processFeedbackSource = async (
  */
 export const handleFeedbackSourcePipeline = async (
   response: TResponse,
-  survey: Pick<TSurvey, "id" | "name" | "blocks" | "languages">,
+  survey: Pick<TSurvey, "id" | "name" | "type" | "blocks" | "languages">,
   workspaceId: string
 ): Promise<void> => {
   try {

--- a/apps/web/lib/feedback-source/response-metadata.test.ts
+++ b/apps/web/lib/feedback-source/response-metadata.test.ts
@@ -68,6 +68,24 @@ describe("stripUrlQuery", () => {
   });
 
   test.each([
+    // The personal-link token is the credential itself, and stripping the query does not touch it.
+    ["personal link", "https://app.example.com/c/eyJhbGci.tok.sig?foo=1", "https://app.example.com/c"],
+    ["personal link, no query", "https://app.example.com/c/eyJhbGci.tok.sig", "https://app.example.com/c"],
+    [
+      "an ordinary survey path is untouched",
+      "https://app.example.com/s/cm123",
+      "https://app.example.com/s/cm123",
+    ],
+  ])("drops the personal-link token (%s)", (_label, input, expected) => {
+    expect(stripUrlQuery(input)).toBe(expected);
+  });
+
+  test("drops userinfo up to the last @, not the first", () => {
+    // Cutting at the first `@` would publish the tail of the password.
+    expect(stripUrlQuery("//user:p@ss@host/path?token=1")).toBe("//host/path");
+  });
+
+  test.each([
     ["empty", ""],
     ["whitespace", "   "],
     ["query only", "?token=secret"],
@@ -81,9 +99,15 @@ describe("buildResponseMetadata", () => {
     // Asserted with toEqual, not toMatchObject: this is the published payload, so a newly added
     // key has to be seen and decided on here rather than shipping unnoticed.
     expect(
-      buildResponseMetadata(buildResponse({ meta: fullMeta, finished: true, ttc: { _total: 45_500 } }), {
-        type: "app",
-      })
+      buildResponseMetadata(
+        buildResponse({
+          meta: fullMeta,
+          finished: true,
+          ttc: { _total: 45_500 },
+          endingId: "ending-1",
+        }),
+        { type: "app" }
+      )
     ).toEqual({
       source: "link",
       url: "https://app.example.com/s/abc",
@@ -94,6 +118,7 @@ describe("buildResponseMetadata", () => {
       action: "Clicked pricing CTA",
       finished: true,
       duration_seconds: 46,
+      ending_id: "ending-1",
       survey_type: "app",
     });
   });
@@ -210,6 +235,13 @@ describe("buildResponseMetadata", () => {
       ).toBe("feedback \u{1F600}");
     });
 
+    test("does not leave trailing whitespace where the cut landed", () => {
+      expect(
+        buildResponseMetadata(buildResponse({ meta: { source: `${"a".repeat(255)} tail` } }), linkSurvey)
+          .source
+      ).toBe("a".repeat(255));
+    });
+
     test("strips NUL bytes, which Hub cannot store", () => {
       expect(
         buildResponseMetadata(buildResponse({ meta: { source: "li\u0000nk" } }), linkSurvey).source
@@ -273,6 +305,7 @@ describe("HUB_METADATA_FIELDS", () => {
       "action",
       "finished",
       "duration_seconds",
+      "ending_id",
       "survey_type",
     ]);
   });

--- a/apps/web/lib/feedback-source/response-metadata.test.ts
+++ b/apps/web/lib/feedback-source/response-metadata.test.ts
@@ -129,6 +129,38 @@ describe("buildResponseMetadata", () => {
     expect(result).toEqual({});
   });
 
+  describe("values the column can hold but the type does not describe", () => {
+    // Response.meta is a Prisma `Json` column and stored rows are never re-validated on read, so
+    // these shapes are reachable in production even though TResponseMeta forbids them. A throw here
+    // aborts the whole transform and the caller's catch drops the response's records silently.
+    test("treats a null value as absent", () => {
+      const result = buildResponseMetadata(
+        buildResponse({ meta: { source: "link", action: null } as never }),
+        linkSurvey
+      );
+
+      expect(result).not.toHaveProperty("action");
+      expect(result.source).toBe("link");
+    });
+
+    test("drops a value that is not a scalar, and passes a stray scalar through", () => {
+      const result = buildResponseMetadata(
+        buildResponse({ meta: { source: 42, url: { nested: true }, country: ["PT"] } as never }),
+        linkSurvey
+      );
+
+      // A number is a legal JSONB scalar, so publishing it loses nothing; an object or array is
+      // what the metadata contract cannot carry.
+      expect(result.source).toBe(42);
+      expect(result).not.toHaveProperty("url");
+      expect(result).not.toHaveProperty("country");
+    });
+
+    test("survives a meta object that is null outright", () => {
+      expect(() => buildResponseMetadata(buildResponse({ meta: null as never }), linkSurvey)).not.toThrow();
+    });
+  });
+
   describe("bounds", () => {
     test("truncates oversized values so an inflated meta cannot fail the Hub create", () => {
       const result = buildResponseMetadata(

--- a/apps/web/lib/feedback-source/response-metadata.test.ts
+++ b/apps/web/lib/feedback-source/response-metadata.test.ts
@@ -55,6 +55,16 @@ describe("stripUrlQuery", () => {
   });
 
   test.each([
+    // `user:pass@host` parses as a URL whose protocol is `user:`, so it dodges the origin branch —
+    // the fallback has to drop the credentials itself.
+    ["scheme-less credentials", "user:pass@app.example.com/p?token=1", "app.example.com/p"],
+    ["credentials on a custom scheme", "myapp://u:p@host/x?t=1", "myapp://host/x"],
+    ["credentials with nothing after them", "user:pass@", undefined],
+  ])("drops userinfo the origin branch never saw (%s)", (_label, input, expected) => {
+    expect(stripUrlQuery(input)).toBe(expected);
+  });
+
+  test.each([
     ["empty", ""],
     ["whitespace", "   "],
     ["query only", "?token=secret"],
@@ -215,6 +225,15 @@ describe("buildResponseMetadata", () => {
       expect(
         buildResponseMetadata(buildResponse({ ttc: { _total: 45_500 } }), linkSurvey).duration_seconds
       ).toBe(46);
+    });
+
+    test("publishes a duration of exactly seven days", () => {
+      // The cap is inclusive: a week is a plausible longest-lived link-survey tab, noise starts
+      // beyond it.
+      expect(
+        buildResponseMetadata(buildResponse({ ttc: { _total: 7 * 24 * 60 * 60 * 1000 } }), linkSurvey)
+          .duration_seconds
+      ).toBe(604_800);
     });
 
     test("publishes a zero duration", () => {

--- a/apps/web/lib/feedback-source/response-metadata.test.ts
+++ b/apps/web/lib/feedback-source/response-metadata.test.ts
@@ -76,6 +76,11 @@ describe("stripUrlQuery", () => {
       "https://app.example.com/s/cm123",
       "https://app.example.com/s/cm123",
     ],
+    // The fallback shape: never produced by the SDK (which sends an absolute href), but `meta.url`
+    // is client-supplied, so the helper's contract has to hold on this path too.
+    ["protocol-relative personal link", "//app.example.com/c/eyJhbGci.tok.sig?foo=1", "//app.example.com/c"],
+    ["scheme-less personal link", "app.example.com/c/eyJhbGci.tok.sig", "app.example.com/c"],
+    ["a /c segment that is not the first is left alone", "//host/a/c/keep", "//host/a/c/keep"],
   ])("drops the personal-link token (%s)", (_label, input, expected) => {
     expect(stripUrlQuery(input)).toBe(expected);
   });

--- a/apps/web/lib/feedback-source/response-metadata.test.ts
+++ b/apps/web/lib/feedback-source/response-metadata.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import {
-  METADATA_FIELDS,
+  HUB_METADATA_FIELDS,
   type TMetadataContext,
   buildResponseMetadata,
   projectMetadataFields,
@@ -237,11 +237,11 @@ describe("buildResponseMetadata", () => {
   });
 });
 
-describe("METADATA_FIELDS", () => {
+describe("HUB_METADATA_FIELDS", () => {
   test("publishes exactly the reviewed allowlist", () => {
     // Adding a field to the catalog is a privacy decision (see the module comment), so it has to be
     // made here too. `ipAddress` is absent by construction and must stay absent.
-    expect(METADATA_FIELDS.filter((field) => field.enabled).map((field) => field.key)).toEqual([
+    expect(HUB_METADATA_FIELDS.filter((field) => field.enabled).map((field) => field.key)).toEqual([
       "source",
       "url",
       "browser",
@@ -256,14 +256,14 @@ describe("METADATA_FIELDS", () => {
   });
 
   test("names every field in snake_case, as Hub metadata keys are conventionally written", () => {
-    const offenders = METADATA_FIELDS.filter((field) => !/^[a-z][a-z0-9_]*$/.test(field.key));
+    const offenders = HUB_METADATA_FIELDS.filter((field) => !/^[a-z][a-z0-9_]*$/.test(field.key));
     expect(offenders.map((field) => field.key)).toEqual([]);
   });
 });
 
 describe("projectMetadataFields", () => {
   test("skips a field that has been withdrawn", () => {
-    // Driven through an ad-hoc table rather than by mutating METADATA_FIELDS, which other callers
+    // Driven through an ad-hoc table rather than by mutating HUB_METADATA_FIELDS, which other callers
     // share: the point is that flipping `enabled` is all it takes to stop publishing a field.
     const result = projectMetadataFields(
       [

--- a/apps/web/lib/feedback-source/response-metadata.test.ts
+++ b/apps/web/lib/feedback-source/response-metadata.test.ts
@@ -177,6 +177,26 @@ describe("buildResponseMetadata", () => {
       expect(result.url).toHaveLength(512);
     });
 
+    test("never cuts a surrogate pair in half", () => {
+      // 255 single-unit characters plus one emoji is 257 UTF-16 code units, so the 256 cap lands
+      // between the emoji's two halves.
+      const result = buildResponseMetadata(
+        buildResponse({ meta: { source: `${"a".repeat(255)}\u{1F600}` } }),
+        linkSurvey
+      );
+
+      expect(result.source).toHaveLength(255);
+      // A lone surrogate is rejected on the jsonb insert just like a NUL byte, so the whole
+      // submission's records would never be published.
+      expect(String(result.source)).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    });
+
+    test("keeps a multi-byte character that fits within the cap", () => {
+      expect(
+        buildResponseMetadata(buildResponse({ meta: { source: "feedback \u{1F600}" } }), linkSurvey).source
+      ).toBe("feedback \u{1F600}");
+    });
+
     test("strips NUL bytes, which Hub cannot store", () => {
       expect(
         buildResponseMetadata(buildResponse({ meta: { source: "li\u0000nk" } }), linkSurvey).source

--- a/apps/web/lib/feedback-source/response-metadata.test.ts
+++ b/apps/web/lib/feedback-source/response-metadata.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "vitest";
+import type { TSurvey } from "@formbricks/types/surveys/types";
+import {
+  METADATA_FIELDS,
+  type TMetadataContext,
+  buildResponseMetadata,
+  projectMetadataFields,
+  stripUrlQuery,
+} from "./response-metadata";
+
+type TMetadataResponse = TMetadataContext["response"];
+
+const buildResponse = (overrides: Partial<TMetadataResponse> = {}): TMetadataResponse => ({
+  meta: {},
+  finished: true,
+  ttc: {},
+  ...overrides,
+});
+
+const linkSurvey: Pick<TSurvey, "type"> = { type: "link" };
+
+const fullMeta = {
+  source: "link",
+  url: "https://app.example.com/s/abc?token=secret&utm_source=newsletter#question-2",
+  userAgent: { browser: "Chrome", os: "macOS", device: "desktop" },
+  country: "PT",
+  action: "Clicked pricing CTA",
+  // Present on every IP-capturing survey's response and must never be published.
+  ipAddress: "203.0.113.7",
+};
+
+describe("stripUrlQuery", () => {
+  test("reduces an absolute url to origin and path", () => {
+    expect(stripUrlQuery("https://app.example.com/s/abc?token=secret#question-2")).toBe(
+      "https://app.example.com/s/abc"
+    );
+  });
+
+  test("leaves a url that carries no query or fragment untouched", () => {
+    expect(stripUrlQuery("https://app.example.com/pricing")).toBe("https://app.example.com/pricing");
+  });
+
+  test("drops embedded credentials", () => {
+    expect(stripUrlQuery("https://user:pass@app.example.com/s/abc")).toBe("https://app.example.com/s/abc");
+  });
+
+  test("cuts the query off a value that is not an absolute url", () => {
+    // The scheme-less form cannot be parsed, and passing it through would leak the token this
+    // helper exists to remove.
+    expect(stripUrlQuery("app.example.com/s/abc?token=secret")).toBe("app.example.com/s/abc");
+  });
+
+  test("cuts the query off a non-web scheme", () => {
+    expect(stripUrlQuery("myapp://survey/abc?token=secret")).toBe("myapp://survey/abc");
+  });
+
+  test.each([
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["query only", "?token=secret"],
+  ])("returns undefined for a %s value", (_label, input) => {
+    expect(stripUrlQuery(input)).toBeUndefined();
+  });
+});
+
+describe("buildResponseMetadata", () => {
+  test("publishes the full response and survey context", () => {
+    // Asserted with toEqual, not toMatchObject: this is the published payload, so a newly added
+    // key has to be seen and decided on here rather than shipping unnoticed.
+    expect(
+      buildResponseMetadata(buildResponse({ meta: fullMeta, finished: true, ttc: { _total: 45_500 } }), {
+        type: "app",
+      })
+    ).toEqual({
+      source: "link",
+      url: "https://app.example.com/s/abc",
+      browser: "Chrome",
+      os: "macOS",
+      device: "desktop",
+      country: "PT",
+      action: "Clicked pricing CTA",
+      finished: true,
+      duration_seconds: 46,
+      survey_type: "app",
+    });
+  });
+
+  test("never publishes the respondent's IP address", () => {
+    const result = buildResponseMetadata(buildResponse({ meta: fullMeta }), linkSurvey);
+
+    expect(Object.keys(result)).not.toContain("ipAddress");
+    expect(Object.keys(result)).not.toContain("ip_address");
+    expect(Object.values(result)).not.toContain(fullMeta.ipAddress);
+  });
+
+  test("falls back to row context when the response carries no meta", () => {
+    // meta defaults to {} in Prisma, so this is the shape of a link response with no tracking.
+    expect(buildResponseMetadata(buildResponse({ meta: {} }), linkSurvey)).toEqual({
+      finished: true,
+      survey_type: "link",
+    });
+  });
+
+  test("omits blank values instead of publishing empty keys", () => {
+    expect(
+      buildResponseMetadata(
+        buildResponse({
+          meta: {
+            source: "",
+            url: "",
+            country: "   ",
+            action: "",
+            userAgent: { browser: "", os: "", device: "" },
+          },
+        }),
+        linkSurvey
+      )
+    ).toEqual({ finished: true, survey_type: "link" });
+  });
+
+  test("returns nothing for a row that carries no context at all", () => {
+    // Legacy rows predate several of these fields; the transform relies on an empty result to omit
+    // the metadata key entirely rather than storing {}.
+    const result = buildResponseMetadata(
+      { meta: undefined, finished: undefined, ttc: undefined } as unknown as TMetadataResponse,
+      {} as Pick<TSurvey, "type">
+    );
+
+    expect(result).toEqual({});
+  });
+
+  describe("bounds", () => {
+    test("truncates oversized values so an inflated meta cannot fail the Hub create", () => {
+      const result = buildResponseMetadata(
+        buildResponse({
+          meta: {
+            source: "s".repeat(400),
+            url: `https://app.example.com/${"p".repeat(900)}`,
+          },
+        }),
+        linkSurvey
+      );
+
+      expect(result.source).toHaveLength(256);
+      expect(result.url).toHaveLength(512);
+    });
+
+    test("strips NUL bytes, which Hub cannot store", () => {
+      expect(
+        buildResponseMetadata(buildResponse({ meta: { source: "li\u0000nk" } }), linkSurvey).source
+      ).toBe("link");
+    });
+
+    test("omits a value that is nothing but NUL bytes", () => {
+      expect(
+        buildResponseMetadata(buildResponse({ meta: { source: "\u0000" } }), linkSurvey)
+      ).not.toHaveProperty("source");
+    });
+  });
+
+  describe("duration_seconds", () => {
+    test("converts the total time-to-complete from milliseconds", () => {
+      expect(
+        buildResponseMetadata(buildResponse({ ttc: { _total: 45_500 } }), linkSurvey).duration_seconds
+      ).toBe(46);
+    });
+
+    test("publishes a zero duration", () => {
+      // Zero is a measurement, not a missing value — an omit-on-falsy check would drop it.
+      expect(buildResponseMetadata(buildResponse({ ttc: { _total: 0 } }), linkSurvey).duration_seconds).toBe(
+        0
+      );
+    });
+
+    test.each([
+      ["no _total key", {}],
+      ["a negative total", { _total: -1 }],
+      ["a non-finite total", { _total: Number.NaN }],
+      ["a total beyond a week", { _total: 8 * 24 * 60 * 60 * 1000 }],
+    ])("omits the duration for %s", (_label, ttc) => {
+      expect(buildResponseMetadata(buildResponse({ ttc }), linkSurvey)).not.toHaveProperty(
+        "duration_seconds"
+      );
+    });
+  });
+});
+
+describe("METADATA_FIELDS", () => {
+  test("publishes exactly the reviewed allowlist", () => {
+    // Adding a field to the catalog is a privacy decision (see the module comment), so it has to be
+    // made here too. `ipAddress` is absent by construction and must stay absent.
+    expect(METADATA_FIELDS.filter((field) => field.enabled).map((field) => field.key)).toEqual([
+      "source",
+      "url",
+      "browser",
+      "os",
+      "device",
+      "country",
+      "action",
+      "finished",
+      "duration_seconds",
+      "survey_type",
+    ]);
+  });
+
+  test("names every field in snake_case, as Hub metadata keys are conventionally written", () => {
+    const offenders = METADATA_FIELDS.filter((field) => !/^[a-z][a-z0-9_]*$/.test(field.key));
+    expect(offenders.map((field) => field.key)).toEqual([]);
+  });
+});
+
+describe("projectMetadataFields", () => {
+  test("skips a field that has been withdrawn", () => {
+    // Driven through an ad-hoc table rather than by mutating METADATA_FIELDS, which other callers
+    // share: the point is that flipping `enabled` is all it takes to stop publishing a field.
+    const result = projectMetadataFields(
+      [
+        { key: "kept", enabled: true, read: () => "published" },
+        { key: "withdrawn", enabled: false, read: () => "should not appear" },
+      ],
+      { response: buildResponse(), survey: linkSurvey }
+    );
+
+    expect(result).toEqual({ kept: "published" });
+  });
+
+  test("applies a field's own maxLength ahead of the default", () => {
+    const result = projectMetadataFields(
+      [{ key: "roomy", enabled: true, maxLength: 400, read: () => "x".repeat(500) }],
+      { response: buildResponse(), survey: linkSurvey }
+    );
+
+    expect(result.roomy).toHaveLength(400);
+  });
+});

--- a/apps/web/lib/feedback-source/response-metadata.test.ts
+++ b/apps/web/lib/feedback-source/response-metadata.test.ts
@@ -59,6 +59,9 @@ describe("stripUrlQuery", () => {
     // the fallback has to drop the credentials itself.
     ["scheme-less credentials", "user:pass@app.example.com/p?token=1", "app.example.com/p"],
     ["credentials on a custom scheme", "myapp://u:p@host/x?t=1", "myapp://host/x"],
+    // A network-path reference: new URL() rejects it without a base, so only the fallback can
+    // strip these — and its userinfo cut has to see past the leading slashes.
+    ["credentials on a protocol-relative url", "//user:pass@host/path?token=1", "//host/path"],
     ["credentials with nothing after them", "user:pass@", undefined],
   ])("drops userinfo the origin branch never saw (%s)", (_label, input, expected) => {
     expect(stripUrlQuery(input)).toBe(expected);

--- a/apps/web/lib/feedback-source/response-metadata.ts
+++ b/apps/web/lib/feedback-source/response-metadata.ts
@@ -106,7 +106,7 @@ const readDurationSeconds = (ttc: TResponse["ttc"]): number | undefined => {
  * the module comment. Readers are optional-chained throughout: stored rows predate several of these
  * fields, and `meta` defaults to `{}` in Prisma.
  */
-export const METADATA_FIELDS: readonly TMetadataFieldSpec[] = [
+export const HUB_METADATA_FIELDS: readonly TMetadataFieldSpec[] = [
   { key: "source", enabled: true, read: ({ response }) => response.meta?.source },
   {
     key: "url",
@@ -197,4 +197,4 @@ export const projectMetadataFields = (
 export const buildResponseMetadata = (
   response: TMetadataContext["response"],
   survey: TMetadataContext["survey"]
-): TResponseMetadata => projectMetadataFields(METADATA_FIELDS, { response, survey });
+): TResponseMetadata => projectMetadataFields(HUB_METADATA_FIELDS, { response, survey });

--- a/apps/web/lib/feedback-source/response-metadata.ts
+++ b/apps/web/lib/feedback-source/response-metadata.ts
@@ -26,8 +26,15 @@ import type { TSurvey } from "@formbricks/types/surveys/types";
  * private copies of that list drifted from it.
  */
 
-/** Metadata values are scalars only, which keeps sanitation total — no recursion, no nested JSON. */
-type TMetadataValue = string | number | boolean | undefined;
+/**
+ * Metadata values are scalars only, which keeps sanitation total — no recursion, no nested JSON.
+ *
+ * `null` is in the union because `Response.meta` is a Prisma `Json` column: its Zod type describes
+ * what the API writes, not what the table holds, and stored rows are never re-validated on read. A
+ * reader can therefore surface a `null` — or a value of the wrong type entirely — where the type
+ * says `string | undefined`.
+ */
+type TMetadataValue = string | number | boolean | null | undefined;
 
 export type TResponseMetadata = Record<string, string | number | boolean>;
 
@@ -107,7 +114,7 @@ export const METADATA_FIELDS: readonly TMetadataFieldSpec[] = [
     maxLength: MAX_METADATA_URL_LENGTH,
     read: ({ response }) => {
       const url = response.meta?.url;
-      return url ? stripUrlQuery(url) : undefined;
+      return typeof url === "string" ? stripUrlQuery(url) : undefined;
     },
   },
   { key: "browser", enabled: true, read: ({ response }) => response.meta?.userAgent?.browser },
@@ -124,10 +131,22 @@ export const METADATA_FIELDS: readonly TMetadataFieldSpec[] = [
   { key: "survey_type", enabled: true, read: ({ survey }) => survey.type },
 ];
 
-const sanitizeValue = (value: TMetadataValue, maxLength: number): TMetadataValue => {
+/**
+ * Narrow one read value to something Hub can store, or drop it.
+ *
+ * Takes `unknown` rather than TMetadataValue on purpose: the readers are typed against
+ * `TResponseMeta`, which describes what the API writes into a `Json` column rather than what the
+ * column holds. A throw here is not a local failure — it aborts the whole transform, and the
+ * caller's catch turns that into a response whose records are silently never published.
+ */
+const sanitizeValue = (value: unknown, maxLength: number): string | number | boolean | undefined => {
   if (value === undefined || typeof value === "boolean") return value;
 
   if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+
+  // Catches a stored null (typeof null === "object") as well as an object or array, neither of
+  // which the scalar-only metadata contract can carry.
+  if (typeof value !== "string") return undefined;
 
   // NUL bytes are the one input Hub cannot store: its validator skips non-string kinds, so the
   // jsonb insert reaches Postgres and fails as a 500 rather than a rejected field.

--- a/apps/web/lib/feedback-source/response-metadata.ts
+++ b/apps/web/lib/feedback-source/response-metadata.ts
@@ -15,6 +15,13 @@ import type { TSurvey } from "@formbricks/types/surveys/types";
  *    the same object, it is personal data under GDPR, and Hub applies no validation or redaction of
  *    its own. A spread would publish it the moment a survey enables IP capture. Absence by
  *    construction is the guard — there is no filter to forget.
+ *
+ *    The other response fields left out, so a reader can tell decided from forgotten:
+ *    `contactAttributes` (arbitrary customer-set values — the richest dimension set here, and the
+ *    one most likely to carry personal data, so it needs its own decision rather than riding along),
+ *    `tags` (curated in the UI after submission, so at `responseFinished` they are near-always empty
+ *    and would publish a stale value), `variables` (per-survey and unbounded), and `displayId` /
+ *    `singleUseId` / `updatedAt` (internal plumbing, and `singleUseId` is itself a link token).
  * 2. Values are bounded here. `source`, `url` and `action` are client-supplied on the public
  *    response endpoint (`ZResponseInput.meta` declares no maximum lengths) and Hub caps only the
  *    total request body at 512 KiB, so an oversized value would fail the create and silently cost
@@ -39,7 +46,7 @@ type TMetadataValue = string | number | boolean | null | undefined;
 export type TResponseMetadata = Record<string, string | number | boolean>;
 
 export type TMetadataContext = {
-  response: Pick<TResponse, "meta" | "finished" | "ttc">;
+  response: Pick<TResponse, "meta" | "finished" | "ttc" | "endingId">;
   survey: Pick<TSurvey, "type">;
 };
 
@@ -67,6 +74,22 @@ const MAX_METADATA_URL_LENGTH = 512;
  * would skew an average silently.
  */
 const MAX_DURATION_SECONDS = 7 * 24 * 60 * 60;
+/**
+ * A high surrogate as the final UTF-16 code unit — the signature of a cut that split a pair. A
+ * complete pair ends on its LOW half, so this matches only the orphaned case.
+ */
+const TRAILING_HIGH_SURROGATE = /[\uD800-\uDBFF]$/;
+/**
+ * The personal-link route's token segment (`apps/web/app/c/[jwt]`). Stripping the query is not
+ * enough there: the JWT *is* the authorization to answer as that contact, and it sits in the path,
+ * so `origin + pathname` would move a live credential into a second datastore. It is also unique
+ * per recipient, which would give `url` unbounded cardinality precisely where a dashboard wants a
+ * dimension. Keep the route, drop the secret.
+ */
+const PERSONAL_LINK_TOKEN_PATH = /^(\/c)\/[^/]+/;
+
+/** Userinfo up to the LAST `@` before the path, so `u:p@ss@host` cannot leak `ss`. */
+const LEADING_USERINFO = /^((?:[a-z][a-z0-9+.-]*:)?\/\/)?[^/]*@/i;
 
 /**
  * Reduce a URL to origin + path.
@@ -84,7 +107,7 @@ export const stripUrlQuery = (rawUrl: string): string | undefined => {
     const parsed = new URL(trimmed);
     // `origin` also drops any embedded credentials (https://user:pass@host).
     if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-      return `${parsed.origin}${parsed.pathname}`;
+      return `${parsed.origin}${parsed.pathname.replace(PERSONAL_LINK_TOKEN_PATH, "$1")}`;
     }
   } catch {
     // Not an absolute URL — fall through to the textual cut below.
@@ -93,11 +116,11 @@ export const stripUrlQuery = (rawUrl: string): string | undefined => {
   // The origin branch never ran, so credentials have not been dropped — and this path is easy to
   // reach with them: `user:pass@host/p` parses as a URL whose protocol is `user:`, and the
   // protocol-relative `//user:pass@host/p` cannot be parsed without a base, so both skip the
-  // branch above. Cut the query first, then remove any userinfo (everything up to a trailing `@`
-  // before the first path segment), keeping a `scheme://` or bare `//` prefix when one is present.
-  const cut = trimmed.split(/[?#]/)[0];
+  // branch above. Cut the query first, then remove any userinfo, keeping a `scheme://` or bare
+  // `//` prefix when one is present.
+  const cut = trimmed.split(/[?#]/)[0].replace(LEADING_USERINFO, "$1").trim();
 
-  return cut.replace(/^((?:[a-z][a-z0-9+.-]*:)?\/\/)?[^/@]*@/i, "$1") || undefined;
+  return cut || undefined;
 };
 
 const readDurationSeconds = (ttc: TResponse["ttc"]): number | undefined => {
@@ -135,6 +158,9 @@ export const HUB_METADATA_FIELDS: readonly TMetadataFieldSpec[] = [
     read: ({ response }) => (typeof response.finished === "boolean" ? response.finished : undefined),
   },
   { key: "duration_seconds", enabled: true, read: ({ response }) => readDurationSeconds(response.ttc) },
+  // Which ending the respondent reached — the branch they came out of. Bounded per survey and
+  // author-defined, so it groups cleanly.
+  { key: "ending_id", enabled: true, read: ({ response }) => response.endingId },
   { key: "survey_type", enabled: true, read: ({ survey }) => survey.type },
 ];
 
@@ -166,10 +192,10 @@ const sanitizeValue = (value: unknown, maxLength: number): string | number | boo
   // same silently-dropped-records outcome. The caller picks the offset by choosing the value's
   // length, so this is reachable on purpose and not only by accident.
   const truncated = cleaned.slice(0, maxLength);
-  const lastUnit = truncated.charCodeAt(truncated.length - 1);
-  const endsOnHighSurrogate = lastUnit >= 0xd800 && lastUnit <= 0xdbff;
+  const whole = TRAILING_HIGH_SURROGATE.test(truncated) ? truncated.slice(0, -1) : truncated;
 
-  return endsOnHighSurrogate ? truncated.slice(0, -1) : truncated;
+  // The cut can land mid-word and leave trailing space the pre-truncation trim never saw.
+  return whole.trimEnd() || undefined;
 };
 
 /**
@@ -177,7 +203,8 @@ const sanitizeValue = (value: unknown, maxLength: number): string | number | boo
  * unrepresentable.
  *
  * Separate from the table so the mechanism can be proven against an arbitrary table — a disabled
- * field, a field that throws — without mutating the module-level catalog other callers share.
+ * field, a field with its own maxLength — without mutating the module-level catalog other callers
+ * share.
  */
 export const projectMetadataFields = (
   fields: readonly TMetadataFieldSpec[],

--- a/apps/web/lib/feedback-source/response-metadata.ts
+++ b/apps/web/lib/feedback-source/response-metadata.ts
@@ -87,6 +87,12 @@ const TRAILING_HIGH_SURROGATE = /[\uD800-\uDBFF]$/;
  * dimension. Keep the route, drop the secret.
  */
 const PERSONAL_LINK_TOKEN_PATH = /^(\/c)\/[^/]+/;
+/**
+ * The same token, for the fallback's input shape. A parsed `pathname` starts at `/`, but a value
+ * that never parsed still carries its scheme and authority, so the route has to be matched after
+ * them — and only as the FIRST path segment, so an unrelated `/a/c/x` is left alone.
+ */
+const PERSONAL_LINK_TOKEN_URL = /^((?:[a-z][a-z0-9+.-]*:)?\/\/[^/]*|[^/]*)(\/c)\/[^/]+/i;
 
 /** Userinfo up to the LAST `@` before the path, so `u:p@ss@host` cannot leak `ss`. */
 const LEADING_USERINFO = /^((?:[a-z][a-z0-9+.-]*:)?\/\/)?[^/]*@/i;
@@ -118,7 +124,11 @@ export const stripUrlQuery = (rawUrl: string): string | undefined => {
   // protocol-relative `//user:pass@host/p` cannot be parsed without a base, so both skip the
   // branch above. Cut the query first, then remove any userinfo, keeping a `scheme://` or bare
   // `//` prefix when one is present.
-  const cut = trimmed.split(/[?#]/)[0].replace(LEADING_USERINFO, "$1").trim();
+  const cut = trimmed
+    .split(/[?#]/)[0]
+    .replace(LEADING_USERINFO, "$1")
+    .replace(PERSONAL_LINK_TOKEN_URL, "$1$2")
+    .trim();
 
   return cut || undefined;
 };

--- a/apps/web/lib/feedback-source/response-metadata.ts
+++ b/apps/web/lib/feedback-source/response-metadata.ts
@@ -1,0 +1,172 @@
+import "server-only";
+import type { TResponse } from "@formbricks/types/responses";
+import type { TSurvey } from "@formbricks/types/surveys/types";
+
+/**
+ * Response- and survey-level context published on every FeedbackRecord's `metadata` (ENG-1554).
+ *
+ * Records used to carry only the answer itself, so Hub held no dimension to slice a dashboard by —
+ * no channel, no device, no completion state. Everything below already existed on the response and
+ * was simply dropped on the floor.
+ *
+ * Two rules govern what may be added here:
+ *
+ * 1. It is an allowlist, never a spread of `response.meta`. `ipAddress` is the reason: it lives on
+ *    the same object, it is personal data under GDPR, and Hub applies no validation or redaction of
+ *    its own. A spread would publish it the moment a survey enables IP capture. Absence by
+ *    construction is the guard — there is no filter to forget.
+ * 2. Values are bounded here. `source`, `url` and `action` are client-supplied on the public
+ *    response endpoint (`ZResponseInput.meta` declares no maximum lengths) and Hub caps only the
+ *    total request body at 512 KiB, so an oversized value would fail the create and silently cost
+ *    the response its records.
+ *
+ * The shape below deliberately mirrors `RESERVED_FIELD_CATALOG` on `epic/embedded-data-v1` (a key,
+ * a typed reader, a publish decision per field). When that lands, this table becomes a projection
+ * of the catalog rather than a second list of the same fields — see ENG-2538, which exists because
+ * private copies of that list drifted from it.
+ */
+
+/** Metadata values are scalars only, which keeps sanitation total — no recursion, no nested JSON. */
+type TMetadataValue = string | number | boolean | undefined;
+
+export type TResponseMetadata = Record<string, string | number | boolean>;
+
+export type TMetadataContext = {
+  response: Pick<TResponse, "meta" | "finished" | "ttc">;
+  survey: Pick<TSurvey, "type">;
+};
+
+export type TMetadataFieldSpec = {
+  /** snake_case key as it appears in the Hub record's metadata object. */
+  readonly key: string;
+  /**
+   * Whether the field is published. Every field ships enabled; the flag exists so withdrawing one
+   * (a privacy decision, a customer request) is a one-word edit to this table rather than a change
+   * to the projection below, and so the epic's `privacy: "drop"` verdicts have somewhere to land.
+   */
+  readonly enabled: boolean;
+  /** Overrides MAX_METADATA_TEXT_LENGTH for string values. */
+  readonly maxLength?: number;
+  readonly read: (context: TMetadataContext) => TMetadataValue;
+};
+
+const MAX_METADATA_TEXT_LENGTH = 256;
+/** URLs are legitimately longer than other values, even after the query string is stripped. */
+const MAX_METADATA_URL_LENGTH = 512;
+/**
+ * Per-element `ttc` is clamped to 24h at the response boundary (ENG-1083), but stored rows keep the
+ * unbounded schema so historical data still parses — and `_total` sums every element. A duration
+ * past a week is noise rather than a measurement, and omitting it beats publishing a number that
+ * would skew an average silently.
+ */
+const MAX_DURATION_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * Reduce a URL to origin + path.
+ *
+ * Query strings on survey URLs carry recovery tokens, verified emails and prefilled answers, so the
+ * query is the part that must not leave the product. Anything that is not an absolute http(s) URL
+ * still gets cut at the first `?` or `#`: a scheme-less value like `app.example.com/p?token=…`
+ * cannot be parsed, and passing it through unchanged would leak exactly what this strips.
+ */
+export const stripUrlQuery = (rawUrl: string): string | undefined => {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const parsed = new URL(trimmed);
+    // `origin` also drops any embedded credentials (https://user:pass@host).
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return `${parsed.origin}${parsed.pathname}`;
+    }
+  } catch {
+    // Not an absolute URL — fall through to the textual cut below.
+  }
+
+  return trimmed.split(/[?#]/)[0] || undefined;
+};
+
+const readDurationSeconds = (ttc: TResponse["ttc"]): number | undefined => {
+  const total = ttc?._total;
+  if (typeof total !== "number" || !Number.isFinite(total) || total < 0) return undefined;
+
+  const seconds = Math.round(total / 1000);
+  return seconds <= MAX_DURATION_SECONDS ? seconds : undefined;
+};
+
+/**
+ * The published field set. `ipAddress` is absent deliberately and must stay absent — see rule 1 in
+ * the module comment. Readers are optional-chained throughout: stored rows predate several of these
+ * fields, and `meta` defaults to `{}` in Prisma.
+ */
+export const METADATA_FIELDS: readonly TMetadataFieldSpec[] = [
+  { key: "source", enabled: true, read: ({ response }) => response.meta?.source },
+  {
+    key: "url",
+    enabled: true,
+    maxLength: MAX_METADATA_URL_LENGTH,
+    read: ({ response }) => {
+      const url = response.meta?.url;
+      return url ? stripUrlQuery(url) : undefined;
+    },
+  },
+  { key: "browser", enabled: true, read: ({ response }) => response.meta?.userAgent?.browser },
+  { key: "os", enabled: true, read: ({ response }) => response.meta?.userAgent?.os },
+  { key: "device", enabled: true, read: ({ response }) => response.meta?.userAgent?.device },
+  { key: "country", enabled: true, read: ({ response }) => response.meta?.country },
+  { key: "action", enabled: true, read: ({ response }) => response.meta?.action },
+  {
+    key: "finished",
+    enabled: true,
+    read: ({ response }) => (typeof response.finished === "boolean" ? response.finished : undefined),
+  },
+  { key: "duration_seconds", enabled: true, read: ({ response }) => readDurationSeconds(response.ttc) },
+  { key: "survey_type", enabled: true, read: ({ survey }) => survey.type },
+];
+
+const sanitizeValue = (value: TMetadataValue, maxLength: number): TMetadataValue => {
+  if (value === undefined || typeof value === "boolean") return value;
+
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+
+  // NUL bytes are the one input Hub cannot store: its validator skips non-string kinds, so the
+  // jsonb insert reaches Postgres and fails as a 500 rather than a rejected field.
+  const cleaned = value.replaceAll("\u0000", "").trim();
+  if (!cleaned) return undefined;
+
+  return cleaned.length > maxLength ? cleaned.slice(0, maxLength) : cleaned;
+};
+
+/**
+ * Read a field table into a flat metadata object, dropping every value that is absent, empty or
+ * unrepresentable.
+ *
+ * Separate from the table so the mechanism can be proven against an arbitrary table — a disabled
+ * field, a field that throws — without mutating the module-level catalog other callers share.
+ */
+export const projectMetadataFields = (
+  fields: readonly TMetadataFieldSpec[],
+  context: TMetadataContext
+): TResponseMetadata => {
+  const metadata: TResponseMetadata = {};
+
+  for (const field of fields) {
+    if (!field.enabled) continue;
+
+    const value = sanitizeValue(field.read(context), field.maxLength ?? MAX_METADATA_TEXT_LENGTH);
+    if (value !== undefined) metadata[field.key] = value;
+  }
+
+  return metadata;
+};
+
+/**
+ * Build the metadata object shared by every FeedbackRecord of one response.
+ *
+ * Called once per response, not per record: the result is spread into each record by
+ * `buildBaseFields`, so a submission's records agree on their context by construction.
+ */
+export const buildResponseMetadata = (
+  response: TMetadataContext["response"],
+  survey: TMetadataContext["survey"]
+): TResponseMetadata => projectMetadataFields(METADATA_FIELDS, { response, survey });

--- a/apps/web/lib/feedback-source/response-metadata.ts
+++ b/apps/web/lib/feedback-source/response-metadata.ts
@@ -90,7 +90,13 @@ export const stripUrlQuery = (rawUrl: string): string | undefined => {
     // Not an absolute URL — fall through to the textual cut below.
   }
 
-  return trimmed.split(/[?#]/)[0] || undefined;
+  // The origin branch never ran, so credentials have not been dropped — and this path is easy to
+  // reach with them: `user:pass@host/p` parses as a URL whose protocol is `user:`, skipping the
+  // branch above. Cut the query first, then remove any userinfo (everything up to a trailing `@`
+  // before the first path segment), keeping a scheme prefix when one is present.
+  const cut = trimmed.split(/[?#]/)[0];
+
+  return cut.replace(/^([a-z][a-z0-9+.-]*:\/\/)?[^/@]*@/i, "$1") || undefined;
 };
 
 const readDurationSeconds = (ttc: TResponse["ttc"]): number | undefined => {

--- a/apps/web/lib/feedback-source/response-metadata.ts
+++ b/apps/web/lib/feedback-source/response-metadata.ts
@@ -152,8 +152,17 @@ const sanitizeValue = (value: unknown, maxLength: number): string | number | boo
   // jsonb insert reaches Postgres and fails as a 500 rather than a rejected field.
   const cleaned = value.replaceAll("\u0000", "").trim();
   if (!cleaned) return undefined;
+  if (cleaned.length <= maxLength) return cleaned;
 
-  return cleaned.length > maxLength ? cleaned.slice(0, maxLength) : cleaned;
+  // maxLength counts UTF-16 code units, so the cut can land between the halves of a surrogate
+  // pair — and a lone surrogate is rejected on the jsonb insert exactly like a NUL byte, with the
+  // same silently-dropped-records outcome. The caller picks the offset by choosing the value's
+  // length, so this is reachable on purpose and not only by accident.
+  const truncated = cleaned.slice(0, maxLength);
+  const lastUnit = truncated.charCodeAt(truncated.length - 1);
+  const endsOnHighSurrogate = lastUnit >= 0xd800 && lastUnit <= 0xdbff;
+
+  return endsOnHighSurrogate ? truncated.slice(0, -1) : truncated;
 };
 
 /**

--- a/apps/web/lib/feedback-source/response-metadata.ts
+++ b/apps/web/lib/feedback-source/response-metadata.ts
@@ -91,12 +91,13 @@ export const stripUrlQuery = (rawUrl: string): string | undefined => {
   }
 
   // The origin branch never ran, so credentials have not been dropped — and this path is easy to
-  // reach with them: `user:pass@host/p` parses as a URL whose protocol is `user:`, skipping the
+  // reach with them: `user:pass@host/p` parses as a URL whose protocol is `user:`, and the
+  // protocol-relative `//user:pass@host/p` cannot be parsed without a base, so both skip the
   // branch above. Cut the query first, then remove any userinfo (everything up to a trailing `@`
-  // before the first path segment), keeping a scheme prefix when one is present.
+  // before the first path segment), keeping a `scheme://` or bare `//` prefix when one is present.
   const cut = trimmed.split(/[?#]/)[0];
 
-  return cut.replace(/^([a-z][a-z0-9+.-]*:\/\/)?[^/@]*@/i, "$1") || undefined;
+  return cut.replace(/^((?:[a-z][a-z0-9+.-]*:)?\/\/)?[^/@]*@/i, "$1") || undefined;
 };
 
 const readDurationSeconds = (ttc: TResponse["ttc"]): number | undefined => {

--- a/apps/web/lib/feedback-source/transform.test.ts
+++ b/apps/web/lib/feedback-source/transform.test.ts
@@ -28,6 +28,7 @@ const bilingualLanguages = [
 const mockSurvey = {
   id: "survey-1",
   name: "Product Feedback",
+  type: "link",
   blocks: [
     {
       elements: [
@@ -48,6 +49,17 @@ const mockSurvey = {
 
 const mockTenantId = "cmp2f6428000504la7iyh87h1";
 
+// Populated the way the public response endpoint populates it: source/url/action come from the
+// client, userAgent/country/ipAddress are derived server-side.
+const mockMeta = {
+  source: "link",
+  url: "https://app.example.com/s/survey-1?token=secret",
+  userAgent: { browser: "Chrome", os: "macOS", device: "desktop" },
+  country: "PT",
+  action: "Clicked pricing CTA",
+  ipAddress: "203.0.113.7",
+};
+
 const mockResponse = {
   id: "resp-1",
   createdAt: NOW,
@@ -61,6 +73,9 @@ const mockResponse = {
   },
   language: "en",
   contact: { userId: "user-42" },
+  finished: true,
+  ttc: { "el-text": 4_000, _total: 45_500 },
+  meta: mockMeta,
 } as unknown as TResponse;
 
 const createMapping = (
@@ -1062,6 +1077,160 @@ describe("transformResponseToFeedbackRecords", () => {
         value_text: "Good",
         value_id: "col-1",
       });
+    });
+  });
+
+  describe("response metadata (ENG-1554)", () => {
+    // One survey covering all four record-building paths, so the merge invariant below is asserted
+    // against every one of them rather than only the generic case.
+    const everyPathSurvey = {
+      id: "survey-1",
+      name: "Every Path",
+      type: "app",
+      blocks: [
+        {
+          elements: [
+            { id: "el-text", type: "openText", headline: { default: "How can we improve?" } },
+            {
+              id: "el-matrix",
+              type: "matrix",
+              headline: { default: "Rate each feature" },
+              rows: [{ id: "row-1", label: { default: "Speed" } }],
+              columns: [{ id: "col-1", label: { default: "Good" } }],
+            },
+            {
+              id: "el-ranking",
+              type: "ranking",
+              headline: { default: "Rank these" },
+              choices: [
+                { id: "ch-1", label: { default: "Reports" } },
+                { id: "ch-2", label: { default: "Alerts" } },
+              ],
+            },
+            { id: "el-multi", type: "multipleChoiceMulti", headline: { default: "Select features" } },
+          ],
+        },
+      ],
+    } as unknown as TSurvey;
+
+    const everyPathResponse = {
+      id: "resp-every-path",
+      createdAt: NOW,
+      data: {
+        "el-text": "Great product!",
+        "el-matrix": { Speed: "Good" },
+        "el-ranking": ["Alerts", "Reports"],
+        "el-multi": ["feat-a", "feat-b"],
+      },
+      language: "default",
+      contact: { userId: "user-42" },
+      finished: true,
+      ttc: { _total: 45_500 },
+      meta: mockMeta,
+    } as unknown as TResponse;
+
+    const everyPathMappings = [
+      createMapping({ elementId: "el-text", hubFieldType: "text" }),
+      createMapping({ elementId: "el-matrix", hubFieldType: "categorical" }),
+      createMapping({ elementId: "el-ranking", hubFieldType: "categorical" }),
+      createMapping({ elementId: "el-multi", hubFieldType: "categorical" }),
+    ];
+
+    const sharedContext = {
+      source: "link",
+      url: "https://app.example.com/s/survey-1",
+      browser: "Chrome",
+      os: "macOS",
+      device: "desktop",
+      country: "PT",
+      action: "Clicked pricing CTA",
+      finished: true,
+      duration_seconds: 46,
+      survey_type: "app",
+    };
+
+    test("publishes the response context on a single-value record", () => {
+      const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
+
+      const result = transformResponseToFeedbackRecords(
+        everyPathResponse,
+        everyPathSurvey,
+        mappings,
+        mockTenantId
+      );
+
+      expect(result).toHaveLength(1);
+      // The generic path published no metadata at all before ENG-1554.
+      expect(result[0].metadata).toEqual(sharedContext);
+    });
+
+    test("keeps question_type alongside the response context on every expanded record", () => {
+      const result = transformResponseToFeedbackRecords(
+        everyPathResponse,
+        everyPathSurvey,
+        everyPathMappings,
+        mockTenantId
+      );
+
+      // Each composite path sets `metadata` after spreading baseFields, so a missing merge silently
+      // drops the response context from exactly these records.
+      expect(result.length).toBeGreaterThan(4);
+      for (const record of result) {
+        expect(record.metadata).toMatchObject(sharedContext);
+      }
+
+      const byField = (id: string) => result.find((record) => record.field_id?.startsWith(id))?.metadata;
+      expect(byField("el-matrix")).toMatchObject({ question_type: "matrix" });
+      expect(byField("el-ranking")).toMatchObject({ question_type: "ranking", total_items: 2 });
+      expect(byField("el-multi")).toMatchObject({ question_type: "multipleChoiceMulti" });
+      expect(byField("el-text")).not.toHaveProperty("question_type");
+    });
+
+    test("never publishes the respondent's IP address on any record", () => {
+      const result = transformResponseToFeedbackRecords(
+        everyPathResponse,
+        everyPathSurvey,
+        everyPathMappings,
+        mockTenantId
+      );
+
+      for (const record of result) {
+        expect(Object.keys(record.metadata ?? {})).not.toContain("ipAddress");
+        expect(Object.values(record.metadata ?? {})).not.toContain(mockMeta.ipAddress);
+      }
+    });
+
+    test("strips the query string from the published url", () => {
+      const result = transformResponseToFeedbackRecords(
+        everyPathResponse,
+        everyPathSurvey,
+        everyPathMappings,
+        mockTenantId
+      );
+
+      // The survey url carries recovery tokens and prefilled answers in its query.
+      for (const record of result) {
+        expect(record.metadata?.url).toBe("https://app.example.com/s/survey-1");
+      }
+    });
+
+    test("omits metadata entirely when the response carries no context", () => {
+      // Hub stores metadata nullable and compares it byte-wise, so sending {} would count as a
+      // change and fire a pointless feedback_record.updated webhook.
+      const bareResponse = {
+        id: "resp-bare",
+        createdAt: NOW,
+        data: { "el-text": "Great product!" },
+        language: "default",
+        meta: {},
+      } as unknown as TResponse;
+      const bareSurvey = { ...everyPathSurvey, type: undefined } as unknown as TSurvey;
+      const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
+
+      const result = transformResponseToFeedbackRecords(bareResponse, bareSurvey, mappings, mockTenantId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).not.toHaveProperty("metadata");
     });
   });
 });

--- a/apps/web/lib/feedback-source/transform.ts
+++ b/apps/web/lib/feedback-source/transform.ts
@@ -15,6 +15,7 @@ import { getTextContent } from "@formbricks/types/surveys/validation";
 import { getLanguageCode, getLocalizedValue } from "@/lib/i18n/utils";
 import { getElementsFromBlocks } from "@/lib/survey/utils";
 import type { FeedbackRecordCreateParams } from "@/modules/hub";
+import { type TResponseMetadata, buildResponseMetadata } from "./response-metadata";
 
 const getHeadlineFromElement = (element?: TSurveyElement): string => {
   if (!element?.headline) return "Untitled";
@@ -158,22 +159,32 @@ type BaseRecordFields = Pick<
 > & {
   language?: string;
   user_id?: string;
+  metadata?: TResponseMetadata;
 };
 
 const buildBaseFields = (
   response: TResponse,
-  survey: Pick<TSurvey, "id" | "name">,
+  survey: Pick<TSurvey, "id" | "name" | "type">,
   tenantId: string
-): BaseRecordFields => ({
-  collected_at: getCollectedAt(response),
-  source_type: "formbricks_survey",
-  submission_id: response.id,
-  tenant_id: tenantId,
-  source_id: survey.id,
-  source_name: survey.name,
-  ...(response.language && response.language !== "default" ? { language: response.language } : {}),
-  ...(response.contact?.userId ? { user_id: response.contact.userId } : {}),
-});
+): BaseRecordFields => {
+  // Built once per response and shared by every record of the submission (ENG-1554).
+  const metadata = buildResponseMetadata(response, survey);
+
+  return {
+    collected_at: getCollectedAt(response),
+    source_type: "formbricks_survey",
+    submission_id: response.id,
+    tenant_id: tenantId,
+    source_id: survey.id,
+    source_name: survey.name,
+    ...(response.language && response.language !== "default" ? { language: response.language } : {}),
+    ...(response.contact?.userId ? { user_id: response.contact.userId } : {}),
+    // Omitted rather than sent as {}: Hub stores metadata nullable and compares it byte-wise, so an
+    // empty object on a record that has none would count as a change and fire a pointless
+    // feedback_record.updated webhook.
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+};
 
 const expandMatrixToRecords = (
   element: TSurveyMatrixElement,
@@ -213,7 +224,9 @@ const expandMatrixToRecords = (
       field_label: getChoiceLabel(row, "default"),
       field_group_id: element.id,
       field_group_label: groupLabel,
-      metadata: { question_type: "matrix" },
+      // Spread the shared response context first: this property overrides the one in ...baseFields,
+      // so anything not re-stated here is dropped from the record.
+      metadata: { ...baseFields.metadata, question_type: "matrix" },
       ...valueFields,
       ...(matchedColumn.valueId ? { value_id: matchedColumn.valueId } : {}),
     });
@@ -250,7 +263,7 @@ const expandRankingToRecords = (
       field_label: getChoiceLabel(choice, "default"),
       field_group_id: element.id,
       field_group_label: groupLabel,
-      metadata: { question_type: "ranking", total_items: value.length },
+      metadata: { ...baseFields.metadata, question_type: "ranking", total_items: value.length },
       value_number: index + 1,
     });
   });
@@ -302,7 +315,7 @@ const expandMultiChoiceToRecords = (
       field_label: fieldLabel,
       field_group_id: element.id,
       field_group_label: fieldLabel,
-      metadata: { question_type: "multipleChoiceMulti" },
+      metadata: { ...baseFields.metadata, question_type: "multipleChoiceMulti" },
       ...valueFields,
       ...(valueId ? { value_id: valueId } : {}),
     });
@@ -357,7 +370,7 @@ const normalizeElementValue = (
  */
 export function transformResponseToFeedbackRecords(
   response: TResponse,
-  survey: Pick<TSurvey, "id" | "name" | "blocks" | "languages">,
+  survey: Pick<TSurvey, "id" | "name" | "type" | "blocks" | "languages">,
   mappings: TFeedbackSourceFormbricksMapping[],
   tenantId: string
 ): FeedbackRecordCreateParams[] {


### PR DESCRIPTION
Fixes ENG-1554

## What & why

**Was:** feedback records sent to the Hub carried only the answer itself — `response.meta` (channel, device, browser, OS, country, action), completion state and duration were dropped on the floor, so there was no dimension to slice a dashboard by.

**Now:** every record's `metadata` carries source, url (redacted), browser, os, device, country, action, finished, duration_seconds, ending_id and survey_type, built once per response and shared by the live pipeline and the historical import.

- the field set is a declarative allowlist (`HUB_METADATA_FIELDS`), never a spread of `response.meta` — `ipAddress` stays out by construction
- values are bounded here (256 chars, url 512) because `source`/`url`/`action` are client-supplied and unbounded upstream
- `url` loses its query, its userinfo and the `/c/<jwt>` personal-link token — that token is the credential, and it sits in the path
- forward-only: existing records pick the keys up on the next historical import (reconcile PATCHes on 409; metadata-only changes trigger no enrichment)

## Where to look

- [response-metadata.ts](https://github.com/formbricks/formbricks/blob/feat/ENG-1554_pipe-response-metadata-into-feedback-records/apps/web/lib/feedback-source/response-metadata.ts) — the allowlist, url stripping, truncation
- [transform.ts `buildBaseFields` + the three composite merges](https://github.com/formbricks/formbricks/blob/feat/ENG-1554_pipe-response-metadata-into-feedback-records/apps/web/lib/feedback-source/transform.ts) — merge order is load-bearing
- [v3 `metadata` description](https://github.com/formbricks/formbricks/blob/feat/ENG-1554_pipe-response-metadata-into-feedback-records/apps/web/app/api/v3/feedbackRecords/lib/schemas.ts) — inherited verbatim by three MCP tools

## Breaking changes

- [ ] This PR contains breaking changes

None — purely additive: new optional keys inside an already-optional `metadata` object, plus description text.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm build --filter=@formbricks/web^... && pnpm --filter @formbricks/web test -- lib/feedback-source app/api/v3/feedbackRecords modules/mcp`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| generic-path records publish the response context | unit (red on main) | `transform.test.ts` › "publishes the response context on a single-value record" |
| composite paths keep `question_type` alongside the shared context | unit (red on main) | matrix/ranking/multi-choice each carry both, none clobbered |
| `ipAddress` never published; url query, userinfo and personal-link token stripped | unit (mutation) | `response-metadata.ts:115` (allowlist) / `:99` (fallback strip) turn named tests red |
| stored meta the type doesn't describe (null, wrong types) can't drop a submission's records | unit (mutation) | `response-metadata.ts:148` — sanitize narrows before use |
| truncation never leaves a lone UTF-16 surrogate (Hub rejects it like a NUL) | unit (mutation) | `response-metadata.ts` truncation tail; boundary emoji test red without it |
| full pipeline → real Hub: create, 409→reconcile PATCH, read-back | manual | verified against a local Hub; details in the fold |

**Open gaps**

- already-imported records get metadata only when someone re-runs the historical import (deliberate, forward-only)
- `utm_*` / referrer dimensions are unreachable from this pipeline: they live in the query, which is stripped
- no Unify Feedback E2E exists to extend (tracked as ENG-2357)

**Risks**

- generic single-value records carried no metadata before, so a re-import now overwrites metadata a customer set on them via the Hub API (PATCH replaces wholesale)
- a user-triggered re-import PATCHes every existing record once → one `feedback_record.updated` webhook each, no enrichment cost
- when `epic/embedded-data-v1` lands, `HUB_METADATA_FIELDS` should become a projection of `RESERVED_FIELD_CATALOG` (noted in the module comment)

<details>
<summary>Example: what a record carries now (real transform output, read back from a live Hub)</summary>

Input meta: `url` with `?token=SECRET&email=a@b.com#q2`, an `ipAddress`, UA Safari/iOS/phone, country PT, `ttc._total` 45500ms. Stored record:

```json
{
  "source_type": "formbricks_survey",
  "submission_id": "resp_xyz",
  "source_id": "svy_abc",
  "source_name": "Onboarding NPS",
  "field_id": "el-nps",
  "field_type": "nps",
  "value_number": 9,
  "language": "en-US",
  "user_id": "usr_42",
  "metadata": {
    "source": "link",
    "url": "https://app.formbricks.com/s/svy_abc",
    "browser": "Safari",
    "os": "iOS",
    "device": "phone",
    "country": "PT",
    "finished": true,
    "duration_seconds": 46,
    "survey_type": "link"
  }
}
```

The token and email never leave the product; `ipAddress` has no key. A ranking record from the same response carries the same object plus `"question_type": "ranking", "total_items": 2`.

</details>

<details>
<summary>Live Hub verification detail</summary>

Ran the real transform → real `createFeedbackRecordsBatch` SDK → local Hub (pgvector/pg18, migrations applied), then read records back via the Hub API. One adversarial response exercising every guard at once: a token+email in the url query, an IP on meta, and an emoji sitting exactly on the 256-unit truncation boundary of `action`.

Stored result: url `https://app.formbricks.com/s/svy_e2e` (token and email gone), no `ipAddress` key and the IP in no value, `action` cut to 255 chars with no lone surrogate — and accepted by the Hub. The ranking records carried `question_type`/`total_items` merged alongside the shared context. A second run of the same records hit the Hub's `(tenant_id, submission_id, field_id)` uniqueness, independently confirming the writes; a re-send with changed meta reconciled (`created: 0, reconciled: 1`) and the Hub read back the new values.

Payload envelope, measured: ~228 bytes typical, 5.3 KiB absolute ceiling (every capped field maxed with 3-byte CJK). Metadata size bound on the Hub side is deliberately out of scope here — ENG-2746 carries that with the measurement plan.

</details>

---

> [!NOTE]
> **AI model used** — `claude-fable-5`, reasoning effort `unknown`.

