### PR TITLE
fix: make CSAT and CES scale labels translatable

### DIFF
--- a/apps/web/modules/survey/multi-language-surveys/lib/utils.test.ts
+++ b/apps/web/modules/survey/multi-language-surveys/lib/utils.test.ts
@@ -10,6 +10,8 @@ const t = ((key: string, options?: Record<string, unknown>) => {
     "common.headline": "Headline",
     "common.other_placeholder": "Other Placeholder",
     "workspace.surveys.edit.please_specify": "Please specify",
+    "workspace.surveys.edit.lower_label": "Lower label",
+    "workspace.surveys.edit.upper_label": "Upper label",
   };
 
   return translations[key] ?? key;
@@ -71,6 +73,65 @@ describe("multi-language survey utils", () => {
           path: "blocks.0.elements.1.otherOptionPlaceholder",
           fieldLabel: "Other Placeholder",
           value: { default: "Please specify" },
+        }),
+      ])
+    );
+  });
+
+  test("extracts the scale labels of csat and ces elements", () => {
+    const survey = createSurvey({
+      blocks: [
+        {
+          id: "block-1",
+          elements: [
+            {
+              id: "csat",
+              type: TSurveyElementTypeEnum.CSAT,
+              headline: { default: "How satisfied are you?" },
+              required: true,
+              scale: "smiley",
+              range: 5,
+              lowerLabel: { default: "Not satisfied at all" },
+              upperLabel: { default: "Very satisfied" },
+            },
+            {
+              id: "ces",
+              type: TSurveyElementTypeEnum.CES,
+              headline: { default: "How easy was it?" },
+              required: true,
+              scale: "number",
+              range: 5,
+              lowerLabel: { default: "Very difficult" },
+              upperLabel: { default: "Very easy" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const strings = extractTranslatableStrings(survey, t);
+
+    expect(strings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "blocks.0.elements.0.lowerLabel",
+          fieldLabel: "Lower label",
+          value: { default: "Not satisfied at all" },
+        }),
+        expect.objectContaining({
+          path: "blocks.0.elements.0.upperLabel",
+          fieldLabel: "Upper label",
+          value: { default: "Very satisfied" },
+        }),
+        expect.objectContaining({
+          path: "blocks.0.elements.1.lowerLabel",
+          fieldLabel: "Lower label",
+          value: { default: "Very difficult" },
+        }),
+        expect.objectContaining({
+          path: "blocks.0.elements.1.upperLabel",
+          fieldLabel: "Upper label",
+          value: { default: "Very easy" },
         }),
       ])
     );

--- a/apps/web/modules/survey/multi-language-surveys/lib/utils.ts
+++ b/apps/web/modules/survey/multi-language-surveys/lib/utils.ts
@@ -151,6 +151,8 @@ export const extractTranslatableStrings = (survey: TSurvey, t: TFunction): Trans
         }
         case TSurveyElementTypeEnum.NPS:
         case TSurveyElementTypeEnum.Rating:
+        case TSurveyElementTypeEnum.CSAT:
+        case TSurveyElementTypeEnum.CES:
           pushIfI18n(result, element, "lowerLabel", base, did, t("workspace.surveys.edit.lower_label"), eid);
           pushIfI18n(result, element, "upperLabel", base, did, t("workspace.surveys.edit.upper_label"), eid);
           break;


### PR DESCRIPTION
<!-- No Linear ticket: reported directly as a bug report while inspecting a live multi-language survey. -->

## What & why

**Was:** The lower and upper scale labels of CSAT and CES elements never showed up in the Manage translations modal, so they could not be translated — a survey in another language rendered its default-language labels next to a translated question.

**Now:** Those labels are listed like every other translatable string, and they count towards each language's translation progress.

The extractor that feeds the modal switched on element type and handled `lowerLabel`/`upperLabel` for `nps` and `rating` only. CSAT and CES carry the same two fields but fell through to no case at all.

## Where to look

- [`utils.ts:152-158`](https://github.com/formbricks/formbricks/blob/320338c5d6f5febe6222562e4b06e76ddebba1d4/apps/web/modules/survey/multi-language-surveys/lib/utils.ts#L152-L158) — the two added switch cases

## Breaking changes

- [ ] This PR contains breaking changes

None — internal editor helper, no API, SDK or stored-survey shape touched. Surveys that already have translated CSAT/CES labels keep them.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && npx vitest run modules/survey/multi-language-surveys/lib/utils.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| CSAT and CES scale labels are extracted as translatable strings | unit (red on main) | 4 expected paths absent before the fix, present after |
| NPS, Rating and every other element type keep their existing fields | unit (guard) | 5 pre-existing tests in the same file still pass |

**Open gaps**

- No screenshot of the modal: no Docker daemon here, so no local database and no running app. The diff changes a pure `.ts` extractor, not rendering code, so the unit test carries it.
- Existing surveys need the labels translated once in the modal; nothing backfills them.

**Risks**

- Translation progress drops for existing multi-language surveys with CSAT/CES elements — correct, since those labels were previously uncounted.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.
