### PR TITLE
fix(notifications): name the workspace of each survey on the email alerts page

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/notifications/components/EditAlerts.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/notifications/components/EditAlerts.tsx
@@ -9,6 +9,7 @@ import { organizationSettingsPath } from "@/modules/settings/lib/routes";
 import { EmptyState } from "@/modules/ui/components/empty-state";
 import { SettingsTable, type TSettingsTableColumn } from "@/modules/ui/components/settings-table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/modules/ui/components/tooltip";
+import { type TAlertRow, getAlertRows } from "../lib/alert-rows";
 import { Membership } from "../types";
 import { NotificationSwitch } from "./NotificationSwitch";
 
@@ -18,9 +19,6 @@ interface EditAlertsProps {
   autoDisableNotificationType: string;
   autoDisableNotificationElementId: string;
 }
-
-/** A survey to alert on, carrying the workspace it belongs to for the row's sub-line. */
-type TAlertRow = { surveyId: string; surveyName: string; workspaceName: string };
 
 /**
  * Defined at module level rather than inside the component: an inline `cell` that returns JSX reads as a
@@ -39,15 +37,22 @@ const getAlertColumns = ({
 }>): TSettingsTableColumn<TAlertRow>[] => [
   {
     id: "survey",
-    header: t("common.surveys"),
-    headerClassName: "w-[70%]",
+    header: t("common.survey"),
+    headerClassName: "w-[45%]",
+    cellClassName: "font-medium text-slate-900",
     skeletonWidth: "w-48",
-    cell: (row) => (
-      <>
-        <div className="font-medium text-slate-900">{row.surveyName}</div>
-        <div className="text-xs text-slate-400">{row.workspaceName}</div>
-      </>
-    ),
+    cell: (row) => row.surveyName,
+  },
+  {
+    // A column of its own rather than a sub-line under the survey name: the surveys of an organization
+    // are listed together here, so the same name can appear once per workspace, and an unlabelled second
+    // line left the reader to guess what it named.
+    id: "workspace",
+    header: t("common.workspace"),
+    headerClassName: "w-[30%]",
+    cellClassName: "text-slate-500",
+    skeletonWidth: "w-32",
+    cell: (row) => row.workspaceName,
   },
   {
     id: "alert",
@@ -64,7 +69,7 @@ const getAlertColumns = ({
         </Tooltip>
       </TooltipProvider>
     ),
-    headerClassName: "w-[30%]",
+    headerClassName: "w-[25%]",
     align: "center",
     skeletonWidth: "w-10",
     cell: (row) => (
@@ -103,15 +108,9 @@ export const EditAlerts = ({
   return (
     <>
       {memberships.map((membership) => {
-        // One row list per organization: the surveys were nested one level deeper, under workspaces, and
-        // the workspace only contributes a sub-line to each row.
-        const rows: TAlertRow[] = membership.organization.workspaces.flatMap((workspace) =>
-          workspace.surveys.map((survey) => ({
-            surveyId: survey.id,
-            surveyName: survey.name,
-            workspaceName: workspace.name,
-          }))
-        );
+        // One row list per organization: the surveys are nested one level deeper, under workspaces, and
+        // each row names the workspace it came from.
+        const rows: TAlertRow[] = getAlertRows(membership.organization.workspaces);
 
         return (
           <div key={membership.organization.id}>

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/notifications/lib/alert-rows.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/notifications/lib/alert-rows.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+import { getAlertRows } from "./alert-rows";
+
+const workspace = (name: string, surveys: { id: string; name: string }[]) => ({ id: name, name, surveys });
+
+describe("getAlertRows", () => {
+  test("names the workspace on every survey row", () => {
+    const rows = getAlertRows([
+      workspace("Website", [{ id: "s1", name: "NPS Survey" }]),
+      workspace("Mobile App", [{ id: "s2", name: "Churn Survey" }]),
+    ]);
+
+    expect(rows).toEqual([
+      { surveyId: "s2", surveyName: "Churn Survey", workspaceName: "Mobile App" },
+      { surveyId: "s1", surveyName: "NPS Survey", workspaceName: "Website" },
+    ]);
+  });
+
+  test("keeps a workspace's surveys together when the input interleaves them", () => {
+    // What the page's own query returns: no `orderBy` on either level, so a second workspace can sit
+    // between two surveys that belong to the same one.
+    const rows = getAlertRows([
+      workspace("Website", [{ id: "s1", name: "NPS Survey" }]),
+      workspace("Docs Portal", [{ id: "s2", name: "Onboarding Feedback" }]),
+      workspace("Website", [{ id: "s3", name: "Churn Survey" }]),
+    ]);
+
+    expect(rows.map((row) => [row.workspaceName, row.surveyName])).toEqual([
+      ["Docs Portal", "Onboarding Feedback"],
+      ["Website", "Churn Survey"],
+      ["Website", "NPS Survey"],
+    ]);
+  });
+
+  test("orders same-named surveys in one workspace by id, so their rows cannot swap", () => {
+    const duplicates = [
+      { id: "s2", name: "NPS Survey" },
+      { id: "s1", name: "NPS Survey" },
+    ];
+
+    expect(getAlertRows([workspace("Website", duplicates)]).map((row) => row.surveyId)).toEqual(["s1", "s2"]);
+    expect(
+      getAlertRows([workspace("Website", [...duplicates].reverse())]).map((row) => row.surveyId)
+    ).toEqual(["s1", "s2"]);
+  });
+
+  test("orders numbered workspaces the way a reader counts them", () => {
+    const rows = getAlertRows([
+      workspace("Workspace 10", [{ id: "s1", name: "NPS Survey" }]),
+      workspace("Workspace 2", [{ id: "s2", name: "NPS Survey" }]),
+    ]);
+
+    expect(rows.map((row) => row.workspaceName)).toEqual(["Workspace 2", "Workspace 10"]);
+  });
+
+  test("returns no rows for an organization whose workspaces hold no surveys", () => {
+    expect(getAlertRows([workspace("Website", []), workspace("Mobile App", [])])).toEqual([]);
+  });
+});

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/notifications/lib/alert-rows.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/notifications/lib/alert-rows.ts
@@ -1,0 +1,41 @@
+import type { Membership } from "../types";
+
+/** A survey to alert on, carrying the workspace it belongs to so the list can name it. */
+export type TAlertRow = { surveyId: string; surveyName: string; workspaceName: string };
+
+type TWorkspaces = Membership["organization"]["workspaces"];
+
+/**
+ * Pinned to one locale rather than left to `localeCompare`'s default, because the list is rendered by a
+ * client component: the server sorts under Node's locale and the browser re-sorts under the visitor's,
+ * and a collation that disagrees between the two puts the rows in a different order on each side, which
+ * is a hydration mismatch. `numeric` is what keeps "Workspace 2" ahead of "Workspace 10".
+ */
+const collator = new Intl.Collator("en", { numeric: true });
+
+/**
+ * Flattens one organization's workspaces into a row per survey, ordered by workspace, then by survey
+ * name, then by id.
+ *
+ * The order carries the workspace column: the query returns surveys grouped by workspace but with no
+ * order inside or between those groups, so a workspace's surveys can arrive interleaved with another's
+ * and two same-named surveys from different workspaces can land rows apart. Sorting keeps each
+ * workspace's surveys together, so the column reads as a group label rather than a value repeated at
+ * random. The id breaks the remaining tie, because nothing stops two surveys in one workspace sharing a
+ * name — without it their rows could swap places between renders.
+ */
+export const getAlertRows = (workspaces: TWorkspaces): TAlertRow[] =>
+  workspaces
+    .flatMap((workspace) =>
+      workspace.surveys.map((survey) => ({
+        surveyId: survey.id,
+        surveyName: survey.name,
+        workspaceName: workspace.name,
+      }))
+    )
+    .sort(
+      (a, b) =>
+        collator.compare(a.workspaceName, b.workspaceName) ||
+        collator.compare(a.surveyName, b.surveyName) ||
+        collator.compare(a.surveyId, b.surveyId)
+    );


