### PR TITLE
refactor: extract a shared response-file URL collector [ENG-2547]

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.ts
@@ -6,7 +6,7 @@ import { DatabaseError } from "@formbricks/types/errors";
 import { convertFloatTo2Decimal } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/utils";
 import { getSurvey } from "@/lib/survey/service";
 import { deleteResponseFileUrls } from "@/modules/storage/lib/delete-response-files";
-import { getSurveyFileUploadConfigs } from "@/modules/storage/utils";
+import { collectResponseFileUrls, getSurveyFileUploadElementIds } from "@/modules/storage/utils";
 
 /**
  * Responses are scanned in pages so resetting a survey with a large response count never holds every
@@ -22,9 +22,6 @@ const RESPONSE_FILE_SCAN_PAGE_SIZE = 500;
  * collected.
  */
 const STORAGE_DELETE_CHUNK_SIZE = 100;
-
-/** One response row as the scan below selects it. */
-type ScannedResponseRow = { id: string; createdAt: Date; data: Prisma.JsonValue };
 
 /** Keyset position in the scan: the last row read, ordered by (createdAt, id). */
 type ResponseScanCursor = { createdAt: Date; id: string };
@@ -43,40 +40,15 @@ const afterCursor = (cursor: ResponseScanCursor) => ({
 });
 
 /**
- * Pulls the storage URLs out of one page of scanned responses.
- *
- * Only file-upload answers hold storage URLs, and they are always stored as an array of strings.
- * Anything else under the same key is skipped rather than cast, so malformed data cannot produce a
- * bogus delete target.
- */
-const collectFileUrlsFromPage = (
-  responses: ScannedResponseRow[],
-  fileUploadElementIds: Set<string>
-): string[] => {
-  const fileUrls: string[] = [];
-
-  for (const response of responses) {
-    for (const [elementId, answer] of Object.entries(response.data ?? {})) {
-      if (fileUploadElementIds.has(elementId) && Array.isArray(answer)) {
-        fileUrls.push(...answer.filter((url): url is string => typeof url === "string"));
-      }
-    }
-  }
-
-  return fileUrls;
-};
-
-/**
  * Collects the storage URLs a survey's file-upload answers point at, so they can be deleted once the
  * responses themselves are gone.
  *
  * Must run *before* the responses are deleted: the URLs only exist inside `response.data`, so once the
  * rows are gone there is nothing left to tell storage which objects are now unreferenced.
  *
- * Mirrors the single-response delete path (`findAndDeleteUploadedFilesInResponse` in
- * lib/response/service.ts): the id set comes from the union of `blocks` and `questions` via
- * `getSurveyFileUploadConfigs`, because a survey holds file uploads in either shape and keying off one
- * of them silently skips the other.
+ * The extraction itself is shared with the single-response delete paths
+ * (`getSurveyFileUploadElementIds` + `collectResponseFileUrls` in modules/storage/utils), so all three
+ * read the same id set and skip the same malformed answers.
  */
 const collectSurveyResponseFileUrls = async (
   surveyId: string
@@ -91,11 +63,7 @@ const collectSurveyResponseFileUrls = async (
     return { fileUrls: [], workspaceId: undefined };
   }
 
-  const fileUploadElementIds = new Set(
-    getSurveyFileUploadConfigs({ blocks: survey.blocks, questions: survey.questions }).map(
-      (config) => config.id
-    )
-  );
+  const fileUploadElementIds = getSurveyFileUploadElementIds(survey);
 
   // No file-upload element in the survey's *current* definition, so there is no key this scan would
   // match — skip it. Note this is about today's blocks/questions, not the response history: answers
@@ -122,7 +90,9 @@ const collectSurveyResponseFileUrls = async (
       break;
     }
 
-    fileUrls.push(...collectFileUrlsFromPage(responses, fileUploadElementIds));
+    for (const response of responses) {
+      fileUrls.push(...collectResponseFileUrls(response.data, fileUploadElementIds));
+    }
 
     // A short page means the last one. The `lastRow` check only guards the cursor from going undefined
     // and re-reading the same page forever; a full page always has a last row.

--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -20,7 +20,11 @@ import { TTag } from "@formbricks/types/tags";
 import { getIsQuotasEnabled } from "@/modules/ee/license-check/lib/utils";
 import { reduceQuotaLimits } from "@/modules/ee/quotas/lib/quotas";
 import { deleteResponseFileUrls } from "@/modules/storage/lib/delete-response-files";
-import { getSurveyFileUploadConfigs, resolveStorageUrlsInObject } from "@/modules/storage/utils";
+import {
+  collectResponseFileUrls,
+  getSurveyFileUploadElementIds,
+  resolveStorageUrlsInObject,
+} from "@/modules/storage/utils";
 import { getOrganizationIdFromWorkspaceId } from "@/modules/survey/lib/organization";
 import { getOrganizationBilling } from "@/modules/survey/lib/survey";
 import { ITEMS_PER_PAGE } from "../constants";
@@ -630,18 +634,7 @@ export const updateResponse = async (
 };
 
 const findAndDeleteUploadedFilesInResponse = async (response: TResponse, survey: TSurvey): Promise<void> => {
-  // Match write-time validation: a survey holds file uploads in either blocks or questions, so build
-  // the id set from the union of both rather than one shape (getSurveyFileUploadConfigs is exactly what
-  // validateClientFileUploads uses). Keying off a single shape silently skips deletes for the other.
-  const fileUploadElementIds = new Set(
-    getSurveyFileUploadConfigs({ blocks: survey.blocks, questions: survey.questions }).map(
-      (config) => config.id
-    )
-  );
-
-  const fileUrls = Object.entries(response.data)
-    .filter(([elementId]) => fileUploadElementIds.has(elementId))
-    .flatMap(([, elementResponse]) => elementResponse as string[]);
+  const fileUrls = collectResponseFileUrls(response.data, getSurveyFileUploadElementIds(survey));
 
   await deleteResponseFileUrls(fileUrls, survey.workspaceId);
 };

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/utils.test.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/utils.test.ts
@@ -1,5 +1,6 @@
 import { fileUploadQuestion, openTextQuestion, responseData, workspaceId } from "./__mocks__/utils.mock";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Response } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { okVoid } from "@formbricks/types/error-handlers";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
