### PR TITLE
feat: expose survey lifecycle events to host applications

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -176,7 +176,8 @@
                       "surveys/website-app-surveys/recontact",
                       "surveys/website-app-surveys/cooldown-period",
                       "surveys/website-app-surveys/survey-display-logic",
-                      "surveys/website-app-surveys/show-survey-to-percent-of-users"
+                      "surveys/website-app-surveys/show-survey-to-percent-of-users",
+                      "surveys/website-app-surveys/lifecycle-events"
                     ]
                   }
                 ]

--- a/docs/surveys/website-app-surveys/lifecycle-events.mdx
+++ b/docs/surveys/website-app-surveys/lifecycle-events.mdx
@@ -1,0 +1,80 @@
+---
+title: "Lifecycle Events"
+description: "Subscribe to survey lifecycle events to find out when a survey was actually shown, answered or closed in your app."
+icon: "bell"
+---
+
+Calling `formbricks.track()` does not mean a survey appeared. Formbricks still checks the cooldown period, recontact options, targeting and the percentage setting, and often decides not to show anything.
+
+Lifecycle events tell you what really happened, so your app can react to the survey it actually displayed.
+
+## The three events
+
+| Event | Fires when | How often |
+| --- | --- | --- |
+| `displayed` | The survey becomes visible | Once per display |
+| `responded` | The user submits their first answer | Once per survey |
+| `closed` | The user dismisses or finishes the survey | Once per display |
+
+Every event is an object with the event type and the survey it belongs to:
+
+```js
+{ type: "displayed", surveyId: "cltxyz1234567890" }
+```
+
+## Listening for events
+
+```js
+formbricks.on("displayed", (event) => {
+  console.log("Survey shown:", event.surveyId);
+});
+```
+
+You can subscribe before or after `formbricks.setup()`, and your listeners stay registered after `formbricks.logout()`.
+
+## Stopping a listener
+
+`formbricks.on()` returns a function that removes the listener:
+
+```js
+const unsubscribe = formbricks.on("responded", handleResponse);
+
+// later
+unsubscribe();
+```
+
+If you kept the handler in a variable, `formbricks.off()` does the same:
+
+```js
+formbricks.off("responded", handleResponse);
+```
+
+## Example: show a survey once per session
+
+```js
+let surveyShown = false;
+
+formbricks.on("displayed", () => {
+  surveyShown = true;
+});
+
+function onCheckout() {
+  if (surveyShown) return;
+  formbricks.track("checkout_completed");
+}
+```
+
+<Note>
+  A survey that is never shown sends no events at all. That silence is the signal: it means the user did not
+  see a survey, so nothing needs to be recorded.
+</Note>
+
+<Tip>
+  There is no separate "finished" event. `closed` covers both dismissing and completing a survey. To tell them
+  apart, check whether `responded` arrived first.
+</Tip>
+
+<Note>
+  Lifecycle events are available in the JavaScript SDK. Support for React Native, iOS, Android and Flutter is
+  coming in a later release.
+</Note>

