### PR TITLE
ci: restore automated PR path labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,9 @@
 "❗️ migrations":
-  - packages/database/migration/**/migration.sql
+  - changed-files:
+      - any-glob-to-any-file: packages/database/migration/**/migration.sql
 
 "❗️ .env changes":
-  - .env.example
-  - .env.docker
+  - changed-files:
+      - any-glob-to-any-file:
+          - .env.example
+          - .env.docker

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,29 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-path-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Label pull request from changed paths
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          configuration-path: .github/labeler.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes ENG-2263

## What & why

**Was:** The path-label configuration was orphaned and still used the pre-v5 syntax, so migration and env changes were never labeled.

**Now:** Fork and same-repository PRs receive the existing migration and env labels from a pinned, least-privilege path-labeler workflow.

## Where to look

- [Workflow](https://github.com/formbricks/formbricks/blob/681fe87d7/.github/workflows/labeler.yml) — trigger, permissions, and pinned actions
- [Label rules](https://github.com/formbricks/formbricks/blob/681fe87d7/.github/labeler.yml) — v7 path matching

## Breaking changes

- [ ] This PR contains breaking changes

None. This changes internal PR automation only.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm exec prettier --check .github/labeler.yml .github/workflows/labeler.yml && go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/labeler.yml`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Workflow and config syntax | manual | Prettier, YAML parsing, and actionlint accepted both files. |
| Migration and env path matching | manual | Positive and negative glob assertions matched only intended paths. |
| Least privilege and pinned actions | manual | Only required scopes and two verified action SHAs remain. |
| Required repository labels | manual | Both exact emoji label names already exist. |

**Open gaps**

- The introducing PR cannot execute a new `pull_request_target` workflow; run the planned fork smoke test after merge.

**Risks**

- Path labels remain inactive until this workflow exists on the PR base branch.

---

> [!NOTE]
> **AI model used** — `unknown`, reasoning effort `unknown`.