### PR TITLE
fix: block 22 personal and burner email domains on Cloud signup

### DIFF
--- a/apps/web/modules/auth/lib/personal-email-domains.ts
+++ b/apps/web/modules/auth/lib/personal-email-domains.ts
@@ -21,10 +21,12 @@ export const PERSONAL_EMAIL_DOMAINS: readonly string[] = [
   "hotmail.com",
   "hotmail.fr",
   "live.com",
+  "live.nl",
   "msn.com",
   // Yahoo / AOL
   "yahoo.com",
   "yahoo.co.uk",
+  "yahoo.fr",
   "ymail.com",
   "rocketmail.com",
   "aol.com",
@@ -32,6 +34,7 @@ export const PERSONAL_EMAIL_DOMAINS: readonly string[] = [
   "icloud.com",
   "me.com",
   "mac.com",
+  "privaterelay.appleid.com",
   // Privacy-focused / relay
   "proton.me",
   "protonmail.com",
@@ -42,21 +45,41 @@ export const PERSONAL_EMAIL_DOMAINS: readonly string[] = [
   "fastmail.com",
   "mozmail.com",
   "duck.com",
+  "anonaddy.com", // addy.io alias service
+  "8alias.com", // SimpleLogin alias domain
+  "keemail.me", // Tutanota
+  "ik.me", // Infomaniak
+  "murena.io", // /e/ OS (Murena)
+  "firemail.cc", // same operator as cock.li
+  // Burner / temp providers the disposable-email-domains package misses
+  "cock.li",
+  "tmpmailtor.com",
+  "allwebemails.com",
   // Other mainstream / international
   "gmx.com",
   "gmx.net",
   "yandex.com",
   "yandex.ru",
   "zoho.com",
+  "zohomail.com",
   "mail.com",
+  // A mail.com free domain despite the name — same MX and SPF as mail.com, not a data artifact.
+  "null.net",
   "qq.com",
   "foxmail.com",
   "163.com",
   "126.com",
+  "139.com",
   "yeah.net",
   "emailn.de",
   "sfr.fr",
+  "orange.fr",
   "ukr.net",
-  // Common typo of gmail.com
+  "centrum.cz",
+  "wp.pl",
+  "earthlink.net",
+  "roadrunner.com",
+  // Typos / lookalikes of gmail.com — neither is Google's, and gmail.cz has no MX at all.
   "gmaill.com",
+  "gmail.cz",
 ];

--- a/apps/web/modules/auth/lib/personal-email-domains.ts
+++ b/apps/web/modules/auth/lib/personal-email-domains.ts
@@ -39,6 +39,7 @@ export const PERSONAL_EMAIL_DOMAINS: readonly string[] = [
   "passmail.com",
   "mailbox.org",
   "posteo.de",
+  "fastmail.com",
   "mozmail.com",
   "duck.com",
   // Other mainstream / international

--- a/apps/web/modules/auth/lib/signup-email-domain.test.ts
+++ b/apps/web/modules/auth/lib/signup-email-domain.test.ts
@@ -42,6 +42,27 @@ describe("isBlockedEmailDomain", () => {
       "test@yandex.com",
       "test@aol.com",
       "test@fastmail.com",
+      "test@live.nl",
+      "test@yahoo.fr",
+      "test@privaterelay.appleid.com",
+      "test@anonaddy.com",
+      "test@8alias.com",
+      "test@keemail.me",
+      "test@ik.me",
+      "test@murena.io",
+      "test@firemail.cc",
+      "test@cock.li",
+      "test@tmpmailtor.com",
+      "test@allwebemails.com",
+      "test@zohomail.com",
+      "test@null.net",
+      "test@139.com",
+      "test@orange.fr",
+      "test@centrum.cz",
+      "test@wp.pl",
+      "test@earthlink.net",
+      "test@roadrunner.com",
+      "test@gmail.cz",
     ]) {
       expect(isBlockedEmailDomain(email)).toBe(true);
     }
@@ -54,6 +75,7 @@ describe("isBlockedEmailDomain", () => {
       "test@yopmail.com",
       "test@10minutemail.com",
       "test@sharklasers.com",
+      "test@33mail.com",
     ]) {
       expect(isBlockedEmailDomain(email)).toBe(true);
     }

--- a/apps/web/modules/auth/lib/signup-email-domain.test.ts
+++ b/apps/web/modules/auth/lib/signup-email-domain.test.ts
@@ -41,6 +41,7 @@ describe("isBlockedEmailDomain", () => {
       "test@gmx.com",
       "test@yandex.com",
       "test@aol.com",
+      "test@fastmail.com",
     ]) {
       expect(isBlockedEmailDomain(email)).toBe(true);
     }


### PR DESCRIPTION
No ticket — directly requested blocklist additions.

## What & why

**Was:** 22 free, alias and burner email domains could create a Formbricks Cloud account. Some had sibling domains blocked but not the one people actually signed up with — the package carried `fastmail.name` and `fastmailnow.com`, but not `fastmail.com`.

**Now:** all 22 are rejected as personal-email domains. Cloud only; self-hosted is unaffected, and invited users stay exempt unless `SIGNUP_DOMAIN_CHECK_ON_INVITES` is on.

Two additions are not what their names suggest, so both carry a comment in the list:

- `null.net` is a **mail.com free domain** — same MX (`mx00/mx01.mail.com`) and SPF (`redirect=_spf.mail.com`) as `mail.com` and `dr.com`. Not a data artifact.
- `gmail.cz` has **no MX at all**, so it cannot receive mail. It is a gmail.com lookalike, not Google and not a provider — it joins the existing typo group.

## Where to look

- [personal-email-domains.ts:36-79](apps/web/modules/auth/lib/personal-email-domains.ts#L36-L79) — the added entries and their grouping

## Breaking changes

- [ ] This PR contains breaking changes

None — additive data in a Cloud-only signup blocklist. No API, SDK, env or config surface moves.

## Migrations & env

- none

## How this was tested

Rerun: `npx vitest run apps/web/modules/auth/lib/signup-email-domain.test.ts --root apps/web`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| All 22 domains are blocked | unit (red on main) | Reverting the list file alone turns the suite red; 15/15 green with it |
| `33mail.com` blocked via the disposable package | unit (guard) | Asserted in the disposable loop, so a future package version dropping it goes red |
| `null.page` stays allowed | manual | SPF `include:spf.protection.outlook.com` — a real M365 tenant, so not blocked |

<details><summary>Per-domain check (the loop aborts at its first failure, so green-once is not per-entry proof)</summary>

A one-off script resolved each requested domain against the union of both sources: 21 via the curated list, `33mail.com` via the package, `mozmail.com` already curated, 0 unblocked, 0 duplicate entries in the curated list, and `null.page` absent.

</details>

**Open gaps**

- `mozmail.com` was already in the list and `33mail.com` already in the package — neither was re-added, to keep the curated file free of dead duplicates.
- Providers' remaining domains stay allowed (`fastmail.fm`, `sent.com`, other mail.com aliases); only the requested ones were added.
- No real Cloud signup was exercised; the policy gate itself is unchanged and already covered.

**Risks**

- Anyone at these 22 domains now needs an invite or a work address. `orange.fr`, `wp.pl`, `centrum.cz` and `earthlink.net` are consumer ISP/portal mail, so a sole trader using one as their work address is now blocked.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.
