### PR TITLE
docs: Embedded Data concept, SDK reference and source matrix [ENG-1849]

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,6 +125,17 @@
                 ]
               },
               {
+                "group": "Embedded Data",
+                "icon": "database",
+                "pages": [
+                  "surveys/embedded-data/overview",
+                  "surveys/embedded-data/reserved-fields",
+                  "surveys/embedded-data/set-embedded-data",
+                  "surveys/embedded-data/mobile-sdks",
+                  "surveys/embedded-data/migration"
+                ]
+              },
+              {
                 "group": "Link Surveys",
                 "icon": "link",
                 "pages": [

--- a/docs/surveys/embedded-data/migration.mdx
+++ b/docs/surveys/embedded-data/migration.mdx
@@ -1,0 +1,83 @@
+---
+title: "Hidden Fields & Variables"
+description: "What Embedded Data changes for surveys that already use hidden fields and variables, and what it deliberately leaves alone."
+icon: "arrow-right-arrow-left"
+---
+
+If you already use hidden fields or variables, the short version is: **nothing renames, nothing moves, and no survey needs editing.** Embedded Data is the name for the concepts you already have, now sharing one type system and one read path, plus a set of fields Formbricks fills in for you.
+
+## The Mapping
+
+| You know it as        | It is now called   | Where you author it            |
+| --------------------- | ------------------ | ------------------------------ |
+| Hidden field          | an ingested field  | the **Hidden Fields** card     |
+| Variable              | a computed field   | the **Variables** card         |
+| Response metadata     | a reserved field   | nowhere, it is always captured |
+
+The distinction the two names were always making is the one the new vocabulary makes explicit: a hidden field arrives from **outside** the survey, a variable is computed **inside** it.
+
+## What Does Not Change
+
+- **Existing surveys keep working, unedited.** Field names, ids and stored values are untouched.
+- **Recall tokens keep resolving.** `#recall:<name>/fallback:x#` for a hidden field and `#recall:<id>/fallback:x#` for a variable both still point at the same value.
+- **Logic conditions keep matching.** Hidden field and variable operands are unchanged.
+- **`?field=value` in a survey link keeps filling hidden fields**, including the case-insensitive matching that was already there.
+- **`formbricks.track("action", { hiddenFields: { … } })` keeps working**, and an explicit value there still beats an ambient one.
+- **API payloads are unchanged.** `hiddenFields` and `variables` on the survey resource look exactly as they did.
+- **Exports keep their hidden field and variable columns.**
+
+## What Is New
+
+- **[Reserved fields](/surveys/embedded-data/reserved-fields).** Twenty-eight auto-captured fields (page, campaign, device, timing, request context) are available on every response by name, with no declaration. Thirteen of them are newly captured in the browser, so they only exist on responses collected from now on.
+- **[`setEmbeddedData()`](/surveys/embedded-data/set-embedded-data).** Ambient context for app surveys that is not tied to a trigger, in the JavaScript SDK and in all four [mobile SDKs](/surveys/embedded-data/mobile-sdks).
+- **Stable export columns.** The reserved column set is derived from the catalog rather than from whatever the first response happened to carry, so a column no longer disappears because response #1 lacked the value, and headers read `Page Path` rather than `userAgent - browser`.
+- **Typed values in exports.** A numeric field such as `viewportWidth` exports as a number rather than as text.
+- **An [Anonymize responses](/surveys/embedded-data/reserved-fields#anonymize-responses) toggle** that suppresses the privacy-sensitive reserved fields at ingest.
+
+<Note>
+  Older responses carry nothing for the fields that did not exist when they were collected, and read back as
+  unset rather than empty. Filters and export columns can therefore be blank for historic responses on a
+  survey that is otherwise capturing everything.
+</Note>
+
+## Naming Rules for New Fields
+
+New hidden field and variable names must start with a lowercase letter and then contain only lowercase letters, numbers and underscores, and cannot be one of the reserved names in any casing. Names your surveys already use are grandfathered: they load, collect values and re-save unchanged.
+
+The one thing to know before you delete a grandfathered field: **the reprieve is spent once it is gone**, so a name that is refused today cannot be re-added afterwards. That also means re-creating a survey from an export fails with a `400` when the export declares a refused name; rename the field in the payload before importing.
+
+The full rule and the refused list are on the [Hidden Fields](/surveys/general-features/hidden-fields#naming) page.
+
+## Don't Pass Sensitive Data via the URL
+
+Hidden field values passed in a survey link are visible to anyone who sees or shares that link, gets it forwarded, or reads it out of a browser history, a referrer header or a proxy log. **Do not pass email addresses, tokens, account numbers or any other personal identifier that way.**
+
+The editor shows this warning next to the Hidden Fields card, and it is worth taking literally rather than treating as boilerplate:
+
+- Pass an opaque reference you can resolve on your own side, not the identifier itself.
+- For app surveys, prefer [`setEmbeddedData()`](/surveys/embedded-data/set-embedded-data), which never puts the value in a URL.
+- Remember that the page URL is itself captured as the reserved `url` field. Formbricks always strips the query string and fragment before recall, logic or an export can read it, and the [Anonymize responses](/surveys/embedded-data/reserved-fields#anonymize-responses) toggle strips it from storage too, but neither of those protects the link while it is in transit.
+
+## Should I Change Anything?
+
+Only if you want the new capability:
+
+<Steps>
+  <Step title="Move ambient context off track()">
+    If you pass the same `hiddenFields` on several different `track()` calls just to make sure whichever
+    survey opens has them, push them once with `setEmbeddedData()` instead. Both work; the bag stops you
+    repeating yourself, and works for surveys you did not know would open.
+  </Step>
+
+  <Step title="Drop fields you were only using for metadata">
+    A hidden field you fill with the page URL, the referrer, a UTM parameter, the device or the time zone is
+    now redundant: the [reserved field](/surveys/embedded-data/reserved-fields) of that name is captured for
+    free. Keep the declared field if you have historic responses that depend on it, since a declared field
+    always shadows the reserved one of the same name.
+  </Step>
+
+  <Step title="Decide on Anonymize responses">
+    Off by default and nothing changes. Turn it on per survey where you do not want the IP address, the
+    country or the parsed device details stored, and read what it does and does not cover first.
+  </Step>
+</Steps>

--- a/docs/surveys/embedded-data/mobile-sdks.mdx
+++ b/docs/surveys/embedded-data/mobile-sdks.mdx
@@ -110,12 +110,14 @@ Values must be a `String`, `num`, `bool` or `DateTime`; anything else is logged 
 
 ## Value Types at a Glance
 
-| SDK          | Argument type                                                              | Removes a key | Leaves a key alone | Clears everything                 |
-| ------------ | -------------------------------------------------------------------------- | ------------- | ------------------ | --------------------------------- |
-| React Native | `Record<string, string \| number \| boolean \| Date \| null \| undefined>` | `null`        | `undefined`        | `clearEmbeddedData()`             |
-| Swift        | `[String: EmbeddedDataValue?]`                                             | `nil`         | omitting the key   | `clearEmbeddedData()` overload    |
-| Kotlin       | `Map<String, EmbeddedDataValue?>`                                          | `null`        | omitting the key   | `clearEmbeddedData()` overload    |
-| Dart         | `Map<String, Object?>`                                                     | `null`        | omitting the key   | `clearEmbeddedData()` no argument |
+| SDK          | Value type                                                      | Removes a key | Leaves a key alone |
+| ------------ | ---------------------------------------------------------------- | ------------- | ------------------ |
+| React Native | `string`, `number`, `boolean`, `Date`                           | `null`        | `undefined`        |
+| Swift        | `EmbeddedDataValue`: `.string`, `.number`, `.bool`, `.date`     | `nil`         | omitting the key   |
+| Kotlin       | `EmbeddedDataValue`: `string()`, `number()`, `boolean()`, `date()` | `null`     | omitting the key   |
+| Dart         | `String`, `num`, `bool`, `DateTime`                             | `null`        | omitting the key   |
+
+On all four, `clearEmbeddedData("key")` removes one key and `clearEmbeddedData()` with no argument clears the whole bag.
 
 Only React Native has a **value** that means "leave this key alone". On the other three, leaving the key out of the map is the way to skip it, which is why the warnings above matter for code that builds the map from optionals.
 

--- a/docs/surveys/embedded-data/mobile-sdks.mdx
+++ b/docs/surveys/embedded-data/mobile-sdks.mdx
@@ -1,0 +1,162 @@
+---
+title: "Mobile SDKs"
+description: "setEmbeddedData and clearEmbeddedData on React Native, iOS, Android and Flutter, and what mobile responses auto-capture."
+icon: "mobile"
+---
+
+All four mobile SDKs carry the same [Embedded Data](/surveys/embedded-data/overview) API as the JavaScript SDK, with the same contract: merge into an in-memory bag, snapshot it when a survey is displayed, never persist it.
+
+The rules are identical everywhere, so read the [`setEmbeddedData` reference](/surveys/embedded-data/set-embedded-data) for the semantics. This page covers what differs per language.
+
+<Note>
+  Values reach a response only through the fields the survey declares in its **Hidden Fields** card. Declare
+  the field first, then push a value under the same name.
+</Note>
+
+<Note>
+  `setEmbeddedData` lives in the SDK, so it needs an SDK upgrade and a new build of your app. The
+  [auto-captured fields](#what-mobile-responses-auto-capture) further down do not: those come from the survey
+  renderer, which is loaded from your Formbricks instance at display time.
+</Note>
+
+## React Native
+
+```javascript
+import { setEmbeddedData, clearEmbeddedData } from "@formbricks/react-native";
+
+setEmbeddedData({
+  plan: "pro",
+  seats: 25,
+  isTrial: false,
+  signedUpAt: new Date(),
+  screen: null, // removes the key
+});
+
+clearEmbeddedData("plan"); // one key
+clearEmbeddedData(); // everything
+```
+
+Values are `string`, `number`, `boolean` or `Date`. `null` removes a key and `undefined` is a no-op, exactly as in the browser SDK.
+
+## Swift (iOS)
+
+```swift
+Formbricks.setEmbeddedData([
+    "plan": "pro",
+    "seats": 25,
+    "isTrial": false,
+    "signedUpAt": .date(Date()),
+    "screen": nil,   // removes the key
+])
+
+Formbricks.clearEmbeddedData("plan")  // one key
+Formbricks.clearEmbeddedData()        // everything
+```
+
+Values are an `EmbeddedDataValue`: `.string`, `.number`, `.bool` or `.date`. String, integer, floating-point and boolean literals convert on their own, so the common call reads as plain data; a `Date` needs the explicit `.date(…)` case.
+
+<Warning>
+  **On iOS, `nil` removes a key — there is no "leave this alone" value.** Swift has no `undefined`, so this
+  SDK maps `nil` onto the JavaScript SDK's `null` and has nothing that spells its `undefined`.
+
+  The cross-platform idiom of passing every field unconditionally therefore behaves differently here:
+
+  ```swift
+  // ⚠️ clears `plan` whenever the optional is empty
+  Formbricks.setEmbeddedData(["plan": user.plan.map(EmbeddedDataValue.string)])
+  ```
+
+  Build the dictionary from the keys you actually have, and use `clearEmbeddedData(_:)` when you mean to
+  remove one.
+</Warning>
+
+The single-key and clear-everything forms are separate overloads, so a `String` that cannot be `nil` means reading the key from your own state can never accidentally wipe the whole bag.
+
+## Kotlin (Android)
+
+```kotlin
+Formbricks.setEmbeddedData(mapOf(
+    "plan" to EmbeddedDataValue.string("pro"),
+    "seats" to EmbeddedDataValue.number(25.0),
+    "isTrial" to EmbeddedDataValue.boolean(false),
+    "signedUpAt" to EmbeddedDataValue.date(Date()),
+    "screen" to null,   // removes the key
+))
+
+Formbricks.clearEmbeddedData("plan")  // one key
+Formbricks.clearEmbeddedData()        // everything
+```
+
+Values are an `EmbeddedDataValue`, built with `string()`, `number()`, `boolean()` or `date()`. Kotlin has no `undefined` either, so `null` removes a key and the iOS warning above applies here too. As on iOS, the two clear forms are separate overloads.
+
+## Flutter
+
+```dart
+Formbricks.setEmbeddedData({
+  'plan': 'pro',
+  'seats': 25,
+  'isTrial': false,
+  'signedUpAt': DateTime.now(),
+  'screen': null, // removes the key
+});
+
+Formbricks.clearEmbeddedData('plan'); // one key
+Formbricks.clearEmbeddedData();       // everything
+```
+
+Values must be a `String`, `num`, `bool` or `DateTime`; anything else is logged and skipped. `null` removes a key.
+
+`clearEmbeddedData()` with no argument clears everything, while `clearEmbeddedData(null)` is a logged no-op — the same distinction the JavaScript SDK draws by argument count, so reading the key name from your own state cannot wipe the bag when that state is empty.
+
+## Value Types at a Glance
+
+| SDK          | Argument type                                                              | Removes a key | Leaves a key alone | Clears everything                 |
+| ------------ | -------------------------------------------------------------------------- | ------------- | ------------------ | --------------------------------- |
+| React Native | `Record<string, string \| number \| boolean \| Date \| null \| undefined>` | `null`        | `undefined`        | `clearEmbeddedData()`             |
+| Swift        | `[String: EmbeddedDataValue?]`                                             | `nil`         | omitting the key   | `clearEmbeddedData()` overload    |
+| Kotlin       | `Map<String, EmbeddedDataValue?>`                                          | `null`        | omitting the key   | `clearEmbeddedData()` overload    |
+| Dart         | `Map<String, Object?>`                                                     | `null`        | omitting the key   | `clearEmbeddedData()` no argument |
+
+Only React Native has a **value** that means "leave this key alone". On the other three, leaving the key out of the map is the way to skip it, which is why the warnings above matter for code that builds the map from optionals.
+
+Dates are sent as ISO 8601 on every platform, which is what a `date` field accepts.
+
+<Note>
+  Swift, Kotlin and Dart refuse a non-finite number (`NaN`, `infinity`) at the door and log it. That guard is
+  not politeness: on those platforms the payload being serialized is the whole survey's configuration, so one
+  unserializable value would mean **no survey at all** rather than one missing field. React Native matches the
+  browser SDK instead, where such a value simply arrives as unusable and is dropped by the renderer.
+</Note>
+
+## Lifetime on Mobile
+
+Same three rules as the browser, with one wording change: the bag is **process** scoped rather than page-load scoped.
+
+- **In memory, never persisted.** A cold app start begins with an empty bag and your app re-pushes. Nothing is written to `UserDefaults`, `SharedPreferences` or async storage, so there is no PII at rest.
+- **Snapshot at display, then frozen.** A value set while a survey is on screen reaches the next response.
+- **Cleared on an identity switch.** `logout()`, or `setUserId()` with a different id, empties the bag. Identifying for the first time keeps it.
+
+All four SDKs let you call `setEmbeddedData` **before** `setup()`: the bag is pure memory and needs nothing running, so context pushed at launch is not silently dropped.
+
+<Note>
+  `setUserId("a")` immediately followed by `setUserId("b")` in the same tick clears neither the user state nor
+  the bag on any of the four SDKs, because the first id has not been committed yet. This is existing identity
+  behavior rather than something Embedded Data introduces.
+</Note>
+
+## What Mobile Responses Auto-Capture
+
+The [reserved fields](/surveys/embedded-data/reserved-fields) work in a WebView with **no extra wiring**: the survey renderer is loaded from your Formbricks instance at display time, so an already-installed app picks this up without a rebuild or an SDK upgrade.
+
+| Captured on mobile                                                                                     | Absent on mobile                                            |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`, `locale`                 | `url`, `source`, `pagePath`, `pageReferrer`, every `utm*`   |
+| `browser`, `os`, `deviceType`, `country`, `ipAddress` — derived server-side from the request           |                                                             |
+| `finished`, `language`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`         |                                                             |
+
+The absent ones are absent on purpose. A WebView has no host page, so `location` and `document.referrer` describe nothing real, and filling those fields would produce values that look valid and mean nothing. A screen name is host-supplied rather than observed, which makes it ingested data by definition: declare a `screen` hidden field and push it yourself with `setEmbeddedData`.
+
+<Note>
+  [Lifecycle events](/surveys/website-app-surveys/lifecycle-events) are JavaScript-only for now. React Native,
+  iOS, Android and Flutter support is tracked separately and will land in a later release.
+</Note>

--- a/docs/surveys/embedded-data/mobile-sdks.mdx
+++ b/docs/surveys/embedded-data/mobile-sdks.mdx
@@ -13,11 +13,13 @@ The rules are identical everywhere, so read the [`setEmbeddedData` reference](/s
   the field first, then push a value under the same name.
 </Note>
 
-<Note>
-  `setEmbeddedData` lives in the SDK, so it needs an SDK upgrade and a new build of your app. The
-  [auto-captured fields](#what-mobile-responses-auto-capture) further down do not: those come from the survey
-  renderer, which is loaded from your Formbricks instance at display time.
-</Note>
+<Warning>
+  **Not in a released SDK version yet.** `setEmbeddedData` and `clearEmbeddedData` are merged on `main` in
+  all four SDKs but ship with each one's next release, so upgrading to today's latest version will not give
+  you them. The [auto-captured fields](#what-mobile-responses-auto-capture) further down are unaffected:
+  those come from the survey renderer, which is loaded from your Formbricks instance at display time, so an
+  already-installed app picks them up with no upgrade and no rebuild.
+</Warning>
 
 ## React Native
 

--- a/docs/surveys/embedded-data/mobile-sdks.mdx
+++ b/docs/surveys/embedded-data/mobile-sdks.mdx
@@ -13,13 +13,12 @@ The rules are identical everywhere, so read the [`setEmbeddedData` reference](/s
   the field first, then push a value under the same name.
 </Note>
 
-<Warning>
-  **Not in a released SDK version yet.** `setEmbeddedData` and `clearEmbeddedData` are merged on `main` in
-  all four SDKs but ship with each one's next release, so upgrading to today's latest version will not give
-  you them. The [auto-captured fields](#what-mobile-responses-auto-capture) further down are unaffected:
+<Note>
+  `setEmbeddedData` lives in the SDK itself, so adopting it means upgrading the SDK dependency and shipping a
+  new build of your app. The [auto-captured fields](#what-mobile-responses-auto-capture) further down do not:
   those come from the survey renderer, which is loaded from your Formbricks instance at display time, so an
   already-installed app picks them up with no upgrade and no rebuild.
-</Warning>
+</Note>
 
 ## React Native
 

--- a/docs/surveys/embedded-data/overview.mdx
+++ b/docs/surveys/embedded-data/overview.mdx
@@ -1,0 +1,161 @@
+---
+title: "Embedded Data"
+description: "Everything on a response that is not an answer to a question: values you pass in, values the survey calculates, and the context Formbricks captures on its own."
+icon: "database"
+---
+
+Embedded Data is **data about this response**. A page type, a plan, a campaign, a quiz score, the device the survey was answered on. It rides along with the answers, shows up in the response table and in exports, and can be used in recall, logic and redirect URLs.
+
+That makes it the counterpart to **contact attributes**, which are **data about this person** and persist across every response they ever give.
+
+|                       | Embedded Data                                | Contact attributes                                   |
+| --------------------- | -------------------------------------------- | ---------------------------------------------------- |
+| Describes             | one response / one session                   | one person, across responses                         |
+| Stored on             | the response                                 | the contact record, snapshotted onto the response    |
+| Set with              | URL params, `setEmbeddedData()`, survey logic | `setUserId()`, `setAttributes()`, `setEmail()`        |
+| Lives past the survey | no                                           | yes                                                  |
+
+<Note>
+  Nothing renames. In the survey editor these are still the **Hidden Fields** and **Variables** cards, and the
+  API payloads are unchanged. Embedded Data is the name for those two plus the auto-captured fields, now that
+  they share one type system and one read path. See [Hidden Fields and
+  Variables](/surveys/embedded-data/migration) if you already use them.
+</Note>
+
+## The Three Sources
+
+Every Embedded Data field has exactly one source, and the source decides who is allowed to write it.
+
+| Source       | Written by                                   | Called this in the editor | Types today                           |
+| ------------ | -------------------------------------------- | ------------------------- | ------------------------------------- |
+| **Ingested** | the outside world: URL params or the SDK     | Hidden Fields             | `string`                              |
+| **Computed** | the survey itself, through logic actions      | Variables                 | `string`, `number`                    |
+| **Reserved** | Formbricks, automatically, on every response | not authored at all       | `string`, `number`, `boolean`, `date` |
+
+Ingested fields are the only ones anything outside the survey can write. Computed fields are set by logic while the respondent answers, and reserved fields are read-only auto-capture, so a URL param or an SDK call naming one of them is dropped and logged rather than stored.
+
+## Where Values Come From
+
+Which capture channel is available depends on the survey type, and this is the part worth reading twice, because a URL param does nothing for an app survey and `setEmbeddedData()` does nothing for a link survey.
+
+| Capture channel                                                       | Link surveys | Website & app surveys (JS) | App surveys (mobile SDKs) |
+| --------------------------------------------------------------------- | ------------ | -------------------------- | ------------------------- |
+| Ingested via **URL parameter** (`?plan=pro`)                          | Yes          | No                         | No                        |
+| Ingested via **`setEmbeddedData()`**                                   | No           | Yes                        | Yes                       |
+| Computed by **survey logic**                                           | Yes          | Yes                        | Yes                       |
+| Reserved — **page and campaign** (`pagePath`, `pageReferrer`, `utm*`, `url`, `source`) | Yes          | Yes                        | No                        |
+| Reserved — **device** (`screenWidth`, `viewportWidth`, `timezone`, `locale`, …)         | Yes          | Yes                        | Yes                       |
+| Reserved — **server-derived** (`country`, `browser`, `os`, `deviceType`, `ipAddress`, timings) | Yes          | Yes                        | Yes                       |
+
+<Note>
+  Mobile SDKs render the survey inside a WebView that has no host page, so `location` and `document.referrer`
+  describe nothing real there. The page and campaign fields are left **absent** on mobile responses rather
+  than filled with a meaningless value. The device fields are honest measurements of the device and are
+  captured. If you want the equivalent of a page name on mobile, pass it yourself:
+  `setEmbeddedData({ screen: "checkout" })`.
+</Note>
+
+A field does not care which channel filled it. `plan` is declared the same way, filled by `?plan=pro` on a link survey and by `setEmbeddedData({ plan: "pro" })` on an app survey, and reads back identically in recall, logic, filters and exports.
+
+## Declaring a Field
+
+An ingested or computed field has to exist on the survey before anything can fill it. Add it in the survey editor: **Hidden Fields** for ingested, **Variables** for computed. Reserved fields are never declared, they are always available.
+
+A field's **name** is the key you use everywhere: in a URL parameter, in `setEmbeddedData()`, in recall tokens, in logic operands and as the export column header.
+
+Field names follow one rule everywhere, and reserved names are refused for new fields in any casing. The full rule and the refused list live on the [Hidden Fields](/surveys/general-features/hidden-fields#naming) page.
+
+A field also carries a **type** that decides how its value is read back and compared. In this release:
+
+- **Hidden fields** are `string`. Anything you pass is stored as text.
+- **Variables** are text or number, and the initial value you set in the editor is the default the field falls back to.
+- **Reserved fields** are typed by Formbricks, and several of them are genuinely numeric: `viewportWidth < 768` is a numeric comparison in logic, not a comparison of digit strings.
+
+<Note>
+  Typing hidden fields (`number`, `boolean`, `date`), giving them a default, and locking a field so nothing
+  outside the survey can write it, are part of the Embedded Data manager and are not authorable yet. The
+  ingest rules below already honour all of them, so nothing changes for you when they arrive.
+</Note>
+
+## What Happens to an Incoming Value
+
+The same contract runs in the browser when the survey is displayed, and again on the server when the response is saved, so what the client accepts is never taken on trust.
+
+<Steps>
+  <Step title="Allow-list">
+    Only names the survey declares as **ingested** fields are stored. An unknown key, a computed field, a
+    reserved field or a locked field is dropped and logged, never stored, and never an error.
+  </Step>
+
+  <Step title="Case-insensitive matching">
+    A field declared `customerRef` is filled by `?customerref=x` as well as `?customerRef=x`. The value is
+    always stored under the declared spelling, so exports and recall see one key.
+  </Step>
+
+  <Step title="Coercion to the declared type">
+    Values are coerced rather than rejected. `"42"` into a `number` field becomes `42`; `true`, `1`, `yes`
+    and `on` (and their negatives) become booleans; a `date` field accepts `2026-08-06` and full ISO 8601
+    datetimes, stores ISO 8601, and reads a datetime with no zone as UTC rather than as the respondent's
+    local time. A value that cannot be coerced is stored verbatim and flagged, so a bad parameter never
+    blocks a response. Today every hidden field is a `string`, and every scalar has a lossless text form, so
+    this step only starts doing visible work once fields can be typed.
+  </Step>
+
+  <Step title="Size limit">
+    One value is capped at **16 KB** of UTF-8. Anything longer is truncated on a character boundary and
+    flagged, not rejected.
+  </Step>
+
+  <Step title="Collision with a question">
+    A question's answer always wins its own key. A field whose name collides with a question id can never
+    hold a value, and the collision is reported.
+  </Step>
+</Steps>
+
+<Note>
+  A field nothing arrived for keeps its key **absent** rather than empty, and reads back as its default value
+  if it has one. That is what makes `#recall:plan/fallback:unknown#` show the fallback instead of a blank.
+</Note>
+
+### Precedence
+
+When two sources offer the same field on the same response, the more explicit one wins:
+
+1. a question's answer, always, for its own key;
+2. an explicit `formbricks.track("action", { hiddenFields: { plan: "pro" } })` value;
+3. the ambient bag set with `setEmbeddedData()`, or the URL parameter on a link survey;
+4. the field's default value;
+5. otherwise the field is unset.
+
+Reserved fields sit outside this list because they are never written from outside. The one interaction is **shadowing**: if a survey declares its own field named `url` or `country`, that name resolves to the declared field everywhere, and the reserved field of the same name is not offered, listed or exported for that survey.
+
+## Reading the Values Back
+
+Once a value is on a response it behaves like any other response data:
+
+- **Recall** it into question copy, ending cards and redirect URLs with `#recall:<name>/fallback:<text>#`.
+- Use it as a **logic** operand to branch the survey.
+- Filter and group **responses** by it.
+- **Export** it as a stable, typed column in CSV and Excel.
+
+Mid-survey surfaces (recall inside a running survey, logic conditions) can only use values that exist while the respondent is still answering. Server-derived reserved fields such as `country` or `durationSeconds` are only known once the response reaches Formbricks, so they are available on the response but not offered to a running survey. The [Reserved Fields](/surveys/embedded-data/reserved-fields) page marks which is which.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Reserved Fields" icon="list-check" href="/surveys/embedded-data/reserved-fields">
+    The full catalog of auto-captured fields, their types, and what the Anonymize toggle suppresses.
+  </Card>
+
+  <Card title="setEmbeddedData" icon="code" href="/surveys/embedded-data/set-embedded-data">
+    The JavaScript SDK reference: merge semantics, SPA route changes, GTM and the debug trace.
+  </Card>
+
+  <Card title="Mobile SDKs" icon="mobile" href="/surveys/embedded-data/mobile-sdks">
+    `setEmbeddedData` on React Native, iOS, Android and Flutter, with each language's value types.
+  </Card>
+
+  <Card title="Hidden Fields & Variables" icon="arrow-right-arrow-left" href="/surveys/embedded-data/migration">
+    What changes for surveys you already run, and what does not.
+  </Card>
+</CardGroup>

--- a/docs/surveys/embedded-data/overview.mdx
+++ b/docs/surveys/embedded-data/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Embedded Data"
+sidebarTitle: "Overview"
 description: "Everything on a response that is not an answer to a question: values you pass in, values the survey calculates, and the context Formbricks captures on its own."
 icon: "database"
 ---

--- a/docs/surveys/embedded-data/reserved-fields.mdx
+++ b/docs/surveys/embedded-data/reserved-fields.mdx
@@ -4,7 +4,9 @@ description: "The system fields Formbricks captures on every response without yo
 icon: "list-check"
 ---
 
-Reserved fields are the auto-captured half of [Embedded Data](/surveys/embedded-data/overview). They are the same for every survey in every workspace, you never declare them, and nothing outside the survey can write them. They are simply there, on every response, ready to be recalled, filtered, grouped and exported.
+Reserved fields are the auto-captured half of [Embedded Data](/surveys/embedded-data/overview). The catalog is the same for every survey in every workspace, you never declare them, and nothing outside the survey can write them. Whatever gets captured is there to be recalled, filtered, grouped and exported.
+
+**Captured is not the same as declared, though.** A reserved field needs no declaration, but whether a value actually lands depends on the field, the survey type and the survey's settings: `ipAddress` only when the survey captures it, `durationSeconds` only on finished responses, the page and campaign fields only where there is a host page, and none of the newer fields on responses collected before they existed. The catalog and the sections below say which is which.
 
 ## The Catalog
 

--- a/docs/surveys/embedded-data/reserved-fields.mdx
+++ b/docs/surveys/embedded-data/reserved-fields.mdx
@@ -1,0 +1,124 @@
+---
+title: "Reserved Fields"
+description: "The system fields Formbricks captures on every response without you declaring anything: page, campaign, device, timing and request context."
+icon: "list-check"
+---
+
+Reserved fields are the auto-captured half of [Embedded Data](/surveys/embedded-data/overview). They are the same for every survey in every workspace, you never declare them, and nothing outside the survey can write them. They are simply there, on every response, ready to be recalled, filtered, grouped and exported.
+
+## The Catalog
+
+**Captured by** says where the value comes from, and that decides whether a running survey can use it:
+
+- **Browser** — read in the page when the survey is displayed, then frozen. Usable in recall and logic *while the respondent is answering*.
+- **Server** — derived from the request or from the stored response when it reaches Formbricks. Available on the response, in filters and in exports, but not offered to a running survey, because mid-survey the answer does not exist yet.
+
+| Field             | Type      | Captured by     | What it holds                                                                 |
+| ----------------- | --------- | --------------- | ----------------------------------------------------------------------------- |
+| `source`          | `string`  | Browser         | How the response was collected: `link`, `app`, …                              |
+| `url`             | `string`  | Browser         | The page URL the survey ran on. Always read back without its query string     |
+| `pagePath`        | `string`  | Browser         | The same page without the query string, to group by page rather than by visit |
+| `pageReferrer`    | `string`  | Browser         | Where the respondent came from. Also read back without its query string       |
+| `utmSource`       | `string`  | Browser         | `utm_source` from the page's own query string                                 |
+| `utmMedium`       | `string`  | Browser         | `utm_medium`                                                                  |
+| `utmCampaign`     | `string`  | Browser         | `utm_campaign`                                                                |
+| `utmTerm`         | `string`  | Browser         | `utm_term`                                                                    |
+| `utmContent`      | `string`  | Browser         | `utm_content`                                                                 |
+| `action`          | `string`  | Browser         | The action that triggered an app survey                                       |
+| `screenWidth`     | `number`  | Browser         | Screen width in CSS pixels                                                    |
+| `screenHeight`    | `number`  | Browser         | Screen height in CSS pixels                                                   |
+| `viewportWidth`   | `number`  | Browser         | Width of the window the survey was rendered into                              |
+| `viewportHeight`  | `number`  | Browser         | Height of that window                                                         |
+| `timezone`        | `string`  | Browser         | The respondent's IANA time zone, e.g. `Europe/Berlin`                         |
+| `locale`          | `string`  | Browser         | How the device is configured, e.g. `de-AT`, from `navigator.language`         |
+| `language`        | `string`  | Browser, Server | The language the respondent is **answering in**                               |
+| `country`         | `string`  | Server          | Country from the CDN request header. Formbricks runs no GeoIP lookup          |
+| `browser`         | `string`  | Server          | Parsed from the `user-agent` request header                                   |
+| `os`              | `string`  | Server          | Parsed from the `user-agent` request header                                   |
+| `deviceType`      | `string`  | Server          | Parsed from the `user-agent` request header                                   |
+| `ipAddress`       | `string`  | Server          | Only when the survey has **Capture IP address** enabled                       |
+| `finished`        | `boolean` | Server          | Complete vs. partial response                                                 |
+| `durationSeconds` | `number`  | Server          | Total time to complete. Only set on finished responses                        |
+| `startedAt`       | `date`    | Server          | When the response record was opened                                           |
+| `finishedAt`      | `date`    | Server          | When the response was last written, i.e. its submission when finished         |
+| `responseId`      | `string`  | Server          | The response id                                                               |
+| `surveyId`        | `string`  | Server          | The survey id                                                                 |
+
+<Note>
+  `locale` and `language` are different questions. `locale` is how the respondent's device is configured;
+  `language` is the survey language they actually answered in. A German speaker taking an English-only survey
+  has `locale: "de-DE"` and `language: "en"`, and the gap between the two is exactly what "should we translate
+  this survey?" is asking.
+</Note>
+
+<Note>
+  Responses collected before a field existed carry nothing for it and read back as unset, so a filter or an
+  export column can legitimately be empty for older responses.
+</Note>
+
+### What Link, Web and Mobile Each Capture
+
+Link surveys and website & app surveys render through the same component, so both capture the full browser set. What those fields *describe* differs: on a link survey `url`, `pagePath`, `pageReferrer` and `utm*` are about the Formbricks-hosted survey page and how the respondent reached it; on an app survey they are about the host page the survey was triggered on.
+
+Mobile SDKs render the survey in a WebView with no host page, so the page and campaign fields are absent there while the device fields (`screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`, `locale`) and every server-derived field are captured normally.
+
+<Note>
+  `screenWidth` and `screenHeight` are orientation-invariant on iOS and rotate with the device on Android.
+  That is browser behavior rather than a Formbricks decision, so compare `viewportWidth` against a breakpoint
+  if you want to know how wide the survey actually rendered.
+</Note>
+
+## Name Collisions
+
+A survey may already declare a hidden field called `url`, `country` or `source`. When it does, that name **resolves to the survey's own field** everywhere: in recall, in logic, in the response table and in exports. The reserved field of the same name is not offered and not exported for that survey, so there is never a column that could mean two things.
+
+New fields cannot be created under a reserved name in any casing, which is what keeps this to the surveys that already had one. The rule and the full refused list live on the [Hidden Fields](/surveys/general-features/hidden-fields#naming) page.
+
+## Anonymize Responses
+
+The **Anonymize responses** toggle in the survey editor's **Settings** tab, under **Response Options**, is off by default and decides which reserved fields are captured at all. It acts at ingest, so a suppressed field is never stored rather than stored and hidden, and responses collected before you turned it on are untouched.
+
+| With the toggle on         | Fields                                                                                                                                                                                    |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Not captured**           | `country`, `ipAddress`, `browser`, `os`, `deviceType`                                                                                                                                     |
+| **Query string stripped**  | `url`, `pageReferrer`                                                                                                                                                                     |
+| **Captured unchanged**     | `source`, `action`, `pagePath`, all five `utm*`, `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`, `locale`, `language`, `finished`, `durationSeconds`, `startedAt`, `finishedAt`, `responseId`, `surveyId` |
+
+A suppressed field resolves as **unset**, never as an empty string or a stale value, so `#recall:country/fallback:unknown#` shows `unknown` and a logic condition on it simply does not match.
+
+Turning the toggle on also disables **Capture IP address** for that survey, because anonymizing drops the IP whatever that switch says. Your stored choice is kept, so turning anonymize back off restores it.
+
+<Warning>
+  **"Anonymize" here means "no direct identifiers", not "not re-identifiable".** The toggle removes the IP
+  address, the country and the parsed device details, and strips query strings from captured URLs. It does
+  **not** coarsen the fields it keeps, and `screenWidth` + `screenHeight` + `viewportWidth` +
+  `viewportHeight` + `timezone` + `locale` taken together are a browser fingerprint that can narrow a
+  respondent down further than `browser: "Chrome"` ever could. Those fields are kept because they are what
+  makes response analysis useful, but if your threat model is re-identification rather than direct
+  identifiers, do not treat this toggle as sufficient on its own.
+</Warning>
+
+### Query Stripping Is Not Only for Anonymized Surveys
+
+`url` and `pageReferrer` are **always** stripped of their query string and fragment before recall, logic or an export can read them, on every survey, whether or not the toggle is on. Only the stored value keeps the full URL, and only while anonymize is off.
+
+That is deliberate: a recall token can end up interpolated into a redirect URL or a follow-up email, and a survey URL's query string can carry a single-use token or an email address. The campaign parameters you actually want are already available as `utmSource` and friends.
+
+<Warning>
+  Query strings are where identifiers hide. Do not pass emails, tokens or personal identifiers in a survey
+  link, whatever this toggle is set to. See [Hidden Fields and
+  Variables](/surveys/embedded-data/migration#dont-pass-sensitive-data-via-the-url).
+</Warning>
+
+## Where Reserved Fields Show Up
+
+**On the response card**, `source`, `url`, `country`, `action`, `browser`, `os` and `deviceType` are always listed. The remaining auto-captured fields sit behind a disclosure so the card does not grow a dozen rows.
+
+**In the response table**, the same seven are visible columns by default, and the other auto-captured fields are real columns that start hidden and can be switched on from the column settings. `responseId`, `surveyId`, `finished`, `language`, `durationSeconds`, `startedAt` and `finishedAt` are not listed as fields on either surface, because the card header and the table's own fixed columns already show them.
+
+**In exports**, the column set is derived from the catalog rather than from whatever the first response happened to carry, so it is stable for the survey: every response gets every column, and absent values export as empty. `Response ID`, `Survey ID`, `Finished` and the timestamp already have fixed basic columns, so they are not repeated. Anonymized surveys omit the columns they never capture, and `Ip Address` is only a column when the survey captures it.
+
+<Note>
+  Export headers are Title Case renderings of the field name (`Page Path`, `Utm Source`) and are deliberately
+  **not** localized, so a download has the same column names whoever clicks it.
+</Note>

--- a/docs/surveys/embedded-data/set-embedded-data.mdx
+++ b/docs/surveys/embedded-data/set-embedded-data.mdx
@@ -141,7 +141,9 @@ Keys land on a response only if the survey declares them as ingested Embedded Da
 
 The older `formbricks.track("action", { hiddenFields: { … } })` form still works and still wins. An explicit per-trigger value beats the ambient bag for the same field, whatever the casing on either side, so migrating one call site at a time is safe.
 
-<Note>
-  npm users need `@formbricks/js` at a version that proxies `setEmbeddedData` / `clearEmbeddedData` through
-  to the SDK. Loading the script directly from `/js/formbricks.umd.cjs` always has them.
-</Note>
+<Warning>
+  **The npm wrapper does not have this yet.** `@formbricks/js` proxies the SDK's methods explicitly, and
+  `setEmbeddedData` / `clearEmbeddedData` are not in its current release — they arrive in a later one. Loading
+  the script directly from your Formbricks instance (`/js/formbricks.umd.cjs`) has them as soon as the
+  instance is updated, because that bundle is served rather than installed.
+</Warning>

--- a/docs/surveys/embedded-data/set-embedded-data.mdx
+++ b/docs/surveys/embedded-data/set-embedded-data.mdx
@@ -141,9 +141,9 @@ Keys land on a response only if the survey declares them as ingested Embedded Da
 
 The older `formbricks.track("action", { hiddenFields: { … } })` form still works and still wins. An explicit per-trigger value beats the ambient bag for the same field, whatever the casing on either side, so migrating one call site at a time is safe.
 
-<Warning>
-  **The npm wrapper does not have this yet.** `@formbricks/js` proxies the SDK's methods explicitly, and
-  `setEmbeddedData` / `clearEmbeddedData` are not in its current release — they arrive in a later one. Loading
-  the script directly from your Formbricks instance (`/js/formbricks.umd.cjs`) has them as soon as the
-  instance is updated, because that bundle is served rather than installed.
-</Warning>
+<Note>
+  Two ways to load the SDK, two ways to pick this up. The script served by your Formbricks instance
+  (`/js/formbricks.umd.cjs`) carries it as soon as the instance is updated, because that bundle is served
+  rather than installed. The npm package proxies the SDK's methods explicitly, so there you get it by bumping
+  `@formbricks/js`.
+</Note>

--- a/docs/surveys/embedded-data/set-embedded-data.mdx
+++ b/docs/surveys/embedded-data/set-embedded-data.mdx
@@ -1,0 +1,144 @@
+---
+title: "setEmbeddedData"
+description: "Attach context from your app to the next Formbricks response, without tying it to a trigger. The JavaScript SDK reference for setEmbeddedData and clearEmbeddedData."
+icon: "code"
+---
+
+In an app survey the integrator usually does not know which action will open a survey: your app fires a dozen of them and Formbricks decides. Passing context on `track()` therefore means repeating the same values on every possible call.
+
+`setEmbeddedData()` decouples the two. You push context whenever you have it, and whichever survey is displayed next picks it up.
+
+```js
+formbricks.setEmbeddedData({ pageType: "product", plan: "pro" });
+```
+
+<Note>
+  This is for **website & app surveys** only, where the JavaScript SDK runs. Link surveys have no SDK on the
+  page and are filled from [URL parameters](/surveys/general-features/hidden-fields#set-hidden-field-via-url)
+  instead. For React Native, iOS, Android and Flutter see [Mobile SDKs](/surveys/embedded-data/mobile-sdks).
+</Note>
+
+## What It Writes
+
+The bag reaches a response only through the survey's **declared ingested fields**, which are the entries in the survey editor's Hidden Fields card. A key nothing declares is dropped and logged; so is a key naming a variable, a reserved field or a locked field. Nothing here is ever fatal, and a rejected key never blocks a response.
+
+That means the workflow is always: declare the field on the survey first, then push a value under the same name.
+
+Values are scoped to the response. They are **never** written to the contact record, so this is not a back door into contact attributes.
+
+## Merge Semantics
+
+`setEmbeddedData()` merges into the current bag rather than replacing it, and per key the last write wins:
+
+```js
+formbricks.setEmbeddedData({ plan: "pro", pageType: "product" });
+formbricks.setEmbeddedData({ pageType: "checkout" });
+// bag is now { plan: "pro", pageType: "checkout" }
+```
+
+That is what lets you set stable fields once and refresh volatile ones as the user moves, without the second call wiping the first.
+
+### `null` Removes, `undefined` Does Nothing
+
+The two are deliberately different, and the difference is the whole reason the "pass every field unconditionally" idiom is safe:
+
+```js
+formbricks.setEmbeddedData({ pageType: null });      // removes pageType
+formbricks.setEmbeddedData({ pageType: undefined }); // no-op — pageType keeps its value
+```
+
+A tag manager or a shared helper typically reads keys off a data layer and passes all of them on every page. On a page where `pageType` does not exist the key arrives as `undefined`, and it must not clear the value the previous page set. So `undefined` is a documented no-op, not an accident.
+
+### Accepted Values
+
+`string`, `number`, `boolean` and `Date`, plus `null` to remove a key and `undefined` to skip it. Dates are serialized as ISO 8601, which is what a `date` field accepts.
+
+Anything else is refused rather than mangled. Passing a primitive, an array or a missing object logs an error and writes nothing, so `setEmbeddedData(dataLayerObj)` on a page where that object does not exist is a survivable mistake rather than a broken tag. Arrays in particular would otherwise spread into junk numeric keys.
+
+## Clearing
+
+```js
+formbricks.clearEmbeddedData("pageType"); // remove one key
+formbricks.clearEmbeddedData();           // clear the whole bag
+```
+
+Only a literal zero-argument call clears everything. `clearEmbeddedData(someValue)` where `someValue` turned out to be `undefined` is a logged no-op, for the same reason as above: code that reads the key name from its own state must not wipe the bag when that state is empty.
+
+## Lifetime
+
+<Steps>
+  <Step title="In memory, never persisted">
+    The bag lives in SDK memory for the page load. It is not written to `localStorage`, so a full page load
+    starts empty and your app re-pushes. A classic multi-page app does that for free on every navigation.
+  </Step>
+
+  <Step title="Snapshot at display, then frozen">
+    When a survey is shown, the bag is copied onto it. A `setEmbeddedData()` call made while that survey is
+    on screen reaches the **next** response, never the one being answered.
+  </Step>
+
+  <Step title="Cleared on an identity switch">
+    Calling `formbricks.logout()`, or `formbricks.setUserId()` with a **different** id, clears the bag: one
+    user's context must not ride onto the next user's responses on a shared device. Identifying for the first
+    time keeps the bag, because pushing context before you know who the user is is a legitimate order.
+  </Step>
+</Steps>
+
+## Stable vs. Volatile Fields
+
+Two patterns, and mixing them up is the one failure mode worth designing against.
+
+**Stable** context (`plan`, `role`, `accountType`) changes rarely. Set it once after setup and let the next page load re-push it.
+
+**Volatile** context (`pageType`, `screen`, `channel`) is only true for the page you are on. In a single-page app one page load spans many routes, so nothing re-pushes on your behalf and a value set on `/pricing` is still in the bag when a survey opens on `/settings`.
+
+```js
+// Call this from your router's navigation hook
+function onRouteChange(route) {
+  // `null` clears the key when the new route has no page type,
+  // so the previous route's value cannot leak onto the next response
+  formbricks.setEmbeddedData({ pageType: route.pageType ?? null });
+  formbricks.registerRouteChange();
+}
+```
+
+Setting the key to `null` when the new route has no page type is what stops the previous route's value from leaking. `setEmbeddedData()` is a synchronous memory write with no network call, so doing this on every route change costs nothing.
+
+## Calling It Before Setup
+
+`setEmbeddedData()` is synchronous and does not go through the SDK's command queue, so a call made before `setup()` finishes is kept rather than dropped. What it does need is for the SDK **script** to have loaded, since `window.formbricks` does not exist before that.
+
+If your code cannot guarantee the script is there — a tag that fires on page load, or a setup deliberately delayed until a consent banner resolves — subscribe to the readiness event instead of polling for the global:
+
+```js
+formbricks.on("formbricks_setup_successful", () => {
+  formbricks.setEmbeddedData({ plan: currentUser.plan });
+});
+```
+
+See [Lifecycle Events](/surveys/website-app-surveys/lifecycle-events) for the full list of events and the subscription API. In Google Tag Manager the equivalent is a Custom Event trigger on `formbricks_setup_successful`; see [Google Tag Manager](/surveys/website-app-surveys/google-tag-manager#set-embedded-data).
+
+## Checking What Is in the Bag
+
+The bag is invisible: it is memory, so there is nothing in devtools storage, and the API has no getter. Add `?formbricksDebug=true` to your URL and every write prints:
+
+```text
+setEmbeddedData: set [pageType], removed [plan] — the bag now holds [pageType, accountType].
+Keys land on a response only if the survey declares them as ingested Embedded Data fields.
+```
+
+`clearEmbeddedData()` traces too, including the "that key was not in the bag" case, which is usually the answer to "why is my value not there".
+
+<Note>
+  The trace prints **keys only, never values**, and only at debug level, so a respondent's console stays
+  clean and nothing you pushed is echoed into it.
+</Note>
+
+## Precedence Against `track()`
+
+The older `formbricks.track("action", { hiddenFields: { … } })` form still works and still wins. An explicit per-trigger value beats the ambient bag for the same field, whatever the casing on either side, so migrating one call site at a time is safe.
+
+<Note>
+  npm users need `@formbricks/js` at a version that proxies `setEmbeddedData` / `clearEmbeddedData` through
+  to the SDK. Loading the script directly from `/js/formbricks.umd.cjs` always has them.
+</Note>

--- a/docs/surveys/embedded-data/set-embedded-data.mdx
+++ b/docs/surveys/embedded-data/set-embedded-data.mdx
@@ -6,7 +6,7 @@ icon: "code"
 
 In an app survey the integrator usually does not know which action will open a survey: your app fires a dozen of them and Formbricks decides. Passing context on `track()` therefore means repeating the same values on every possible call.
 
-`setEmbeddedData()` decouples the two. You push context whenever you have it, and whichever survey is displayed next picks it up.
+`setEmbeddedData()` decouples the two. You push context whenever you have it, and every survey displayed from then on picks it up — until you remove the key, or the page loads again.
 
 ```js
 formbricks.setEmbeddedData({ pageType: "product", plan: "pro" });

--- a/docs/surveys/embedded-data/set-embedded-data.mdx
+++ b/docs/surveys/embedded-data/set-embedded-data.mdx
@@ -106,17 +106,20 @@ Setting the key to `null` when the new route has no page type is what stops the 
 
 ## Calling It Before Setup
 
-`setEmbeddedData()` is synchronous and does not go through the SDK's command queue, so a call made before `setup()` finishes is kept rather than dropped. What it does need is for the SDK **script** to have loaded, since `window.formbricks` does not exist before that.
+`setEmbeddedData()` is synchronous and does not go through the SDK's command queue, so a call made before `setup()` finishes is kept rather than dropped. Two things do have to be true first, and they have different answers.
 
-If your code cannot guarantee the script is there — a tag that fires on page load, or a setup deliberately delayed until a consent banner resolves — subscribe to the readiness event instead of polling for the global:
+**The script must have loaded.** `window.formbricks` does not exist until then, and neither does anything on it — `setEmbeddedData` and `on` alike. Push your context from the script tag's own `onload`, or from a Google Tag Manager tag: the dataLayer buffers across load order, so a GTM trigger cannot be too early. Do not poll for the global.
+
+**`setup()` may be delayed, and that is what the readiness event is for.** When the script has loaded but `setup()` waits on something like a consent banner, subscribe first and push when it resolves:
 
 ```js
+// the script has loaded; setup() has not been called yet
 formbricks.on("formbricks_setup_successful", () => {
   formbricks.setEmbeddedData({ plan: currentUser.plan });
 });
 ```
 
-See [Lifecycle Events](/surveys/website-app-surveys/lifecycle-events) for the full list of events and the subscription API. In Google Tag Manager the equivalent is a Custom Event trigger on `formbricks_setup_successful`; see [Google Tag Manager](/surveys/website-app-surveys/google-tag-manager#set-embedded-data).
+The order matters. Events are delivered live rather than replayed, so a handler registered after `setup()` has already finished never fires and logs nothing. See [Lifecycle Events](/surveys/website-app-surveys/lifecycle-events) for the full list and the subscription API, and [Google Tag Manager](/surveys/website-app-surveys/google-tag-manager#set-embedded-data) for the tag-manager wiring.
 
 ## Checking What Is in the Bag
 

--- a/docs/surveys/general-features/hidden-fields.mdx
+++ b/docs/surveys/general-features/hidden-fields.mdx
@@ -4,6 +4,12 @@ description: "Add data to a submission without asking the user to type it in. Th
 icon: "eye-slash"
 ---
 
+<Note>
+  Hidden fields are the **ingested** half of [Embedded Data](/surveys/embedded-data/overview) — the values
+  that arrive from outside the survey. Nothing renames and nothing changes for surveys you already run; see
+  [Hidden Fields & Variables](/surveys/embedded-data/migration) for what is new around them.
+</Note>
+
 ## How to Add Hidden Fields
 
 ### Enable Hidden Fields
@@ -52,11 +58,17 @@ https://formbricks.com/s/clin34bjy?screen=landing_page&job=Founder
 
 ## Set Hidden Fields via SDK
 
-<Note>
-  We are reworking how to add Hidden Fields via SDK moving away from binding them to Actions over to Context.
-  Until then, we will **continue to support the current approach for the JS SDK**. However, we don't support
-  Hidden Fields for the Android and iOS SDKs.
-</Note>
+Attach the values once, and whichever survey is displayed next picks them up:
+
+```js
+formbricks.setEmbeddedData({ my_field: "value" });
+```
+
+This works in the JavaScript SDK and in the React Native, iOS, Android and Flutter SDKs. See
+[`setEmbeddedData`](/surveys/embedded-data/set-embedded-data) for merge and clearing semantics, and
+[Mobile SDKs](/surveys/embedded-data/mobile-sdks) for the mobile call syntax.
+
+The older per-trigger form still works, and an explicit value there still wins over an ambient one:
 
 ```js
 formbricks.track("action_name", { hiddenFields: { my_field: "value" } });

--- a/docs/surveys/general-features/hidden-fields.mdx
+++ b/docs/surveys/general-features/hidden-fields.mdx
@@ -58,7 +58,7 @@ https://formbricks.com/s/clin34bjy?screen=landing_page&job=Founder
 
 ## Set Hidden Fields via SDK
 
-Attach the values once, and whichever survey is displayed next picks them up:
+Attach the values once and every survey displayed afterwards picks them up, until you remove the key or the page reloads:
 
 ```js
 formbricks.setEmbeddedData({ my_field: "value" });

--- a/docs/surveys/general-features/metadata.mdx
+++ b/docs/surveys/general-features/metadata.mdx
@@ -23,11 +23,13 @@ icon: "user"
 - **Action**: The action that triggered the survey. This is only available for App surveys.
 
 <Note>
-  These seven are the ones shown by default. Formbricks captures more than twenty auto-captured fields on
-  every response, including the page path, the campaign parameters, the screen and viewport size, the time
-  zone and the device locale. They are behind a disclosure on the response card and as switchable columns in
-  the response table. See [Reserved Fields](/surveys/embedded-data/reserved-fields) for the full catalog and
-  for what the **Anonymize responses** toggle suppresses.
+  These seven are the ones shown by default. Formbricks captures more than twenty auto-captured fields
+  in total, including the page path, the campaign parameters, the screen and viewport size, the time zone
+  and the device locale. They are behind a disclosure on the response card and as switchable columns in the
+  response table. Which of them actually land depends on the survey type and its settings — a mobile app
+  survey has no host page, so it records nothing for the page and campaign fields. See [Reserved
+  Fields](/surveys/embedded-data/reserved-fields) for the full catalog, what each survey type captures, and
+  what the **Anonymize responses** toggle suppresses.
 </Note>
 
 ## View Response Metadata

--- a/docs/surveys/general-features/metadata.mdx
+++ b/docs/surveys/general-features/metadata.mdx
@@ -22,6 +22,14 @@ icon: "user"
 
 - **Action**: The action that triggered the survey. This is only available for App surveys.
 
+<Note>
+  These seven are the ones shown by default. Formbricks captures more than twenty auto-captured fields on
+  every response, including the page path, the campaign parameters, the screen and viewport size, the time
+  zone and the device locale. They are behind a disclosure on the response card and as switchable columns in
+  the response table. See [Reserved Fields](/surveys/embedded-data/reserved-fields) for the full catalog and
+  for what the **Anonymize responses** toggle suppresses.
+</Note>
+
 ## View Response Metadata
 
 1. Go to the Responses tab of your survey.

--- a/docs/surveys/general-features/variables.mdx
+++ b/docs/surveys/general-features/variables.mdx
@@ -4,6 +4,12 @@ description: "Variables are a powerful feature in Formbricks that allows you to 
 icon: "x"
 ---
 
+<Note>
+  Variables are the **computed** half of [Embedded Data](/surveys/embedded-data/overview) — the values the
+  survey works out for itself while the respondent answers. Nothing renames; see [Hidden Fields &
+  Variables](/surveys/embedded-data/migration) for what is new around them.
+</Note>
+
 ## Types of Variables
 
 There are two types of variables you can add to your survey:

--- a/docs/surveys/website-app-surveys/framework-guides.mdx
+++ b/docs/surveys/website-app-surveys/framework-guides.mdx
@@ -344,6 +344,21 @@ export default function App() {
 | workspaceId    | string | Formbricks Workspace ID.               |
 | appUrl         | string | URL of the hosted Formbricks instance. |
 
+Drive the SDK through its named exports from anywhere:
+
+```javascript
+import { track, setUserId, setAttributes, setEmbeddedData, logout } from "@formbricks/react-native";
+
+await track("button_clicked");
+await setUserId("user_123");
+setEmbeddedData({ screen: "checkout", plan: "pro" });
+```
+
+<Note>
+  `setEmbeddedData` attaches context to whichever survey is displayed next, without tying it to a trigger.
+  See [Mobile SDKs](/surveys/embedded-data/mobile-sdks) for the full Embedded Data reference.
+</Note>
+
 Now, visit the [Validate Your Setup](#validate-your-setup) section to verify your setup!
 
 ## Swift
@@ -414,14 +429,23 @@ Formbricks.setAttributes([
 // 6. Change language (no userId required):
 Formbricks.setLanguage("de")
 
-// 7. Log out (no userId required):
+// 7. Attach Embedded Data to future responses
+Formbricks.setEmbeddedData(["screen": "checkout", "plan": "pro"])
+
+// 8. Log out (no userId required):
 Formbricks.logout()
 
-// 8. Clean up SDK state (optional):
+// 9. Clean up SDK state (optional):
 Formbricks.cleanup(waitForOperations: true) {
     print("SDK torn down")
 }
 ```
+
+<Note>
+  `setEmbeddedData` attaches context to whichever survey is displayed next, without tying it to a trigger.
+  See [Mobile SDKs](/surveys/embedded-data/mobile-sdks) for the value types and for the `nil` caveat that is
+  specific to Swift.
+</Note>
 
 ### Required Customizations
 
@@ -493,9 +517,20 @@ Formbricks.setAttributes(mapOf(Pair("attr1", "val1"), Pair("attr2", "val2")))
 // 6. Change language (no userId required):
 Formbricks.setLanguage("de")
 
-// 7. Log out:
+// 7. Attach Embedded Data to future responses
+Formbricks.setEmbeddedData(mapOf(
+  "screen" to EmbeddedDataValue.string("checkout"),
+  "plan" to EmbeddedDataValue.string("pro")
+))
+
+// 8. Log out:
 Formbricks.logout()
 ```
+
+<Note>
+  `setEmbeddedData` attaches context to whichever survey is displayed next, without tying it to a trigger.
+  See [Mobile SDKs](/surveys/embedded-data/mobile-sdks) for the value types and clearing semantics.
+</Note>
 
 ### Required Customizations
 
@@ -561,7 +596,10 @@ await Formbricks.setAttributes({"plan": "pro", "mrr": 99, "signup_date": DateTim
 // 4. Set the survey language.
 await Formbricks.setLanguage("de");
 
-// 5. Reset to an anonymous session on sign-out.
+// 5. Attach Embedded Data to future responses (synchronous, no queue).
+Formbricks.setEmbeddedData({"screen": "checkout", "plan": "pro"});
+
+// 6. Reset to an anonymous session on sign-out.
 await Formbricks.logout();
 ```
 
@@ -580,6 +618,8 @@ await Formbricks.logout();
 | `Formbricks.setAttribute(String key, Object value)` | Set one attribute (`String` / `num` / `DateTime`).                       |
 | `Formbricks.setAttributes(Map<String, Object>)`     | Set several attributes at once.                                          |
 | `Formbricks.setLanguage(String language)`           | Set the survey language.                                                 |
+| `Formbricks.setEmbeddedData(Map<String, Object?>)`  | Attach [Embedded Data](/surveys/embedded-data/mobile-sdks) to future responses. Synchronous. |
+| `Formbricks.clearEmbeddedData('key')`               | Remove one Embedded Data key. With no argument, clears all of them.      |
 | `Formbricks.logout()`                               | Reset to an anonymous session.                                           |
 
 Attribute keys must be lowercase letters, numbers, and underscores, and start with a letter. `DateTime` values are sent as UTC ISO-8601 strings; numbers stay numbers. Identity and attribute changes are debounced (~500 ms) and coalesced into a single backend request.

--- a/docs/surveys/website-app-surveys/framework-guides.mdx
+++ b/docs/surveys/website-app-surveys/framework-guides.mdx
@@ -604,7 +604,7 @@ await Formbricks.logout();
 ```
 
 <Note>
-  Prefer to initialize before any UI mounts? Call `Formbricks.setup(appUrl: ..., workspaceId: ...)` directly — the widget still needs to be in the tree to render surveys, but it won't re-run setup (setup is idempotent). All static methods are sequenced through an internal command queue, so calls run in submission order and return a `Future<Result<void, FormbricksError>>`.
+  Prefer to initialize before any UI mounts? Call `Formbricks.setup(appUrl: ..., workspaceId: ...)` directly — the widget still needs to be in the tree to render surveys, but it won't re-run setup (setup is idempotent). `setup`, `track`, `setUserId`, `setAttribute`, `setAttributes`, `setLanguage` and `logout` are sequenced through an internal command queue, so they run in submission order and return a `Future<Result<void, FormbricksError>>`. `setEmbeddedData` and `clearEmbeddedData` are the exceptions: they are synchronous and return `void`, so a context push at launch is not dropped while setup is still running.
 </Note>
 
 ### Public API

--- a/docs/surveys/website-app-surveys/google-tag-manager.mdx
+++ b/docs/surveys/website-app-surveys/google-tag-manager.mdx
@@ -247,7 +247,7 @@ window.dataLayer.push({
 
 ## Set Embedded Data
 
-`setEmbeddedData()` attaches context to whichever survey is displayed next, without tying it to a trigger. It is the GTM-native way to get a page type, a plan or a campaign onto a response. Read the [full reference](/surveys/embedded-data/set-embedded-data) for the semantics; this is the tag manager wiring.
+`setEmbeddedData()` attaches context to the surveys displayed after it, without tying it to a trigger. A value stays in the bag for the rest of the page load, so it reaches every survey shown from then on until you remove the key. It is the GTM-native way to get a page type, a plan or a campaign onto a response. Read the [full reference](/surveys/embedded-data/set-embedded-data) for the semantics; this is the tag manager wiring.
 
 <Steps>
   <Step title="Declare the fields on the survey">
@@ -276,8 +276,12 @@ if (window.formbricks) {
   </Step>
 
   <Step title="Trigger it">
-    On **All Pages**, plus `formbricks_setup_successful` if your `setup()` is delayed behind a consent
-    banner. The tag is safe to fire more than once: each call merges into the bag rather than replacing it.
+    Attach **two** triggers: **All Pages**, and a Custom Event trigger on `formbricks_setup_successful`.
+
+    Both are needed. The SDK script loads asynchronously, so on an ordinary page load the All Pages trigger
+    can run before `window.formbricks` exists — the tag returns having set nothing. The readiness trigger
+    covers that, and All Pages covers the pushes that happen once the SDK is already running. The tag is
+    safe to fire more than once: each call merges into the bag rather than replacing it.
   </Step>
 </Steps>
 
@@ -290,7 +294,8 @@ if (window.formbricks) {
 <Warning>
   On a single-page app, one page load spans many routes and nothing re-pushes for you, so a `pageType` set on
   the pricing page is still in the bag when a survey opens somewhere else. Fire the tag on your app's own
-  route-change event as well, and push `null` for keys the new route has no value for.
+  route-change event as well, and push `null` for keys the new route has no value for. See
+  [Clearing](/surveys/embedded-data/set-embedded-data#clearing) for removing one key or the whole bag.
 </Warning>
 
 ## Troubleshooting

--- a/docs/surveys/website-app-surveys/google-tag-manager.mdx
+++ b/docs/surveys/website-app-surveys/google-tag-manager.mdx
@@ -69,13 +69,15 @@ icon: "tags"
 
 The SDK pushes its own lifecycle events to `window.dataLayer`, so you can trigger GTM tags off what Formbricks actually did rather than guessing at timing.
 
-| Event                           | Fires when                                                                | Payload                             |
-| ------------------------------- | ------------------------------------------------------------------------- | ----------------------------------- |
-| `formbricks_setup_successful`   | `setup()` finished, so `window.formbricks` is ready to use                | `{ workspaceId }`                   |
-| `formbricks_action_tracked`     | An action was tracked (code or no-code)                                   | `{ action }`                        |
-| `formbricks_survey_shown`       | A survey became visible                                                   | `{ surveyId }`                      |
-| `formbricks_response_submitted` | The first answer is stored (`finished: false`) and again when it completes | `{ surveyId, responseId, finished }` |
-| `formbricks_survey_closed`      | The survey was dismissed or finished                                      | `{ surveyId }`                      |
+| Event                           | Fires when                                                                | Payload                              |
+| ------------------------------- | ------------------------------------------------------------------------- | ------------------------------------ |
+| `formbricks_setup_successful`   | `setup()` finished — the SDK is ready                                     | `{ workspaceId }`                    |
+| `formbricks_action_tracked`     | An action was tracked (code or no-code)                                   | `{ action }`                         |
+| `formbricks_survey_shown`       | A survey became visible (once per appearance)                             | `{ surveyId }`                       |
+| `formbricks_response_submitted` | The first answer is stored (`finished: false`) and again when it completes | `{ surveyId, responseId?, finished }` |
+| `formbricks_survey_closed`      | The survey was dismissed or finished (once per appearance)                | `{ surveyId }`                       |
+
+`formbricks_survey_shown` reports what the respondent saw, so every appearance is paired with a `formbricks_survey_closed`. The Displays number in your Formbricks dashboard counts what reached the server instead, so it can be lower if the network dropped — worth knowing before you reconcile a GTM-side count against the dashboard.
 
 The push happens through the standard `window.dataLayer = window.dataLayer || []` idiom, so it survives load order: events emitted before GTM loads are still in the array when GTM drains it.
 
@@ -101,7 +103,9 @@ The push happens through the standard `window.dataLayer = window.dataLayer || []
 <Note>
   Every push carries the full set of keys, with `null` for the ones that event does not set. That is
   deliberate: GTM merges pushes recursively, so a partial push would let survey A's `responseId` still resolve
-  under survey B's `formbricks_survey_shown`. Check for `null` rather than assuming a key is absent.
+  under survey B's `formbricks_survey_shown`. Check for `null` rather than assuming a key is absent — and note
+  that `responseId` is optional on `formbricks_response_submitted` itself, so it reads `null` there too
+  whenever the stored id is not available. A tag that needs the id has to tolerate that.
 </Note>
 
 For the JavaScript equivalent of these events, see [Lifecycle Events](/surveys/website-app-surveys/lifecycle-events).

--- a/docs/surveys/website-app-surveys/google-tag-manager.mdx
+++ b/docs/surveys/website-app-surveys/google-tag-manager.mdx
@@ -65,6 +65,47 @@ icon: "tags"
 </Steps>
 
 
+## Formbricks Events in the Data Layer
+
+The SDK pushes its own lifecycle events to `window.dataLayer`, so you can trigger GTM tags off what Formbricks actually did rather than guessing at timing.
+
+| Event                           | Fires when                                                                | Payload                             |
+| ------------------------------- | ------------------------------------------------------------------------- | ----------------------------------- |
+| `formbricks_setup_successful`   | `setup()` finished, so `window.formbricks` is ready to use                | `{ workspaceId }`                   |
+| `formbricks_action_tracked`     | An action was tracked (code or no-code)                                   | `{ action }`                        |
+| `formbricks_survey_shown`       | A survey became visible                                                   | `{ surveyId }`                      |
+| `formbricks_response_submitted` | The first answer is stored (`finished: false`) and again when it completes | `{ surveyId, responseId, finished }` |
+| `formbricks_survey_closed`      | The survey was dismissed or finished                                      | `{ surveyId }`                      |
+
+The push happens through the standard `window.dataLayer = window.dataLayer || []` idiom, so it survives load order: events emitted before GTM loads are still in the array when GTM drains it.
+
+<Steps>
+  <Step title="Create a Custom Event trigger">
+    1. Triggers → New → Trigger Type: **Custom Event**
+    2. Event name: the event you want, e.g. `formbricks_setup_successful`
+    3. Save and publish
+  </Step>
+
+  <Step title="Read the payload with a Data Layer Variable">
+    The payload is nested under a `formbricks` key rather than spread flat, so it cannot collide with your
+    own data layer keys — `action` in particular is one of the most common keys in an ecommerce data layer.
+
+    1. Variables → New User-defined Variable
+    2. Variable Type: **Data Layer Variable**
+    3. Data Layer Variable Name: `formbricks.surveyId` (or `formbricks.responseId`, `formbricks.finished`,
+       `formbricks.action`, `formbricks.workspaceId`)
+    4. Save and publish
+  </Step>
+</Steps>
+
+<Note>
+  Every push carries the full set of keys, with `null` for the ones that event does not set. That is
+  deliberate: GTM merges pushes recursively, so a partial push would let survey A's `responseId` still resolve
+  under survey B's `formbricks_survey_shown`. Check for `null` rather than assuming a key is absent.
+</Note>
+
+For the JavaScript equivalent of these events, see [Lifecycle Events](/surveys/website-app-surveys/lifecycle-events).
+
 ## User Identification
 
 Identify users to enable targeting and attributes. Learn more about [user identification](/surveys/website-app-surveys/user-identification).
@@ -92,38 +133,34 @@ Identify users to enable targeting and attributes. Learn more about [user identi
 ```html
 <script>
 (function() {
-    var check = setInterval(function() {
-        if (window.formbricks && window.formbricks.setUserId) {
-            clearInterval(check);
-            var userId = {{User ID}};
-            if (userId) {
-                window.formbricks.setUserId(userId);
-                var attrs = {};
-                if ({{User Email}}) attrs.email = {{User Email}};
-                if ({{User Plan}}) attrs.plan = {{User Plan}};
-                if (Object.keys(attrs).length) {
-                    window.formbricks.setAttributes(attrs);
-                }
-            }
-        }
-    }, 100);
-    setTimeout(function() { clearInterval(check); }, 10000);
+    if (!window.formbricks) return;
+    var userId = {{User ID}};
+    if (!userId) return;
+    window.formbricks.setUserId(userId);
+    var attrs = {};
+    if ({{User Email}}) attrs.email = {{User Email}};
+    if ({{User Plan}}) attrs.plan = {{User Plan}};
+    if (Object.keys(attrs).length) {
+        window.formbricks.setAttributes(attrs);
+    }
 })();
 </script>
 ```
 
   </Step>
 
-  <Step title="Set trigger and push data">
-    1. Create a custom event trigger in GTM
-    2. Trigger Type: Custom Event
-    3. Event name: `user-login` (or your preferred event name)
-    4. Attach this trigger to your "Formbricks - User" tag
-    5. Save and publish
+  <Step title="Set triggers and push data">
+    Attach **two** Custom Event triggers to the "Formbricks - User" tag, so it runs whichever of the two
+    things happens last:
+
+    1. `user-login` — your own event, for a user who signs in after Formbricks is already running.
+    2. `formbricks_setup_successful` — the SDK's readiness event, for a user who was already signed in when
+       the page loaded. GTM's data layer is a merged model, so `{{User ID}}` still resolves to what your
+       earlier `user-login` push set.
 
     ![User Login Trigger](/images/surveys/website-app-surveys/google-tag-manager/user-login-trigger.webp)
 
-    6. In your code, push data with the same event name:
+    3. In your code, push data with the same event name:
 
 ```javascript
 window.dataLayer = window.dataLayer || [];
@@ -137,6 +174,18 @@ window.dataLayer.push({
 
   </Step>
 </Steps>
+
+<Note>
+  Both guards in the tag are cheap and both matter: `window.formbricks` may not exist yet on the `user-login`
+  path, and `{{User ID}}` may not be set yet on the `formbricks_setup_successful` path. Whichever fires
+  second does the work.
+</Note>
+
+<Tip>
+  Earlier versions of this guide polled for `window.formbricks` every 100 ms. Use the
+  `formbricks_setup_successful` trigger instead: it is exactly the signal the polling was approximating, it
+  fires once, and it cannot time out on a slow connection.
+</Tip>
 
 ## Track Custom Events
 
@@ -196,6 +245,54 @@ window.dataLayer.push({
   </Step>
 </Steps>
 
+## Set Embedded Data
+
+`setEmbeddedData()` attaches context to whichever survey is displayed next, without tying it to a trigger. It is the GTM-native way to get a page type, a plan or a campaign onto a response. Read the [full reference](/surveys/embedded-data/set-embedded-data) for the semantics; this is the tag manager wiring.
+
+<Steps>
+  <Step title="Declare the fields on the survey">
+    In the Formbricks editor, add a **Hidden Field** for every key you intend to push. A key no survey
+    declares is dropped and logged, never stored.
+  </Step>
+
+  <Step title="Create Data Layer Variables for your values">
+    One per key, e.g. a Data Layer Variable reading `pageType`, and another reading `plan`.
+  </Step>
+
+  <Step title="Create the tag">
+    New Custom HTML tag named "Formbricks - Embedded Data":
+
+```html
+<script>
+if (window.formbricks) {
+    window.formbricks.setEmbeddedData({
+        pageType: {{Page Type}},
+        plan: {{User Plan}}
+    });
+}
+</script>
+```
+
+  </Step>
+
+  <Step title="Trigger it">
+    On **All Pages**, plus `formbricks_setup_successful` if your `setup()` is delayed behind a consent
+    banner. The tag is safe to fire more than once: each call merges into the bag rather than replacing it.
+  </Step>
+</Steps>
+
+<Note>
+  Passing every key unconditionally is the intended idiom here. A variable that resolves to `undefined` on
+  the current page is **skipped**, so it cannot clear the value another page set. Push `null` when you
+  actually want to remove a key.
+</Note>
+
+<Warning>
+  On a single-page app, one page load spans many routes and nothing re-pushes for you, so a `pageType` set on
+  the pricing page is still in the bag when a survey opens somewhere else. Fire the tag on your app's own
+  route-change event as well, and push `null` for keys the new route has no value for.
+</Warning>
+
 ## Troubleshooting
 
 **Surveys not showing?**
@@ -207,12 +304,17 @@ window.dataLayer.push({
 **User ID not working?**
 - Verify Data Layer push syntax
 - Check GTM variables are reading correct values
-- Ensure user tag fires after initialization
+- Make sure the tag is also triggered by `formbricks_setup_successful`, so it runs whichever of "user logged in" and "SDK ready" happens last
 
 **Events not tracking?**
 - Confirm `window.formbricks` exists before calling track
 - Match event names exactly with Formbricks action names
-- Check timing - Formbricks must be initialized first
+- Check timing - Formbricks must be initialized first. Trigger on `formbricks_setup_successful` rather than polling for the global
+
+**Embedded Data not on the response?**
+- Confirm the survey declares a **Hidden Field** with exactly that name
+- Add `?formbricksDebug=true` to the URL: every `setEmbeddedData` call prints the keys it set and what the bag now holds
+- Remember the bag is snapshotted when the survey is displayed, so a value pushed after that lands on the next response
 
 ## Need Help?
 
@@ -220,4 +322,6 @@ window.dataLayer.push({
 - [Framework Guides](/surveys/website-app-surveys/framework-guides)
 - [Actions](/surveys/website-app-surveys/actions)
 - [User Identification](/surveys/website-app-surveys/user-identification)
+- [Embedded Data](/surveys/embedded-data/overview)
+- [setEmbeddedData](/surveys/embedded-data/set-embedded-data)
 


### PR DESCRIPTION
Fixes ENG-1849

## What & why

**Was:** Embedded Data had no documentation. Hidden fields were described as untyped strings that the mobile SDKs did not support, the metadata page listed 7 of the 28 auto-captured fields, and the GTM guide told integrators to poll `window.formbricks` every 100 ms.

**Now:** Five pages under **Surveys → Embedded Data** cover the concept and source matrix, the reserved-field catalog, `setEmbeddedData` on JS and on all four mobile SDKs, and what changes for existing hidden-field and variable users. GTM triggers on `formbricks_setup_successful` instead of polling.

- Anonymize is stated as **"no direct identifiers", not "not re-identifiable"**: the viewport/timezone/locale set it keeps is a finer fingerprint than the `browser` it drops.
- Field types are documented as they are today (`string`), not as the model allows — typing, defaults and `locked` arrive with the manager.

## Where to look

- [reserved-fields.mdx L79-104][anon] — the privacy claim customers will rely on
- [set-embedded-data.mdx L107-123][ready] — which precondition each readiness answer solves
- [google-tag-manager.mdx L72-80][gtm] — event table, kept in step with `lifecycle-events.mdx`

[anon]: https://github.com/formbricks/formbricks/blob/6a2cf326/docs/surveys/embedded-data/reserved-fields.mdx#L79-L104
[ready]: https://github.com/formbricks/formbricks/blob/6a2cf326/docs/surveys/embedded-data/set-embedded-data.mdx#L107-L123
[gtm]: https://github.com/formbricks/formbricks/blob/6a2cf326/docs/surveys/website-app-surveys/google-tag-manager.mdx#L72-L80

## Breaking changes

- [ ] This PR contains breaking changes

None. Documentation only; no shipped code changes.

## Migrations & env

- none

## How this was tested

Rerun: `cd docs && npx mint dev` — then open the five pages under Surveys → Embedded Data.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Five new pages render; sidebar group ordered | manual | all 200 in `mint dev`; caught a duplicated sidebar entry and a clipped table |
| Internal links and heading anchors resolve | manual | script over `docs/**/*.mdx` against the base with #9133 merged: clean, `lifecycle-events` included |
| Reserved catalog, Anonymize split, export columns | manual | re-derived from `RESERVED_FIELD_CATALOG`: 5 dropped, 2 query-stripped, 21 kept — matches the page |
| Ingest rules and precedence | manual | read off `applyIngestContract` and `buildDisplayHiddenFields` |
| Mobile call syntax and async-ness, four SDKs | manual | signatures read off each SDK's shipped `main`; Flutter's two sync methods excluded from its queue claim |
| Event table and readiness ordering | manual | diffed against the merged `lifecycle-events.mdx`: same five events, cardinality and `responseId?` |

**Open gaps**

- GTM steps are reasoned from the snippet's `async` flag, not executed against a live container.
- Screenshots come from a local `mint dev`, not a deployed docs preview, and predate `c4b92ed1`.
- The Anonymize framing ("no direct identifiers") is read off the catalog's `privacy` values. ENG-1842 raised whether that is the intended promise; if the answer is "not re-identifiable", the fix is in those values, not here.

**Risks**

- The GTM event table restates the one in `lifecycle-events.mdx`. They agree today; edit them together.

<details>
<summary>Rendered pages (local mint dev, 1440px)</summary>

**Embedded Data** — concept, three sources, source matrix, ingest contract, precedence

![Overview page](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/01-overview.png)

**Reserved Fields** — the catalog, name collisions, Anonymize, where the fields surface

![Reserved Fields page](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/02-reserved-fields.png)

**setEmbeddedData** — merge semantics, lifetime, SPA pattern, readiness, debug trace

![setEmbeddedData page](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/03-set-embedded-data.png)

**Mobile SDKs** — RN / Swift / Kotlin / Dart, value types, WebView auto-capture

![Mobile SDKs page](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/04-mobile-sdks.png)

**Hidden Fields & Variables** — what changes, what does not, the URL warning

![Migration page](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/05-migration.png)

</details>

<details>
<summary>Changed sections, before and after</summary>

| | Before | After |
| --- | --- | --- |
| GTM › User Identification | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/07-gtm-identification-before.png" width="420"> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/07-gtm-identification-after.png" width="420"> |
| Hidden Fields › Set via SDK | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/08-hidden-fields-before.png" width="420"> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/08-hidden-fields-after.png" width="420"> |

New GTM sections, no before:

![GTM data layer events](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/06-gtm-events-after.png)

![GTM Set Embedded Data](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/pr-9137/09-gtm-set-embedded-data-after.png)

</details>

<details>
<summary>Why this is one PR and not five</summary>

The size bot flags ~950 lines. The pages cross-link heavily — the overview's cards, the reserved-field and clearing deep links, the mobile page's pointer back to the JS reference — so a per-page split lands dangling links in every intermediate state and needs the same `docs.json` edit five times. There is no shipped code and no shared file except `docs.json`, so the review risk a split would reduce is not present.

</details>

<details>
<summary>Verification commands</summary>

- Link and anchor check: a script walking every `](/…)` in `docs/**/*.mdx`, resolving the page and, where present, the heading anchor. Run against this branch merged with the current base.
- Merge with the base carrying #9133 (`57c81b9e`): `docs.json` auto-merges, keeping both nav additions; every link resolves and the nav lists `lifecycle-events` plus all five Embedded Data pages.
- Anonymize table re-derived by parsing `RESERVED_FIELD_CATALOG` and grouping the 28 entries by `privacy`.
- `npx prettier --check docs/docs.json` passes. `.mdx` is not prettier-managed here — the existing docs pages fail it too — so nothing was reformatted.

</details>

---

> [!NOTE]
> **AI model used** — `claude-opus-5 (Claude Code 2.1.259)`, reasoning effort `max`.