@@ -64,6 +65,25 @@ describe("findAndDeleteUploadedFilesInResponse", () => {
 
     expect(deleteFile).toHaveBeenCalledTimes(1);
     expect(deleteFile).toHaveBeenCalledWith(workspaceId, "private", "block-file.png", workspaceId);
+    expect(result).toEqual(okVoid());
+  });
+
+  // Before ENG-2547 this path cast a matching answer straight to string[], so a non-array value became
+  // a delete target: a bare string holding a valid same-workspace URL was deleted off malformed data.
+  test("not call deleteFile for a non-array answer under a file-upload key", async () => {
+    // A plain string is a valid TResponseData value, so this needs no cast — which is exactly why the
+    // old `as string[]` cast was unsafe.
+    const malformedData: Response["data"] = {
+      [fileUploadQuestion.id]: `https://example.com/storage/${workspaceId}/private/file1.png`,
+    };
+
+    const result = await findAndDeleteUploadedFilesInResponse(
+      malformedData,
+      questionsSurvey([fileUploadQuestion]),
+      workspaceId
+    );
+
+    expect(deleteFile).not.toHaveBeenCalled();
     expect(result).toEqual(okVoid());
   });
 

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/utils.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/utils.ts
@@ -2,26 +2,14 @@ import { Response, Survey } from "@formbricks/database/prisma";
 import { Result, okVoid } from "@formbricks/types/error-handlers";
 import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
 import { deleteResponseFileUrls } from "@/modules/storage/lib/delete-response-files";
