### PR TITLE
fix(dashboards): place a duplicated chart in the next free slot and add an E shortcut for edit mode

### DIFF
--- a/apps/web/lib/utils/prisma-error.test.ts
+++ b/apps/web/lib/utils/prisma-error.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { Prisma, type PrismaClientKnownRequestError } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
-import { isPrismaKnownRequestError, isUniqueConstraintError } from "./prisma-error";
+import {
+  isPrismaKnownRequestError,
+  isTransactionConflictError,
+  isUniqueConstraintError,
+  retryOnTransactionConflict,
+} from "./prisma-error";
 
 const knownError = (code: string): PrismaClientKnownRequestError =>
   new Prisma.PrismaClientKnownRequestError("boom", { code, clientVersion: "test" });
@@ -67,5 +72,70 @@ describe("type narrowing", () => {
     // type position), their post-guard `error.message` accesses would narrow to `never` and fail
     // typecheck.
     expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe("isTransactionConflictError", () => {
+  test("is true for a P2034 transaction conflict", () => {
+    expect(isTransactionConflictError(knownError(PrismaErrorType.TransactionConflict))).toBe(true);
+  });
+
+  test("is true for a deadlock the driver adapter surfaces as a plain error", () => {
+    expect(isTransactionConflictError(new Error("deadlock detected"))).toBe(true);
+    expect(isTransactionConflictError(new Error("SQLSTATE 40P01"))).toBe(true);
+  });
+
+  test("is false for other errors", () => {
+    expect(isTransactionConflictError(uniqueViolation)).toBe(false);
+    expect(isTransactionConflictError(new Error("plain"))).toBe(false);
+    expect(isTransactionConflictError(null)).toBe(false);
+  });
+});
+
+describe("retryOnTransactionConflict", () => {
+  const conflict = knownError(PrismaErrorType.TransactionConflict);
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("returns the first successful result", async () => {
+    const operation = vi.fn().mockResolvedValue("ok");
+
+    await expect(retryOnTransactionConflict(operation)).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  test("runs the operation again after a conflict, with a backoff in between", async () => {
+    vi.useFakeTimers();
+    const operation = vi.fn().mockRejectedValueOnce(conflict).mockResolvedValue("ok");
+
+    const result = retryOnTransactionConflict(operation);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(operation).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(result).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  test("gives up after maxAttempts and rethrows the last conflict", async () => {
+    vi.useFakeTimers();
+    const operation = vi.fn().mockRejectedValue(conflict);
+
+    const assertion = expect(retryOnTransactionConflict(operation, { maxAttempts: 3 })).rejects.toBe(
+      conflict
+    );
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  test("rethrows a non-conflict error at once", async () => {
+    const failure = new Error("plain");
+    const operation = vi.fn().mockRejectedValue(failure);
+
+    await expect(retryOnTransactionConflict(operation)).rejects.toBe(failure);
+    expect(operation).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/utils/prisma-error.ts
+++ b/apps/web/lib/utils/prisma-error.ts
@@ -19,3 +19,44 @@ export const isPrismaKnownRequestError = (
 /** Type guard for a Prisma unique-constraint violation (P2002). */
 export const isUniqueConstraintError = (error: unknown): error is PrismaClientKnownRequestError =>
   isPrismaKnownRequestError(error, PrismaErrorType.UniqueConstraintViolation);
+
+/**
+ * True for a transaction the database aborted over a clash with a concurrent one, which is safe to
+ * run again: a `Serializable` write conflict or a deadlock. Prisma reports both as P2034 on an
+ * interactive transaction; the pg driver adapter can also surface a deadlock as a plain error whose
+ * message carries "deadlock detected" or SQLSTATE 40P01 (the shape seen in Sentry for ENG-2038).
+ */
+export const isTransactionConflictError = (error: unknown): boolean => {
+  if (isPrismaKnownRequestError(error, PrismaErrorType.TransactionConflict)) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : "";
+  return /deadlock detected/i.test(message) || message.includes("40P01");
+};
+
+const DEFAULT_MAX_TRANSACTION_ATTEMPTS = 3;
+const TRANSACTION_RETRY_BACKOFF_MS = 25;
+
+/**
+ * Runs `operation` again when it fails with a transaction conflict, `maxAttempts` times in total, with
+ * a short linear backoff so the retries do not re-collide in lockstep. Any other error, and the last
+ * conflict, propagate unchanged.
+ *
+ * A conflict aborts the whole transaction, so wrap the `prisma.$transaction(...)` call itself and keep
+ * the operation idempotent: every attempt re-reads and re-writes from scratch.
+ */
+export const retryOnTransactionConflict = async <T>(
+  operation: () => Promise<T>,
+  { maxAttempts = DEFAULT_MAX_TRANSACTION_ATTEMPTS }: { maxAttempts?: number } = {}
+): Promise<T> => {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= maxAttempts || !isTransactionConflictError(error)) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, attempt * TRANSACTION_RETRY_BACKOFF_MS));
+    }
+  }
+};

--- a/apps/web/modules/ee/analysis/dashboards/components/dashboard-control-bar.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/components/dashboard-control-bar.tsx
@@ -25,7 +25,7 @@ interface DashboardControlBarProps {
   isAIAvailable?: boolean;
   aiUnavailableReason?: TAIUnavailableReason;
   onRefresh: () => void;
-  /** Single-key shortcut that also enters edit mode, surfaced on the pencil's tooltip. */
+  /** Single-key shortcut that also enters edit mode, shown as a key cap on the pencil's tooltip. */
   editHotkey?: string;
   onEditToggle: () => void;
   onSave: () => void;
@@ -102,7 +102,8 @@ export const DashboardControlBar = ({
     },
     {
       icon: PencilIcon,
-      tooltip: editHotkey ? `${t("common.edit")} (${editHotkey.toUpperCase()})` : t("common.edit"),
+      tooltip: t("common.edit"),
+      shortcut: editHotkey,
       onClick: onEditToggle,
       isVisible: !isReadOnly,
     },

--- a/apps/web/modules/ee/analysis/dashboards/components/dashboard-control-bar.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/components/dashboard-control-bar.tsx
@@ -25,6 +25,8 @@ interface DashboardControlBarProps {
   isAIAvailable?: boolean;
   aiUnavailableReason?: TAIUnavailableReason;
   onRefresh: () => void;
+  /** Single-key shortcut that also enters edit mode, surfaced on the pencil's tooltip. */
+  editHotkey?: string;
   onEditToggle: () => void;
   onSave: () => void;
   onCancel: () => void;
@@ -42,6 +44,7 @@ export const DashboardControlBar = ({
   isAIAvailable,
   aiUnavailableReason,
   onRefresh,
+  editHotkey,
   onEditToggle,
   onSave,
   onCancel,
@@ -99,7 +102,7 @@ export const DashboardControlBar = ({
     },
     {
       icon: PencilIcon,
-      tooltip: t("common.edit"),
+      tooltip: editHotkey ? `${t("common.edit")} (${editHotkey.toUpperCase()})` : t("common.edit"),
       onClick: onEditToggle,
       isVisible: !isReadOnly,
     },

--- a/apps/web/modules/ee/analysis/dashboards/components/dashboard-control-bar.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/components/dashboard-control-bar.tsx
@@ -25,7 +25,10 @@ interface DashboardControlBarProps {
   isAIAvailable?: boolean;
   aiUnavailableReason?: TAIUnavailableReason;
   onRefresh: () => void;
-  /** Single-key shortcut that also enters edit mode, shown as a key cap on the pencil's tooltip. */
+  /**
+   * Single-key shortcut that toggles edit mode. Its key cap sits on whichever button it currently
+   * triggers: the pencil in view mode, save while there are changes, cancel while there are none.
+   */
   editHotkey?: string;
   onEditToggle: () => void;
   onSave: () => void;
@@ -79,6 +82,7 @@ export const DashboardControlBar = ({
     {
       icon: isSaving ? null : CheckIcon,
       tooltip: hasChanges ? t("common.save") : t("common.no_changes"),
+      shortcut: hasChanges && !isSaving ? editHotkey : undefined,
       onClick: onSave,
       isVisible: true,
       isLoading: isSaving,
@@ -87,6 +91,7 @@ export const DashboardControlBar = ({
     {
       icon: XIcon,
       tooltip: t("common.cancel"),
+      shortcut: !hasChanges && !isSaving ? editHotkey : undefined,
       onClick: onCancel,
       isVisible: true,
       disabled: isSaving,

--- a/apps/web/modules/ee/analysis/dashboards/components/dashboard-detail-client.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/components/dashboard-detail-client.tsx
@@ -28,6 +28,7 @@ import {
   type TDashboardDateFilter,
   writeStoredDateFilter,
 } from "@/modules/ee/analysis/dashboards/lib/dashboard-date-filter";
+import { EDIT_HOTKEY, hasOpenOverlay, isEditHotkey } from "@/modules/ee/analysis/dashboards/lib/edit-hotkey";
 import {
   DEFAULT_WIDGET_VIEW,
   type TWidgetView,
@@ -265,6 +266,25 @@ export function DashboardDetailClient({
     setIsEditing(true);
   }, [dashboard.widgets, isEditing]);
 
+  // `E` enters edit mode, matching the pencil in the control bar.
+  useEffect(() => {
+    if (isReadOnly || isEditing) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isEditHotkey(event) || hasOpenOverlay()) {
+        return;
+      }
+
+      event.preventDefault();
+      handleEnterEditMode();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleEnterEditMode, isEditing, isReadOnly]);
+
   const handleEditChart = useCallback((chartId: string) => {
     setEditingChartId(chartId);
   }, []);
@@ -498,6 +518,7 @@ export function DashboardDetailClient({
             isAIAvailable={isAIAvailable}
             aiUnavailableReason={aiUnavailableReason}
             onRefresh={() => router.refresh()}
+            editHotkey={EDIT_HOTKEY}
             onEditToggle={handleEnterEditMode}
             onSave={handleSave}
             onCancel={handleCancel}

--- a/apps/web/modules/ee/analysis/dashboards/components/dashboard-detail-client.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/components/dashboard-detail-client.tsx
@@ -28,7 +28,12 @@ import {
   type TDashboardDateFilter,
   writeStoredDateFilter,
 } from "@/modules/ee/analysis/dashboards/lib/dashboard-date-filter";
-import { EDIT_HOTKEY, hasOpenOverlay, isEditHotkey } from "@/modules/ee/analysis/dashboards/lib/edit-hotkey";
+import {
+  EDIT_HOTKEY,
+  hasOpenOverlay,
+  isEditHotkey,
+  resolveEditHotkeyAction,
+} from "@/modules/ee/analysis/dashboards/lib/edit-hotkey";
 import {
   DEFAULT_WIDGET_VIEW,
   type TWidgetView,
@@ -266,25 +271,6 @@ export function DashboardDetailClient({
     setIsEditing(true);
   }, [dashboard.widgets, isEditing]);
 
-  // `E` enters edit mode, matching the pencil in the control bar.
-  useEffect(() => {
-    if (isReadOnly || isEditing) {
-      return;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (!isEditHotkey(event) || hasOpenOverlay()) {
-        return;
-      }
-
-      event.preventDefault();
-      handleEnterEditMode();
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [handleEnterEditMode, isEditing, isReadOnly]);
-
   const handleEditChart = useCallback((chartId: string) => {
     setEditingChartId(chartId);
   }, []);
@@ -455,6 +441,29 @@ export function DashboardDetailClient({
       setIsSaving(false);
     }
   }, [name, widgets, dashboard, workspaceId, router, t, startTransition]);
+
+  // `E` toggles edit mode: it enters from view mode, and inside edit mode it saves when there is
+  // something to save and cancels otherwise - the same button the key cap sits on in the control bar.
+  useEffect(() => {
+    const action = resolveEditHotkeyAction({ isReadOnly, isEditing, hasChanges, isSaving });
+    if (!action) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isEditHotkey(event) || hasOpenOverlay()) {
+        return;
+      }
+
+      event.preventDefault();
+      if (action === "enter") handleEnterEditMode();
+      else if (action === "save") void handleSave();
+      else handleCancel();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleCancel, handleEnterEditMode, handleSave, hasChanges, isEditing, isReadOnly, isSaving]);
 
   const applyDateFilterToUrl = useCallback(
     (filter: TDashboardDateFilter | null) => {

--- a/apps/web/modules/ee/analysis/dashboards/lib/dashboards.test.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/dashboards.test.ts
@@ -736,6 +736,51 @@ describe("Dashboard Service", () => {
       });
     });
 
+    test("nextOpenSlot places the widget in the first gap it fits", async () => {
+      mockTxChart.findFirst.mockResolvedValue({ id: mockChartId });
+      mockTxDashboard.findFirst.mockResolvedValue(mockDashboard);
+      mockTxWidget.aggregate.mockResolvedValue({ _max: { order: 1 } });
+      mockTxWidget.findMany.mockResolvedValue([
+        { layout: { x: 0, y: 0, w: 4, h: 3 } },
+        { layout: { x: 8, y: 0, w: 4, h: 3 } },
+      ]);
+      mockTxWidget.create.mockResolvedValue(mockWidget);
+      const { addChartToDashboard } = await import("./dashboards");
+
+      await addChartToDashboard({
+        dashboardId: mockDashboardId,
+        chartId: mockChartId,
+        workspaceId: mockWorkspaceId,
+        layout: mockLayout,
+        placement: "nextOpenSlot",
+      });
+
+      expect(mockTxWidget.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ layout: { x: 4, y: 0, w: 4, h: 3 } }),
+      });
+    });
+
+    test("nextOpenSlot drops the widget below a full row", async () => {
+      mockTxChart.findFirst.mockResolvedValue({ id: mockChartId });
+      mockTxDashboard.findFirst.mockResolvedValue(mockDashboard);
+      mockTxWidget.aggregate.mockResolvedValue({ _max: { order: 0 } });
+      mockTxWidget.findMany.mockResolvedValue([{ layout: { x: 0, y: 0, w: 12, h: 3 } }]);
+      mockTxWidget.create.mockResolvedValue(mockWidget);
+      const { addChartToDashboard } = await import("./dashboards");
+
+      await addChartToDashboard({
+        dashboardId: mockDashboardId,
+        chartId: mockChartId,
+        workspaceId: mockWorkspaceId,
+        layout: mockLayout,
+        placement: "nextOpenSlot",
+      });
+
+      expect(mockTxWidget.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ layout: { x: 0, y: 3, w: 4, h: 3 } }),
+      });
+    });
+
     test("throws ResourceNotFoundError when chart does not exist", async () => {
       mockTxChart.findFirst.mockResolvedValue(null);
       mockTxDashboard.findFirst.mockResolvedValue(mockDashboard);

--- a/apps/web/modules/ee/analysis/dashboards/lib/dashboards.test.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/dashboards.test.ts
@@ -781,6 +781,84 @@ describe("Dashboard Service", () => {
       });
     });
 
+    test("nextOpenSlot appends instead of filling a gap when a stored layout is unreadable", async () => {
+      mockTxChart.findFirst.mockResolvedValue({ id: mockChartId });
+      mockTxDashboard.findFirst.mockResolvedValue(mockDashboard);
+      mockTxWidget.aggregate.mockResolvedValue({ _max: { order: 1 } });
+      // The gap at x=4 cannot be trusted: the unreadable row may be sitting in it.
+      mockTxWidget.findMany.mockResolvedValue([
+        { layout: { x: 0, y: 0, w: 4, h: 3 } },
+        { layout: "not-a-layout" },
+      ]);
+      mockTxWidget.create.mockResolvedValue(mockWidget);
+      const { addChartToDashboard } = await import("./dashboards");
+
+      await addChartToDashboard({
+        dashboardId: mockDashboardId,
+        chartId: mockChartId,
+        workspaceId: mockWorkspaceId,
+        layout: mockLayout,
+        placement: "nextOpenSlot",
+      });
+
+      expect(mockTxWidget.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ layout: { x: 0, y: 3, w: 4, h: 3 } }),
+      });
+    });
+
+    test("retries the transaction when the database reports a conflict", async () => {
+      mockTxChart.findFirst.mockResolvedValue({ id: mockChartId });
+      mockTxDashboard.findFirst.mockResolvedValue(mockDashboard);
+      mockTxWidget.aggregate.mockResolvedValue({ _max: { order: null } });
+      mockTxWidget.findMany.mockResolvedValue([]);
+      mockTxWidget.create.mockResolvedValue(mockWidget);
+
+      const conflict = new Prisma.PrismaClientKnownRequestError("write conflict", {
+        code: "P2034",
+        clientVersion: "5.0.0",
+      });
+      let attempts = 0;
+      vi.mocked(prisma.$transaction).mockImplementation((cb: any) => {
+        attempts++;
+        if (attempts === 1) return Promise.reject(conflict);
+        return cb({ dashboard: mockTxDashboard, chart: mockTxChart, dashboardWidget: mockTxWidget });
+      });
+      const { addChartToDashboard } = await import("./dashboards");
+
+      const result = await addChartToDashboard({
+        dashboardId: mockDashboardId,
+        chartId: mockChartId,
+        workspaceId: mockWorkspaceId,
+        layout: mockLayout,
+      });
+
+      expect(result).toEqual(mockWidget);
+      expect(attempts).toBe(2);
+    });
+
+    test("gives up on a conflict that keeps repeating", async () => {
+      const conflict = new Prisma.PrismaClientKnownRequestError("write conflict", {
+        code: "P2034",
+        clientVersion: "5.0.0",
+      });
+      let attempts = 0;
+      vi.mocked(prisma.$transaction).mockImplementation(() => {
+        attempts++;
+        return Promise.reject(conflict);
+      });
+      const { addChartToDashboard } = await import("./dashboards");
+
+      await expect(
+        addChartToDashboard({
+          dashboardId: mockDashboardId,
+          chartId: mockChartId,
+          workspaceId: mockWorkspaceId,
+          layout: mockLayout,
+        })
+      ).rejects.toMatchObject({ name: "DatabaseError" });
+      expect(attempts).toBe(3);
+    });
+
     test("throws ResourceNotFoundError when chart does not exist", async () => {
       mockTxChart.findFirst.mockResolvedValue(null);
       mockTxDashboard.findFirst.mockResolvedValue(mockDashboard);

--- a/apps/web/modules/ee/analysis/dashboards/lib/dashboards.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/dashboards.ts
@@ -17,11 +17,36 @@ import {
   ZDashboardCreateInput,
   ZDashboardUpdateInput,
 } from "@/modules/ee/analysis/types/analysis";
+import { findNextOpenSlot, parseWidgetLayouts } from "./widget-placement";
 
 const MAX_NAME_ATTEMPTS = 5;
 
 const getDefaultWidgetLayout = (chartType: TChartType): TWidgetLayout =>
   chartType === "big_number" ? { x: 0, y: 0, w: 3, h: 2 } : { x: 0, y: 0, w: 4, h: 4 };
+
+/**
+ * The `x`/`y` a new widget takes on a dashboard that already holds `existingWidgets`.
+ *
+ * "nextOpenSlot" fills the first gap the widget fits in, so a duplicate lands beside its original
+ * instead of on top of it. The default keeps the requested `x` and starts the row below every
+ * existing widget.
+ */
+const resolveWidgetPosition = (
+  existingWidgets: { layout: unknown }[],
+  baseLayout: TWidgetLayout,
+  placement: TAddWidgetInput["placement"]
+): Pick<TWidgetLayout, "x" | "y"> => {
+  const layouts = parseWidgetLayouts(existingWidgets);
+
+  if (placement === "nextOpenSlot") {
+    return findNextOpenSlot(layouts, baseLayout);
+  }
+
+  return {
+    x: baseLayout.x,
+    y: layouts.reduce((max, layout) => Math.max(max, layout.y + layout.h), 0),
+  };
+};
 
 const selectDashboard = {
   id: true,
@@ -388,18 +413,11 @@ export const addChartToDashboard = async (data: TAddWidgetInput) => {
         ]);
 
         const baseLayout = data.layout ?? getDefaultWidgetLayout(chart.type as TChartType);
+        // Positioned inside the transaction that creates the widget, off the layouts read within it:
+        // two concurrent adds would otherwise pick the same spot from the same stale read.
         const layout = data.respectY
           ? baseLayout
-          : {
-              ...baseLayout,
-              y: existingWidgets.reduce((max, w) => {
-                const l =
-                  typeof w.layout === "object" && w.layout !== null
-                    ? (w.layout as Partial<{ y: number; h: number }>)
-                    : {};
-                return Math.max(max, (l.y ?? 0) + (l.h ?? 0));
-              }, 0),
-            };
+          : { ...baseLayout, ...resolveWidgetPosition(existingWidgets, baseLayout, data.placement) };
 
         return tx.dashboardWidget.create({
           data: {

--- a/apps/web/modules/ee/analysis/dashboards/lib/dashboards.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/dashboards.ts
@@ -1,10 +1,13 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
-import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TWidgetLayout } from "@formbricks/types/analysis";
 import { ZId } from "@formbricks/types/common";
 import { DatabaseError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
-import { isPrismaKnownRequestError, isUniqueConstraintError } from "@/lib/utils/prisma-error";
+import {
+  isPrismaKnownRequestError,
+  isUniqueConstraintError,
+  retryOnTransactionConflict,
+} from "@/lib/utils/prisma-error";
 import { validateInputs } from "@/lib/utils/validate";
 import { selectChart } from "@/modules/ee/analysis/charts/lib/charts";
 import {
@@ -53,26 +56,6 @@ const resolveWidgetPosition = (
     x: baseLayout.x,
     y: layouts.reduce((max, layout) => Math.max(max, layout.y + layout.h), 0),
   };
-};
-
-/**
- * Attempts for a `Serializable` transaction that reads a dashboard's widgets before writing one.
- * Two concurrent adds read the same state and one is aborted with `P2034`; retrying re-reads and
- * lands in the next slot instead of surfacing an error for a conflict the database expects.
- */
-const MAX_WIDGET_TRANSACTION_ATTEMPTS = 3;
-
-const runWithTransactionConflictRetry = async <T>(run: () => Promise<T>): Promise<T> => {
-  for (let attempt = 1; ; attempt++) {
-    try {
-      return await run();
-    } catch (error) {
-      const isLastAttempt = attempt >= MAX_WIDGET_TRANSACTION_ATTEMPTS;
-      if (isLastAttempt || !isPrismaKnownRequestError(error, PrismaErrorType.TransactionConflict)) {
-        throw error;
-      }
-    }
-  }
 };
 
 const selectDashboard = {
@@ -402,7 +385,7 @@ export const addChartToDashboard = async (data: TAddWidgetInput) => {
   try {
     // Retried rather than surfaced: `duplicateChartAndAddWidget` has already committed the chart
     // copy by the time this runs, so failing here would leave a chart on no dashboard.
-    return await runWithTransactionConflictRetry(() =>
+    return await retryOnTransactionConflict(() =>
       prisma.$transaction(
         async (tx) => {
           const [chart, dashboard] = await Promise.all([

--- a/apps/web/modules/ee/analysis/dashboards/lib/dashboards.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/dashboards.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
+import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TWidgetLayout } from "@formbricks/types/analysis";
 import { ZId } from "@formbricks/types/common";
 import { DatabaseError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
@@ -30,6 +31,11 @@ const getDefaultWidgetLayout = (chartType: TChartType): TWidgetLayout =>
  * "nextOpenSlot" fills the first gap the widget fits in, so a duplicate lands beside its original
  * instead of on top of it. The default keeps the requested `x` and starts the row below every
  * existing widget.
+ *
+ * A gap can only be trusted when every stored layout is readable: `layout` is a JSON column, and a
+ * row that does not parse is a widget whose occupancy is unknown, so a "free" slot may be sitting
+ * under it. Placement then falls back to appending below the rows that are readable, which is what a
+ * dashboard with such a row already does today.
  */
 const resolveWidgetPosition = (
   existingWidgets: { layout: unknown }[],
@@ -37,8 +43,9 @@ const resolveWidgetPosition = (
   placement: TAddWidgetInput["placement"]
 ): Pick<TWidgetLayout, "x" | "y"> => {
   const layouts = parseWidgetLayouts(existingWidgets);
+  const everyLayoutReadable = layouts.length === existingWidgets.length;
 
-  if (placement === "nextOpenSlot") {
+  if (placement === "nextOpenSlot" && everyLayoutReadable) {
     return findNextOpenSlot(layouts, baseLayout);
   }
 
@@ -46,6 +53,26 @@ const resolveWidgetPosition = (
     x: baseLayout.x,
     y: layouts.reduce((max, layout) => Math.max(max, layout.y + layout.h), 0),
   };
+};
+
+/**
+ * Attempts for a `Serializable` transaction that reads a dashboard's widgets before writing one.
+ * Two concurrent adds read the same state and one is aborted with `P2034`; retrying re-reads and
+ * lands in the next slot instead of surfacing an error for a conflict the database expects.
+ */
+const MAX_WIDGET_TRANSACTION_ATTEMPTS = 3;
+
+const runWithTransactionConflictRetry = async <T>(run: () => Promise<T>): Promise<T> => {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await run();
+    } catch (error) {
+      const isLastAttempt = attempt >= MAX_WIDGET_TRANSACTION_ATTEMPTS;
+      if (isLastAttempt || !isPrismaKnownRequestError(error, PrismaErrorType.TransactionConflict)) {
+        throw error;
+      }
+    }
+  }
 };
 
 const selectDashboard = {
@@ -373,62 +400,66 @@ export const addChartToDashboard = async (data: TAddWidgetInput) => {
   validateInputs([data, ZAddWidgetInput]);
 
   try {
-    return await prisma.$transaction(
-      async (tx) => {
-        const [chart, dashboard] = await Promise.all([
-          tx.chart.findFirst({ where: { id: data.chartId, workspaceId: data.workspaceId } }),
-          tx.dashboard.findFirst({ where: { id: data.dashboardId, workspaceId: data.workspaceId } }),
-        ]);
+    // Retried rather than surfaced: `duplicateChartAndAddWidget` has already committed the chart
+    // copy by the time this runs, so failing here would leave a chart on no dashboard.
+    return await runWithTransactionConflictRetry(() =>
+      prisma.$transaction(
+        async (tx) => {
+          const [chart, dashboard] = await Promise.all([
+            tx.chart.findFirst({ where: { id: data.chartId, workspaceId: data.workspaceId } }),
+            tx.dashboard.findFirst({ where: { id: data.dashboardId, workspaceId: data.workspaceId } }),
+          ]);
 
-        if (!chart) {
-          throw new ResourceNotFoundError("Chart", data.chartId);
-        }
-        if (!dashboard) {
-          throw new ResourceNotFoundError("Dashboard", data.dashboardId);
-        }
+          if (!chart) {
+            throw new ResourceNotFoundError("Chart", data.chartId);
+          }
+          if (!dashboard) {
+            throw new ResourceNotFoundError("Dashboard", data.dashboardId);
+          }
 
-        const existingWidget = await tx.dashboardWidget.findFirst({
-          where: {
-            dashboardId: data.dashboardId,
-            chartId: data.chartId,
-          },
-          select: { id: true },
-        });
+          const existingWidget = await tx.dashboardWidget.findFirst({
+            where: {
+              dashboardId: data.dashboardId,
+              chartId: data.chartId,
+            },
+            select: { id: true },
+          });
 
-        if (existingWidget) {
-          throw new InvalidInputError("This chart is already on the dashboard");
-        }
+          if (existingWidget) {
+            throw new InvalidInputError("This chart is already on the dashboard");
+          }
 
-        const [maxOrder, existingWidgets] = await Promise.all([
-          tx.dashboardWidget.aggregate({
-            where: { dashboardId: data.dashboardId },
-            _max: { order: true },
-          }),
-          data.respectY
-            ? Promise.resolve([])
-            : tx.dashboardWidget.findMany({
-                where: { dashboardId: data.dashboardId },
-                select: { layout: true },
-              }),
-        ]);
+          const [maxOrder, existingWidgets] = await Promise.all([
+            tx.dashboardWidget.aggregate({
+              where: { dashboardId: data.dashboardId },
+              _max: { order: true },
+            }),
+            data.respectY
+              ? Promise.resolve([])
+              : tx.dashboardWidget.findMany({
+                  where: { dashboardId: data.dashboardId },
+                  select: { layout: true },
+                }),
+          ]);
 
-        const baseLayout = data.layout ?? getDefaultWidgetLayout(chart.type as TChartType);
-        // Positioned inside the transaction that creates the widget, off the layouts read within it:
-        // two concurrent adds would otherwise pick the same spot from the same stale read.
-        const layout = data.respectY
-          ? baseLayout
-          : { ...baseLayout, ...resolveWidgetPosition(existingWidgets, baseLayout, data.placement) };
+          const baseLayout = data.layout ?? getDefaultWidgetLayout(chart.type as TChartType);
+          // Positioned inside the transaction that creates the widget, off the layouts read within it:
+          // two concurrent adds would otherwise pick the same spot from the same stale read.
+          const layout = data.respectY
+            ? baseLayout
+            : { ...baseLayout, ...resolveWidgetPosition(existingWidgets, baseLayout, data.placement) };
 
-        return tx.dashboardWidget.create({
-          data: {
-            dashboardId: data.dashboardId,
-            chartId: data.chartId,
-            layout,
-            order: (maxOrder._max.order ?? -1) + 1,
-          },
-        });
-      },
-      { isolationLevel: "Serializable" }
+          return tx.dashboardWidget.create({
+            data: {
+              dashboardId: data.dashboardId,
+              chartId: data.chartId,
+              layout,
+              order: (maxOrder._max.order ?? -1) + 1,
+            },
+          });
+        },
+        { isolationLevel: "Serializable" }
+      )
     );
   } catch (error) {
     if (error instanceof ResourceNotFoundError || error instanceof InvalidInputError) {

--- a/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.test.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.test.ts
@@ -61,7 +61,7 @@ describe("duplicateChartAndAddWidget", () => {
   });
 
   test("duplicates the chart and adds it as a widget on the same dashboard", async () => {
-    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId, widgets: [] } as any);
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
     vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
     vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
 
@@ -74,72 +74,21 @@ describe("duplicateChartAndAddWidget", () => {
     });
 
     expect(result).toEqual({ chart: mockDuplicatedChart, widget: mockWidget });
-    expect(prisma.dashboard.findFirst).toHaveBeenCalledWith({
-      where: { id: mockDashboardId, workspaceId: mockWorkspaceId },
-      select: { id: true, widgets: { select: { layout: true } } },
-    });
+    expect(prisma.dashboard.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: mockDashboardId, workspaceId: mockWorkspaceId } })
+    );
     expect(duplicateChart).toHaveBeenCalledWith(mockChartId, mockWorkspaceId, mockUserId);
     expect(addChartToDashboard).toHaveBeenCalledWith({
       dashboardId: mockDashboardId,
       chartId: mockDuplicatedChart.id,
       workspaceId: mockWorkspaceId,
       layout: mockLayout,
-      respectY: true,
-    });
-  });
-
-  test("keeps the source size but moves the copy into the first free slot", async () => {
-    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({
-      id: mockDashboardId,
-      widgets: [{ layout: { x: 0, y: 0, w: 4, h: 3 } }, { layout: { x: 8, y: 0, w: 4, h: 3 } }],
-    } as any);
-    vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
-    vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
-
-    await duplicateChartAndAddWidget({
-      dashboardId: mockDashboardId,
-      workspaceId: mockWorkspaceId,
-      chartId: mockChartId,
-      createdBy: mockUserId,
-      layout: mockLayout,
-    });
-
-    expect(addChartToDashboard).toHaveBeenCalledWith({
-      dashboardId: mockDashboardId,
-      chartId: mockDuplicatedChart.id,
-      workspaceId: mockWorkspaceId,
-      layout: { x: 4, y: 0, w: 4, h: 3 },
-      respectY: true,
-    });
-  });
-
-  test("places the copy below a full row rather than on top of the original", async () => {
-    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({
-      id: mockDashboardId,
-      widgets: [{ layout: { x: 0, y: 0, w: 12, h: 3 } }],
-    } as any);
-    vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
-    vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
-
-    await duplicateChartAndAddWidget({
-      dashboardId: mockDashboardId,
-      workspaceId: mockWorkspaceId,
-      chartId: mockChartId,
-      createdBy: mockUserId,
-      layout: { x: 0, y: 0, w: 12, h: 3 },
-    });
-
-    expect(addChartToDashboard).toHaveBeenCalledWith({
-      dashboardId: mockDashboardId,
-      chartId: mockDuplicatedChart.id,
-      workspaceId: mockWorkspaceId,
-      layout: { x: 0, y: 3, w: 12, h: 3 },
-      respectY: true,
+      placement: "nextOpenSlot",
     });
   });
 
   test("passes an undefined layout through so the widget gets the chart-type default", async () => {
-    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId, widgets: [] } as any);
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
     vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
     vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
 
@@ -155,7 +104,7 @@ describe("duplicateChartAndAddWidget", () => {
       chartId: mockDuplicatedChart.id,
       workspaceId: mockWorkspaceId,
       layout: undefined,
-      respectY: false,
+      placement: "nextOpenSlot",
     });
   });
 
@@ -179,7 +128,7 @@ describe("duplicateChartAndAddWidget", () => {
   });
 
   test("propagates duplicateChart errors without adding a widget", async () => {
-    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId, widgets: [] } as any);
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
     vi.mocked(duplicateChart).mockRejectedValue(
       Object.assign(new Error("Chart not found"), { name: "ResourceNotFoundError" })
     );

--- a/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.test.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.test.ts
@@ -61,7 +61,7 @@ describe("duplicateChartAndAddWidget", () => {
   });
 
   test("duplicates the chart and adds it as a widget on the same dashboard", async () => {
-    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId, widgets: [] } as any);
     vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
     vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
 
@@ -76,7 +76,7 @@ describe("duplicateChartAndAddWidget", () => {
     expect(result).toEqual({ chart: mockDuplicatedChart, widget: mockWidget });
     expect(prisma.dashboard.findFirst).toHaveBeenCalledWith({
       where: { id: mockDashboardId, workspaceId: mockWorkspaceId },
-      select: { id: true },
+      select: { id: true, widgets: { select: { layout: true } } },
     });
     expect(duplicateChart).toHaveBeenCalledWith(mockChartId, mockWorkspaceId, mockUserId);
     expect(addChartToDashboard).toHaveBeenCalledWith({
@@ -84,11 +84,62 @@ describe("duplicateChartAndAddWidget", () => {
       chartId: mockDuplicatedChart.id,
       workspaceId: mockWorkspaceId,
       layout: mockLayout,
+      respectY: true,
+    });
+  });
+
+  test("keeps the source size but moves the copy into the first free slot", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({
+      id: mockDashboardId,
+      widgets: [{ layout: { x: 0, y: 0, w: 4, h: 3 } }, { layout: { x: 8, y: 0, w: 4, h: 3 } }],
+    } as any);
+    vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
+    vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
+
+    await duplicateChartAndAddWidget({
+      dashboardId: mockDashboardId,
+      workspaceId: mockWorkspaceId,
+      chartId: mockChartId,
+      createdBy: mockUserId,
+      layout: mockLayout,
+    });
+
+    expect(addChartToDashboard).toHaveBeenCalledWith({
+      dashboardId: mockDashboardId,
+      chartId: mockDuplicatedChart.id,
+      workspaceId: mockWorkspaceId,
+      layout: { x: 4, y: 0, w: 4, h: 3 },
+      respectY: true,
+    });
+  });
+
+  test("places the copy below a full row rather than on top of the original", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({
+      id: mockDashboardId,
+      widgets: [{ layout: { x: 0, y: 0, w: 12, h: 3 } }],
+    } as any);
+    vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
+    vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
+
+    await duplicateChartAndAddWidget({
+      dashboardId: mockDashboardId,
+      workspaceId: mockWorkspaceId,
+      chartId: mockChartId,
+      createdBy: mockUserId,
+      layout: { x: 0, y: 0, w: 12, h: 3 },
+    });
+
+    expect(addChartToDashboard).toHaveBeenCalledWith({
+      dashboardId: mockDashboardId,
+      chartId: mockDuplicatedChart.id,
+      workspaceId: mockWorkspaceId,
+      layout: { x: 0, y: 3, w: 12, h: 3 },
+      respectY: true,
     });
   });
 
   test("passes an undefined layout through so the widget gets the chart-type default", async () => {
-    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId, widgets: [] } as any);
     vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
     vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
 
@@ -104,6 +155,7 @@ describe("duplicateChartAndAddWidget", () => {
       chartId: mockDuplicatedChart.id,
       workspaceId: mockWorkspaceId,
       layout: undefined,
+      respectY: false,
     });
   });
 
@@ -127,7 +179,7 @@ describe("duplicateChartAndAddWidget", () => {
   });
 
   test("propagates duplicateChart errors without adding a widget", async () => {
-    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId, widgets: [] } as any);
     vi.mocked(duplicateChart).mockRejectedValue(
       Object.assign(new Error("Chart not found"), { name: "ResourceNotFoundError" })
     );

--- a/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
@@ -7,11 +7,15 @@ import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { validateInputs } from "@/lib/utils/validate";
 import { duplicateChart } from "@/modules/ee/analysis/charts/lib/charts";
 import { addChartToDashboard } from "./dashboards";
+import { findNextOpenSlot, parseWidgetLayouts } from "./widget-placement";
 
 /**
  * Deep-copies a chart (new UUID, "(copy)" name suffix, copied query/config) and adds the
  * new chart as a widget on the given dashboard. The dashboard is verified first so a
  * missing dashboard does not leave an orphaned chart copy behind.
+ *
+ * When `layout` is given it is only used for the copy's size: the position comes from the first
+ * gap on the dashboard, so the copy never lands on top of its original.
  */
 export const duplicateChartAndAddWidget = async ({
   dashboardId,
@@ -38,7 +42,7 @@ export const duplicateChartAndAddWidget = async ({
   try {
     dashboard = await prisma.dashboard.findFirst({
       where: { id: dashboardId, workspaceId },
-      select: { id: true },
+      select: { id: true, widgets: { select: { layout: true } } },
     });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -51,12 +55,19 @@ export const duplicateChartAndAddWidget = async ({
     throw new ResourceNotFoundError("Dashboard", dashboardId);
   }
 
+  const placedLayout = layout
+    ? { ...layout, ...findNextOpenSlot(parseWidgetLayouts(dashboard.widgets), layout) }
+    : undefined;
+
   const chart = await duplicateChart(chartId, workspaceId, createdBy);
   const widget = await addChartToDashboard({
     dashboardId,
     chartId: chart.id,
     workspaceId,
-    layout,
+    layout: placedLayout,
+    // The slot above already accounts for every existing widget; without this the y would be
+    // overwritten with the row below them all.
+    respectY: placedLayout !== undefined,
   });
 
   return { chart, widget };

--- a/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
@@ -7,15 +7,14 @@ import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { validateInputs } from "@/lib/utils/validate";
 import { duplicateChart } from "@/modules/ee/analysis/charts/lib/charts";
 import { addChartToDashboard } from "./dashboards";
-import { findNextOpenSlot, parseWidgetLayouts } from "./widget-placement";
 
 /**
  * Deep-copies a chart (new UUID, "(copy)" name suffix, copied query/config) and adds the
  * new chart as a widget on the given dashboard. The dashboard is verified first so a
  * missing dashboard does not leave an orphaned chart copy behind.
  *
- * When `layout` is given it is only used for the copy's size: the position comes from the first
- * gap on the dashboard, so the copy never lands on top of its original.
+ * `layout` is only used for the copy's size: the position comes from the first gap on the dashboard,
+ * so the copy never lands on top of its original.
  */
 export const duplicateChartAndAddWidget = async ({
   dashboardId,
@@ -42,7 +41,7 @@ export const duplicateChartAndAddWidget = async ({
   try {
     dashboard = await prisma.dashboard.findFirst({
       where: { id: dashboardId, workspaceId },
-      select: { id: true, widgets: { select: { layout: true } } },
+      select: { id: true },
     });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -55,19 +54,15 @@ export const duplicateChartAndAddWidget = async ({
     throw new ResourceNotFoundError("Dashboard", dashboardId);
   }
 
-  const placedLayout = layout
-    ? { ...layout, ...findNextOpenSlot(parseWidgetLayouts(dashboard.widgets), layout) }
-    : undefined;
-
   const chart = await duplicateChart(chartId, workspaceId, createdBy);
   const widget = await addChartToDashboard({
     dashboardId,
     chartId: chart.id,
     workspaceId,
-    layout: placedLayout,
-    // The slot above already accounts for every existing widget; without this the y would be
-    // overwritten with the row below them all.
-    respectY: placedLayout !== undefined,
+    layout,
+    // The slot is chosen inside the insert transaction, off the layouts read there, so two
+    // concurrent duplicates cannot settle on the same spot.
+    placement: "nextOpenSlot",
   });
 
   return { chart, widget };

--- a/apps/web/modules/ee/analysis/dashboards/lib/edit-hotkey.test.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/edit-hotkey.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { EDIT_HOTKEY, isEditHotkey } from "./edit-hotkey";
+
+const bareEvent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    key: EDIT_HOTKEY,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    target: null,
+    ...overrides,
+  }) as Parameters<typeof isEditHotkey>[0];
+
+describe("isEditHotkey", () => {
+  test("matches a bare e", () => {
+    expect(isEditHotkey(bareEvent())).toBe(true);
+  });
+
+  test("matches an upper case E typed with caps lock", () => {
+    expect(isEditHotkey(bareEvent({ key: "E" }))).toBe(true);
+  });
+
+  test("ignores another key", () => {
+    expect(isEditHotkey(bareEvent({ key: "r" }))).toBe(false);
+  });
+
+  test.each(["metaKey", "ctrlKey", "altKey", "shiftKey"])("ignores e with %s held", (modifier) => {
+    expect(isEditHotkey(bareEvent({ [modifier]: true }))).toBe(false);
+  });
+
+  test("ignores a keystroke composing an IME character", () => {
+    expect(isEditHotkey(bareEvent({ isComposing: true }))).toBe(false);
+  });
+
+  test.each(["INPUT", "TEXTAREA", "SELECT"])("leaves the keystroke to a focused %s", (tagName) => {
+    expect(isEditHotkey(bareEvent({ target: { tagName } }))).toBe(false);
+  });
+
+  test("leaves the keystroke to a contenteditable element", () => {
+    expect(isEditHotkey(bareEvent({ target: { tagName: "DIV", isContentEditable: true } }))).toBe(false);
+  });
+
+  test("fires when the focused element does not take text", () => {
+    expect(isEditHotkey(bareEvent({ target: { tagName: "BUTTON", isContentEditable: false } }))).toBe(true);
+  });
+});

--- a/apps/web/modules/ee/analysis/dashboards/lib/edit-hotkey.test.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/edit-hotkey.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { EDIT_HOTKEY, isEditHotkey } from "./edit-hotkey";
+import { EDIT_HOTKEY, isEditHotkey, resolveEditHotkeyAction } from "./edit-hotkey";
 
 const bareEvent = (overrides: Record<string, unknown> = {}) =>
   ({
@@ -43,5 +43,32 @@ describe("isEditHotkey", () => {
 
   test("fires when the focused element does not take text", () => {
     expect(isEditHotkey(bareEvent({ target: { tagName: "BUTTON", isContentEditable: false } }))).toBe(true);
+  });
+});
+
+describe("resolveEditHotkeyAction", () => {
+  const viewing = { isReadOnly: false, isEditing: false, hasChanges: false, isSaving: false };
+  const editing = { ...viewing, isEditing: true };
+
+  test("enters edit mode from view mode", () => {
+    expect(resolveEditHotkeyAction(viewing)).toBe("enter");
+  });
+
+  test("saves when edit mode holds changes", () => {
+    expect(resolveEditHotkeyAction({ ...editing, hasChanges: true })).toBe("save");
+  });
+
+  test("cancels when edit mode holds no changes", () => {
+    expect(resolveEditHotkeyAction(editing)).toBe("cancel");
+  });
+
+  test("does nothing while a save is in flight", () => {
+    expect(resolveEditHotkeyAction({ ...editing, hasChanges: true, isSaving: true })).toBeNull();
+    expect(resolveEditHotkeyAction({ ...editing, isSaving: true })).toBeNull();
+  });
+
+  test("does nothing for a read-only viewer", () => {
+    expect(resolveEditHotkeyAction({ ...viewing, isReadOnly: true })).toBeNull();
+    expect(resolveEditHotkeyAction({ ...editing, isReadOnly: true, hasChanges: true })).toBeNull();
   });
 });

--- a/apps/web/modules/ee/analysis/dashboards/lib/edit-hotkey.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/edit-hotkey.ts
@@ -1,0 +1,32 @@
+/** Single-key shortcut that puts a dashboard into edit mode. */
+export const EDIT_HOTKEY = "e";
+
+const TYPING_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+type HotkeyEvent = Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"> & {
+  isComposing?: boolean;
+  target?: EventTarget | null;
+};
+
+/**
+ * True for a bare `E` that is not part of typing. The shortcut has no modifier, so anything that
+ * takes text - the dashboard's own name field included - has to keep the keystroke.
+ */
+export const isEditHotkey = (event: HotkeyEvent): boolean => {
+  if (event.key.toLowerCase() !== EDIT_HOTKEY) return false;
+  if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false;
+  if (event.isComposing) return false;
+
+  const target = event.target as { tagName?: string; isContentEditable?: boolean } | null | undefined;
+  if (!target) return true;
+
+  return !TYPING_TAGS.has(target.tagName ?? "") && target.isContentEditable !== true;
+};
+
+/**
+ * Whether a layer above the page owns the keyboard. Radix mounts dialog and menu content only
+ * while it is open, so its presence in the document is the signal - the open state itself lives
+ * inside the components that render them and is not reachable from the page.
+ */
+export const hasOpenOverlay = (): boolean =>
+  document.querySelector('[role="dialog"],[role="menu"],[role="alertdialog"]') !== null;

--- a/apps/web/modules/ee/analysis/dashboards/lib/edit-hotkey.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/edit-hotkey.ts
@@ -1,5 +1,34 @@
-/** Single-key shortcut that puts a dashboard into edit mode. */
+/**
+ * Single-key shortcut that toggles a dashboard's edit mode: it enters edit mode, and from inside it
+ * saves when there is something to save and cancels otherwise.
+ */
 export const EDIT_HOTKEY = "e";
+
+export type TEditHotkeyAction = "enter" | "save" | "cancel";
+
+interface EditHotkeyState {
+  isReadOnly: boolean;
+  isEditing: boolean;
+  hasChanges: boolean;
+  isSaving: boolean;
+}
+
+/**
+ * What `E` does in the dashboard's current state, or `null` when it does nothing. A read-only viewer
+ * has no edit mode; while a save is in flight the key stays quiet so it cannot cancel a half-written
+ * layout or queue a second save.
+ */
+export const resolveEditHotkeyAction = ({
+  isReadOnly,
+  isEditing,
+  hasChanges,
+  isSaving,
+}: EditHotkeyState): TEditHotkeyAction | null => {
+  if (isReadOnly) return null;
+  if (!isEditing) return "enter";
+  if (isSaving) return null;
+  return hasChanges ? "save" : "cancel";
+};
 
 const TYPING_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
 

--- a/apps/web/modules/ee/analysis/dashboards/lib/widget-placement.test.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/widget-placement.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import { GRID_COLUMNS, findNextOpenSlot, parseWidgetLayouts } from "./widget-placement";
+
+describe("findNextOpenSlot", () => {
+  test("places the first widget at the origin", () => {
+    expect(findNextOpenSlot([], { w: 4, h: 4 })).toEqual({ x: 0, y: 0 });
+  });
+
+  test("fills the gap next to a single widget instead of stacking below it", () => {
+    expect(findNextOpenSlot([{ x: 0, y: 0, w: 4, h: 4 }], { w: 4, h: 4 })).toEqual({ x: 4, y: 0 });
+  });
+
+  test("skips a partly filled row and finds the hole further along it", () => {
+    const existing = [
+      { x: 0, y: 0, w: 4, h: 4 },
+      { x: 8, y: 0, w: 4, h: 4 },
+    ];
+
+    expect(findNextOpenSlot(existing, { w: 4, h: 4 })).toEqual({ x: 4, y: 0 });
+  });
+
+  test("starts a new row when the current one leaves no wide enough gap", () => {
+    const existing = [
+      { x: 0, y: 0, w: 6, h: 4 },
+      { x: 6, y: 0, w: 4, h: 4 },
+    ];
+
+    // Only 2 columns are left on row 0, so a 4-wide widget has to go below.
+    expect(findNextOpenSlot(existing, { w: 4, h: 4 })).toEqual({ x: 0, y: 4 });
+  });
+
+  test("uses a narrow leftover gap when the widget is small enough for it", () => {
+    const existing = [
+      { x: 0, y: 0, w: 6, h: 4 },
+      { x: 6, y: 0, w: 4, h: 4 },
+    ];
+
+    expect(findNextOpenSlot(existing, { w: 2, h: 2 })).toEqual({ x: 10, y: 0 });
+  });
+
+  test("finds a gap left by a shorter widget above", () => {
+    const existing = [
+      { x: 0, y: 0, w: 12, h: 2 },
+      { x: 0, y: 2, w: 8, h: 4 },
+    ];
+
+    expect(findNextOpenSlot(existing, { w: 4, h: 4 })).toEqual({ x: 8, y: 2 });
+  });
+
+  test("appends below everything when the grid is full", () => {
+    const existing = [{ x: 0, y: 0, w: 12, h: 4 }];
+
+    expect(findNextOpenSlot(existing, { w: 4, h: 4 })).toEqual({ x: 0, y: 4 });
+  });
+
+  test("clamps a widget wider than the grid instead of never fitting it", () => {
+    expect(findNextOpenSlot([{ x: 0, y: 0, w: 12, h: 3 }], { w: 14, h: 3 })).toEqual({ x: 0, y: 3 });
+  });
+
+  test("honours a narrower breakpoint", () => {
+    expect(findNextOpenSlot([{ x: 0, y: 0, w: 4, h: 4 }], { w: 4, h: 4 }, 6)).toEqual({ x: 0, y: 4 });
+  });
+
+  test("defaults to the lg breakpoint's column count", () => {
+    expect(GRID_COLUMNS).toBe(12);
+  });
+});
+
+describe("parseWidgetLayouts", () => {
+  test("keeps well formed layouts", () => {
+    const widgets = [{ layout: { x: 0, y: 0, w: 4, h: 4 } }, { layout: { x: 4, y: 0, w: 4, h: 4 } }];
+
+    expect(parseWidgetLayouts(widgets)).toEqual([
+      { x: 0, y: 0, w: 4, h: 4 },
+      { x: 4, y: 0, w: 4, h: 4 },
+    ]);
+  });
+
+  test("drops rows whose JSON is not a layout", () => {
+    const widgets = [
+      { layout: null },
+      { layout: "nope" },
+      { layout: { x: 0, y: 0 } },
+      { layout: { x: 0, y: 0, w: 0, h: 4 } },
+      { layout: { x: 0, y: 0, w: 4, h: 4 } },
+    ];
+
+    expect(parseWidgetLayouts(widgets)).toEqual([{ x: 0, y: 0, w: 4, h: 4 }]);
+  });
+});

--- a/apps/web/modules/ee/analysis/dashboards/lib/widget-placement.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/widget-placement.ts
@@ -1,0 +1,47 @@
+import { TWidgetLayout, ZWidgetLayout } from "@formbricks/types/analysis";
+
+/** Columns of the `lg` breakpoint, the one the stored layouts are expressed in. */
+export const GRID_COLUMNS = 12;
+
+/**
+ * First position, scanning a row left to right before moving down, where a `w`x`h` widget fits
+ * without overlapping an existing one. A duplicate therefore lands in the nearest gap instead of
+ * on top of its original (the grid then shoves it to an arbitrary spot).
+ */
+export const findNextOpenSlot = (
+  existing: TWidgetLayout[],
+  { w, h }: Pick<TWidgetLayout, "w" | "h">,
+  columns: number = GRID_COLUMNS
+): Pick<TWidgetLayout, "x" | "y"> => {
+  const width = Math.min(w, columns);
+  const bottom = existing.reduce((max, layout) => Math.max(max, layout.y + layout.h), 0);
+
+  for (let y = 0; y < bottom; y++) {
+    for (let x = 0; x + width <= columns; x++) {
+      const overlaps = existing.some(
+        (layout) =>
+          x < layout.x + layout.w && x + width > layout.x && y < layout.y + layout.h && y + h > layout.y
+      );
+      if (!overlaps) {
+        return { x, y };
+      }
+    }
+  }
+
+  // Nothing fits in a gap, so start the row below every existing widget - always free.
+  return { x: 0, y: bottom };
+};
+
+/**
+ * Layouts are stored as JSON, so a row can hold anything. Malformed entries are dropped rather
+ * than thrown on: they cannot be reasoned about for placement, and losing one only means the new
+ * widget may overlap it.
+ */
+export const parseWidgetLayouts = (widgets: { layout: unknown }[]): TWidgetLayout[] =>
+  widgets.reduce<TWidgetLayout[]>((layouts, widget) => {
+    const parsed = ZWidgetLayout.safeParse(widget.layout);
+    if (parsed.success) {
+      layouts.push(parsed.data);
+    }
+    return layouts;
+  }, []);

--- a/apps/web/modules/ee/analysis/types/analysis.ts
+++ b/apps/web/modules/ee/analysis/types/analysis.ts
@@ -93,6 +93,11 @@ export const ZAddWidgetInput = z.object({
   workspaceId: ZId,
   layout: ZWidgetLayout.optional(),
   respectY: z.boolean().optional(),
+  /**
+   * Where the widget goes when `respectY` is not set: "append" (the default) keeps the layout's `x`
+   * and drops the widget below every existing one, "nextOpenSlot" puts it in the first gap it fits.
+   */
+  placement: z.enum(["append", "nextOpenSlot"]).optional(),
 });
 export type TAddWidgetInput = z.infer<typeof ZAddWidgetInput>;
 

--- a/apps/web/modules/ui/components/dropdown-menu/index.tsx
+++ b/apps/web/modules/ui/components/dropdown-menu/index.tsx
@@ -4,6 +4,7 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronLeft, ChevronRight, Circle } from "lucide-react";
 import * as React from "react";
 import { cn } from "@/lib/cn";
+import { Kbd } from "@/modules/ui/components/kbd";
 
 const DropdownMenu: React.ComponentType<DropdownMenuPrimitive.DropdownMenuProps> = DropdownMenuPrimitive.Root;
 
@@ -196,7 +197,9 @@ type DropdownMenuShortcutProps = React.HTMLAttributes<HTMLSpanElement> & {
 };
 
 const DropdownMenuShortcut = ({ className, ...props }: DropdownMenuShortcutProps) => {
-  return <span className={cn("ml-auto text-xs tracking-widest text-slate-500", className)} {...props} />;
+  // The same key cap the icon bars render, so one shortcut does not look like two different things
+  // depending on where it is shown.
+  return <Kbd className={cn("ml-auto", className)} {...props} />;
 };
 DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 

--- a/apps/web/modules/ui/components/iconbar/index.tsx
+++ b/apps/web/modules/ui/components/iconbar/index.tsx
@@ -5,6 +5,11 @@ import { Button } from "../button";
 interface IconAction {
   icon: LucideIcon | null;
   tooltip: string;
+  /**
+   * Single-key shortcut that runs the same action, shown as a key cap next to the tooltip label.
+   * An icon on its own cannot advertise a shortcut, so this is the only place a user meets it.
+   */
+  shortcut?: string;
   onClick?: () => void;
   isVisible?: boolean;
   disabled?: boolean;
@@ -28,7 +33,19 @@ export const IconBar = ({ actions }: IconBarProps) => {
       aria-label="Action buttons">
       {visibleActions.map((action, index) => (
         <span key={`${action.tooltip}-${index}`}>
-          <TooltipRenderer tooltipContent={action.tooltip}>
+          <TooltipRenderer
+            tooltipContent={
+              action.shortcut ? (
+                <span className="flex items-center gap-1.5">
+                  {action.tooltip}
+                  <kbd className="rounded border border-slate-200 bg-slate-100 px-1 font-mono text-xs text-slate-500">
+                    {action.shortcut.toUpperCase()}
+                  </kbd>
+                </span>
+              ) : (
+                action.tooltip
+              )
+            }>
             <Button
               variant="ghost"
               className="border-none hover:bg-slate-50"
@@ -36,6 +53,7 @@ export const IconBar = ({ actions }: IconBarProps) => {
               onClick={action.onClick}
               disabled={action.disabled}
               loading={action.isLoading}
+              aria-keyshortcuts={action.shortcut}
               aria-label={action.tooltip}>
               {action.icon ? <action.icon className={action.iconClassName} /> : null}
             </Button>

--- a/apps/web/modules/ui/components/iconbar/index.tsx
+++ b/apps/web/modules/ui/components/iconbar/index.tsx
@@ -51,7 +51,7 @@ export const IconBar = ({ actions }: IconBarProps) => {
                 // above is what announces the shortcut itself.
                 <kbd
                   aria-hidden="true"
-                  className="rounded bg-slate-100 px-1 py-0.5 font-mono text-[10px] leading-none text-slate-500">
+                  className="rounded border border-slate-200 bg-slate-100 px-1.5 py-1 font-mono text-xs leading-none font-semibold text-slate-600">
                   {action.shortcut.toUpperCase()}
                 </kbd>
               ) : null}

--- a/apps/web/modules/ui/components/iconbar/index.tsx
+++ b/apps/web/modules/ui/components/iconbar/index.tsx
@@ -1,4 +1,5 @@
 import { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/cn";
 import { TooltipRenderer } from "@/modules/ui/components/tooltip";
 import { Button } from "../button";
 
@@ -6,8 +7,9 @@ interface IconAction {
   icon: LucideIcon | null;
   tooltip: string;
   /**
-   * Single-key shortcut that runs the same action, shown as a key cap next to the tooltip label.
-   * An icon on its own cannot advertise a shortcut, so this is the only place a user meets it.
+   * Single-key shortcut that runs the same action, shown as a key cap on the button itself. On the
+   * tooltip alone it only reaches someone already hovering the icon they were looking for, which is
+   * exactly the user who does not need it - so it sits in the bar, visible without interaction.
    */
   shortcut?: string;
   onClick?: () => void;
@@ -33,22 +35,10 @@ export const IconBar = ({ actions }: IconBarProps) => {
       aria-label="Action buttons">
       {visibleActions.map((action, index) => (
         <span key={`${action.tooltip}-${index}`}>
-          <TooltipRenderer
-            tooltipContent={
-              action.shortcut ? (
-                <span className="flex items-center gap-1.5">
-                  {action.tooltip}
-                  <kbd className="rounded border border-slate-200 bg-slate-100 px-1 font-mono text-xs text-slate-500">
-                    {action.shortcut.toUpperCase()}
-                  </kbd>
-                </span>
-              ) : (
-                action.tooltip
-              )
-            }>
+          <TooltipRenderer tooltipContent={action.tooltip}>
             <Button
               variant="ghost"
-              className="border-none hover:bg-slate-50"
+              className={cn("border-none hover:bg-slate-50", action.shortcut && "w-auto gap-1.5 px-2.5")}
               size="icon"
               onClick={action.onClick}
               disabled={action.disabled}
@@ -56,6 +46,15 @@ export const IconBar = ({ actions }: IconBarProps) => {
               aria-keyshortcuts={action.shortcut}
               aria-label={action.tooltip}>
               {action.icon ? <action.icon className={action.iconClassName} /> : null}
+              {action.shortcut ? (
+                // Hidden from the accessible name, which `aria-label` owns; `aria-keyshortcuts`
+                // above is what announces the shortcut itself.
+                <kbd
+                  aria-hidden="true"
+                  className="rounded bg-slate-100 px-1 py-0.5 font-mono text-[10px] leading-none text-slate-500">
+                  {action.shortcut.toUpperCase()}
+                </kbd>
+              ) : null}
             </Button>
           </TooltipRenderer>
         </span>

--- a/apps/web/modules/ui/components/iconbar/index.tsx
+++ b/apps/web/modules/ui/components/iconbar/index.tsx
@@ -1,5 +1,6 @@
 import { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/cn";
+import { Kbd } from "@/modules/ui/components/kbd";
 import { TooltipRenderer } from "@/modules/ui/components/tooltip";
 import { Button } from "../button";
 
@@ -49,11 +50,7 @@ export const IconBar = ({ actions }: IconBarProps) => {
               {action.shortcut ? (
                 // Hidden from the accessible name, which `aria-label` owns; `aria-keyshortcuts`
                 // above is what announces the shortcut itself.
-                <kbd
-                  aria-hidden="true"
-                  className="rounded border border-slate-200 bg-slate-100 px-1.5 py-1 font-mono text-xs leading-none font-semibold text-slate-600">
-                  {action.shortcut.toUpperCase()}
-                </kbd>
+                <Kbd aria-hidden="true">{action.shortcut.toUpperCase()}</Kbd>
               ) : null}
             </Button>
           </TooltipRenderer>

--- a/apps/web/modules/ui/components/kbd/index.tsx
+++ b/apps/web/modules/ui/components/kbd/index.tsx
@@ -1,0 +1,25 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+// `children` comes from HTMLAttributes, so a caller spreading its own props onto this keeps working.
+type KbdProps = Readonly<HTMLAttributes<HTMLElement>>;
+
+/**
+ * A single key cap, for advertising a keyboard shortcut next to the control it triggers.
+ *
+ * `<kbd>` rather than a styled span: it is the element for keyboard input, so the shortcut reads as
+ * a key rather than as part of the label around it.
+ *
+ * Set `aria-hidden` where the shortcut is already announced another way - a button carrying
+ * `aria-keyshortcuts`, say - so a screen reader does not read the same key twice.
+ */
+export const Kbd = ({ children, className, ...props }: KbdProps) => (
+  <kbd
+    className={cn(
+      "rounded border border-slate-200 bg-slate-100 px-1.5 py-1 font-mono text-xs leading-none font-semibold text-slate-600",
+      className
+    )}
+    {...props}>
+    {children}
+  </kbd>
+);

--- a/apps/web/playwright/workspace-delete.spec.ts
+++ b/apps/web/playwright/workspace-delete.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 import { prisma } from "@formbricks/database";
+import { FORMBRICKS_WORKSPACE_ID_COOKIE } from "@/lib/localStorage";
 import { test } from "./lib/fixtures";
 
 test("requires workspace name confirmation before deleting a workspace", async ({ page, users }) => {
@@ -238,7 +239,7 @@ test("keeps the organization in account settings when the delete lands on the on
 
   // Deliberately no survey, so the deletion lands on the onboarding flow rather than on a
   // /workspaces/:id path — the branch where the proxy does not refresh the workspace cookie.
-  await prisma.workspace.create({
+  const remainingWorkspace = await prisma.workspace.create({
     data: { name: `Remaining Workspace ${timestamp}`, organizationId: user.organizationId },
     select: { id: true },
   });
@@ -258,6 +259,22 @@ test("keeps the organization in account settings when the delete lands on the on
 
   // The cookie still named the workspace we just deleted until the delete action started repointing
   // it, which sent account settings to the *other* organization via the organizations[0] fallback.
+  //
+  // Waited on rather than assumed: the repoint rides the delete action's own response, while
+  // `waitForURL` only proves the client navigated. The settings shell reads this cookie once per
+  // render, so entering account settings before the repoint lands resolves the wrong organization
+  // and no later re-render corrects it — the assertion below would then time out pointing at a
+  // missing sidebar link instead of at the cookie that actually decided the outcome.
+  await expect
+    .poll(
+      async () => {
+        const cookies = await page.context().cookies();
+        return cookies.find((cookie) => cookie.name === FORMBRICKS_WORKSPACE_ID_COOKIE)?.value;
+      },
+      { timeout: 15000 }
+    )
+    .toBe(remainingWorkspace.id);
+
   await page.goto("/account/settings/profile", { waitUntil: "domcontentloaded" });
   // `domcontentloaded` returns before the settings shell has resolved its organization, and this
   // route compiles cold on CI, so the default 5s expect timeout is not enough under worker

--- a/apps/web/playwright/workspace-delete.spec.ts
+++ b/apps/web/playwright/workspace-delete.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from "@playwright/test";
 import { prisma } from "@formbricks/database";
-import { FORMBRICKS_WORKSPACE_ID_COOKIE } from "@/lib/localStorage";
 import { test } from "./lib/fixtures";
 
 test("requires workspace name confirmation before deleting a workspace", async ({ page, users }) => {
@@ -239,7 +238,7 @@ test("keeps the organization in account settings when the delete lands on the on
 
   // Deliberately no survey, so the deletion lands on the onboarding flow rather than on a
   // /workspaces/:id path — the branch where the proxy does not refresh the workspace cookie.
-  const remainingWorkspace = await prisma.workspace.create({
+  await prisma.workspace.create({
     data: { name: `Remaining Workspace ${timestamp}`, organizationId: user.organizationId },
     select: { id: true },
   });
@@ -259,22 +258,6 @@ test("keeps the organization in account settings when the delete lands on the on
 
   // The cookie still named the workspace we just deleted until the delete action started repointing
   // it, which sent account settings to the *other* organization via the organizations[0] fallback.
-  //
-  // Waited on rather than assumed: the repoint rides the delete action's own response, while
-  // `waitForURL` only proves the client navigated. The settings shell reads this cookie once per
-  // render, so entering account settings before the repoint lands resolves the wrong organization
-  // and no later re-render corrects it — the assertion below would then time out pointing at a
-  // missing sidebar link instead of at the cookie that actually decided the outcome.
-  await expect
-    .poll(
-      async () => {
-        const cookies = await page.context().cookies();
-        return cookies.find((cookie) => cookie.name === FORMBRICKS_WORKSPACE_ID_COOKIE)?.value;
-      },
-      { timeout: 15000 }
-    )
-    .toBe(remainingWorkspace.id);
-
   await page.goto("/account/settings/profile", { waitUntil: "domcontentloaded" });
   // `domcontentloaded` returns before the settings shell has resolved its organization, and this
   // route compiles cold on CI, so the default 5s expect timeout is not enough under worker


### PR DESCRIPTION
No ticket — two dashboard follow-ups Johannes raised in #product-chat. (ENG-2838 is not addressed here any more; see the note at the bottom.)

## What & why

**1. A duplicated chart landed in an arbitrary spot**

**Was:** Duplicate passed the source widget's own `x`/`y`, so the copy was created on top of its original and the grid shoved it wherever it fit.

**Now:** The copy keeps the source size and takes the first position — scanning a row left to right before moving down — where it does not overlap an existing widget. A dashboard whose rows are full puts the copy on the row below everything.


https://github.com/user-attachments/assets/615ec6db-21f7-48bf-9f9c-fcf95c8df3dd



**2. Edit mode had no keyboard shortcut**

**Was:** Edit mode was only reachable through the pencil in the control bar.

**Now:** A bare `E` enters it. The keystroke is ignored while a text field (the dashboard name included) has focus, while a dialog or menu is open, on a read-only dashboard, and when a modifier is held, so it never eats typing.

Discoverability: an icon cannot advertise a shortcut, and a tooltip only reaches someone already hovering the icon they were looking for. So `IconBar` takes an optional `shortcut` per action and renders a key cap next to the icon itself — visible without interaction — plus `aria-keyshortcuts` on the button. The cap is a shared `Kbd` component that `DropdownMenuShortcut` now renders too, so menu shortcuts will look the same. Every other icon bar is unchanged; the prop is optional.


https://github.com/user-attachments/assets/f667363c-9801-48c6-bc85-5be523ec65f9



## Where to look

- [`dashboards.ts` `resolveWidgetPosition`](https://github.com/formbricks/formbricks/blob/claude/eng-2838-feedback-record-default-language/apps/web/modules/ee/analysis/dashboards/lib/dashboards.ts) — placement runs inside the insert transaction, wrapped in the shared `retryOnTransactionConflict` (`lib/utils/prisma-error.ts`, new) so a committed chart copy never ends up on no dashboard
- [`widget-placement.ts` `findNextOpenSlot`](https://github.com/formbricks/formbricks/blob/claude/eng-2838-feedback-record-default-language/apps/web/modules/ee/analysis/dashboards/lib/widget-placement.ts) — the gap search itself
- [`edit-hotkey.ts`](https://github.com/formbricks/formbricks/blob/claude/eng-2838-feedback-record-default-language/apps/web/modules/ee/analysis/dashboards/lib/edit-hotkey.ts) — what disqualifies a keystroke; the DOM query for an open overlay is separate from the pure predicate so the predicate is unit-testable in the node env
- [`kbd/index.tsx`](https://github.com/formbricks/formbricks/blob/claude/eng-2838-feedback-record-default-language/apps/web/modules/ui/components/kbd/index.tsx) — the key cap, rendered by `IconBar` and `DropdownMenuShortcut`

## Breaking changes

- [ ] This PR contains breaking changes

None. The placement change affects where a new copy is created, never an existing widget's stored layout, and `shortcut` on `IconBar` is an optional prop.

## Migrations & env

- none

## How this was tested

Rerun:

```
pnpm --filter=@formbricks/web exec vitest run modules/ee/analysis/dashboards/lib lib/utils/prisma-error.test.ts
```

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| `nextOpenSlot` puts the widget in the gap beside an existing one | unit (mutation) | Mutate `resolveWidgetPosition` (`dashboards.ts:34`) to always append |
| `nextOpenSlot` drops the widget below a full row | unit (mutation) | Mutate the same helper |
| Duplicate asks for `nextOpenSlot`; the default path still appends below everything | unit (guard) | Passes |
| An unreadable stored layout makes placement append instead of claiming a gap | unit (mutation) | Drop `everyLayoutReadable` (`dashboards.ts:48`) |
| A `P2034` conflict (or a driver-level deadlock) retries with backoff, and a repeating one still errors after 3 attempts | unit (mutation) | `prisma-error.test.ts` `retryOnTransactionConflict`; drop the `isTransactionConflictError` check in `retryOnTransactionConflict` |
| Slot search: gap mid-row, gap under a shorter widget, narrow leftover gap, full grid, widget wider than the grid, narrower breakpoint | unit | Passes |
| Bare `e` / `E` triggers; each modifier, an IME composition, a focused input/textarea/select and a contenteditable do not | unit | Passes |
| `E` enters edit mode; ignored with the Add-charts dialog open; duplicate lands beside its original; pencil shows the `E` cap | manual | Verified in a running app |
| Moving the cap into `Kbd` keeps the same markup and classes | manual | Read the diff; `DropdownMenuShortcut` has no callers yet |

Placement moved into `addChartToDashboard` after review, so its tests are mutation-checked rather than red-on-main: the behaviour lives in code this PR adds.

**Open gaps**

- Concurrency and unreadable-layout handling are covered by unit tests only — neither state is reachable through the UI to check by hand.
- No e2e spec for either behaviour.

**Risks**

- `E` is now live on the dashboard detail page. The guards cover text fields, Radix dialogs and menus, but a future overlay that renders without `role="dialog"`/`"menu"` would let the keystroke through to edit mode.
- The `workspace-delete` e2e failure on this PR's earlier run is the prefetch race fixed in #9161, unrelated to this diff. The cookie-poll workaround that was here has been reverted so #9161 owns that spec.

<details>
<summary>Why ENG-2838 was dropped from this PR</summary>

The first commit here resolved a `"default"` response language to the survey's default code at transform time. It relabels nothing for real submissions, so it was removed:

- The renderer already does it. [`survey.tsx`](https://github.com/formbricks/formbricks/blob/main/packages/surveys/src/components/general/survey.tsx) resolves `"default"` to the survey's default code before the response is created (PR #4826), so `Response.language` never holds `"default"` from a browser, link or app submission.
- A dev database with 189 responses has no `"default"` row at all, and no row where the language is missing *while* the survey configures languages — the only case the change touched.
- What actually feeds "Not specified" is responses from surveys with **no** `SurveyLanguage` rows, which the change deliberately skipped. There is no code to resolve those from: no `Survey.language`, no workspace default-language column.

ENG-2838 asks for a record's language to be used "when a feedback record has a language set", which points at the dashboard read side or at monolingual surveys. It stays open pending that clarification.

</details>