### PR DESCRIPTION
Fixes ENG-1823

## What & why

**Was:** the email alerts list stacked every survey of an organization together, with the workspace as an unlabelled grey sub-line and the rows in no defined order, so two same-named surveys from different workspaces were told apart by guessing.

**Now:** the workspace has a column of its own next to the survey, and rows are ordered by workspace, then survey name, then id, so each workspace's surveys sit together.

- The order is what lets the column read as a group label instead of a value repeated at random.
- The id tiebreak matters because nothing stops two surveys in one workspace sharing a name.

## Where to look

- [alert-rows.ts](https://github.com/formbricks/formbricks/blob/bf9360c/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/notifications/lib/alert-rows.ts) — row derivation, sort keys, pinned collator
- `EditAlerts.tsx` lines 46-56 — the new column; widths go from 70/30 to 45/30/25

## Breaking changes

- [ ] This PR contains breaking changes

None. One account settings page changes how it lists surveys; no API, route, env var or SDK surface is touched.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run "app/(app)/workspaces/[workspaceId]/settings/account/notifications/lib/alert-rows.test.ts"`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Every row names its workspace, and a workspace's surveys stay together | unit (mutation) | 5 pass; blank `alert-rows.ts:38` to `0` and 2 go red |
| `Workspace 2` sorts ahead of `Workspace 10` | unit (mutation) | Passes; `numeric: false` at `alert-rows.ts:14` turns it red |
| An organization whose workspaces hold no surveys renders no rows | unit (guard) | Empty array, so the table keeps its "No surveys found" message |
| Page renders the labelled column at 1280px | manual | Three workspaces, five surveys, one org; see the pair below |

| Before | After |
| --- | --- |
| ![Survey list where the workspace is an unlabelled grey sub-line under each survey name](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1823/email-alerts-before.png) | ![Survey list with a labelled Workspace column and rows grouped by workspace](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-1823/email-alerts-after.png) |

**Open gaps**

- Not shot at a narrow viewport; the third column relies on the table's own horizontal scroll there.
- The ticket also floated filtering the list down to one workspace; this labels and groups instead.

**Risks**

- Rows now move: a user who knew a survey by its position in the list will find it elsewhere.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `max`.
