### PR TITLE
fix: keep Redis connections alive

### DIFF
--- a/apps/web/modules/auth/lib/secondary-storage.test.ts
+++ b/apps/web/modules/auth/lib/secondary-storage.test.ts
@@ -1,3 +1,4 @@
+import { createClient } from "redis";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { redisSecondaryStorage } from "./secondary-storage";
 
@@ -23,9 +24,14 @@ describe("redisSecondaryStorage", () => {
     mockClient.connect.mockResolvedValue(undefined);
   });
 
-  test("get reads through to the client", async () => {
+  test("creates the client with a heartbeat and reads through to it", async () => {
     mockClient.get.mockResolvedValue("value");
     expect(await redisSecondaryStorage.get("k")).toBe("value");
+    expect(createClient).toHaveBeenCalledWith({
+      url: "redis://localhost:6379",
+      socket: { connectTimeout: 3000 },
+      pingInterval: 300_000,
+    });
     expect(mockClient.get).toHaveBeenCalledWith("k");
   });
 

--- a/apps/web/modules/auth/lib/secondary-storage.test.ts
+++ b/apps/web/modules/auth/lib/secondary-storage.test.ts
@@ -24,14 +24,9 @@ describe("redisSecondaryStorage", () => {
     mockClient.connect.mockResolvedValue(undefined);
   });
 
-  test("creates the client with a heartbeat and reads through to it", async () => {
+  test("get reads through to the client", async () => {
     mockClient.get.mockResolvedValue("value");
     expect(await redisSecondaryStorage.get("k")).toBe("value");
-    expect(createClient).toHaveBeenCalledWith({
-      url: "redis://localhost:6379",
-      socket: { connectTimeout: 3000 },
-      pingInterval: 300_000,
-    });
     expect(mockClient.get).toHaveBeenCalledWith("k");
   });
 
@@ -76,5 +71,18 @@ describe("redisSecondaryStorage", () => {
   test("increment coerces the Lua reply to a number", async () => {
     mockClient.eval.mockResolvedValue("5");
     expect(await redisSecondaryStorage.increment("k", 90)).toBe(5);
+  });
+
+  test("creates the client with a heartbeat", async () => {
+    vi.resetModules();
+    const { redisSecondaryStorage: freshStorage } = await import("./secondary-storage");
+    mockClient.get.mockResolvedValue("value");
+
+    expect(await freshStorage.get("k")).toBe("value");
+    expect(createClient).toHaveBeenCalledWith({
+      url: "redis://localhost:6379",
+      socket: { connectTimeout: 3000 },
+      pingInterval: 300_000,
+    });
   });
 });

--- a/apps/web/modules/auth/lib/secondary-storage.test.ts
+++ b/apps/web/modules/auth/lib/secondary-storage.test.ts
@@ -85,4 +85,16 @@ describe("redisSecondaryStorage", () => {
       pingInterval: 300_000,
     });
   });
+
+  test("retries the lazy connection after a failed connect", async () => {
+    vi.resetModules();
+    const connectionError = new Error("Connection failed");
+    mockClient.connect.mockRejectedValueOnce(connectionError).mockResolvedValueOnce(undefined);
+    mockClient.get.mockResolvedValue("value");
+    const { redisSecondaryStorage: freshStorage } = await import("./secondary-storage");
+
+    await expect(freshStorage.get("k")).rejects.toBe(connectionError);
+    await expect(freshStorage.get("k")).resolves.toBe("value");
+    expect(mockClient.connect).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/modules/auth/lib/secondary-storage.ts
+++ b/apps/web/modules/auth/lib/secondary-storage.ts
@@ -19,7 +19,12 @@ let clientPromise: Promise<RedisClient> | undefined;
 
 const getClient = (): Promise<RedisClient> => {
   if (!clientPromise) {
-    const client = createClient({ url: env.REDIS_URL, socket: { connectTimeout: 3000 } });
+    const client = createClient({
+      url: env.REDIS_URL,
+      socket: { connectTimeout: 3000 },
+      // Azure Cache for Redis closes idle connections after 10 minutes.
+      pingInterval: 300_000,
+    });
     client.on("error", (error) => logger.error(error, "Better Auth Redis secondary storage error"));
     clientPromise = client
       .connect()

--- a/apps/web/modules/auth/lib/secondary-storage.ts
+++ b/apps/web/modules/auth/lib/secondary-storage.ts
@@ -22,7 +22,8 @@ const getClient = (): Promise<RedisClient> => {
     const client = createClient({
       url: env.REDIS_URL,
       socket: { connectTimeout: 3000 },
-      // Azure Cache for Redis closes idle connections after 10 minutes.
+      // Managed Redis services and their network paths can reap idle connections (for example,
+      // Azure Cache for Redis documents a 10-minute idle timeout). Ping well inside that limit.
       pingInterval: 300_000,
     });
     client.on("error", (error) => logger.error(error, "Better Auth Redis secondary storage error"));

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -149,7 +149,6 @@ export default defineConfig({
         // tests, so they are excluded from the unit-coverage gate below (ENG-1054).
         "modules/auth/lib/auth.ts",
         "modules/auth/lib/auth-client.ts",
-        "modules/auth/lib/secondary-storage.ts",
         "modules/auth/lib/better-auth-email-verification.ts",
         "packages/js-core/src/index.ts", // JS Core index file
 

--- a/packages/cache/src/client.test.ts
+++ b/packages/cache/src/client.test.ts
@@ -100,6 +100,7 @@ describe("@formbricks/cache factory", () => {
         socket: {
           connectTimeout: 3000,
         },
+        pingInterval: 300_000,
       });
 
       // Verify event handlers are set up
@@ -138,6 +139,7 @@ describe("@formbricks/cache factory", () => {
         socket: {
           connectTimeout: 3000,
         },
+        pingInterval: 300_000,
       });
       expect(mockClient.connect).toHaveBeenCalled();
     });

--- a/packages/cache/src/client.ts
+++ b/packages/cache/src/client.ts
@@ -22,7 +22,8 @@ export async function createRedisClientFromEnv(): Promise<Result<RedisClient, Ca
     socket: {
       connectTimeout: 3000,
     },
-    // Azure Cache for Redis closes idle connections after 10 minutes.
+    // Managed Redis services and their network paths can reap idle connections (for example,
+    // Azure Cache for Redis documents a 10-minute idle timeout). Ping well inside that limit.
     pingInterval: 300_000,
   });
 

--- a/packages/cache/src/client.ts
+++ b/packages/cache/src/client.ts
@@ -22,6 +22,8 @@ export async function createRedisClientFromEnv(): Promise<Result<RedisClient, Ca
     socket: {
       connectTimeout: 3000,
     },
+    // Azure Cache for Redis closes idle connections after 10 minutes.
+    pingInterval: 300_000,
   });
 
   client.on("error", (error) => {


### PR DESCRIPTION
Ref ENG-2835

## What & why

**Was:** Managed Redis services and network paths can reap idle connections. The observed Azure socket closures recur at 600–630 seconds, matching its approximately 10-minute idle timeout.

**Now:** Both node-redis clients send `PING` every five minutes: Better Auth secondary storage and the shared cache/rate-limit client. Existing reconnect and error handling remain unchanged. Better Auth Redis storage is included in unit coverage so Sonar receives LCOV data for the new heartbeat.

## Where to look

- [Better Auth heartbeat](https://github.com/formbricks/formbricks/blob/3e444e56d16299fc14e3d8f071d6446f4ebcc3cd/apps/web/modules/auth/lib/secondary-storage.ts#L20-L29)
- [Shared cache heartbeat](https://github.com/formbricks/formbricks/blob/3e444e56d16299fc14e3d8f071d6446f4ebcc3cd/packages/cache/src/client.ts#L20-L28)
- [Coverage and order-independent regressions](https://github.com/formbricks/formbricks/blob/3e444e56d16299fc14e3d8f071d6446f4ebcc3cd/apps/web/modules/auth/lib/secondary-storage.test.ts#L76-L99)

## Breaking changes

- [ ] This PR contains breaking changes

None. The change adds background heartbeat traffic without changing public APIs or deployment configuration.

## Migrations & env

- none

## How this was tested

Rerun:

- `pnpm --filter @formbricks/web exec vitest run modules/auth/lib/secondary-storage.test.ts`
- `pnpm --filter @formbricks/cache exec vitest run src/client.test.ts`
- `pnpm --filter @formbricks/web exec vitest run modules/auth/lib/secondary-storage.test.ts --coverage --coverage.include=modules/auth/lib/secondary-storage.ts --coverage.reporter=text --silent`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Better Auth configures a five-minute heartbeat independently of test order | unit (red on main): first rerun command | Fails without `pingInterval`; all 10 tests pass, including when the client-construction assertion runs after ordinary storage calls |
| Shared cache configures the same heartbeat on successful and failed connection paths | unit (red on main): second rerun command | Two assertions fail without `pingInterval`; all 10 tests pass with it |
| Better Auth Redis storage contributes LCOV data | unit (guard): third rerun command | 100% lines, 100% branches, and 88.88% functions; the lazy-connect failure path is covered and retries successfully |

**Open gaps**

- Production confirmation is post-deploy: verify that the 600–630 second socket-close cadence disappears in pod logs or SigNoz and Azure connection metrics.

**Risks**

- Each active client sends one additional `PING` every five minutes; monitor Redis command volume and connection errors after rollout.

---

> [!NOTE]
> **AI model used** — `unknown`, reasoning effort `unknown`.