### PR TITLE
feat: let host apps subscribe to formbricks events via formbricks.on [ENG-1814]

### DIFF
--- a/apps/web/playwright/js.spec.ts
+++ b/apps/web/playwright/js.spec.ts
@@ -7,20 +7,22 @@ import { useSelectedTemplate } from "./utils/helper";
 
 const HTML_TEMPLATE = `<head>
   <script type="text/javascript">
-    // Registered before the SDK loads, which is the load order the event bus is designed for
-    // (ENG-1846): a host page must be able to subscribe without knowing when the SDK arrives.
-    window.formbricksEvents = [];
-    window.addEventListener("formbricks_response_submitted", function (e) {
-      window.formbricksEvents.push(e.detail);
-    });
-  </script>
-  <script type="text/javascript">
     !(function () {
       var t = document.createElement("script");
       (t.type = "text/javascript"), (t.async = !0), (t.src = "http://localhost:3000/js/formbricks.umd.cjs");
       var e = document.getElementsByTagName("script")[0];
       t.onload = function(){
         if (window.formbricks) {
+          // formbricks.on() is the only JS subscription surface (ENG-1814); registered before
+          // setup(), which the API promises works. Same names as the GTM dataLayer pushes.
+          window.formbricksEvents = [];
+          ["formbricks_survey_shown", "formbricks_response_submitted", "formbricks_survey_closed"].forEach(
+            function (name) {
+              window.formbricks.on(name, function (payload) {
+                window.formbricksEvents.push(Object.assign({ event: name }, payload));
+              });
+            }
+          );
           window.formbricks.setup({workspaceId: "WORKSPACE_ID", appUrl: "http://localhost:3000"});
         } else {
           console.error("Formbricks library failed to load properly. The formbricks object is not available.");
@@ -139,16 +141,25 @@ test.describe("JS Package Test", async () => {
     await page.waitForLoadState("networkidle");
     await page.waitForTimeout(5000);
 
-    // The `responseId` on the bus is the PERSISTED id (ENG-1846). This is the only level that can
-    // prove it: the id is minted by the server, so `onResponseCreated`/`onFinished` can only carry it
-    // by firing from the response queue's creation ack — and the renderer that passes it lives in a
-    // .tsx, which the repo does not unit-test. Asserted against the stored row rather than for
-    // self-consistency, so a client-minted or dropped id fails here.
-    await test.step("the submitted event carries the persisted responseId", async () => {
+    // The `responseId` on the events is the PERSISTED id (ENG-1846). This is the only level that
+    // can prove it: the id is minted by the server, so `onResponseCreated`/`onFinished` can only
+    // carry it by firing from the response queue's creation ack — and the renderer that passes it
+    // lives in a .tsx, which the repo does not unit-test. Asserted against the stored row rather
+    // than for self-consistency, so a client-minted or dropped id fails here (ENG-1814: the
+    // formbricks.on() surface, registered before setup(), is what captured them).
+    await test.step("the journey reaches formbricks.on subscribers with the persisted responseId", async () => {
       const events = await page.evaluate(
         () =>
-          (window as unknown as { formbricksEvents: { responseId?: string; finished?: boolean }[] })
-            .formbricksEvents
+          (
+            window as unknown as {
+              formbricksEvents: {
+                event: string;
+                surveyId: string;
+                responseId?: string;
+                finished?: boolean;
+              }[];
+            }
+          ).formbricksEvents
       );
 
       const storedResponse = await prisma.response.findFirst({
@@ -158,11 +169,20 @@ test.describe("JS Package Test", async () => {
       });
       expect(storedResponse).not.toBeNull();
 
-      expect(events.length).toBeGreaterThan(0);
-      expect(events.some((event) => event.finished === true)).toBe(true);
+      // Shown, first answer, completion, and — after the ending card auto-closes the modal —
+      // closed exactly once. One vocabulary, in order.
+      expect(events.map((event) => event.event)).toEqual([
+        "formbricks_survey_shown",
+        "formbricks_response_submitted",
+        "formbricks_response_submitted",
+        "formbricks_survey_closed",
+      ]);
+      expect(events.map((event) => event.finished)).toEqual([undefined, false, true, undefined]);
       for (const event of events) {
-        expect(event.responseId).toBe(storedResponse?.id);
+        expect(event.surveyId).toBe(surveyId);
       }
+      expect(events[1].responseId).toBe(storedResponse?.id);
+      expect(events[2].responseId).toBe(storedResponse?.id);
     });
 
     // Validate displays and response

--- a/apps/web/playwright/js.spec.ts
+++ b/apps/web/playwright/js.spec.ts
@@ -167,7 +167,9 @@ test.describe("JS Package Test", async () => {
         orderBy: { createdAt: "desc" },
         select: { id: true },
       });
-      expect(storedResponse).not.toBeNull();
+      // A hard throw rather than expect().not.toBeNull(): it narrows the type, so the id
+      // comparisons below cannot silently compare undefined against undefined.
+      if (!storedResponse) throw new Error("No response was persisted for the survey");
 
       // Shown, first answer, completion, and — after the ending card auto-closes the modal —
       // closed exactly once. One vocabulary, in order.
@@ -181,8 +183,8 @@ test.describe("JS Package Test", async () => {
       for (const event of events) {
         expect(event.surveyId).toBe(surveyId);
       }
-      expect(events[1].responseId).toBe(storedResponse?.id);
-      expect(events[2].responseId).toBe(storedResponse?.id);
+      expect(events[1].responseId).toBe(storedResponse.id);
+      expect(events[2].responseId).toBe(storedResponse.id);
     });
 
     // Validate displays and response

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -169,7 +169,8 @@
                       "surveys/website-app-surveys/recontact",
                       "surveys/website-app-surveys/cooldown-period",
                       "surveys/website-app-surveys/survey-display-logic",
-                      "surveys/website-app-surveys/show-survey-to-percent-of-users"
+                      "surveys/website-app-surveys/show-survey-to-percent-of-users",
+                      "surveys/website-app-surveys/lifecycle-events"
                     ]
                   }
                 ]

--- a/docs/surveys/website-app-surveys/lifecycle-events.mdx
+++ b/docs/surveys/website-app-surveys/lifecycle-events.mdx
@@ -10,15 +10,15 @@ Lifecycle events tell you what really happened, so your app can react to the sur
 
 ## The events
 
-| Event                           | Fires when                                                                                               | Payload                              |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `formbricks_survey_shown`       | A survey becomes visible (once per display)                                                              | `{ surveyId }`                       |
-| `formbricks_response_submitted` | The first answer is stored (`finished: false`) and again when the survey is completed (`finished: true`) | `{ surveyId, responseId, finished }` |
-| `formbricks_survey_closed`      | The survey is dismissed or finishes (once per display)                                                   | `{ surveyId }`                       |
-| `formbricks_setup_successful`   | `setup()` finished — the SDK is ready                                                                    | `{ workspaceId }`                    |
-| `formbricks_action_tracked`     | An action was tracked (code or no-code)                                                                  | `{ action }`                         |
+| Event                           | Fires when                                                                                               | Payload                               |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `formbricks_survey_shown`       | A survey becomes visible (once per display)                                                              | `{ surveyId }`                        |
+| `formbricks_response_submitted` | The first answer is stored (`finished: false`) and again when the survey is completed (`finished: true`) | `{ surveyId, responseId?, finished }` |
+| `formbricks_survey_closed`      | The survey is dismissed or finishes (once per display)                                                   | `{ surveyId }`                        |
+| `formbricks_setup_successful`   | `setup()` finished — the SDK is ready                                                                    | `{ workspaceId }`                     |
+| `formbricks_action_tracked`     | An action was tracked (code or no-code)                                                                  | `{ action }`                          |
 
-`responseId` is the id of the stored response — the same id you see in the Responses tab — so your app can link its own analytics or session replays to the exact response.
+`responseId` is the id of the stored response — the same id you see in the Responses tab — so your app can link its own analytics or session replays to the exact response. It is optional: in survey previews nothing is stored, so the key is absent (GTM's dataLayer carries `null` for it there).
 
 ## Listening for events
 
@@ -38,10 +38,10 @@ You can subscribe before or after `formbricks.setup()`, and your listeners stay 
 
 <Note>
   Events are delivered live, not replayed: a listener registered after an event fired will not receive it.
-  This matters most for `formbricks_setup_successful` — register it before calling `setup()`. If you only
-  need to know when your own `setup()` call finished, you can also simply `await` the promise it returns;
-  the event is for code that did not make that call, like a decoupled module or a tag. On GTM the dataLayer
-  buffers, so its triggers are immune to this ordering.
+  This matters most for `formbricks_setup_successful` — register it before calling `setup()`. If you only need
+  to know when your own `setup()` call finished, you can also simply `await` the promise it returns; the event
+  is for code that did not make that call, like a decoupled module or a tag. On GTM the dataLayer buffers, so
+  its triggers are immune to this ordering.
 </Note>
 
 ## Stopping a listener

--- a/docs/surveys/website-app-surveys/lifecycle-events.mdx
+++ b/docs/surveys/website-app-surveys/lifecycle-events.mdx
@@ -12,13 +12,15 @@ Lifecycle events tell you what really happened, so your app can react to the sur
 
 | Event                           | Fires when                                                                                               | Payload                               |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `formbricks_survey_shown`       | A survey becomes visible (once per display)                                                              | `{ surveyId }`                        |
+| `formbricks_survey_shown`       | A survey becomes visible (once per appearance)                                                           | `{ surveyId }`                        |
 | `formbricks_response_submitted` | The first answer is stored (`finished: false`) and again when the survey is completed (`finished: true`) | `{ surveyId, responseId?, finished }` |
-| `formbricks_survey_closed`      | The survey is dismissed or finishes (once per display)                                                   | `{ surveyId }`                        |
+| `formbricks_survey_closed`      | The survey is dismissed or finishes (once per appearance)                                                | `{ surveyId }`                        |
 | `formbricks_setup_successful`   | `setup()` finished — the SDK is ready                                                                    | `{ workspaceId }`                     |
 | `formbricks_action_tracked`     | An action was tracked (code or no-code)                                                                  | `{ action }`                          |
 
-`responseId` is the id of the stored response — the same id you see in the Responses tab — so your app can link its own analytics or session replays to the exact response. It is optional: in survey previews nothing is stored, so the key is absent (GTM's dataLayer carries `null` for it there).
+`responseId` is the id of the stored response — the same id you see in the Responses tab — so your app can link its own analytics or session replays to the exact response. It is optional: when the id is not available the key is absent, and GTM's dataLayer carries `null` for it.
+
+`formbricks_survey_shown` reports what the respondent saw, so every appearance is paired with a `formbricks_survey_closed`. The Displays number in your Formbricks dashboard counts what reached the server instead, so it can be lower if the network dropped.
 
 ## Listening for events
 
@@ -83,7 +85,10 @@ function onCheckout() {
 
 <Tip>
   There is no separate "finished" event. `formbricks_survey_closed` covers both dismissing and completing a
-  survey — a `formbricks_response_submitted` with `finished: true` arriving first is what tells them apart.
+  survey — a `formbricks_response_submitted` with `finished: true` for the same `surveyId` is what tells them
+  apart. Correlate on the id, not on arrival order: that event is sent once the server has stored the
+  response, so it normally lands before the close but can follow it, and if the response cannot be saved it
+  never lands at all.
 </Tip>
 
 ## Google Tag Manager

--- a/docs/surveys/website-app-surveys/lifecycle-events.mdx
+++ b/docs/surveys/website-app-surveys/lifecycle-events.mdx
@@ -1,0 +1,99 @@
+---
+title: "Lifecycle Events"
+description: "Subscribe to Formbricks events to find out when a survey was actually shown, answered or closed in your app."
+icon: "bell"
+---
+
+Calling `formbricks.track()` does not mean a survey appeared. Formbricks still checks the cooldown period, recontact options, targeting and the percentage setting, and often decides not to show anything.
+
+Lifecycle events tell you what really happened, so your app can react to the survey it actually displayed.
+
+## The events
+
+| Event                           | Fires when                                                                                               | Payload                              |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `formbricks_survey_shown`       | A survey becomes visible (once per display)                                                              | `{ surveyId }`                       |
+| `formbricks_response_submitted` | The first answer is stored (`finished: false`) and again when the survey is completed (`finished: true`) | `{ surveyId, responseId, finished }` |
+| `formbricks_survey_closed`      | The survey is dismissed or finishes (once per display)                                                   | `{ surveyId }`                       |
+| `formbricks_setup_successful`   | `setup()` finished — the SDK is ready                                                                    | `{ workspaceId }`                    |
+| `formbricks_action_tracked`     | An action was tracked (code or no-code)                                                                  | `{ action }`                         |
+
+`responseId` is the id of the stored response — the same id you see in the Responses tab — so your app can link its own analytics or session replays to the exact response.
+
+## Listening for events
+
+```js
+formbricks.on("formbricks_survey_shown", (payload) => {
+  console.log("Survey shown:", payload.surveyId);
+});
+
+formbricks.on("formbricks_response_submitted", (payload) => {
+  if (!payload.finished) {
+    console.log("First answer stored:", payload.responseId);
+  }
+});
+```
+
+You can subscribe before or after `formbricks.setup()`, and your listeners stay registered after `formbricks.logout()`. `window.formbricks` exists as soon as the SDK script has loaded — `setup()` does not need to have run — so the reliable order is: load the script, register your listeners, then call `setup()`.
+
+<Note>
+  Events are delivered live, not replayed: a listener registered after an event fired will not receive it.
+  This matters most for `formbricks_setup_successful` — register it before calling `setup()`. If you only
+  need to know when your own `setup()` call finished, you can also simply `await` the promise it returns;
+  the event is for code that did not make that call, like a decoupled module or a tag. On GTM the dataLayer
+  buffers, so its triggers are immune to this ordering.
+</Note>
+
+## Stopping a listener
+
+`formbricks.on()` returns a function that removes the listener:
+
+```js
+const unsubscribe = formbricks.on("formbricks_survey_closed", handleClose);
+
+// later
+unsubscribe();
+```
+
+If you kept the handler in a variable, `formbricks.off()` does the same:
+
+```js
+formbricks.off("formbricks_survey_closed", handleClose);
+```
+
+## Example: show a survey once per session
+
+```js
+let surveyShown = false;
+
+formbricks.on("formbricks_survey_shown", () => {
+  surveyShown = true;
+});
+
+function onCheckout() {
+  if (surveyShown) return;
+  formbricks.track("checkout_completed");
+}
+```
+
+<Note>
+  A survey that is never shown sends no events at all. That silence is the signal: it means the user did not
+  see a survey, so nothing needs to be recorded.
+</Note>
+
+<Tip>
+  There is no separate "finished" event. `formbricks_survey_closed` covers both dismissing and completing a
+  survey — a `formbricks_response_submitted` with `finished: true` arriving first is what tells them apart.
+</Tip>
+
+## Google Tag Manager
+
+The same events, under the same names, are pushed to `window.dataLayer` automatically — no `formbricks.on()`
+call needed. Create a GTM Custom Event trigger matching the event name (for example
+`formbricks_setup_successful`) and read the payload from Data Layer Variables under the `formbricks` key.
+See [Google Tag Manager](/surveys/website-app-surveys/google-tag-manager) for the full setup.
+
+<Note>
+  Lifecycle events are available in the JavaScript SDK. Support for React Native, iOS, Android and Flutter is
+  coming in a later release.
+</Note>

--- a/packages/js-core/src/index.ts
+++ b/packages/js-core/src/index.ts
@@ -1,4 +1,10 @@
 import { CommandQueue, CommandType } from "@/lib/common/command-queue";
+import {
+  type TFormbricksEventName,
+  type TFormbricksEventPayloads,
+  offFormbricksEvent,
+  onFormbricksEvent,
+} from "@/lib/common/events";
 import * as Setup from "@/lib/common/setup";
 import { getIsDebug } from "@/lib/common/utils";
 import * as Action from "@/lib/survey/action";
@@ -107,6 +113,41 @@ const clearEmbeddedData = (...args: [] | [key: string]): void => {
 };
 
 /**
+ * Subscribe to a Formbricks event (ENG-1814).
+ *
+ * The host application is notified about what the SDK actually did — a survey reached the screen
+ * (`formbricks_survey_shown`), was answered (`formbricks_response_submitted`, with the persisted
+ * `responseId` and a `finished` flag), was dismissed or completed (`formbricks_survey_closed`), an
+ * action was tracked, or setup finished — so it can drive frequency capping and analytics off
+ * reality rather than off the `track()` calls it made. The same events, under the same names, go
+ * out as `window.dataLayer` pushes for Google Tag Manager.
+ *
+ * Subscriptions are independent of setup(): registering before or after setup() both work, and a
+ * handler stays registered across logout() until it is removed.
+ *
+ * @param event - Full event name, e.g. "formbricks_survey_shown"
+ * @param handler - Called with that event's payload (survey id, and where it applies the response id)
+ * @returns A function that removes this subscription. `off()` with the same arguments does the same.
+ */
+const on = <E extends TFormbricksEventName>(
+  event: E,
+  handler: (payload: TFormbricksEventPayloads[E]) => void
+): (() => void) => onFormbricksEvent(event, handler);
+
+/**
+ * Remove a subscription registered with on().
+ *
+ * @param event - The event name the handler was registered for
+ * @param handler - The same function reference that was passed to on()
+ */
+const off = <E extends TFormbricksEventName>(
+  event: E,
+  handler: (payload: TFormbricksEventPayloads[E]) => void
+): void => {
+  offFormbricksEvent(event, handler);
+};
+
+/**
  * Set the CSP nonce for inline styles
  * @param nonce - The CSP nonce value (without 'nonce-' prefix), or undefined to clear
  */
@@ -134,6 +175,8 @@ const formbricks = {
   setNonce,
   setEmbeddedData,
   clearEmbeddedData,
+  on,
+  off,
 };
 
 // Explicitly assign to globalThis so the wrapper SDK (@formbricks/js) can
@@ -145,4 +188,5 @@ const formbricks = {
 
 type TFormbricks = typeof formbricks;
 export type { TFormbricks };
+export type { TFormbricksEventName, TFormbricksEventPayloads } from "@/lib/common/events";
 export default formbricks;

--- a/packages/js-core/src/lib/common/events.ts
+++ b/packages/js-core/src/lib/common/events.ts
@@ -39,8 +39,10 @@ export interface TFormbricksEventPayloads {
    * not client-minted — absent only offline/preview.
    */
   formbricks_response_submitted: { surveyId: string; responseId?: string; finished: boolean };
-  /** Dismissed OR finished — the display is over either way; whether a `formbricks_response_submitted`
-   * came first is what tells those apart. Fires once per rendered survey. */
+  /** Dismissed OR finished — the display is over either way; a `formbricks_response_submitted` with
+   * `finished: true` for the same `surveyId` is what tells those apart. Correlate on the id, not on
+   * arrival order: that event is ack-gated, so it can follow this one, or never arrive at all if the
+   * response fails to save. Fires once per rendered survey. */
   formbricks_survey_closed: { surveyId: string };
 }
 
@@ -114,8 +116,10 @@ const notifySubscribers = (event: TFormbricksEventName, payload: unknown): void 
   const handlers = subscribers.get(event);
   if (!handlers?.size) return;
 
-  // Iterate a snapshot: a handler is allowed to unsubscribe itself (a one-shot listener is the
-  // obvious way to capture "the first display of this journey leg") while we are still notifying.
+  // Iterate a snapshot, not the live Set: `Set.prototype.forEach` visits entries appended during
+  // iteration, so a host handler that re-arms itself (`off()` then `on()` inside its own callback)
+  // would be appended behind the cursor and dispatched again, unboundedly — and the catch below
+  // would just keep going.
   [...handlers].forEach((handler) => {
     try {
       handler(payload);

--- a/packages/js-core/src/lib/common/events.ts
+++ b/packages/js-core/src/lib/common/events.ts
@@ -1,47 +1,66 @@
 /**
- * The SDK's outbound event bus (ENG-1846): lifecycle signals the host page can react to — fire
- * GA/GTM tags, link session replays, and (most importantly) know when the SDK is ready, which is
- * what makes a consent-delayed `setup()` integrable without polling for `window.formbricks`.
+ * The SDK's outbound event bus (ENG-1846 / ENG-1814): lifecycle signals the host page can react to —
+ * fire GA/GTM tags, link session replays, run frequency capping off what was actually shown, and
+ * (most importantly) know when the SDK is ready, which is what makes a consent-delayed `setup()`
+ * integrable without polling for `window.formbricks`.
  *
- * Every event goes out on two transports:
+ * One name set, two surfaces:
  *
- * 1. **A `CustomEvent` on `window` — always.** The in-house pattern for host-facing signals
- *    (`formbricks:onFilePick`, the route-change events) and vendor-neutral: nothing accumulates,
- *    and no global we do not own is touched.
+ * 1. **`formbricks.on(name, handler)`** — the subscription surface for host JavaScript. Handlers are
+ *    isolated (a throwing host handler is logged, never propagated into the SDK's critical paths)
+ *    and can be registered before `setup()`.
  * 2. **A `window.dataLayer.push` — via the standard GTM idiom** (`window.dataLayer = window.dataLayer