--- a/packages/js-core/src/index.ts
+++ b/packages/js-core/src/index.ts
@@ -8,7 +8,6 @@ import * as Attribute from "@/lib/user/attribute";
 import * as User from "@/lib/user/user";
 import { type TConfigInput, type TLegacyConfigInput } from "@/types/config";
 import {
-  type TSurveyLifecycleEvent,
   type TSurveyLifecycleEventHandler,
   type TSurveyLifecycleEventType,
   type TTrackProperties,
@@ -152,5 +151,10 @@ const formbricks = {
 (globalThis as unknown as Record<string, unknown>).formbricks = formbricks;
 
 type TFormbricks = typeof formbricks;
-export type { TFormbricks, TSurveyLifecycleEvent, TSurveyLifecycleEventHandler, TSurveyLifecycleEventType };
+export type { TFormbricks };
+export type {
+  TSurveyLifecycleEvent,
+  TSurveyLifecycleEventHandler,
+  TSurveyLifecycleEventType,
+} from "@/types/survey";
 export default formbricks;

--- a/packages/js-core/src/index.ts
+++ b/packages/js-core/src/index.ts
@@ -2,11 +2,17 @@ import { CommandQueue, CommandType } from "@/lib/common/command-queue";
 import * as Setup from "@/lib/common/setup";
 import { getIsDebug } from "@/lib/common/utils";
 import * as Action from "@/lib/survey/action";
+import { SurveyLifecycleEmitter } from "@/lib/survey/lifecycle";
 import { checkPageUrl } from "@/lib/survey/no-code-action";
 import * as Attribute from "@/lib/user/attribute";
 import * as User from "@/lib/user/user";
 import { type TConfigInput, type TLegacyConfigInput } from "@/types/config";
-import { type TTrackProperties } from "@/types/survey";
+import {
+  type TSurveyLifecycleEvent,
+  type TSurveyLifecycleEventHandler,
+  type TSurveyLifecycleEventType,
+  type TTrackProperties,
+} from "@/types/survey";
 
 const queue = CommandQueue.getInstance();
 
@@ -82,6 +88,33 @@ const registerRouteChange = async (): Promise<void> => {
 };
 
 /**
+ * Subscribe to a survey lifecycle event.
+ *
+ * The host application is notified when a survey is actually shown ("displayed"), answered
+ * ("responded") and dismissed or finished ("closed"), so it can drive its own logic — frequency
+ * capping, analytics — off what the SDK really did rather than off the `track()` calls it made.
+ *
+ * Subscriptions are independent of setup(): registering before or after setup() both work, and a
+ * handler stays registered across logout() until it is removed.
+ *
+ * @param eventType - "displayed" | "responded" | "closed"
+ * @param handler - Called with the event type and the survey it concerns
+ * @returns A function that removes this subscription. `off()` with the same arguments does the same.
+ */
+const on = (eventType: TSurveyLifecycleEventType, handler: TSurveyLifecycleEventHandler): (() => void) =>
+  SurveyLifecycleEmitter.getInstance().on(eventType, handler);
+
+/**
+ * Remove a survey lifecycle subscription registered with on().
+ *
+ * @param eventType - The event type the handler was registered for
+ * @param handler - The same function reference that was passed to on()
+ */
+const off = (eventType: TSurveyLifecycleEventType, handler: TSurveyLifecycleEventHandler): void => {
+  SurveyLifecycleEmitter.getInstance().off(eventType, handler);
+};
+
+/**
  * Set the CSP nonce for inline styles
  * @param nonce - The CSP nonce value (without 'nonce-' prefix), or undefined to clear
  */
@@ -107,6 +140,8 @@ const formbricks = {
   logout,
   registerRouteChange,
   setNonce,
+  on,
+  off,
 };
 
 // Explicitly assign to globalThis so the wrapper SDK (@formbricks/js) can
@@ -117,5 +152,5 @@ const formbricks = {
 (globalThis as unknown as Record<string, unknown>).formbricks = formbricks;
 
 type TFormbricks = typeof formbricks;
-export type { TFormbricks };
+export type { TFormbricks, TSurveyLifecycleEvent, TSurveyLifecycleEventHandler, TSurveyLifecycleEventType };
 export default formbricks;

--- a/packages/js-core/src/lib/survey/lifecycle.ts
+++ b/packages/js-core/src/lib/survey/lifecycle.ts
@@ -1,0 +1,70 @@
+import { Logger } from "@/lib/common/logger";
+import type {
+  TSurveyLifecycleEvent,
+  TSurveyLifecycleEventHandler,
+  TSurveyLifecycleEventType,
+} from "@/types/survey";
+
+/**
+ * Fan-out of survey lifecycle events ("displayed" / "responded" / "closed") to the host application.
+ *
+ * The renderer already reports these moments to js-core (onDisplayCreated / onResponseCreated /
+ * onClose); this is the public edge of that channel, so an embedding app can run its own frequency
+ * capping off what was actually shown rather than off what `track()` was called with — an eligible
+ * survey can be skipped by displayPercentage, by a language mismatch, or by a failed identification,
+ * and none of those reach the screen.
+ *
+ * Host handlers run inside the renderer's callbacks, so a throwing handler must not take the survey
+ * down with it: `emit` isolates each call and logs instead of propagating.
+ */
+export class SurveyLifecycleEmitter {
+  private static instance: SurveyLifecycleEmitter | undefined;
+  private readonly handlers = new Map<TSurveyLifecycleEventType, Set<TSurveyLifecycleEventHandler>>();
+
+  static getInstance(): SurveyLifecycleEmitter {
+    SurveyLifecycleEmitter.instance ??= new SurveyLifecycleEmitter();
+    return SurveyLifecycleEmitter.instance;
+  }
+
+  /** Registers a handler and returns the matching unsubscribe function. */
+  public on(eventType: TSurveyLifecycleEventType, handler: TSurveyLifecycleEventHandler): () => void {
+    const handlers = this.handlers.get(eventType) ?? new Set<TSurveyLifecycleEventHandler>();
+    handlers.add(handler);
+    this.handlers.set(eventType, handlers);
+
+    return () => {
+      this.off(eventType, handler);
+    };
+  }
+
+  public off(eventType: TSurveyLifecycleEventType, handler: TSurveyLifecycleEventHandler): void {
+    const handlers = this.handlers.get(eventType);
+    if (!handlers) return;
+
+    handlers.delete(handler);
+    if (handlers.size === 0) {
+      this.handlers.delete(eventType);
+    }
+  }
+
+  public emit(event: TSurveyLifecycleEvent): void {
+    const handlers = this.handlers.get(event.type);
+    if (!handlers?.size) return;
+
+    // Iterate a snapshot: a handler is allowed to unsubscribe itself (a one-shot listener is the
+    // obvious way to capture "the first display of this journey leg") while we are still notifying.
+    [...handlers].forEach((handler) => {
+      try {
+        handler(event);
+      } catch (error) {
+        Logger.getInstance().error(
+          `Survey lifecycle handler for "${event.type}" threw an error: ${String(error)}`
+        );
+      }
+    });
+  }
+
+  public resetInstance(): void {
+    SurveyLifecycleEmitter.instance = undefined;
+  }
+}

--- a/packages/js-core/src/lib/survey/tests/lifecycle.test.ts
+++ b/packages/js-core/src/lib/survey/tests/lifecycle.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Logger } from "@/lib/common/logger";
+import { SurveyLifecycleEmitter } from "@/lib/survey/lifecycle";
+
+describe("SurveyLifecycleEmitter", () => {
+  let emitter: SurveyLifecycleEmitter;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    SurveyLifecycleEmitter.getInstance().resetInstance();
+    emitter = SurveyLifecycleEmitter.getInstance();
+  });
+
+  test("returns the same instance", () => {
+    expect(SurveyLifecycleEmitter.getInstance()).toBe(emitter);
+  });
+
+  test("notifies every handler of the emitted type with the event", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const other = vi.fn();
+
+    emitter.on("displayed", first);
+    emitter.on("displayed", second);
+    emitter.on("closed", other);
+
+    emitter.emit({ type: "displayed", surveyId: "survey_1" });
+
+    expect(first).toHaveBeenCalledWith({ type: "displayed", surveyId: "survey_1" });
+    expect(second).toHaveBeenCalledWith({ type: "displayed", surveyId: "survey_1" });
+    expect(other).not.toHaveBeenCalled();
+  });
+
+  test("registering the same handler twice notifies it once", () => {
+    const handler = vi.fn();
+
+    emitter.on("responded", handler);
+    emitter.on("responded", handler);
+
+    emitter.emit({ type: "responded", surveyId: "survey_1" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("the function returned by on() removes the subscription", () => {
+    const handler = vi.fn();
+    const unsubscribe = emitter.on("displayed", handler);
+
+    unsubscribe();
+    emitter.emit({ type: "displayed", surveyId: "survey_1" });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("off() removes only the handler it names", () => {
+    const removed = vi.fn();
+    const kept = vi.fn();
+
+    emitter.on("closed", removed);
+    emitter.on("closed", kept);
+    emitter.off("closed", removed);
+
+    emitter.emit({ type: "closed", surveyId: "survey_1" });
+
+    expect(removed).not.toHaveBeenCalled();
+    expect(kept).toHaveBeenCalledTimes(1);
+  });
+
+  test("off() on an unknown handler or type is a no-op", () => {
+    const handler = vi.fn();
+
+    expect(() => {
+      emitter.off("displayed", handler);
+    }).not.toThrow();
+
+    emitter.on("displayed", handler);
+    emitter.off("displayed", vi.fn());
+    emitter.emit({ type: "displayed", surveyId: "survey_1" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("a handler that unsubscribes itself still receives the event it is handling", () => {
+    const handler = vi.fn(() => {
+      emitter.off("displayed", handler);
+    });
+
+    emitter.on("displayed", handler);
+
+    expect(() => {
+      emitter.emit({ type: "displayed", surveyId: "survey_1" });
+    }).not.toThrow();
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    emitter.emit({ type: "displayed", surveyId: "survey_2" });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("a throwing handler is logged and does not stop the other handlers", () => {
+    const errorSpy = vi.spyOn(Logger.getInstance(), "error").mockImplementation(() => undefined);
+    const throwing = vi.fn(() => {
+      throw new Error("host blew up");
+    });
+    const healthy = vi.fn();
+
+    emitter.on("responded", throwing);
+    emitter.on("responded", healthy);
+
+    expect(() => {
+      emitter.emit({ type: "responded", surveyId: "survey_1" });
+    }).not.toThrow();
+
+    expect(healthy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("host blew up"));
+  });
+
+  test("emitting with no subscribers does nothing", () => {
+    expect(() => {
+      emitter.emit({ type: "closed", surveyId: "survey_1" });
+    }).not.toThrow();
+  });
+});

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -3,6 +3,7 @@ import { Config } from "@/lib/common/config";
 import { Logger } from "@/lib/common/logger";
 import type * as CommonUtils from "@/lib/common/utils";
 import { filterSurveys, getLanguageCode, shouldDisplayBasedOnPercentage } from "@/lib/common/utils";
+import { SurveyLifecycleEmitter } from "@/lib/survey/lifecycle";
 import { mockSurvey } from "@/lib/survey/tests/__mocks__/widget.mock";
 import * as widget from "@/lib/survey/widget";
 import { type TWorkspaceStateSurvey } from "@/types/config";
@@ -888,6 +889,131 @@ describe("widget-file", () => {
 
       expect(mockUpdateQueue.updateUserId).not.toHaveBeenCalled();
       expect(mockUpdateQueue.processUpdates).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("survey lifecycle events", () => {
+    // The public `formbricks.on()` channel: the host is told what actually reached the screen, so the
+    // assertions here are about which renderer callback maps to which event and about the survey id.
+    const lifecycleConfig = {
+      get: vi.fn().mockReturnValue({
+        appUrl: "https://fake.app",
+        workspaceId: "env_123",
+        workspace: {
+          data: {
+            settings: { clickOutsideClose: true, overlay: "none", placement: "bottomRight" },
+          },
+        },
+        user: {
+          data: {
+            userId: "user_abc",
+            contactId: "contact_abc",
+            displays: [],
+            responses: [],
+            lastDisplayAt: null,
+          },
+        },
+      }),
+      update: vi.fn(),
+    };
+
+    const renderAndGetCallbacks = async (): Promise<{
+      onDisplayCreated: () => void;
+      onResponseCreated: () => void;
+      onClose: () => void;
+    }> => {
+      widget.setIsSurveyRunning(false);
+      window.formbricksSurveys = createMockFormbricksSurveys();
+
+      vi.useFakeTimers();
+      await widget.renderWidget({ ...mockSurvey, delay: 0 });
+      vi.advanceTimersByTime(0);
+      vi.useRealTimers();
+
+      return (getFormbricksSurveys().renderSurvey as Mock).mock.calls[0][0] as {
+        onDisplayCreated: () => void;
+        onResponseCreated: () => void;
+        onClose: () => void;
+      };
+    };
+
+    beforeEach(() => {
+      getInstanceConfigMock.mockReturnValue(lifecycleConfig as unknown as Config);
+      (filterSurveys as Mock).mockReturnValue([]);
+      // Drop any survey an earlier test left on screen, then start from a subscriber-free emitter.
+      widget.closeSurvey();
+      SurveyLifecycleEmitter.getInstance().resetInstance();
+    });
+
+    test("emits displayed once the display is created, not when the survey is triggered", async () => {
+      const handler = vi.fn();
+      SurveyLifecycleEmitter.getInstance().on("displayed", handler);
+
+      const callbacks = await renderAndGetCallbacks();
+      expect(handler).not.toHaveBeenCalled();
+
+      callbacks.onDisplayCreated();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ type: "displayed", surveyId: mockSurvey.id });
+    });
+
+    test("emits responded when the response is created", async () => {
+      const handler = vi.fn();
+      SurveyLifecycleEmitter.getInstance().on("responded", handler);
+
+      const callbacks = await renderAndGetCallbacks();
+      callbacks.onResponseCreated();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ type: "responded", surveyId: mockSurvey.id });
+    });
+
+    test("emits closed once when the survey closes, and not again on a repeated close", async () => {
+      const handler = vi.fn();
+      SurveyLifecycleEmitter.getInstance().on("closed", handler);
+
+      const callbacks = await renderAndGetCallbacks();
+      callbacks.onClose();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ type: "closed", surveyId: mockSurvey.id });
+
+      widget.closeSurvey();
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    test("emits nothing when closeSurvey runs with no survey on screen", () => {
+      const handler = vi.fn();
+      SurveyLifecycleEmitter.getInstance().on("closed", handler);
+
+      widget.closeSurvey();
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    test("renders and closes normally when no host has subscribed", async () => {
+      const callbacks = await renderAndGetCallbacks();
+
+      expect(() => {
+        callbacks.onDisplayCreated();
+        callbacks.onResponseCreated();
+        callbacks.onClose();
+      }).not.toThrow();
+    });
+
+    test("a throwing host handler does not break the survey it is reporting on", async () => {
+      SurveyLifecycleEmitter.getInstance().on("displayed", () => {
+        throw new Error("host blew up");
+      });
+
+      const callbacks = await renderAndGetCallbacks();
+
+      expect(() => {
+        callbacks.onDisplayCreated();
+      }).not.toThrow();
+      // The display was still recorded in the user state.
+      expect(lifecycleConfig.update).toHaveBeenCalled();
     });
   });
 });

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -11,14 +11,26 @@ import {
   shouldDisplayBasedOnPercentage,
   surveyHasSegmentFilters,
 } from "@/lib/common/utils";
+import { SurveyLifecycleEmitter } from "@/lib/survey/lifecycle";
 import { UpdateQueue } from "@/lib/user/update-queue";
 import { type TUserState, type TWorkspaceStateSurvey } from "@/types/config";
-import { type TTrackProperties } from "@/types/survey";
+import { type TSurveyLifecycleEventType, type TTrackProperties } from "@/types/survey";
 
 let isSurveyRunning = false;
 
+// The survey handed to the renderer, held only while it is on screen. `closeSurvey` is the single
+// close path — the renderer's onClose, and tearDown on logout / error — but it is called without
+// arguments, so this is what lets the "closed" lifecycle event name the survey it belongs to. It is
+// set when the widget actually renders (after the delay, after every skip check), so a survey that
+// was never shown never reports a close.
+let activeSurveyId: string | null = null;
+
 export const setIsSurveyRunning = (value: boolean): void => {
   isSurveyRunning = value;
+};
+
+const emitLifecycleEvent = (type: TSurveyLifecycleEventType, surveyId: string): void => {
+  SurveyLifecycleEmitter.getInstance().emit({ type, surveyId });
 };
 
 type TInteractionSource = keyof NonNullable<TWorkspaceStateSurvey["interactionRefresh"]>;
@@ -161,6 +173,8 @@ export const renderWidget = async (
   }
 
   const timeoutId = setTimeout(() => {
+    activeSurveyId = survey.id;
+
     formbricksSurveys.renderSurvey({
       appUrl: config.get().appUrl,
       workspaceId: config.get().workspaceId,
@@ -206,6 +220,10 @@ export const renderWidget = async (
         // coalesced) so interaction targeting is current by the time this survey closes and the next
         // trigger evaluates. The display is already persisted (fires after createDisplay).
         refreshSegmentsAfterInteraction(previousConfig.user.data.userId, survey, "onDisplay");
+
+        // Fires after the display was persisted, i.e. once the survey is on screen — not when the
+        // triggering `track()` ran, which is the distinction the host needs to cap frequency on.
+        emitLifecycleEvent("displayed", survey.id);
       },
       onResponseCreated: () => {
         const responses = config.get().user.data.responses;
@@ -230,6 +248,10 @@ export const renderWidget = async (
         // once, on the first answer (not on subsequent question submits — see survey.tsx), so this is
         // a single refresh covering "started". The "completed X" case is handled in onFinished below.
         refreshSegmentsAfterInteraction(config.get().user.data.userId, survey, "onResponse");
+
+        // Once per survey, on the first answer: the renderer creates the response then and only
+        // updates it on later submits (see survey.tsx).
+        emitLifecycleEvent("responded", survey.id);
       },
       onFinished: () => {
         // Survey completion flips "have completed X" (and clears "have not completed X") segments.
@@ -266,6 +288,14 @@ export const closeSurvey = (): void => {
   });
 
   setIsSurveyRunning(false);
+
+  // Last, so a host handler observes settled state. Guarded on activeSurveyId: closeSurvey also runs
+  // on paths where nothing is open (tearDown), and it must report each rendered survey exactly once.
+  if (activeSurveyId) {
+    const closedSurveyId = activeSurveyId;
+    activeSurveyId = null;
+    emitLifecycleEvent("closed", closedSurveyId);
+  }
 };
 
 export const addWidgetContainer = (): void => {

--- a/packages/js-core/src/types/survey.ts
+++ b/packages/js-core/src/types/survey.ts
@@ -92,3 +92,13 @@ export type TActionClassNoCodeConfig =
 export interface TTrackProperties {
   hiddenFields: Record<string, string | number | string[]>;
 }
+
+/** Survey lifecycle events a host application can subscribe to via `formbricks.on()`. */
+export type TSurveyLifecycleEventType = "displayed" | "responded" | "closed";
+
+export interface TSurveyLifecycleEvent {
+  type: TSurveyLifecycleEventType;
+  surveyId: string;
+}
+
+export type TSurveyLifecycleEventHandler = (event: TSurveyLifecycleEvent) => void;


### PR DESCRIPTION
Fixes ENG-1814

## What & why

**Was:** A host app embedding the JS SDK could only observe its own `track()` calls, which say nothing about whether a survey reached the screen.

**Now:** `formbricks.on("displayed" | "responded" | "closed", handler)` reports what the SDK actually did, with the survey id; the returned function (or `off()`) removes the subscription.

- An eligible survey can still be skipped by `displayPercentage`, a language mismatch, or failed identification.
- Events are wired to renderer callbacks js-core already consumed internally — no behaviour change with no subscriber.
- A throwing host handler is caught and logged, never propagated into the survey.

## Live verification

### ▶ [Open the evidence report](https://claude.ai/code/artifact/5d4da42d-d277-4343-bb8b-4bc83edd09bb)

Four runs against a real app survey on a running instance: full journey, dismissed without answering, after unsubscribing, and with a throwing host handler. Console transcripts, event timings and a database cross-check.

## Where to look

- [lifecycle.ts](packages/js-core/src/lib/survey/lifecycle.ts) — emitter, handler isolation
- [widget.ts:294](packages/js-core/src/lib/survey/widget.ts#L294) — `activeSurveyId` guard on close
- [index.ts:103](packages/js-core/src/index.ts#L103) — public `on` / `off`
- [lifecycle-events.mdx](docs/surveys/website-app-surveys/lifecycle-events.mdx) — new docs page



<details>
<summary>Event sources and the close guard</summary>

| Event | Renderer callback | Timing |
| --- | --- | --- |
| `displayed` | `onDisplayCreated` | after the display is persisted, i.e. on screen |
| `responded` | `onResponseCreated` | once, on the first answer |
| `closed` | `onClose` → `closeSurvey()` | user dismiss, and finish auto-close |

`closeSurvey()` takes no arguments, so widget.ts holds `activeSurveyId`, set at the moment the widget
renders — after the delay and every skip check. That gives three properties: a survey never shown never
reports a close; `tearDown()` on logout with nothing open emits nothing; a repeated close emits once.

</details>

<img width="1225" height="954" alt="Screenshot 2026-09-02 at 2 56 37 PM" src="https://github.com/user-attachments/assets/21681273-c462-4a0a-9a33-e34e27898c5a" />


## Breaking changes

- [ ] This PR contains breaking changes

None. Purely additive: two new methods on the exported `formbricks` object and three new exported types. No existing signature, event, or default changes.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/js-core test`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `displayed` fires on display creation, not on trigger | unit (mutation) | Passes; handler uncalled after `renderWidget`, called on `onDisplayCreated` |
| `responded` fires on response creation | unit (mutation) | Passes with `{ type: "responded", surveyId }` |
| `closed` fires once per rendered survey, silent when none | unit (mutation) | One event on close; repeat and `tearDown()` add none |
| Unsubscribe leaves no live listener | unit (mutation) | Returned fn and `off()` both stop delivery |
| Throwing host handler does not break the survey | unit (mutation) | Logged; other handlers run, display still recorded |
| Whole lifecycle against a running app | manual | Four browser runs on a real app survey — see **Live verification** above |

Mutation targets: [lifecycle.ts:58](packages/js-core/src/lib/survey/lifecycle.ts#L58) (drop the try/catch), [widget.ts:296](packages/js-core/src/lib/survey/widget.ts#L296) (drop the `activeSurveyId` reset). Tests live in `lifecycle.test.ts` and the `survey lifecycle events` block of `widget.test.ts`.

**Open gaps**

- The manual run covered one browser, one placement and a single-question survey.
- No live check of logout/teardown while a survey is open; that path rests on the unit tests.

**Risks**

- `closed` is the only event with cross-call state (`activeSurveyId`); if it ever double-fires, check the render-time assignment in `renderWidget`.
- `SurveyStore` remains dead code — the ticket hinted at it, but it holds the current survey, not events.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.