-import { getSurveyFileUploadConfigs } from "@/modules/storage/utils";
+import { collectResponseFileUrls, getSurveyFileUploadElementIds } from "@/modules/storage/utils";
 
 export const findAndDeleteUploadedFilesInResponse = async (
   responseData: Response["data"],
   survey: Pick<Survey, "blocks" | "questions">,
   workspaceId?: string
 ): Promise<Result<void, ApiErrorResponseV2>> => {
-  // A survey holds file uploads in either blocks or questions, so build the id set from the union of
-  // both — the same source write-time validation uses. A questions-only set silently skipped deletes
-  // for block-based surveys (the common shape), leaking their uploads.
-  const fileUploadElementIds = new Set(
-    getSurveyFileUploadConfigs({
-      blocks: survey.blocks,
-      questions: survey.questions,
-    }).map((config) => config.id)
-  );
-
-  const fileUrls = Object.entries(responseData)
-    .filter(([elementId]) => fileUploadElementIds.has(elementId))
-    .flatMap(([, elementResponse]) => elementResponse as string[]);
+  const fileUrls = collectResponseFileUrls(responseData, getSurveyFileUploadElementIds(survey));
 
   await deleteResponseFileUrls(fileUrls, workspaceId);
 

--- a/apps/web/modules/storage/utils.test.ts
+++ b/apps/web/modules/storage/utils.test.ts
@@ -5,6 +5,8 @@ import { ZAllowedFileExtension } from "@formbricks/types/storage";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import { TSurveyQuestion } from "@formbricks/types/surveys/types";
 import {
+  collectResponseFileUrls,
+  getSurveyFileUploadElementIds,
   isAllowedFileExtension,
   isValidImageFile,
   parseStorageFileUrl,
@@ -406,6 +408,75 @@ describe("storage utils", () => {
         ok: false,
         reason: "file_upload_element_not_found",
       });
+    });
+  });
+
+  describe("getSurveyFileUploadElementIds", () => {
+    test("should union the file-upload ids from blocks and questions", () => {
+      const blocks = [
+        {
+          id: "block1",
+          name: "Block 1",
+          elements: [
+            { id: "block-upload", type: "fileUpload" as const },
+            { id: "block-text", type: "openText" as const },
+          ],
+        },
+      ] as unknown as TSurveyBlock[];
+      const questions = [
+        { id: "question-upload", type: "fileUpload" as const },
+        { id: "question-text", type: "openText" as const },
+      ] as unknown as TSurveyQuestion[];
+
+      expect(getSurveyFileUploadElementIds({ blocks, questions })).toEqual(
+        new Set(["block-upload", "question-upload"])
+      );
+    });
+
+    test("should be empty for a survey with no file-upload element", () => {
+      expect(getSurveyFileUploadElementIds({ blocks: [], questions: [] }).size).toBe(0);
+      expect(getSurveyFileUploadElementIds({}).size).toBe(0);
+    });
+  });
+
+  describe("collectResponseFileUrls", () => {
+    const fileUploadElementIds = new Set(["upload"]);
+    const firstUrl = "https://example.com/storage/ws-1/private/one.png";
+    const secondUrl = "https://example.com/storage/ws-1/private/two.pdf";
+
+    test("should collect the URLs under file-upload keys and ignore every other answer", () => {
+      const data: TResponseData = {
+        upload: [firstUrl, secondUrl],
+        text: "not a file",
+        "not-an-upload-element": ["https://example.com/storage/ws-1/private/other.png"],
+      };
+
+      expect(collectResponseFileUrls(data, fileUploadElementIds)).toEqual([firstUrl, secondUrl]);
+    });
+
+    // The delete paths used to cast a matching answer straight to string[]. A non-array value therefore
+    // became a delete target instead of being skipped, so a plain string holding a valid same-workspace
+    // URL was deleted off malformed data.
+    test("should skip a non-array answer under a file-upload key", () => {
+      expect(collectResponseFileUrls({ upload: firstUrl }, fileUploadElementIds)).toEqual([]);
+      expect(collectResponseFileUrls({ upload: { url: firstUrl } }, fileUploadElementIds)).toEqual([]);
+      expect(collectResponseFileUrls({ upload: 42 }, fileUploadElementIds)).toEqual([]);
+    });
+
+    test("should drop non-string entries inside a file-upload array", () => {
+      expect(collectResponseFileUrls({ upload: [42, null, firstUrl] }, fileUploadElementIds)).toEqual([
+        firstUrl,
+      ]);
+    });
+
+    test("should collect nothing when the survey has no file-upload element", () => {
+      expect(collectResponseFileUrls({ upload: [firstUrl] }, new Set())).toEqual([]);
+    });
+
+    test("should collect nothing for data that is not a response object", () => {
+      for (const data of [null, undefined, "", "a string", 42, [firstUrl]]) {
+        expect(collectResponseFileUrls(data, fileUploadElementIds)).toEqual([]);
+      }
     });
   });
 

--- a/apps/web/modules/storage/utils.ts
+++ b/apps/web/modules/storage/utils.ts
@@ -134,6 +134,55 @@ export const getSurveyFileUploadConfigs = ({
   ] as TSurveyFileUploadElement[];
 };
 
