### PR TITLE
fix: make CSAT and CES scale labels translatable (backport #9136 to release/5.4)

### DIFF
--- a/apps/web/modules/survey/multi-language-surveys/lib/utils.ts
+++ b/apps/web/modules/survey/multi-language-surveys/lib/utils.ts
@@ -151,6 +151,8 @@ export const extractTranslatableStrings = (survey: TSurvey, t: TFunction): Trans
         }
         case TSurveyElementTypeEnum.NPS:
         case TSurveyElementTypeEnum.Rating:
+        case TSurveyElementTypeEnum.CSAT:
+        case TSurveyElementTypeEnum.CES:
           pushIfI18n(result, element, "lowerLabel", base, did, t("workspace.surveys.edit.lower_label"), eid);
           pushIfI18n(result, element, "upperLabel", base, did, t("workspace.surveys.edit.upper_label"), eid);
           break;


### PR DESCRIPTION
<!-- No Linear ticket: the original was reported directly as a bug report while inspecting a live multi-language survey. -->

Backport of #9136 to `release/5.4`. Minimal single-fix backport per the backport policy.

> [!WARNING]
> #9136 is **not merged yet** (it is in the merge queue at the time of writing). This backport was cherry-picked from its branch commit `320338c5d6`. If that PR changes before it merges, re-check this diff.

## What & why

**Was:** The lower and upper scale labels of CSAT and CES elements never showed up in the Manage translations modal, so they could not be translated — a survey in another language rendered its default-language labels next to a translated question.

**Now:** Those labels are listed like every other translatable string, and they count towards each language's translation progress.

The extractor that feeds the modal switched on element type and handled `lowerLabel`/`upperLabel` for `nps` and `rating` only. CSAT and CES carry the same two fields but fell through to no case at all.

**Files changed** — one, two added lines:

- `apps/web/modules/survey/multi-language-surveys/lib/utils.ts` — two added `switch` cases (`CSAT`, `CES`) falling through to the existing NPS/Rating branch.

**Dropped from the original PR:** the net-new unit test case in `utils.test.ts` (and the two `t()` mock keys it needed), per the no-net-new-tests backport rule. No pre-existing test was modified by #9136, so nothing was kept from that file.

## Breaking changes

- [ ] This PR contains breaking changes

None — internal editor helper. No API, SDK, env var or stored-survey shape is touched, and surveys that already have translated CSAT/CES labels keep them.

## Migrations & env

- none

## How this was tested

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| CSAT and CES scale labels are extracted as translatable strings | manual | Verified in the diff against `release/5.4`: both types now hit the branch that pushes `lowerLabel`/`upperLabel`; CSAT and CES both declare those fields as `ZI18nString.optional()`, and both render through `RatingElement`, which localizes them |
| Existing extractor behaviour for every other element type | unit (guard) | 5 pre-existing tests in `utils.test.ts` pass on this branch, unchanged |

Rerun: `cd apps/web && npx vitest run modules/survey/multi-language-surveys/lib/utils.test.ts` → `Test Files 1 passed`, `Tests 5 passed`.

<details>
<summary>Lint and format output</summary>

```
$ npx eslint modules/survey/multi-language-surveys/lib/utils.ts
(no output, exit 0)

$ npx prettier --check apps/web/modules/survey/multi-language-surveys/lib/utils.ts
Checking formatting...
All matched files use Prettier code style!
```

</details>

**Open gaps**

- No screenshot of the modal: no Docker daemon on this machine, so no local database and no running app. The diff changes a pure `.ts` extractor, not rendering code.
- The unit test proving the new behaviour lives on `main` (#9136), not here — dropped per backport policy, so this branch has no automated check that fails without the two added lines.
- Existing surveys need the labels translated once in the modal; nothing backfills them.

**Risks**

- Translation progress drops for existing multi-language surveys with CSAT/CES elements — correct, since those labels were previously uncounted.

---

> [!NOTE]
> **AI model used** — `claude-opus-5` (Claude Code), reasoning effort `unknown`.
