### PR TITLE
fix: fall back to database for Redis session errors (backport #9125 to release/5.4)

### DIFF
--- a/apps/web/modules/auth/lib/__mocks__/secondary-storage.mock.ts
+++ b/apps/web/modules/auth/lib/__mocks__/secondary-storage.mock.ts
@@ -1,0 +1,37 @@
+import type { BetterAuthOptions } from "better-auth";
+import { vi } from "vitest";
+
+export const REDIS_ERROR = new Error("Socket closed unexpectedly");
+
+export const createSecondaryStorageMock = () => {
+  const values = new Map<string, string>();
+  let failReads = false;
+
+  return {
+    storage: {
+      get: vi.fn(async (key: string) => {
+        if (failReads) throw REDIS_ERROR;
+        return values.get(key) ?? null;
+      }),
+      getAndDelete: vi.fn(async (key: string) => {
+        const value = values.get(key) ?? null;
+        values.delete(key);
+        return value;
+      }),
+      increment: vi.fn(async (key: string) => {
+        const value = Number(values.get(key) ?? 0) + 1;
+        values.set(key, String(value));
+        return value;
+      }),
+      set: vi.fn(async (key: string, value: string) => {
+        values.set(key, value);
+      }),
+      delete: vi.fn(async (key: string) => {
+        values.delete(key);
+      }),
+    } satisfies BetterAuthOptions["secondaryStorage"],
+    failReads: () => {
+      failReads = true;
+    },
+  };
+};

--- a/apps/web/modules/auth/lib/better-auth-session-fallback.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-session-fallback.test.ts
@@ -1,45 +1,12 @@
-import { type BetterAuthOptions, betterAuth } from "better-auth";
+import { REDIS_ERROR, createSecondaryStorageMock } from "./__mocks__/secondary-storage.mock";
+import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { describe, expect, test, vi } from "vitest";
 
 const BASE_URL = "https://app.formbricks.test";
-const REDIS_ERROR = new Error("Socket closed unexpectedly");
-
-const createSecondaryStorage = () => {
-  const values = new Map<string, string>();
-  let failReads = false;
-
-  return {
-    storage: {
-      get: vi.fn(async (key: string) => {
-        if (failReads) throw REDIS_ERROR;
-        return values.get(key) ?? null;
-      }),
-      getAndDelete: vi.fn(async (key: string) => {
-        const value = values.get(key) ?? null;
-        values.delete(key);
-        return value;
-      }),
-      increment: vi.fn(async (key: string) => {
-        const value = Number(values.get(key) ?? 0) + 1;
-        values.set(key, String(value));
-        return value;
-      }),
-      set: vi.fn(async (key: string, value: string) => {
-        values.set(key, value);
-      }),
-      delete: vi.fn(async (key: string) => {
-        values.delete(key);
-      }),
-    } satisfies BetterAuthOptions["secondaryStorage"],
-    failReads: () => {
-      failReads = true;
-    },
-  };
-};
 
 const createAuthInstance = (storeSessionInDatabase: boolean) => {
-  const secondaryStorage = createSecondaryStorage();
+  const secondaryStorage = createSecondaryStorageMock();
   const log = vi.fn();
   const auth = betterAuth({
     baseURL: BASE_URL,

--- a/apps/web/modules/auth/lib/better-auth-session-fallback.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-session-fallback.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test, vi } from "vitest";
 
 const BASE_URL = "https://app.formbricks.test";
 
-const createAuthInstance = (storeSessionInDatabase: boolean) => {
+const createAuthInstance = (storeSessionInDatabase: boolean, preserveSessionInDatabase = false) => {
   const secondaryStorage = createSecondaryStorageMock();
   const log = vi.fn();
   const auth = betterAuth({
@@ -15,7 +15,7 @@ const createAuthInstance = (storeSessionInDatabase: boolean) => {
     emailAndPassword: { enabled: true },
     rateLimit: { enabled: false },
     secondaryStorage: secondaryStorage.storage,
-    session: { storeSessionInDatabase },
+    session: { storeSessionInDatabase, preserveSessionInDatabase },
     logger: { level: "error", log },
   });
 
@@ -53,6 +53,17 @@ describe("Better Auth session database fallback", () => {
 
   test("propagates the secondary-storage error when sessions are not stored in the database", async () => {
     const { auth, secondaryStorage, signUp } = createAuthInstance(false);
+    const cookie = await signUp();
+    secondaryStorage.failReads();
+
+    await expect(auth.api.getSession({ headers: new Headers({ cookie }) })).rejects.toMatchObject({
+      status: "INTERNAL_SERVER_ERROR",
+      body: { code: "FAILED_TO_GET_SESSION" },
+    });
+  });
+
+  test("propagates the secondary-storage error when database sessions are preserved", async () => {
+    const { auth, secondaryStorage, signUp } = createAuthInstance(true, true);
     const cookie = await signUp();
     secondaryStorage.failReads();
 

--- a/apps/web/modules/auth/lib/better-auth-session-fallback.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-session-fallback.test.ts
@@ -1,0 +1,87 @@
+import { type BetterAuthOptions, betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { describe, expect, test, vi } from "vitest";
+
+const BASE_URL = "https://app.formbricks.test";
+const REDIS_ERROR = new Error("Socket closed unexpectedly");
+
+const createSecondaryStorage = () => {
+  const values = new Map<string, string>();
+  let failReads = false;
+
+  return {
+    storage: {
+      get: vi.fn(async (key: string) => {
+        if (failReads) throw REDIS_ERROR;
+        return values.get(key) ?? null;
+      }),
+      set: vi.fn(async (key: string, value: string) => {
+        values.set(key, value);
+      }),
+      delete: vi.fn(async (key: string) => {
+        values.delete(key);
+      }),
+    } satisfies BetterAuthOptions["secondaryStorage"],
+    failReads: () => {
+      failReads = true;
+    },
+  };
+};
+
+const createAuthInstance = (storeSessionInDatabase: boolean) => {
+  const secondaryStorage = createSecondaryStorage();
+  const log = vi.fn();
+  const auth = betterAuth({
+    baseURL: BASE_URL,
+    secret: "better-auth-session-fallback-test-secret",
+    database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+    emailAndPassword: { enabled: true },
+    rateLimit: { enabled: false },
+    secondaryStorage: secondaryStorage.storage,
+    session: { storeSessionInDatabase },
+    logger: { level: "error", log },
+  });
+
+  return { auth, secondaryStorage, log };
+};
+
+const signUp = async (auth: ReturnType<typeof betterAuth>): Promise<string> => {
+  const response = await auth.api.signUpEmail({
+    body: { email: "redis-fallback@example.com", password: "Correct-Horse1", name: "Redis Fallback" },
+    asResponse: true,
+  });
+  expect(response.status).toBe(200);
+
+  return response.headers
+    .getSetCookie()
+    .map((cookie) => cookie.split(";")[0])
+    .join("; ");
+};
+
+describe("Better Auth session database fallback", () => {
+  test("returns the database-backed session when secondary storage throws", async () => {
+    const { auth, secondaryStorage, log } = createAuthInstance(true);
+    const cookie = await signUp(auth);
+    secondaryStorage.failReads();
+
+    await expect(auth.api.getSession({ headers: new Headers({ cookie }) })).resolves.toMatchObject({
+      user: { email: "redis-fallback@example.com" },
+    });
+    expect(log).toHaveBeenCalledWith(
+      "error",
+      "Failed to read session from secondary storage; falling back to database",
+      REDIS_ERROR
+    );
+  });
+
+  test("propagates the secondary-storage error when sessions are not stored in the database", async () => {
+    const { auth, secondaryStorage } = createAuthInstance(false);
+    const cookie = await signUp(auth);
+    secondaryStorage.failReads();
+
+    await expect(auth.api.getSession({ headers: new Headers({ cookie }) })).rejects.toMatchObject({
+      status: "INTERNAL_SERVER_ERROR",
+      body: { code: "FAILED_TO_GET_SESSION" },
+    });
+  });
+});

--- a/apps/web/modules/auth/lib/better-auth-session-fallback.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-session-fallback.test.ts
@@ -15,6 +15,16 @@ const createSecondaryStorage = () => {
         if (failReads) throw REDIS_ERROR;
         return values.get(key) ?? null;
       }),
+      getAndDelete: vi.fn(async (key: string) => {
+        const value = values.get(key) ?? null;
+        values.delete(key);
+        return value;
+      }),
+      increment: vi.fn(async (key: string) => {
+        const value = Number(values.get(key) ?? 0) + 1;
+        values.set(key, String(value));
+        return value;
+      }),
       set: vi.fn(async (key: string, value: string) => {
         values.set(key, value);
       }),
@@ -42,26 +52,26 @@ const createAuthInstance = (storeSessionInDatabase: boolean) => {
     logger: { level: "error", log },
   });
 
-  return { auth, secondaryStorage, log };
-};
+  const signUp = async (): Promise<string> => {
+    const response = await auth.api.signUpEmail({
+      body: { email: "redis-fallback@example.com", password: "Correct-Horse1", name: "Redis Fallback" },
+      asResponse: true,
+    });
+    expect(response.status).toBe(200);
 
-const signUp = async (auth: ReturnType<typeof betterAuth>): Promise<string> => {
-  const response = await auth.api.signUpEmail({
-    body: { email: "redis-fallback@example.com", password: "Correct-Horse1", name: "Redis Fallback" },
-    asResponse: true,
-  });
-  expect(response.status).toBe(200);
+    return response.headers
+      .getSetCookie()
+      .map((cookie) => cookie.split(";")[0])
+      .join("; ");
+  };
 
-  return response.headers
-    .getSetCookie()
-    .map((cookie) => cookie.split(";")[0])
-    .join("; ");
+  return { auth, secondaryStorage, log, signUp };
 };
 
 describe("Better Auth session database fallback", () => {
   test("returns the database-backed session when secondary storage throws", async () => {
-    const { auth, secondaryStorage, log } = createAuthInstance(true);
-    const cookie = await signUp(auth);
+    const { auth, secondaryStorage, log, signUp } = createAuthInstance(true);
+    const cookie = await signUp();
     secondaryStorage.failReads();
 
     await expect(auth.api.getSession({ headers: new Headers({ cookie }) })).resolves.toMatchObject({
@@ -75,8 +85,8 @@ describe("Better Auth session database fallback", () => {
   });
 
   test("propagates the secondary-storage error when sessions are not stored in the database", async () => {
-    const { auth, secondaryStorage } = createAuthInstance(false);
-    const cookie = await signUp(auth);
+    const { auth, secondaryStorage, signUp } = createAuthInstance(false);
+    const cookie = await signUp();
     secondaryStorage.failReads();
 
     await expect(auth.api.getSession({ headers: new Headers({ cookie }) })).rejects.toMatchObject({

--- a/patches/better-auth@1.7.0.patch
+++ b/patches/better-auth@1.7.0.patch
@@ -1,0 +1,19 @@
+diff --git a/dist/db/internal-adapter.mjs b/dist/db/internal-adapter.mjs
+index 0f88105d21dea1c2cc9a8f1ab268faede029b47a..c4a61e12810e17d3b2444252448e75155468294e 100644
+--- a/dist/db/internal-adapter.mjs
++++ b/dist/db/internal-adapter.mjs
+@@ -321,7 +321,13 @@ const createInternalAdapter = (adapter, ctx) => {
+ 		},
+ 		findSession: async (token) => {
+ 			if (secondaryStorage) {
+-				const sessionStringified = await secondaryStorage.get(token);
++				let sessionStringified;
++				try {
++					sessionStringified = await secondaryStorage.get(token);
++				} catch (error) {
++					if (!options.session?.storeSessionInDatabase || ctx.options.session?.preserveSessionInDatabase) throw error;
++					logger.error("Failed to read session from secondary storage; falling back to database", error);
++				}
+ 				if (!sessionStringified && (!options.session?.storeSessionInDatabase || ctx.options.session?.preserveSessionInDatabase)) return null;
+ 				if (sessionStringified) {
+ 					const s = safeJSONParse(sessionStringified);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,7 @@ overrides:
 
 patchedDependencies:
   '@better-auth/oauth-provider@1.7.0': c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4
+  better-auth@1.7.0: 1e1eb950e3163ebedbeeb9823f5951a9b9b12cf542ec6b15784bd06ddfb1582e
 
 importers:
 
@@ -352,7 +353,7 @@ importers:
         version: 1.7.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/oauth-provider':
         specifier: 1.7.0
-        version: 1.7.0(patch_hash=c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4)(a7d5e9ad522ca47a6d8a16da19a4e45c)
+        version: 1.7.0(patch_hash=c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4)(ddb3752cb5b0f8e8c6d96ce106aeec89)
       '@better-auth/utils':
         specifier: 0.4.2
         version: 0.4.2
@@ -589,7 +590,7 @@ importers:
         version: 3.0.3
       better-auth:
         specifier: 1.7.0
-        version: 1.7.0(@opentelemetry/api@1.9.0)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.8.0)(mongodb@7.1.0(@aws-sdk/credential-providers@3.1013.0)(socks@2.8.7))(mysql2@3.20.0(@types/node@25.4.0))(next@16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
+        version: 1.7.0(patch_hash=1e1eb950e3163ebedbeeb9823f5951a9b9b12cf542ec6b15784bd06ddfb1582e)(@opentelemetry/api@1.9.0)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.8.0)(mongodb@7.1.0(@aws-sdk/credential-providers@3.1013.0)(socks@2.8.7))(mysql2@3.20.0(@types/node@25.4.0))(next@16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
       boring-avatars:
         specifier: 2.0.4
         version: 2.0.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -14049,12 +14050,12 @@ snapshots:
     optionalDependencies:
       mongodb: 7.1.0(@aws-sdk/credential-providers@3.1013.0)(socks@2.8.7)
 
-  '@better-auth/oauth-provider@1.7.0(patch_hash=c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4)(a7d5e9ad522ca47a6d8a16da19a4e45c)':
+  '@better-auth/oauth-provider@1.7.0(patch_hash=c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4)(ddb3752cb5b0f8e8c6d96ce106aeec89)':
     dependencies:
       '@better-auth/core': 1.7.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.7.0(@opentelemetry/api@1.9.0)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.8.0)(mongodb@7.1.0(@aws-sdk/credential-providers@3.1013.0)(socks@2.8.7))(mysql2@3.20.0(@types/node@25.4.0))(next@16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
+      better-auth: 1.7.0(patch_hash=1e1eb950e3163ebedbeeb9823f5951a9b9b12cf542ec6b15784bd06ddfb1582e)(@opentelemetry/api@1.9.0)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.8.0)(mongodb@7.1.0(@aws-sdk/credential-providers@3.1013.0)(socks@2.8.7))(mysql2@3.20.0(@types/node@25.4.0))(next@16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
       better-call: 1.4.0(zod@4.3.6)
       jose: 6.2.9
       zod: 4.3.6
@@ -19719,7 +19720,7 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  better-auth@1.7.0(@opentelemetry/api@1.9.0)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.8.0)(mongodb@7.1.0(@aws-sdk/credential-providers@3.1013.0)(socks@2.8.7))(mysql2@3.20.0(@types/node@25.4.0))(next@16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6):
+  better-auth@1.7.0(patch_hash=1e1eb950e3163ebedbeeb9823f5951a9b9b12cf542ec6b15784bd06ddfb1582e)(@opentelemetry/api@1.9.0)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.8.0)(mongodb@7.1.0(@aws-sdk/credential-providers@3.1013.0)(socks@2.8.7))(mysql2@3.20.0(@types/node@25.4.0))(next@16.2.11(@babel/core@7.29.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.20.0)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6):
     dependencies:
       '@better-auth/core': 1.7.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.7.0(@better-auth/core@1.7.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -351,3 +351,6 @@ minimumReleaseAgeExclude:
 # Remove this version-pinned patch once upstream defers or safely handles eager seed failures.
 patchedDependencies:
   "@better-auth/oauth-provider@1.7.0": patches/@better-auth__oauth-provider@1.7.0.patch
+  # ENG-2559: a failed secondary-storage session read bypasses Better Auth's configured database
+  # fallback. Remove this version-pinned patch once upstream handles Redis read failures here.
+  better-auth@1.7.0: patches/better-auth@1.7.0.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -353,4 +353,4 @@ patchedDependencies:
   "@better-auth/oauth-provider@1.7.0": patches/@better-auth__oauth-provider@1.7.0.patch
   # ENG-2559: a failed secondary-storage session read bypasses Better Auth's configured database
   # fallback. Remove this version-pinned patch once upstream handles Redis read failures here.
-  better-auth@1.7.0: patches/better-auth@1.7.0.patch
+  "better-auth@1.7.0": patches/better-auth@1.7.0.patch


### PR DESCRIPTION
Ref ENG-2559

## What & why

**Was:** A rejected Redis session read in Formbricks 5.4 bypassed Better Auth's configured PostgreSQL fallback, so direct session lookups failed with `FAILED_TO_GET_SESSION` even when the authoritative database row was available.

**Now:** This backports [#9125](https://github.com/formbricks/formbricks/pull/9125). A version-pinned Better Auth 1.7.0 patch falls back only when database-backed session reads are safe; configurations without that safe fallback remain fail-closed.

## Where to look

- [Version-pinned Better Auth patch](https://github.com/formbricks/formbricks/blob/fc2a0f6d6eddf8b2734aa84b264698811d763ada/patches/better-auth%401.7.0.patch#L1-L19)
- [Fallback and fail-closed regressions](https://github.com/formbricks/formbricks/blob/fc2a0f6d6eddf8b2734aa84b264698811d763ada/apps/web/modules/auth/lib/better-auth-session-fallback.test.ts#L38-L74)
- [Colocated secondary-storage mock](https://github.com/formbricks/formbricks/blob/fc2a0f6d6eddf8b2734aa84b264698811d763ada/apps/web/modules/auth/lib/__mocks__/secondary-storage.mock.ts)

## Breaking changes

- [x] This PR contains breaking changes

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| Direct session lookup when Redis rejects a read and PostgreSQL has a valid session | `500 FAILED_TO_GET_SESSION` | Successful authenticated session response | API consumers and monitors observing this incident-only response | No deployment action; update any alert or client logic that assumes this Redis failure must return 500 |

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/auth/lib/better-auth-session-fallback.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Valid database-backed session when its Redis read throws | unit (mutation): rerun command | Returns the PostgreSQL-backed session |
| Sessions are not stored in the database | unit (guard): rerun command | Redis error still propagates as `FAILED_TO_GET_SESSION` |
| Ended database session rows are preserved | unit (guard): rerun command | Redis error still propagates as `FAILED_TO_GET_SESSION` instead of trusting a potentially revoked row |

**Open gaps**

- `/api/auth/*` remains Redis-dependent at Better Auth's rate-limit stage before `findSession`; direct `auth.api.getSession` callers, including Formbricks SSR/server-action paths, receive this fallback.
- If a hard outage leaves a Redis command queued instead of rejecting it, execution does not reach the fallback until the client throws or times out.
- No live Azure fault injection was run; staging should validate a rejected Redis read while a database-backed session remains available.

**Risks**

- A failed sign-out or revocation can leave its database row usable by the fallback for the remaining one-day session TTL; failed revocations must be retried.
- Each uncached fallback logs at error level and can create a Sentry event; a Redis miss is not rehydrated, so database load can persist for the remaining session TTL.
- The patch is pinned to Better Auth 1.7.0 and must be removed or regenerated when that dependency is upgraded after an upstream fix.

---

> [!NOTE]
> **AI model used** — `unknown`, reasoning effort `unknown`.