+/**
+ * The ids of the elements whose answers hold storage URLs.
+ *
+ * Every response-file delete path needs the id set rather than the configs, and it must come from the
+ * union of `blocks` and `questions` — the same source write-time validation reads — because keying off
+ * a single shape silently skips deletes for the other.
+ *
+ * Split from `collectResponseFileUrls` so a caller scanning many responses builds the set once, and so
+ * it can skip its scan entirely when the set is empty.
+ */
+export const getSurveyFileUploadElementIds = (survey: {
+  blocks?: TSurveyBlock[] | null;
+  questions?: TSurveyQuestion[] | null;
+}): Set<string> =>
+  new Set(
+    getSurveyFileUploadConfigs({ blocks: survey.blocks, questions: survey.questions }).map(
+      (config) => config.id
+    )
+  );
+
+/**
+ * Pulls the storage URLs out of one response's answers, ready to hand to `deleteResponseFileUrls`.
+ *
+ * Only file-upload answers hold storage URLs, and they are always stored as an array of strings.
+ * Anything else under a matching key is skipped rather than cast, so malformed data cannot produce a
+ * bogus delete target.
+ *
+ * `data` is deliberately `unknown`: callers hand this a raw `Prisma.JsonValue` column or an already
+ * typed `TResponseData`, and the shape is checked here either way rather than cast at each call site.
+ */
+export const collectResponseFileUrls = (data: unknown, fileUploadElementIds: Set<string>): string[] => {
+  if (fileUploadElementIds.size === 0 || !data || typeof data !== "object" || Array.isArray(data)) {
+    return [];
+  }
+
+  const fileUrls: string[] = [];
+  // Typed rather than left as `Object.entries`' implicit `any` values, so the guards below are the only
+  // thing that narrows an answer to a string.
+  const answers: [string, unknown][] = Object.entries(data);
+
+  for (const [elementId, answer] of answers) {
+    if (fileUploadElementIds.has(elementId) && Array.isArray(answer)) {
+      fileUrls.push(...answer.filter((url): url is string => typeof url === "string"));
+    }
+  }
+
+  return fileUrls;
+};
+
 export const validateSurveyAllowsFileUpload = ({
   fileName,
   elementId,


### PR DESCRIPTION
Fixes ENG-2547

## What & why

**Was:** three copies of "build the file-upload element id set from the survey, then pull the storage URLs out of `response.data`". Two of them cast a matching answer straight to `string[]`, so a non-array answer became a delete target: a bare string holding a valid same-workspace URL was deleted off malformed data.

**Now:** one `getSurveyFileUploadElementIds` + `collectResponseFileUrls` pair in `modules/storage/utils.ts`. All three delete paths read the same id set and skip the same malformed answers.

- Two functions, not one: the reset scan builds the id set once, not per response.
- They sit in `storage/utils.ts`, not beside `deleteResponseFileUrls`: the reset spec mocks that module wholesale.

## Where to look

- [modules/storage/utils.ts#L147-L184](https://github.com/formbricks/formbricks/blob/anshuman/eng-2547-extract-a-shared-collectresponsefileurls-helper-three/apps/web/modules/storage/utils.ts#L147-L184) — the pair, and the guard
- [v2 responses/[responseId]/lib/utils.ts#L12](https://github.com/formbricks/formbricks/blob/anshuman/eng-2547-extract-a-shared-collectresponsefileurls-helper-three/apps/web/modules/api/v2/management/responses/%5BresponseId%5D/lib/utils.ts#L12) — cast gone
- [summary/lib/survey.ts#L94](https://github.com/formbricks/formbricks/blob/anshuman/eng-2547-extract-a-shared-collectresponsefileurls-helper-three/apps/web/app/(app)/workspaces/%5BworkspaceId%5D/surveys/%5BsurveyId%5D/(analysis)/summary/lib/survey.ts#L94) — private copy dropped

## Breaking changes

- [ ] This PR contains breaking changes

None. Internal helpers behind two delete paths — no API request or response shape, endpoint, route, env var, config key or SDK export changes.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && pnpm vitest run modules/storage/utils.test.ts 'modules/api/v2/management/responses/[responseId]/lib/tests' 'app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/survey.test.ts' lib/response/service.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| A non-array answer under a file-upload key is no longer deleted (v2 management delete) | unit (red on main) | `deleteFile` called once before, zero after — `.../[responseId]/lib/tests/utils.test.ts` |
| Non-string entries inside a file-upload array are dropped | unit (mutation) | Drop the `typeof url === "string"` filter at `modules/storage/utils.ts:179` to turn it red |
| A non-object `data` value collects nothing | unit (mutation) | Drop the object check at `modules/storage/utils.ts:168` to turn it red |
| The id set unions `blocks` and `questions` | unit (guard) | `modules/storage/utils.test.ts` — block-only and question-only surveys both yield their upload id |
| Survey reset still collects the same URLs across pages, chunks and skips | unit (guard) | Existing `summary/lib/survey.test.ts` unchanged and green through the shared helper |

<details>
<summary>Red-on-main reproduction for row 1</summary>

```
git stash push -- "apps/web/modules/api/v2/management/responses/[responseId]/lib/utils.ts"
cd apps/web && pnpm vitest run 'modules/api/v2/management/responses/[responseId]/lib/tests/utils.test.ts' -t "non-array answer"
```

```
× not call deleteFile for a non-array answer under a file-upload key
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

</details>

**Open gaps**

- `lib/response/service.ts` has no test at its own call site; it inherits the guard, proven at the v2 site.

**Risks**

- Files behind a malformed answer now stay in storage. If a non-`string[]` answer shape is ever real, widen `collectResponseFileUrls`.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `xhigh`.