- *    || []`). The idiom survives load order: if GTM initialises after us it drains what is already
- *    queued, whereas pushing only when the array exists would silently drop every event emitted
- *    before GTM loads. Cost, accepted knowingly: a site with no GTM gets a `dataLayer` array that
- *    accumulates small event objects with nothing draining it.
+ *    || []`). GTM triggers can only match dataLayer pushes, and the idiom survives load order: if GTM
+ *    initialises after us it drains what is already queued. Cost, accepted knowingly: a site with no
+ *    GTM gets a `dataLayer` array that accumulates small event objects with nothing draining it.
  *
- * One underscored name per event, identical on both transports, published to integrators — the
- * constants hold the full literal so the string a customer's GTM trigger matches is greppable here.
+ * The same underscored name is used on both surfaces — the constants hold the full literal so the
+ * string a customer's GTM trigger (or `on()` call) matches is greppable here.
  *
  * The payload is nested under a `formbricks` key on the dataLayer (instead of spread flat) because
  * GTM's Data Layer Variables read a *merged* model: a flat `action` or `finished` would persist
  * across pushes and collide with the host's own keys — `action` in particular is one of the most
- * common keys in any ecommerce dataLayer. `CustomEvent.detail` gives the same isolation for free.
+ * common keys in any ecommerce dataLayer. `on()` handlers receive the payload object directly.
  *
  * No PII: payloads carry ids and the `finished` boolean, never response content or scores.
  */
