### PR TITLE
fix: support Redis 6 verification token consumption (backport #9129)

### DIFF
--- a/apps/web/modules/auth/lib/secondary-storage.test.ts
+++ b/apps/web/modules/auth/lib/secondary-storage.test.ts
@@ -62,18 +62,16 @@ describe("redisSecondaryStorage", () => {
     expect(await redisSecondaryStorage.getAndDelete("native-key")).toBe("native");
     await expect(redisSecondaryStorage.getAndDelete("closed-key")).rejects.toBe(connectionError);
     expect(await redisSecondaryStorage.getAndDelete("verification:key")).toBe("once");
-    expect(await redisSecondaryStorage.getAndDelete("verification:missing")).toBeNull();
+    expect(await redisSecondaryStorage.getAndDelete("verification:key")).toBeNull();
 
     expect(mockClient.getDel).toHaveBeenCalledTimes(3);
     expect(mockClient.getDel).toHaveBeenNthCalledWith(1, "native-key");
     expect(mockClient.getDel).toHaveBeenNthCalledWith(2, "closed-key");
     expect(mockClient.getDel).toHaveBeenNthCalledWith(3, "verification:key");
     expect(mockClient.eval).toHaveBeenCalledTimes(2);
-    const [script, options] = mockClient.eval.mock.calls[0];
-    expect(script).toContain("redis.call('GET', KEYS[1])");
-    expect(script).toContain("redis.call('DEL', KEYS[1])");
+    const [, options] = mockClient.eval.mock.calls[0];
     expect(options).toEqual({ keys: ["verification:key"], arguments: [] });
-    expect(mockClient.eval.mock.calls[1][1]).toEqual({ keys: ["verification:missing"], arguments: [] });
+    expect(mockClient.eval.mock.calls[1][1]).toEqual({ keys: ["verification:key"], arguments: [] });
   });
 
   test("increment runs a single atomic INCR+EXPIRE Lua eval and returns the count", async () => {

--- a/apps/web/modules/auth/lib/secondary-storage.test.ts
+++ b/apps/web/modules/auth/lib/secondary-storage.test.ts
@@ -49,10 +49,31 @@ describe("redisSecondaryStorage", () => {
     expect(mockClient.del).toHaveBeenCalledWith("k");
   });
 
-  test("getAndDelete uses GETDEL for atomic single-use consumption", async () => {
-    mockClient.getDel.mockResolvedValue("once");
-    expect(await redisSecondaryStorage.getAndDelete("k")).toBe("once");
-    expect(mockClient.getDel).toHaveBeenCalledWith("k");
+  test("getAndDelete uses GETDEL when supported and otherwise remembers the atomic Lua fallback", async () => {
+    const connectionError = new Error("Socket closed unexpectedly");
+    mockClient.getDel
+      .mockResolvedValueOnce("native")
+      .mockRejectedValueOnce(connectionError)
+      .mockRejectedValueOnce(
+        new Error("ERR unknown command `GETDEL`, with args beginning with: `verification:key`")
+      );
+    mockClient.eval.mockResolvedValueOnce("once").mockResolvedValueOnce(null);
+
+    expect(await redisSecondaryStorage.getAndDelete("native-key")).toBe("native");
+    await expect(redisSecondaryStorage.getAndDelete("closed-key")).rejects.toBe(connectionError);
+    expect(await redisSecondaryStorage.getAndDelete("verification:key")).toBe("once");
+    expect(await redisSecondaryStorage.getAndDelete("verification:missing")).toBeNull();
+
+    expect(mockClient.getDel).toHaveBeenCalledTimes(3);
+    expect(mockClient.getDel).toHaveBeenNthCalledWith(1, "native-key");
+    expect(mockClient.getDel).toHaveBeenNthCalledWith(2, "closed-key");
+    expect(mockClient.getDel).toHaveBeenNthCalledWith(3, "verification:key");
+    expect(mockClient.eval).toHaveBeenCalledTimes(2);
+    const [script, options] = mockClient.eval.mock.calls[0];
+    expect(script).toContain("redis.call('GET', KEYS[1])");
+    expect(script).toContain("redis.call('DEL', KEYS[1])");
+    expect(options).toEqual({ keys: ["verification:key"], arguments: [] });
+    expect(mockClient.eval.mock.calls[1][1]).toEqual({ keys: ["verification:missing"], arguments: [] });
   });
 
   test("increment runs a single atomic INCR+EXPIRE Lua eval and returns the count", async () => {

--- a/apps/web/modules/auth/lib/secondary-storage.ts
+++ b/apps/web/modules/auth/lib/secondary-storage.ts
@@ -16,6 +16,17 @@ import { env } from "@/lib/env";
 type RedisClient = ReturnType<typeof createClient>;
 
 let clientPromise: Promise<RedisClient> | undefined;
+let supportsGetDel = true;
+
+const GET_AND_DELETE_SCRIPT = `local value = redis.call('GET', KEYS[1])
+if value then redis.call('DEL', KEYS[1]) end
+return value`;
+
+const isGetDelUnsupportedError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return message.includes("unknown command") && message.includes("getdel");
+};
 
 const getClient = (): Promise<RedisClient> => {
   if (!clientPromise) {
@@ -54,7 +65,17 @@ export const redisSecondaryStorage = {
   // consumed twice under concurrent requests on different instances.
   getAndDelete: async (key: string): Promise<string | null> => {
     const client = await getClient();
-    return client.getDel(key);
+    if (supportsGetDel) {
+      try {
+        return await client.getDel(key);
+      } catch (error) {
+        if (!isGetDelUnsupportedError(error)) throw error;
+        supportsGetDel = false;
+      }
+    }
+
+    const value = await client.eval(GET_AND_DELETE_SCRIPT, { keys: [key], arguments: [] });
+    return typeof value === "string" ? value : null;
   },
   // Atomic rate-limit counter across instances. INCR + EXPIRE-on-first-write run in a single Lua eval
   // so a crash between the two can't leave a TTL-less (never-expiring) counter that would wedge the

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -128,7 +128,6 @@ export default defineConfig({
         // tests, so they are excluded from the unit-coverage gate below (ENG-1054).
         "modules/auth/lib/auth.ts",
         "modules/auth/lib/auth-client.ts",
-        "modules/auth/lib/secondary-storage.ts",
         "modules/auth/lib/better-auth-email-verification.ts",
         "packages/js-core/src/index.ts", // JS Core index file
 


### PR DESCRIPTION
Ref ENG-2834

## What & why

**Was:** Formbricks 5.4 password reset fails when Redis 6.0 rejects Better Auth's atomic `GETDEL`.

**Now:** This backports [#9129](https://github.com/formbricks/formbricks/pull/9129), keeping native `GETDEL` where supported and using atomic Lua only when unavailable. The storage implementation is included in unit coverage so Sonar receives its LCOV data.

## Where to look

- [Capability detection and fallback](https://github.com/formbricks/formbricks/blob/bda7f5f2d8531a266aa53be614dea7fac93e81e2/apps/web/modules/auth/lib/secondary-storage.ts#L19-L29)
- [Atomic token consumption](https://github.com/formbricks/formbricks/blob/bda7f5f2d8531a266aa53be614dea7fac93e81e2/apps/web/modules/auth/lib/secondary-storage.ts#L63-L78)
- [Compatibility and error guards](https://github.com/formbricks/formbricks/blob/bda7f5f2d8531a266aa53be614dea7fac93e81e2/apps/web/modules/auth/lib/secondary-storage.test.ts#L52-L75)
- [Coverage inclusion](https://github.com/formbricks/formbricks/blob/bda7f5f2d8531a266aa53be614dea7fac93e81e2/apps/web/vite.config.mts#L146-L153)

## Breaking changes

- [ ] This PR contains breaking changes

None. Existing Redis clients keep their native path, with no API, configuration, or deployment changes.

## Migrations & env

- none

## How this was tested

Rerun:

- `pnpm --filter @formbricks/web exec vitest run modules/auth/lib/secondary-storage.test.ts`
- `pnpm --filter @formbricks/web exec vitest run modules/auth/lib/secondary-storage.test.ts --coverage --coverage.include=modules/auth/lib/secondary-storage.ts --coverage.reporter=text --silent`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Redis 6 rejects `GETDEL` | unit (mutation): first rerun command | Returns and deletes once through the fallback |
| Modern Redis supports `GETDEL` | unit (guard): first rerun command | Uses native command without Lua |
| Socket and other command errors | unit (guard): first rerun command | Error propagates without changing capability |
| Redis 6.0 and 7.2 servers | manual | Lua is single-use on 6.0; native command is single-use on 7.2 |
| Secondary-storage LCOV inclusion | unit (guard): second rerun command | All 8 tests pass with 94.28% lines, 92.85% branches, and 80% functions |

**Open gaps**

- Customer Azure Dev validation remains post-deploy because that instance is not directly accessible.

**Risks**

- Redis deployments that disable `EVAL` cannot use the fallback; existing rate limiting already uses `EVAL`.
- Each process probes unsupported `GETDEL` once after startup before remembering the fallback.

---

> [!NOTE]
> **AI model used** — `unknown`, reasoning effort `unknown`.