+
+/**
+ * What each event carries. The single source of truth for both surfaces, so the dataLayer push and
+ * the `on()` handler types cannot drift apart.
+ */
+export interface TFormbricksEventPayloads {
+  formbricks_setup_successful: { workspaceId: string };
+  formbricks_action_tracked: { action: string };
+  formbricks_survey_shown: { surveyId: string };
+  /**
+   * Fired on the first answer (`finished: false`, once per survey) and again when the finished
+   * response has been sent (`finished: true`). `responseId` is the server-acknowledged id — real,
+   * not client-minted — absent only offline/preview.
+   */
+  formbricks_response_submitted: { surveyId: string; responseId?: string; finished: boolean };
+  /** Dismissed OR finished — the display is over either way; whether a `formbricks_response_submitted`
+   * came first is what tells those apart. Fires once per rendered survey. */
+  formbricks_survey_closed: { surveyId: string };
+}
+
+export type TFormbricksEventName = keyof TFormbricksEventPayloads;
+
 export const FORMBRICKS_EVENTS = {
   setupSuccessful: "formbricks_setup_successful",
   actionTracked: "formbricks_action_tracked",
   surveyShown: "formbricks_survey_shown",
   responseSubmitted: "formbricks_response_submitted",
-} as const;
-
-export type TFormbricksEventName = (typeof FORMBRICKS_EVENTS)[keyof typeof FORMBRICKS_EVENTS];
-
-export type TFormbricksEventPayload = Record<string, string | number | boolean | undefined>;
+  surveyClosed: "formbricks_survey_closed",
+} as const satisfies Record<string, TFormbricksEventName>;
 
 /**
  * Every key the event contract can carry, `null` where an event does not set it. The dataLayer push
  * always carries the FULL set because GTM's data model merges pushes recursively — a partial push
  * would let a previous event's `formbricks.responseId` or `formbricks.finished` bleed into a later
  * event's reads (survey A's `responseId` resolving under survey B's `formbricks_survey_shown`).
- * Pushing `null` overwrites the merged value; omitting the key would not. `CustomEvent.detail` has
- * no merge semantics, so it carries only the event's own keys.
+ * Pushing `null` overwrites the merged value; omitting the key would not. `on()` handlers have no
+ * merge semantics, so they receive only the event's own keys.
  */
 const EMPTY_DATALAYER_PAYLOAD: Record<string, null> = {
   workspaceId: null,
@@ -51,31 +70,82 @@ const EMPTY_DATALAYER_PAYLOAD: Record<string, null> = {
   action: null,
 };
 
-export const emitFormbricksEvent = (event: TFormbricksEventName, payload: TFormbricksEventPayload): void => {
-  // js-core is imported by SSR bundles; emitting is meaningless (and crashes) off the browser.
+// Handlers are stored type-erased: a Set cannot hold differently-parameterised function types, and
+// the typed `onFormbricksEvent` signature is what guarantees a handler only ever receives the
+// payload of the event it subscribed to.
+const subscribers = new Map<TFormbricksEventName, Set<(payload: unknown) => void>>();
+
+/**
+ * Subscribe to one event. Works before `setup()` (the registry is module state, no SDK boot
+ * required) and survives `logout()`. Returns the matching unsubscribe function.
+ */
+export const onFormbricksEvent = <E extends TFormbricksEventName>(
+  event: E,
+  handler: (payload: TFormbricksEventPayloads[E]) => void
+): (() => void) => {
+  const handlers = subscribers.get(event) ?? new Set<(payload: unknown) => void>();
+  handlers.add(handler as (payload: unknown) => void);
+  subscribers.set(event, handlers);
+
+  return () => {
+    offFormbricksEvent(event, handler);
+  };
+};
+
+export const offFormbricksEvent = <E extends TFormbricksEventName>(
+  event: E,
+  handler: (payload: TFormbricksEventPayloads[E]) => void
+): void => {
+  const handlers = subscribers.get(event);
+  if (!handlers) return;
+
+  handlers.delete(handler as (payload: unknown) => void);
+  if (handlers.size === 0) {
+    subscribers.delete(event);
+  }
+};
+
+/** Test-only: drop every subscription so suites start from a clean registry. */
+export const resetFormbricksEventSubscribers = (): void => {
+  subscribers.clear();
+};
+
+const notifySubscribers = (event: TFormbricksEventName, payload: unknown): void => {
+  const handlers = subscribers.get(event);
+  if (!handlers?.size) return;
+
+  // Iterate a snapshot: a handler is allowed to unsubscribe itself (a one-shot listener is the
+  // obvious way to capture "the first display of this journey leg") while we are still notifying.
+  [...handlers].forEach((handler) => {
+    try {
+      handler(payload);
+    } catch (error) {
+      console.error(`Formbricks: a "${event}" event handler threw`, error);
+    }
+  });
+};
+
+export const emitFormbricksEvent = <E extends TFormbricksEventName>(
+  event: E,
+  payload: TFormbricksEventPayloads[E]
+): void => {
+  // js-core is imported by SSR bundles; emitting is meaningless off the browser.
   if (globalThis.window === undefined) return;
 
-  // Both transports run host-owned code — the page's event listeners, and `dataLayer.push`, which
-  // GTM replaces with its own function once it loads. The emitter's call sites sit at the head of
+  // Both surfaces run host-owned code — subscriber handlers, and `dataLayer.push`, which GTM
+  // replaces with its own function once it loads. The emitter's call sites sit at the head of
   // SDK-critical paths (display bookkeeping, the response queue's ack), so a host-page throw here
   // must never escape: it would cost us display state or mark a persisted response as failed. Each
-  // transport is isolated separately so one failing cannot silence the other.
-  try {
-    window.dispatchEvent(new CustomEvent<TFormbricksEventPayload>(event, { detail: payload }));
-  } catch (error) {
-    console.error(`Formbricks: a "${event}" event listener threw`, error);
-  }
-
+  // surface is isolated separately so one failing cannot silence the other.
   try {
     // `Array.isArray`, not `?? []`: a host page that set `window.dataLayer = {}` (a hand-rolled
     // shim, or another vendor reusing the name) survives nullish coalescing and then throws on
     // `.push`. GTM's own snippet only ever creates an array, and its loaded state keeps the array
     // and swaps the `push` method, so `Array.isArray` stays true on every real GTM page.
     if (!Array.isArray(window.dataLayer)) window.dataLayer = [];
-    // Undefined-valued keys are stripped before the merge: `TFormbricksEventPayload` admits
-    // `undefined` (the widened callbacks type `responseId` optional), and a key PRESENT with value
-    // `undefined` would replace the `null` sentinel in the spread — re-opening the recursive-merge
-    // bleed the sentinel exists to stop.
+    // Undefined-valued keys are stripped before the merge: a key PRESENT with value `undefined`
+    // (e.g. `responseId` in preview mode) would replace the `null` sentinel in the spread —
+    // re-opening the recursive-merge bleed the sentinel exists to stop.
     const definedPayload = Object.fromEntries(
       Object.entries(payload).filter(([, value]) => value !== undefined)
     );
@@ -83,4 +153,6 @@ export const emitFormbricksEvent = (event: TFormbricksEventName, payload: TFormb
   } catch (error) {
     console.error(`Formbricks: failed to push "${event}" to the dataLayer`, error);
   }
+
+  notifySubscribers(event, payload);
 };

--- a/packages/js-core/src/lib/common/tests/events.test.ts
+++ b/packages/js-core/src/lib/common/tests/events.test.ts
@@ -202,6 +202,33 @@ describe("on() / off() subscriptions", () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
+  test("a handler that re-arms itself mid-dispatch is dispatched once, not unboundedly", () => {
+    // `Set.prototype.forEach` visits entries appended during iteration, so without the snapshot in
+    // notifySubscribers the re-arm lands behind the cursor and loops until the page hangs. `other`
+    // is load-bearing: it keeps the Set non-empty, so off() does not drop the map entry and on()
+    // re-adds into the same Set being iterated.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const other = vi.fn();
+    let calls = 0;
+    const handler = (): void => {
+      calls += 1;
+      if (calls > 2) throw new Error("re-arm re-entered the dispatch in flight");
+      offFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, handler);
+      onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, handler);
+    };
+
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, other);
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, handler);
+
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+    expect(calls).toBe(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    // Still subscribed for the next emit — re-arming is the point.
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_2" });
+    expect(calls).toBe(2);
+  });
+
   test("a throwing handler is logged and stops neither the other handlers nor the dataLayer push", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const throwing = vi.fn(() => {

--- a/packages/js-core/src/lib/common/tests/events.test.ts
+++ b/packages/js-core/src/lib/common/tests/events.test.ts
@@ -1,27 +1,24 @@
-import { type Mock, beforeEach, describe, expect, test } from "vitest";
-import { FORMBRICKS_EVENTS, emitFormbricksEvent } from "@/lib/common/events";
-
-const dispatchEventMock = window.dispatchEvent as unknown as Mock;
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  FORMBRICKS_EVENTS,
+  emitFormbricksEvent,
+  offFormbricksEvent,
+  onFormbricksEvent,
+  resetFormbricksEventSubscribers,
+} from "@/lib/common/events";
 
 describe("emitFormbricksEvent", () => {
   beforeEach(() => {
-    // The emitter creates `window.dataLayer` when absent; start every test from that state.
+    // The emitter creates `window.dataLayer` when absent; start every test from that state, and
+    // from a subscriber-free registry.
     delete (window as { dataLayer?: unknown }).dataLayer;
+    resetFormbricksEventSubscribers();
   });
 
-  test("every event name carries the formbricks_ namespace — the string GTM triggers match", () => {
+  test("every event name carries the formbricks_ namespace — the string GTM triggers and on() match", () => {
     for (const name of Object.values(FORMBRICKS_EVENTS)) {
       expect(name).toMatch(/^formbricks_/);
     }
-  });
-
-  test("dispatches a CustomEvent on window with the payload as detail", () => {
-    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
-
-    expect(dispatchEventMock).toHaveBeenCalledTimes(1);
-    const event = dispatchEventMock.mock.calls[0][0] as CustomEvent;
-    expect(event.type).toBe("formbricks_survey_shown");
-    expect(event.detail).toEqual({ surveyId: "survey_1" });
   });
 
   test("creates window.dataLayer when absent and pushes the nested envelope", () => {
@@ -71,23 +68,6 @@ describe("emitFormbricksEvent", () => {
     });
   });
 
-  test("both transports fire for one emit, carrying the same payload", () => {
-    emitFormbricksEvent(FORMBRICKS_EVENTS.setupSuccessful, { workspaceId: "ws_1" });
-
-    const event = dispatchEventMock.mock.calls[0][0] as CustomEvent;
-    expect(event.detail).toEqual({ workspaceId: "ws_1" });
-    expect(window.dataLayer?.[0]).toEqual({
-      event: "formbricks_setup_successful",
-      formbricks: {
-        workspaceId: "ws_1",
-        surveyId: null,
-        responseId: null,
-        finished: null,
-        action: null,
-      },
-    });
-  });
-
   test("a payload key present with value undefined falls back to the null sentinel, not undefined", () => {
     // `responseId` is typed optional by the widened callbacks, so an emit can carry it as an
     // explicit undefined. If that survived the merge it would replace the null sentinel — and GTM's
@@ -121,30 +101,130 @@ describe("emitFormbricksEvent", () => {
     expect(window.dataLayer).toHaveLength(1);
   });
 
-  test("a throwing event listener cannot silence the dataLayer transport", () => {
-    dispatchEventMock.mockImplementationOnce(() => {
-      throw new Error("host listener exploded");
-    });
-
-    expect(() => {
-      emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
-    }).not.toThrow();
-
-    expect(window.dataLayer).toHaveLength(1);
-  });
-
-  test("a throwing dataLayer.push (GTM replaces it with host-owned code) never escapes into SDK flow", () => {
+  test("a throwing dataLayer.push (GTM replaces it with host-owned code) never escapes, and subscribers still fire", () => {
     const poisoned: Record<string, unknown>[] = [];
     poisoned.push = () => {
       throw new Error("host push exploded");
     };
     window.dataLayer = poisoned;
 
+    const handler = vi.fn();
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, handler);
+
     expect(() => {
       emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
     }).not.toThrow();
 
-    // The CustomEvent transport still fired: the two are isolated separately.
-    expect(dispatchEventMock).toHaveBeenCalledTimes(1);
+    // The subscription surface still fired: the two are isolated separately.
+    expect(handler).toHaveBeenCalledWith({ surveyId: "survey_1" });
+  });
+});
+
+describe("on() / off() subscriptions", () => {
+  beforeEach(() => {
+    delete (window as { dataLayer?: unknown }).dataLayer;
+    resetFormbricksEventSubscribers();
+    vi.restoreAllMocks();
+  });
+
+  test("notifies every handler of the emitted event with its payload, and no other event's handlers", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const other = vi.fn();
+
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, first);
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, second);
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyClosed, other);
+
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+
+    expect(first).toHaveBeenCalledWith({ surveyId: "survey_1" });
+    expect(second).toHaveBeenCalledWith({ surveyId: "survey_1" });
+    expect(other).not.toHaveBeenCalled();
+  });
+
+  test("registering the same handler twice notifies it once", () => {
+    const handler = vi.fn();
+
+    onFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, handler);
+    onFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, handler);
+
+    emitFormbricksEvent(FORMBRICKS_EVENTS.responseSubmitted, { surveyId: "survey_1", finished: false });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("the function returned by on() removes the subscription; off() removes only the handler it names", () => {
+    const viaReturn = vi.fn();
+    const viaOff = vi.fn();
+    const kept = vi.fn();
+
+    const unsubscribe = onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, viaReturn);
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, viaOff);
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, kept);
+
+    unsubscribe();
+    offFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, viaOff);
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+
+    expect(viaReturn).not.toHaveBeenCalled();
+    expect(viaOff).not.toHaveBeenCalled();
+    expect(kept).toHaveBeenCalledTimes(1);
+  });
+
+  test("off() on an unknown handler or event is a no-op", () => {
+    const handler = vi.fn();
+
+    expect(() => {
+      offFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, handler);
+    }).not.toThrow();
+
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, handler);
+    offFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, vi.fn());
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("a handler that unsubscribes itself still receives the event it is handling", () => {
+    const handler = vi.fn(() => {
+      offFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, handler);
+    });
+
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, handler);
+
+    expect(() => {
+      emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+    }).not.toThrow();
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_2" });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("a throwing handler is logged and stops neither the other handlers nor the dataLayer push", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const throwing = vi.fn(() => {
+      throw new Error("host blew up");
+    });
+    const healthy = vi.fn();
+
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyClosed, throwing);
+    onFormbricksEvent(FORMBRICKS_EVENTS.surveyClosed, healthy);
+
+    expect(() => {
+      emitFormbricksEvent(FORMBRICKS_EVENTS.surveyClosed, { surveyId: "survey_1" });
+    }).not.toThrow();
+
+    expect(healthy).toHaveBeenCalledTimes(1);
+    expect(window.dataLayer).toHaveLength(1);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test("emitting with no subscribers still pushes to the dataLayer", () => {
+    expect(() => {
+      emitFormbricksEvent(FORMBRICKS_EVENTS.setupSuccessful, { workspaceId: "ws_1" });
+    }).not.toThrow();
+    expect(window.dataLayer).toHaveLength(1);
   });
 });

--- a/packages/js-core/src/lib/common/tests/events.test.ts
+++ b/packages/js-core/src/lib/common/tests/events.test.ts
@@ -90,12 +90,6 @@ describe("emitFormbricksEvent", () => {
     });
   });
 
-  test("no window CustomEvent is dispatched — formbricks.on replaced that transport (ENG-1814)", () => {
-    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
-
-    expect(window.dispatchEvent).not.toHaveBeenCalled();
-  });
-
   test("a non-array dataLayer (a host shim) is replaced instead of throwing on .push", () => {
     (window as { dataLayer?: unknown }).dataLayer = {};
 

--- a/packages/js-core/src/lib/common/tests/events.test.ts
+++ b/packages/js-core/src/lib/common/tests/events.test.ts
@@ -90,6 +90,12 @@ describe("emitFormbricksEvent", () => {
     });
   });
 
+  test("no window CustomEvent is dispatched — formbricks.on replaced that transport (ENG-1814)", () => {
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: "survey_1" });
+
+    expect(window.dispatchEvent).not.toHaveBeenCalled();
+  });
+
   test("a non-array dataLayer (a host shim) is replaced instead of throwing on .push", () => {
     (window as { dataLayer?: unknown }).dataLayer = {};
 

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -1,5 +1,6 @@
 import { type Mock, type MockInstance, afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { Config } from "@/lib/common/config";
+import { onFormbricksEvent, resetFormbricksEventSubscribers } from "@/lib/common/events";
 import { Logger } from "@/lib/common/logger";
 import type * as CommonUtils from "@/lib/common/utils";
 import { filterSurveys, getLanguageCode, shouldDisplayBasedOnPercentage } from "@/lib/common/utils";
@@ -923,6 +924,143 @@ describe("widget-file", () => {
           formbricks: { ...base, surveyId: mockSurvey.id, responseId: "resp_123", finished: true },
         },
       ]);
+    });
+  });
+
+  describe("survey lifecycle via formbricks.on (ENG-1814)", () => {
+    // The subscription surface over the same emits as the dataLayer transport: which renderer
+    // callback maps to which event, the survey id it names, and the closed-once guard.
+    const renderAndGetLifecycleCallbacks = async (): Promise<{
+      onDisplayCreated: () => void;
+      onResponseCreated: (responseId?: string) => void;
+      onClose: () => void;
+    }> => {
+      const mockConfigValue = {
+        get: vi.fn().mockReturnValue({
+          appUrl: "https://fake.app",
+          workspaceId: "env_123",
+          workspace: {
+            data: {
+              settings: { clickOutsideClose: true, overlay: "none", placement: "bottomRight" },
+            },
+          },
+          user: {
+            data: {
+              userId: null,
+              contactId: "contact_abc",
+              displays: [],
+              responses: [],
+              lastDisplayAt: null,
+            },
+          },
+        }),
+        update: vi.fn(),
+      };
+
+      getInstanceConfigMock.mockReturnValue(mockConfigValue as unknown as Config);
+      (filterSurveys as Mock).mockReturnValue([]);
+      widget.setIsSurveyRunning(false);
+      window.formbricksSurveys = createMockFormbricksSurveys();
+
+      vi.useFakeTimers();
+      await widget.renderWidget({ ...mockSurvey, delay: 0 } as unknown as TWorkspaceStateSurvey);
+      vi.advanceTimersByTime(0);
+      vi.useRealTimers();
+
+      return (getFormbricksSurveys().renderSurvey as Mock).mock.calls[0][0] as {
+        onDisplayCreated: () => void;
+        onResponseCreated: (responseId?: string) => void;
+        onClose: () => void;
+      };
+    };
+
+    beforeEach(() => {
+      // Drop any survey an earlier test left on screen, then start from a subscriber-free registry.
+      widget.closeSurvey();
+      resetFormbricksEventSubscribers();
+      delete (window as { dataLayer?: unknown }).dataLayer;
+    });
+
+    test("notifies formbricks_survey_shown subscribers once the display is created, not on render", async () => {
+      const handler = vi.fn();
+      onFormbricksEvent("formbricks_survey_shown", handler);
+
+      const callbacks = await renderAndGetLifecycleCallbacks();
+      expect(handler).not.toHaveBeenCalled();
+
+      callbacks.onDisplayCreated();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ surveyId: mockSurvey.id });
+    });
+
+    test("notifies formbricks_response_submitted subscribers with the server-acked responseId", async () => {
+      const handler = vi.fn();
+      onFormbricksEvent("formbricks_response_submitted", handler);
+
+      const callbacks = await renderAndGetLifecycleCallbacks();
+      callbacks.onResponseCreated("resp_123");
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({
+        surveyId: mockSurvey.id,
+        responseId: "resp_123",
+        finished: false,
+      });
+    });
+
+    test("emits formbricks_survey_closed once — to subscribers AND the dataLayer — and not again on a repeated close", async () => {
+      const handler = vi.fn();
+      onFormbricksEvent("formbricks_survey_closed", handler);
+
+      const callbacks = await renderAndGetLifecycleCallbacks();
+      callbacks.onClose();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ surveyId: mockSurvey.id });
+      // The same moment reaches GTM through the dataLayer transport.
+      const base = { workspaceId: null, surveyId: null, responseId: null, finished: null, action: null };
+      expect(window.dataLayer).toEqual([
+        { event: "formbricks_survey_closed", formbricks: { ...base, surveyId: mockSurvey.id } },
+      ]);
+
+      widget.closeSurvey();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(window.dataLayer).toHaveLength(1);
+    });
+
+    test("emits nothing when closeSurvey runs with no survey on screen", () => {
+      const handler = vi.fn();
+      onFormbricksEvent("formbricks_survey_closed", handler);
+
+      widget.closeSurvey();
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(window.dataLayer).toBeUndefined();
+    });
+
+    test("renders and closes normally when no host has subscribed", async () => {
+      const callbacks = await renderAndGetLifecycleCallbacks();
+
+      expect(() => {
+        callbacks.onDisplayCreated();
+        callbacks.onResponseCreated("resp_123");
+        callbacks.onClose();
+      }).not.toThrow();
+    });
+
+    test("a throwing host handler does not break the survey it is reporting on", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      onFormbricksEvent("formbricks_survey_shown", () => {
+        throw new Error("host blew up");
+      });
+
+      const callbacks = await renderAndGetLifecycleCallbacks();
+
+      expect(() => {
+        callbacks.onDisplayCreated();
+      }).not.toThrow();
+      expect(errorSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -904,7 +904,7 @@ describe("widget-file", () => {
       };
     };
 
-    test("survey_shown on display; response_submitted with the acked responseId on create and finish", async () => {
+    test("survey_shown on render; response_submitted with the acked responseId on create and finish", async () => {
       delete (window as { dataLayer?: unknown }).dataLayer;
       const callbacks = await renderAndGetEventCallbacks();
 
@@ -981,17 +981,18 @@ describe("widget-file", () => {
       delete (window as { dataLayer?: unknown }).dataLayer;
     });
 
-    test("notifies formbricks_survey_shown subscribers once the display is created, not on render", async () => {
+    test("notifies formbricks_survey_shown subscribers when the survey renders, not when the display acks", async () => {
       const handler = vi.fn();
       onFormbricksEvent("formbricks_survey_shown", handler);
 
       const callbacks = await renderAndGetLifecycleCallbacks();
-      expect(handler).not.toHaveBeenCalled();
-
-      callbacks.onDisplayCreated();
 
       expect(handler).toHaveBeenCalledTimes(1);
       expect(handler).toHaveBeenCalledWith({ surveyId: mockSurvey.id });
+
+      // The display ack does its own bookkeeping; it must not report a second appearance.
+      callbacks.onDisplayCreated();
+      expect(handler).toHaveBeenCalledTimes(1);
     });
 
     test("notifies formbricks_response_submitted subscribers with the server-acked responseId", async () => {
@@ -1018,15 +1019,61 @@ describe("widget-file", () => {
 
       expect(handler).toHaveBeenCalledTimes(1);
       expect(handler).toHaveBeenCalledWith({ surveyId: mockSurvey.id });
-      // The same moment reaches GTM through the dataLayer transport.
+      // The same moment reaches GTM through the dataLayer transport, paired with the render's shown.
       const base = { workspaceId: null, surveyId: null, responseId: null, finished: null, action: null };
       expect(window.dataLayer).toEqual([
+        { event: "formbricks_survey_shown", formbricks: { ...base, surveyId: mockSurvey.id } },
         { event: "formbricks_survey_closed", formbricks: { ...base, surveyId: mockSurvey.id } },
       ]);
 
       widget.closeSurvey();
       expect(handler).toHaveBeenCalledTimes(1);
-      expect(window.dataLayer).toHaveLength(1);
+      expect(window.dataLayer).toHaveLength(2);
+    });
+
+    test("each close names its own survey when a second one renders over the first", async () => {
+      const handler = vi.fn();
+      onFormbricksEvent("formbricks_survey_closed", handler);
+
+      const surveyA = await renderAndGetLifecycleCallbacks();
+
+      // What no-code-action.ts does when the SPA navigates away from a still-open pageView survey: a
+      // fired timeout entry is never pruned, so the guard is released while A is still on screen and
+      // the renderer appends a second container rather than replacing A's.
+      widget.setIsSurveyRunning(false);
+      vi.useFakeTimers();
+      await widget.renderWidget({
+        ...mockSurvey,
+        id: "survey_B",
+        delay: 0,
+      } as unknown as TWorkspaceStateSurvey);
+      vi.advanceTimersByTime(0);
+      vi.useRealTimers();
+
+      const renderCalls = (getFormbricksSurveys().renderSurvey as Mock).mock.calls;
+      const surveyB = renderCalls[renderCalls.length - 1][0] as { onClose: () => void };
+
+      // Each close reports only its own survey: A's must not carry B's id, nor close B on its behalf.
+      surveyA.onClose();
+      expect(handler.mock.calls).toEqual([[{ surveyId: mockSurvey.id }]]);
+
+      surveyB.onClose();
+      expect(handler.mock.calls).toEqual([[{ surveyId: mockSurvey.id }], [{ surveyId: "survey_B" }]]);
+    });
+
+    test("a close landing after logout already tore the survey down still emits once", async () => {
+      const handler = vi.fn();
+      onFormbricksEvent("formbricks_survey_closed", handler);
+
+      const callbacks = await renderAndGetLifecycleCallbacks();
+
+      // tearDown on logout closes whatever is on screen without knowing which survey that is; the
+      // renderer's own onClose still fires as the modal unmounts.
+      widget.closeSurvey();
+      callbacks.onClose();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ surveyId: mockSurvey.id });
     });
 
     test("emits nothing when closeSurvey runs with no survey on screen", () => {
@@ -1057,10 +1104,14 @@ describe("widget-file", () => {
 
       const callbacks = await renderAndGetLifecycleCallbacks();
 
+      // The throw now lands while the widget is rendering, so the survey still has to reach the screen.
+      expect(getFormbricksSurveys().renderSurvey).toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalled();
+
       expect(() => {
         callbacks.onDisplayCreated();
+        callbacks.onClose();
       }).not.toThrow();
-      expect(errorSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -18,12 +18,13 @@ import { type TTrackProperties } from "@/types/survey";
 
 let isSurveyRunning = false;
 
-// The survey handed to the renderer, held only while it is on screen. `closeSurvey` is the single
-// close path — the renderer's onClose, and tearDown on logout / error — but it is called without
-// arguments, so this is what lets the "formbricks_survey_closed" event name the survey it belongs
-// to. It is set when the widget actually renders (after the delay, after every skip check), so a
+// The surveys currently on screen, so each "formbricks_survey_closed" can name its own. A set
+// rather than a single id because a second survey can render over a live one: a fired TimeoutStack
+// entry is never pruned, so a later `checkPageUrl` releases `isSurveyRunning` while the first
+// survey is still up, and the renderer appends a second container instead of replacing the first.
+// Ids are added when the widget actually renders — after the delay, after every skip check — so a
 // survey that was never shown never reports a close.
-let activeSurveyId: string | null = null;
+const openSurveyIds = new Set<string>();
 
 export const setIsSurveyRunning = (value: boolean): void => {
   isSurveyRunning = value;
@@ -168,7 +169,15 @@ export const renderWidget = async (
   }
 
   const timeoutId = setTimeout(() => {
-    activeSurveyId = survey.id;
+    openSurveyIds.add(survey.id);
+
+    // Render-gated, paired with "formbricks_survey_closed" off the same set so a host counting opens
+    // against closes cannot drift. Deliberately not gated on the display POST: the renderer only
+    // logs a failed one and leaves the survey on screen, so waiting for persistence would report a
+    // close for a survey that never reported an open — and a slow POST against a quick dismissal
+    // would deliver the two out of order. What was persisted is the dashboard's Displays count; this
+    // event is what the respondent saw.
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: survey.id });
 
     formbricksSurveys.renderSurvey({
       appUrl: config.get().appUrl,
@@ -219,12 +228,6 @@ export const renderWidget = async (
         // coalesced) so interaction targeting is current by the time this survey closes and the next
         // trigger evaluates. The display is already persisted (fires after createDisplay).
         refreshSegmentsAfterInteraction(previousConfig.user.data.userId, survey, "onDisplay");
-
-        // Emitted LAST, after the SDK's own bookkeeping: the caller swallows throws, so anything the
-        // emitter reaches on the host page must never be able to skip the display update above —
-        // that would leave display caps evaluating stale state and the survey re-showing. The
-        // emitter guards its transports too; this ordering is the second wall.
-        emitFormbricksEvent(FORMBRICKS_EVENTS.surveyShown, { surveyId: survey.id });
       },
       onResponseCreated: (responseId?: string) => {
         const responses = config.get().user.data.responses;
@@ -275,7 +278,11 @@ export const renderWidget = async (
           finished: true,
         });
       },
-      onClose: closeSurvey,
+      // Bound here, not passed as `closeSurvey`: the renderer calls onClose with no arguments, and
+      // this closure is the only place that still knows which survey the container belongs to.
+      onClose: () => {
+        closeSurvey(survey.id);
+      },
       getSetIsResponseSendingFinished: (_f: (value: boolean) => void) => undefined,
     });
   }, survey.delay * 1000);
@@ -285,7 +292,7 @@ export const renderWidget = async (
   }
 };
 
-export const closeSurvey = (): void => {
+export const closeSurvey = (surveyId?: string): void => {
   const config = Config.getInstance();
 
   // remove the survey modal container from DOM
@@ -303,11 +310,12 @@ export const closeSurvey = (): void => {
 
   setIsSurveyRunning(false);
 
-  // Last, so host handlers observe settled state. Guarded on activeSurveyId: closeSurvey also runs
-  // on paths where nothing is open (tearDown), and it must report each rendered survey exactly once.
-  if (activeSurveyId) {
-    const closedSurveyId = activeSurveyId;
-    activeSurveyId = null;
+  // Last, so host handlers observe settled state. `surveyId` is the renderer's own onClose id; the
+  // argument-less callers (tearDown on logout / error) close whatever is on screen. The delete both
+  // drops the survey and answers "was it still open?", which is what keeps this exactly once per
+  // rendered survey.
+  for (const closedSurveyId of surveyId === undefined ? [...openSurveyIds] : [surveyId]) {
+    if (!openSurveyIds.delete(closedSurveyId)) continue;
     emitFormbricksEvent(FORMBRICKS_EVENTS.surveyClosed, { surveyId: closedSurveyId });
   }
 };

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -18,6 +18,13 @@ import { type TTrackProperties } from "@/types/survey";
 
 let isSurveyRunning = false;
 
+// The survey handed to the renderer, held only while it is on screen. `closeSurvey` is the single
+// close path — the renderer's onClose, and tearDown on logout / error — but it is called without
+// arguments, so this is what lets the "formbricks_survey_closed" event name the survey it belongs
+// to. It is set when the widget actually renders (after the delay, after every skip check), so a
+// survey that was never shown never reports a close.
+let activeSurveyId: string | null = null;
+
 export const setIsSurveyRunning = (value: boolean): void => {
   isSurveyRunning = value;
 };
@@ -161,6 +168,8 @@ export const renderWidget = async (
   }
 
   const timeoutId = setTimeout(() => {
+    activeSurveyId = survey.id;
+
     formbricksSurveys.renderSurvey({
       appUrl: config.get().appUrl,
       workspaceId: config.get().workspaceId,
@@ -293,6 +302,14 @@ export const closeSurvey = (): void => {
   });
 
   setIsSurveyRunning(false);
+
+  // Last, so host handlers observe settled state. Guarded on activeSurveyId: closeSurvey also runs
+  // on paths where nothing is open (tearDown), and it must report each rendered survey exactly once.
+  if (activeSurveyId) {
+    const closedSurveyId = activeSurveyId;
+    activeSurveyId = null;
+    emitFormbricksEvent(FORMBRICKS_EVENTS.surveyClosed, { surveyId: closedSurveyId });
+  }
 };
 
 export const addWidgetContainer = (): void => {

--- a/packages/js-core/src/lib/user/tests/user.test.ts
+++ b/packages/js-core/src/lib/user/tests/user.test.ts
@@ -1,5 +1,6 @@
 import { type MockInstance, beforeEach, describe, expect, test, vi } from "vitest";
 import { Config } from "@/lib/common/config";
+import { emitFormbricksEvent, onFormbricksEvent, resetFormbricksEventSubscribers } from "@/lib/common/events";
 import { Logger } from "@/lib/common/logger";
 import { tearDown } from "@/lib/common/setup";
 import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
@@ -252,6 +253,22 @@ describe("user.ts", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("Logging out and cleaning user state");
       expect(tearDown).toHaveBeenCalled();
       expect(result.ok).toBe(true);
+    });
+
+    test("keeps event subscriptions registered — the docs promise handlers survive logout (ENG-1814)", () => {
+      const mockLogger = { debug: vi.fn(), error: vi.fn() };
+      getInstanceLoggerMock.mockReturnValue(mockLogger as unknown as Logger);
+
+      const handler = vi.fn();
+      onFormbricksEvent("formbricks_survey_shown", handler);
+
+      const result = logout();
+      expect(result.ok).toBe(true);
+
+      emitFormbricksEvent("formbricks_survey_shown", { surveyId: "survey_1" });
+      expect(handler).toHaveBeenCalledWith({ surveyId: "survey_1" });
+
+      resetFormbricksEventSubscribers();
     });
 
     test("clears the Embedded Data bag — the previous user's context must not leak (ENG-1844)", () => {


### PR DESCRIPTION
## What & why

Host applications embedding the JS SDK could only observe their own `track()` calls, which say nothing about whether a survey actually reached the screen — an eligible survey can be skipped by `displayPercentage`, a language mismatch, or failed identification. SJ needs the real signals to run its own frequency capping (ENG-1814).

This supersedes #9116 (thanks @Dhruwang — the subscription API shape, handler isolation, close-guard, docs and test structure carry over), rebuilt on the ENG-1846 event bus so there is **one event vocabulary with two surfaces**:

- **`formbricks.on(name, handler)` / `off(name, handler)`** — the JS subscription surface. Takes the full `formbricks_*` names, covers all five events (`formbricks_setup_successful`, `formbricks_action_tracked`, `formbricks_survey_shown`, `formbricks_response_submitted`, `formbricks_survey_closed`), returns an unsubscribe function, isolates throwing host handlers, and works when registered before `setup()`.
- **`window.dataLayer` pushes** — unchanged, same names; this is what GTM triggers match, and the array buffers across load order.

Changes in detail:

- New event **`formbricks_survey_closed`** — dismissed or finished, once per rendered survey (an `activeSurveyId` guard in `closeSurvey`; a never-shown survey never reports a close). Whether a `formbricks_response_submitted` came first tells dismissal and completion apart — there is deliberately no separate "finished" event.
- The **CustomEvent transport is removed**: `formbricks.on()` replaces it as the JS surface. This is pre-release surface — the epic has not shipped, the transport was published nowhere (the customer-facing contract only ever showed dataLayer pushes) — so nothing breaks.
- **Typed payloads**: `TFormbricksEventPayloads` maps each event name to its payload; both the emit sites and `on()` handlers are checked against it, so the two surfaces cannot drift.
- Subscriptions live in module state: registering before `setup()` works, and handlers survive `logout()`.
- New docs page (`lifecycle-events.mdx`) incl. the delivery-timing note (live, not replayed — register `formbricks_setup_successful` before `setup()`; `setup()`'s promise and the buffering dataLayer cover the other cases).

Companion change (separate repo, separate PR): the `@formbricks/js` npm wrapper gets `on`/`off` proxying, with pre-setup subscriptions forwarded to the SDK **before** `setup()` runs — that ordering is what makes `formbricks_setup_successful` catchable through the wrapper. That PR must not merge before this ships in a release.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1814

## How this was tested

- js-core unit suite: **332/332** ✅ — new subscription tests (multi-handler fan-out, same-handler dedupe, unsubscribe via returned fn and `off()`, self-unsubscribe during emit, throwing-handler isolation incl. dataLayer independence) and widget tests for the three survey seams incl. the closed-once guard and the server-acked `responseId`.
- **Mutation fail-checks** (each guard's test goes red without it): handler isolation removed → red; subscriber notify removed → red; closed-once guard removed → red.
- `js.spec.ts` e2e against a real app survey: the full journey arrives through `formbricks.on()` in order — `formbricks_survey_shown` → `formbricks_response_submitted (finished: false)` → `(finished: true)` → `formbricks_survey_closed` — with both submitted events carrying the **persisted** response id (asserted against the stored row). Green locally; **red on the old bundle** (`formbricks.on` does not exist there — revert-proven).
- Live playground run through the npm wrapper (with its companion change): all five events captured on a page panel, including `formbricks_setup_successful` — the one that cannot be observed from a browser console.
- Typecheck ✅, lint ✅.

## Breaking changes

None — these surfaces are unreleased. The window CustomEvent dispatch (added on this epic, never shipped or documented to customers) is removed in favour of `formbricks.on()`; the dataLayer contract published to integrators is untouched.

## QA / Test Plan

**How to test**

- [ ] Create an app survey with a code action trigger (e.g. `code`), "respond multiple" + cooldown ignore. On a host page, load the SDK and register `formbricks.on(...)` for all five events **before** calling `formbricks.setup(...)`, logging each payload.
- [ ] Load the page → `formbricks_setup_successful {workspaceId}` appears after setup finishes.
- [ ] `formbricks.track("code")` → `formbricks_action_tracked {action}` and, when the survey shows, `formbricks_survey_shown {surveyId}`.
- [ ] Answer the first question → `formbricks_response_submitted` with `finished: false` and a `responseId` matching the response in the Responses tab; finish the survey → the same event with `finished: true`, then after the ending card auto-closes → `formbricks_survey_closed` exactly once.
- [ ] Dismiss a survey without answering → `formbricks_survey_shown` + `formbricks_survey_closed`, no `response_submitted`.
- [ ] A survey skipped by `displayPercentage`/cooldown → **no events at all**.
- [ ] `const un = formbricks.on(...); un();` and `formbricks.off(name, handler)` → no further deliveries.
- [ ] A handler that throws → survey behaves normally, error logged, other handlers still fire.
- [ ] GTM: `window.dataLayer` shows the same events under the same names (`formbricks_survey_closed` is new there too).

**Preconditions / test data**

- Any workspace; an app-type survey with a trigger action. Link surveys emit nothing (js-core does not load there) — documented.

**Risks & regressions**

- Pages listening via `window.addEventListener("formbricks_*")` built against this unreleased epic would need to switch to `formbricks.on()` — nothing shipped uses that.
- npm `@formbricks/js` users need the companion wrapper release before `formbricks.on` exists for them (tracked with the ENG-1850 wrapper-release blocker, alongside `setEmbeddedData`).

**Migrations / env / cutover**

- none
