### PR TITLE
fix(sso): stop SSO recovery retries growing the URL into a 414

### DIFF
--- a/apps/web/app/api/auth/sso/recovery/complete/route.test.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.test.ts
@@ -65,7 +65,8 @@ describe("GET /api/auth/sso/recovery/complete", () => {
       )
     );
 
-    expect(vi.mocked(completeSsoRecovery).mock.calls[0][0].sessionToken).toBeDefined();
+    // The exact value, not just "some token": forwarding the wrong one would still be defined.
+    expect(vi.mocked(completeSsoRecovery).mock.calls[0][0].sessionToken).toBe("token-abc");
   });
 
   test("redirects to the failure page when no state is present", async () => {

--- a/apps/web/app/api/auth/sso/recovery/complete/route.test.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getSession } from "@/modules/auth/lib/session";
+import { revokeSessionByToken } from "@/modules/auth/lib/session-revocation";
+import { SsoRecoveryError, completeSsoRecovery } from "@/modules/ee/sso/lib/sso-recovery";
+import { GET } from "./route";
+
+/**
+ * The completion route had no test of its own, which is part of why the ENG-2783 loop went unnoticed:
+ * nothing pinned what it reads out of the URL, so the parameter could change shape without a failure.
+ */
+
+const WEBAPP_URL = "https://test-webapp-url.com";
+
+vi.mock("@formbricks/database", () => ({ prisma: {} }));
+vi.mock("@formbricks/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+vi.mock("@/modules/auth/lib/session", () => ({ getSession: vi.fn() }));
+vi.mock("@/modules/auth/lib/session-revocation", () => ({ revokeSessionByToken: vi.fn() }));
+
+// Only the extraction is stubbed, and only because it verifies Better Auth's HMAC over the cookie —
+// minting a correctly signed one here would test the signature, which `session-cookie.test.ts` already
+// covers. The cookie NAMES stay real, since the clearing assertions below depend on them.
+vi.mock("@/modules/auth/lib/session-cookie", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/auth/lib/session-cookie")>()),
+  getSessionTokenFromCookieHeader: vi.fn((header: string | null) =>
+    header?.includes("session_token=") ? "token-abc" : null
+  ),
+}));
+
+// `SsoRecoveryError` and `getSsoRecoveryFailureRedirectUrl` stay real — the route branches on
+// `instanceof` and builds its redirect from the second, so stubbing either would test the stub.
+vi.mock("@/modules/ee/sso/lib/sso-recovery", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/ee/sso/lib/sso-recovery")>()),
+  completeSsoRecovery: vi.fn(),
+}));
+
+const request = (url: string, cookie?: string) =>
+  new Request(url, cookie ? { headers: { cookie } } : undefined);
+
+const location = (response: Response) => response.headers.get("location");
+
+describe("GET /api/auth/sso/recovery/complete", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getSession).mockResolvedValue({ user: { id: "user_1" } } as never);
+  });
+
+  test("sends the user on to the callback the completed recovery returns", async () => {
+    vi.mocked(completeSsoRecovery).mockResolvedValue(`${WEBAPP_URL}/environments/env_1`);
+
+    const response = await GET(request(`${WEBAPP_URL}/api/auth/sso/recovery/complete?state=state-id`));
+
+    expect(completeSsoRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({ stateId: "state-id", sessionUserId: "user_1" })
+    );
+    expect(location(response)).toBe(`${WEBAPP_URL}/environments/env_1`);
+  });
+
+  test("hands the session token through, so the post-commit sweep can spare it", async () => {
+    vi.mocked(completeSsoRecovery).mockResolvedValue(WEBAPP_URL);
+
+    await GET(
+      request(
+        `${WEBAPP_URL}/api/auth/sso/recovery/complete?state=state-id`,
+        "formbricks.session_token=token-abc.signature"
+      )
+    );
+
+    expect(vi.mocked(completeSsoRecovery).mock.calls[0][0].sessionToken).toBeDefined();
+  });
+
+  test("redirects to the failure page when no state is present", async () => {
+    const response = await GET(request(`${WEBAPP_URL}/api/auth/sso/recovery/complete`));
+
+    expect(completeSsoRecovery).not.toHaveBeenCalled();
+    expect(location(response)).toContain("error=OAuthAccountNotLinked");
+  });
+
+  /**
+   * The parameter changed from a JWT payload to an opaque reference. A stale `?intent=` link — one
+   * emailed before the deploy, valid for up to a day — must land on the ordinary failure page rather
+   * than being treated as a state id.
+   */
+  test("does not accept the old intent parameter", async () => {
+    const response = await GET(request(`${WEBAPP_URL}/api/auth/sso/recovery/complete?intent=some.jwt.value`));
+
+    expect(completeSsoRecovery).not.toHaveBeenCalled();
+    expect(location(response)).toContain("error=OAuthAccountNotLinked");
+  });
+
+  test("carries the intent's own callback into the failure redirect", async () => {
+    vi.mocked(completeSsoRecovery).mockRejectedValue(
+      new SsoRecoveryError(`${WEBAPP_URL}/environments/env_1`)
+    );
+
+    const response = await GET(request(`${WEBAPP_URL}/api/auth/sso/recovery/complete?state=state-id`));
+
+    expect(location(response)).toContain(
+      `callbackUrl=${encodeURIComponent(`${WEBAPP_URL}/environments/env_1`)}`
+    );
+  });
+
+  test("omits the callback when the intent could not be read at all", async () => {
+    vi.mocked(completeSsoRecovery).mockRejectedValue(new SsoRecoveryError());
+
+    const response = await GET(request(`${WEBAPP_URL}/api/auth/sso/recovery/complete?state=unknown`));
+
+    expect(location(response)).toContain("error=OAuthAccountNotLinked");
+    expect(location(response)).not.toContain("callbackUrl=");
+  });
+
+  test("still redirects safely when the failure is not one of ours", async () => {
+    vi.mocked(completeSsoRecovery).mockRejectedValue(new Error("redis exploded"));
+
+    const response = await GET(request(`${WEBAPP_URL}/api/auth/sso/recovery/complete?state=state-id`));
+
+    expect(location(response)).toContain("error=OAuthAccountNotLinked");
+    expect(location(response)).not.toContain("callbackUrl=");
+  });
+
+  test("clears the session cookies and revokes the session it was given on failure", async () => {
+    vi.mocked(completeSsoRecovery).mockRejectedValue(new SsoRecoveryError());
+
+    const response = await GET(
+      request(
+        `${WEBAPP_URL}/api/auth/sso/recovery/complete?state=state-id`,
+        "formbricks.session_token=token-abc.signature"
+      )
+    );
+
+    const setCookies = response.headers.getSetCookie().join("\n");
+    expect(setCookies).toContain("formbricks.session_token=;");
+    expect(setCookies).toContain("__Secure-formbricks.session_token=;");
+    expect(revokeSessionByToken).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/auth/sso/recovery/complete/route.test.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.test.ts
@@ -90,7 +90,7 @@ describe("GET /api/auth/sso/recovery/complete", () => {
 
   test("carries the intent's own callback into the failure redirect", async () => {
     vi.mocked(completeSsoRecovery).mockRejectedValue(
-      new SsoRecoveryError(`${WEBAPP_URL}/environments/env_1`)
+      new SsoRecoveryError("rejected", `${WEBAPP_URL}/environments/env_1`)
     );
 
     const response = await GET(request(`${WEBAPP_URL}/api/auth/sso/recovery/complete?state=state-id`));
@@ -101,12 +101,33 @@ describe("GET /api/auth/sso/recovery/complete", () => {
   });
 
   test("omits the callback when the intent could not be read at all", async () => {
-    vi.mocked(completeSsoRecovery).mockRejectedValue(new SsoRecoveryError());
+    vi.mocked(completeSsoRecovery).mockRejectedValue(new SsoRecoveryError("intent_missing"));
 
     const response = await GET(request(`${WEBAPP_URL}/api/auth/sso/recovery/complete?state=unknown`));
 
     expect(location(response)).toContain("error=OAuthAccountNotLinked");
     expect(location(response)).not.toContain("callbackUrl=");
+  });
+
+  /**
+   * The emailed link is replayable for a day by design, so a second open — the other device, or a
+   * refresh — is an ordinary act. It finds the intent already consumed, and that is not evidence of a
+   * session that should not exist: tearing one down here signed the user in and then straight back out,
+   * reporting that the linking had failed after it had already succeeded.
+   */
+  test("leaves the session alone when the intent is simply gone", async () => {
+    vi.mocked(completeSsoRecovery).mockRejectedValue(new SsoRecoveryError("intent_missing"));
+
+    const response = await GET(
+      request(
+        `${WEBAPP_URL}/api/auth/sso/recovery/complete?state=state-id`,
+        "formbricks.session_token=token-abc.signature"
+      )
+    );
+
+    expect(revokeSessionByToken).not.toHaveBeenCalled();
+    expect(response.headers.getSetCookie().join("\n")).not.toContain("session_token=;");
+    expect(location(response)).toContain("error=OAuthAccountNotLinked");
   });
 
   test("still redirects safely when the failure is not one of ours", async () => {
@@ -118,8 +139,8 @@ describe("GET /api/auth/sso/recovery/complete", () => {
     expect(location(response)).not.toContain("callbackUrl=");
   });
 
-  test("clears the session cookies and revokes the session it was given on failure", async () => {
-    vi.mocked(completeSsoRecovery).mockRejectedValue(new SsoRecoveryError());
+  test("clears the session cookies and revokes the session it was given on a rejected recovery", async () => {
+    vi.mocked(completeSsoRecovery).mockRejectedValue(new SsoRecoveryError("rejected"));
 
     const response = await GET(
       request(

--- a/apps/web/app/api/auth/sso/recovery/complete/route.test.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.test.ts
@@ -78,7 +78,7 @@ describe("GET /api/auth/sso/recovery/complete", () => {
 
   /**
    * The parameter changed from a JWT payload to an opaque reference. A stale `?intent=` link — one
-   * emailed before the deploy, valid for up to a day — must land on the ordinary failure page rather
+   * emailed before the deploy, still inside its window — must land on the ordinary failure page rather
    * than being treated as a state id.
    */
   test("does not accept the old intent parameter", async () => {
@@ -110,7 +110,8 @@ describe("GET /api/auth/sso/recovery/complete", () => {
   });
 
   /**
-   * The emailed link is replayable for a day by design, so a second open — the other device, or a
+   * The emailed link is replayable for its whole window by design, so a second open — the other
+   * device, or a
    * refresh — is an ordinary act. It finds the intent already consumed, and that is not evidence of a
    * session that should not exist: tearing one down here signed the user in and then straight back out,
    * reporting that the linking had failed after it had already succeeded.

--- a/apps/web/app/api/auth/sso/recovery/complete/route.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.ts
@@ -1,13 +1,16 @@
 import { NextResponse } from "next/server";
 import { logger } from "@formbricks/logger";
-import { verifySsoRelinkIntent } from "@/lib/jwt";
 import { getSession } from "@/modules/auth/lib/session";
 import {
   BETTER_AUTH_SESSION_COOKIE_NAMES,
   getSessionTokenFromCookieHeader,
 } from "@/modules/auth/lib/session-cookie";
 import { revokeSessionByToken } from "@/modules/auth/lib/session-revocation";
-import { completeSsoRecovery, getSsoRecoveryFailureRedirectUrl } from "@/modules/ee/sso/lib/sso-recovery";
+import {
+  SsoRecoveryError,
+  completeSsoRecovery,
+  getSsoRecoveryFailureRedirectUrl,
+} from "@/modules/ee/sso/lib/sso-recovery";
 
 const clearSessionCookies = (response: NextResponse) => {
   for (const cookieName of BETTER_AUTH_SESSION_COOKIE_NAMES) {
@@ -43,28 +46,31 @@ const buildFailedRecoveryResponse = async (request: Request, callbackUrl?: strin
 
 export const GET = async (request: Request) => {
   const url = new URL(request.url);
-  const intentToken = url.searchParams.get("intent");
+  // An opaque id standing for a server-side record, not a payload (ENG-2783). The intent used to ride
+  // here as a JWT, which is what let each retry nest the previous attempt's whole URL inside the next.
+  const stateId = url.searchParams.get("state");
 
-  if (!intentToken) {
+  if (!stateId) {
     return NextResponse.redirect(getSsoRecoveryFailureRedirectUrl());
   }
 
   try {
     const session = await getSession();
     const callbackUrl = await completeSsoRecovery({
-      intentToken,
+      stateId,
       sessionUserId: session?.user.id,
       // Spared by the post-commit session sweep, so the redirect below still lands signed in.
       sessionToken: getSessionTokenFromCookieHeader(request.headers.get("cookie")) ?? undefined,
     });
 
     return NextResponse.redirect(callbackUrl);
-  } catch {
-    try {
-      const intent = verifySsoRelinkIntent(intentToken);
-      return await buildFailedRecoveryResponse(request, intent.callbackUrl);
-    } catch {
-      return await buildFailedRecoveryResponse(request);
-    }
+  } catch (error) {
+    // The failure redirect wants the callback the user was originally headed for. It used to be
+    // recovered by decoding the intent a second time; now it rides on the error, so there is nothing
+    // to re-read and no second Redis round trip. Absent when the intent could not be read at all.
+    return await buildFailedRecoveryResponse(
+      request,
+      error instanceof SsoRecoveryError ? error.callbackUrl : undefined
+    );
   }
 };

--- a/apps/web/app/api/auth/sso/recovery/complete/route.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.ts
@@ -65,12 +65,20 @@ export const GET = async (request: Request) => {
 
     return NextResponse.redirect(callbackUrl);
   } catch (error) {
-    // The failure redirect wants the callback the user was originally headed for. It used to be
-    // recovered by decoding the intent a second time; now it rides on the error, so there is nothing
-    // to re-read and no second Redis round trip. Absent when the intent could not be read at all.
-    return await buildFailedRecoveryResponse(
-      request,
-      error instanceof SsoRecoveryError ? error.callbackUrl : undefined
-    );
+    const recoveryError = error instanceof SsoRecoveryError ? error : null;
+
+    // An intent that simply is not there is the ordinary case — this recovery already completed, or it
+    // expired — and it is not evidence of a session that should not exist. Tearing one down here would
+    // punish a second open of a link that is replayable for a day by design: the sign-in endpoint
+    // establishes the session, then this route would revoke it and report that the linking failed,
+    // after it had already succeeded on the first open. So leave the session alone and just redirect.
+    if (recoveryError?.failure === "intent_missing") {
+      return NextResponse.redirect(getSsoRecoveryFailureRedirectUrl());
+    }
+
+    // Everything else — a guard that read an intent and turned it down, or an unexpected throw — keeps
+    // the ENG-2557 teardown. The failure redirect wants the callback the user was originally headed
+    // for, which rides on the error rather than costing a second Redis read.
+    return await buildFailedRecoveryResponse(request, recoveryError?.callbackUrl);
   }
 };

--- a/apps/web/app/api/auth/sso/recovery/complete/route.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.ts
@@ -69,9 +69,10 @@ export const GET = async (request: Request) => {
 
     // An intent that simply is not there is the ordinary case — this recovery already completed, or it
     // expired — and it is not evidence of a session that should not exist. Tearing one down here would
-    // punish a second open of a link that is replayable for its whole window by design: the sign-in endpoint
-    // establishes the session, then this route would revoke it and report that the linking failed,
-    // after it had already succeeded on the first open. So leave the session alone and just redirect.
+    // punish a second open of a link that is replayable for its whole window by design: the sign-in
+    // endpoint establishes the session, then this route would revoke it and report that the linking
+    // failed, after it had already succeeded on the first open. So leave the session alone and
+    // just redirect.
     if (recoveryError?.failure === "intent_missing") {
       return NextResponse.redirect(getSsoRecoveryFailureRedirectUrl());
     }

--- a/apps/web/app/api/auth/sso/recovery/complete/route.ts
+++ b/apps/web/app/api/auth/sso/recovery/complete/route.ts
@@ -69,7 +69,7 @@ export const GET = async (request: Request) => {
 
     // An intent that simply is not there is the ordinary case — this recovery already completed, or it
     // expired — and it is not evidence of a session that should not exist. Tearing one down here would
-    // punish a second open of a link that is replayable for a day by design: the sign-in endpoint
+    // punish a second open of a link that is replayable for its whole window by design: the sign-in endpoint
     // establishes the session, then this route would revoke it and report that the linking failed,
     // after it had already succeeded on the first open. So leave the session alone and just redirect.
     if (recoveryError?.failure === "intent_missing") {

--- a/apps/web/integration/setup.ts
+++ b/apps/web/integration/setup.ts
@@ -36,6 +36,9 @@ vi.mock("server-only", () => ({}));
 // type wrong — which is exactly how the undefined-vs-boolean bug above got in. Add senders here.
 vi.mock("@/modules/email", () => ({
   sendVerificationLinkEmail: vi.fn(async () => true),
+  // The SSO-recovery pair (ENG-2783): startSsoRecovery sends the first, completeSsoRecovery the second.
+  sendVerificationEmail: vi.fn(async () => true),
+  sendSsoRecoveryFactorsRemovedEmail: vi.fn(async () => true),
   sendPasswordResetLinkEmail: vi.fn(async () => true),
   sendPasswordResetNotifyEmail: vi.fn(async () => true),
   sendDeleteAccountConfirmationEmail: vi.fn(async () => true),

--- a/apps/web/lib/jwt.test.ts
+++ b/apps/web/lib/jwt.test.ts
@@ -8,7 +8,6 @@ import {
   createFeedbackRecordsGatewayToken,
   createGatewayServiceToken,
   createInviteToken,
-  createSsoRelinkIntent,
   createToken,
   createTokenForLinkSurvey,
   getEmailFromEmailToken,
@@ -16,7 +15,6 @@ import {
   verifyFeedbackRecordsGatewayToken,
   verifyGatewayServiceToken,
   verifyInviteToken,
-  verifySsoRelinkIntent,
   verifyToken,
   verifyTokenForLinkSurvey,
 } from "./jwt";
@@ -1238,53 +1236,6 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
             purpose: "email_verification",
           })
         );
-      });
-
-      test("round-trips SSO relink intents without losing callback state", () => {
-        const intent = createSsoRelinkIntent({
-          userId: mockUser.id,
-          email: mockUser.email,
-          provider: "google",
-          providerAccountId: "provider-123",
-          callbackUrl: "http://localhost:3000/invite?token=invite-token",
-        });
-
-        expect(verifySsoRelinkIntent(intent)).toEqual({
-          userId: mockUser.id,
-          email: mockUser.email,
-          provider: "google",
-          providerAccountId: "provider-123",
-          callbackUrl: "http://localhost:3000/invite?token=invite-token",
-        });
-      });
-
-      test("rejects expired SSO relink intents", () => {
-        const expiredIntent = jwt.sign(
-          {
-            userId: crypto.symmetricEncrypt(mockUser.id, TEST_ENCRYPTION_KEY),
-            email: crypto.symmetricEncrypt(mockUser.email, TEST_ENCRYPTION_KEY),
-            provider: "google",
-            providerAccountId: crypto.symmetricEncrypt("provider-123", TEST_ENCRYPTION_KEY),
-            callbackUrl: crypto.symmetricEncrypt("http://localhost:3000", TEST_ENCRYPTION_KEY),
-            exp: Math.floor(Date.now() / 1000) - 3600,
-          },
-          TEST_NEXTAUTH_SECRET
-        );
-
-        expect(() => verifySsoRelinkIntent(expiredIntent)).toThrow();
-      });
-
-      test("rejects tampered SSO relink intents", () => {
-        const intent = createSsoRelinkIntent({
-          userId: mockUser.id,
-          email: mockUser.email,
-          provider: "google",
-          providerAccountId: "provider-123",
-          callbackUrl: "http://localhost:3000",
-        });
-
-        const tamperedIntent = `${intent.slice(0, -1)}x`;
-        expect(() => verifySsoRelinkIntent(tamperedIntent)).toThrow();
       });
     });
   });

--- a/apps/web/lib/jwt.ts
+++ b/apps/web/lib/jwt.ts
@@ -46,14 +46,6 @@ type TVerificationTokenOptions = SignOptions & {
   purpose?: TVerificationTokenPurpose;
 };
 
-type TSsoRelinkIntentPayload = {
-  callbackUrl: string;
-  email: string;
-  provider: string;
-  providerAccountId: string;
-  userId: string;
-};
-
 const DEFAULT_VERIFICATION_TOKEN_PURPOSE: TVerificationTokenPurpose = "email_verification";
 
 const getVerificationTokenPurpose = (purpose: unknown): TVerificationTokenPurpose => {
@@ -452,71 +444,6 @@ const getUserEmailForLegacyVerification = async (
   }
 
   return { userId: decryptedId, userEmail: foundUser.email };
-};
-
-const DEFAULT_SSO_RELINK_INTENT_OPTIONS: SignOptions = {
-  expiresIn: "15m",
-};
-
-export const createSsoRelinkIntent = (
-  payload: TSsoRelinkIntentPayload,
-  options: SignOptions = DEFAULT_SSO_RELINK_INTENT_OPTIONS
-): string => {
-  if (!NEXTAUTH_SECRET) {
-    throw new Error("NEXTAUTH_SECRET is not set");
-  }
-
-  if (!ENCRYPTION_KEY) {
-    throw new Error("ENCRYPTION_KEY is not set");
-  }
-
-  return jwt.sign(
-    {
-      userId: symmetricEncrypt(payload.userId, ENCRYPTION_KEY),
-      email: symmetricEncrypt(payload.email, ENCRYPTION_KEY),
-      provider: payload.provider,
-      providerAccountId: symmetricEncrypt(payload.providerAccountId, ENCRYPTION_KEY),
-      callbackUrl: symmetricEncrypt(payload.callbackUrl, ENCRYPTION_KEY),
-    },
-    NEXTAUTH_SECRET,
-    options
-  );
-};
-
-export const verifySsoRelinkIntent = (token: string): TSsoRelinkIntentPayload => {
-  if (!NEXTAUTH_SECRET) {
-    throw new Error("NEXTAUTH_SECRET is not set");
-  }
-
-  if (!ENCRYPTION_KEY) {
-    throw new Error("ENCRYPTION_KEY is not set");
-  }
-
-  const payload = jwt.verify(token, NEXTAUTH_SECRET, { algorithms: ["HS256"] }) as JwtPayload & {
-    userId: string;
-    email: string;
-    provider: string;
-    providerAccountId: string;
-    callbackUrl: string;
-  };
-
-  if (
-    !payload?.userId ||
-    !payload?.email ||
-    !payload?.provider ||
-    !payload?.providerAccountId ||
-    !payload?.callbackUrl
-  ) {
-    throw new Error("Token is invalid or missing required fields");
-  }
-
-  return {
-    userId: decryptWithFallback(payload.userId, ENCRYPTION_KEY),
-    email: decryptWithFallback(payload.email, ENCRYPTION_KEY),
-    provider: payload.provider,
-    providerAccountId: decryptWithFallback(payload.providerAccountId, ENCRYPTION_KEY),
-    callbackUrl: decryptWithFallback(payload.callbackUrl, ENCRYPTION_KEY),
-  };
 };
 
 export const verifyToken = async (token: string): Promise<TVerifyTokenPayload> => {

--- a/apps/web/lib/utils/url.test.ts
+++ b/apps/web/lib/utils/url.test.ts
@@ -1,7 +1,7 @@
 import { cleanup } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
 import { TActionClassPageUrlRule } from "@formbricks/types/action-classes";
-import { getValidatedCallbackUrl, isStringUrl, testURLmatch } from "./url";
+import { MAX_CALLBACK_URL_LENGTH, getValidatedCallbackUrl, isStringUrl, testURLmatch } from "./url";
 
 afterEach(() => {
   cleanup();
@@ -111,6 +111,34 @@ describe("getValidatedCallbackUrl", () => {
     expect(getValidatedCallbackUrl("https://webapp.example.com/dashboard", WEBAPP_URL)).toBe(
       "https://webapp.example.com/dashboard"
     );
+  });
+
+  /**
+   * A callback rides in the request line, and nginx returns a bare 414 once that exceeds one 8K buffer.
+   * Rejecting it here gives every caller something to act on: `proxy.ts` answers 400, the auth flows
+   * fall back to WEBAPP_URL (ENG-2783).
+   */
+  test("rejects a callback URL longer than the cap", () => {
+    const tooLong = `https://webapp.example.com/x?padding=${"a".repeat(MAX_CALLBACK_URL_LENGTH)}`;
+
+    expect(tooLong.length).toBeGreaterThan(MAX_CALLBACK_URL_LENGTH);
+    expect(getValidatedCallbackUrl(tooLong, WEBAPP_URL)).toBeNull();
+  });
+
+  test("accepts a callback URL right at the cap", () => {
+    const prefix = "https://webapp.example.com/x?padding=";
+    const atCap = prefix + "a".repeat(MAX_CALLBACK_URL_LENGTH - prefix.length);
+
+    expect(atCap).toHaveLength(MAX_CALLBACK_URL_LENGTH);
+    expect(getValidatedCallbackUrl(atCap, WEBAPP_URL)).toBe(atCap);
+  });
+
+  test("leaves room for the widest callback the app actually mints", () => {
+    // An invite link, `/invite?token=<jwt>`, is the longest legitimate callback in the app at roughly
+    // 640 characters with a long address. If that ever approaches the cap, this fails before users do.
+    const inviteCallbackUrl = `https://webapp.example.com/invite?token=${"t".repeat(600)}`;
+
+    expect(getValidatedCallbackUrl(inviteCallbackUrl, WEBAPP_URL)).toBe(inviteCallbackUrl);
   });
 });
 

--- a/apps/web/lib/utils/url.test.ts
+++ b/apps/web/lib/utils/url.test.ts
@@ -133,6 +133,34 @@ describe("getValidatedCallbackUrl", () => {
     expect(getValidatedCallbackUrl(atCap, WEBAPP_URL)).toBe(atCap);
   });
 
+  /**
+   * `toString()` percent-encodes, up to ninefold for a 3-byte character, so a check on the input let
+   * through callbacks whose returned form was over the cap. Those then failed the re-validation in
+   * `completeSsoRecovery` and dropped the user on the app root instead of their destination — a
+   * legitimate long callback failing exactly like a malicious one, which is what hid it.
+   */
+  test("rejects a callback whose encoded form exceeds the cap, though its input does not", () => {
+    const input = `https://webapp.example.com/x?search=${"字".repeat(227)}`;
+
+    expect(input.length).toBeLessThan(MAX_CALLBACK_URL_LENGTH);
+    expect(encodeURI(input).length).toBeGreaterThan(MAX_CALLBACK_URL_LENGTH);
+    expect(getValidatedCallbackUrl(input, WEBAPP_URL)).toBeNull();
+  });
+
+  test.each([
+    ["a plain path", "https://webapp.example.com/dashboard"],
+    ["a query string", "https://webapp.example.com/x?a=1&b=2"],
+    ["multi-byte characters", `https://webapp.example.com/x?search=${"字".repeat(50)}`],
+    ["a root-relative path", "/invite?token=abc"],
+  ])("accepts its own output for %s, so a stored callback re-validates", (_label, input) => {
+    const once = getValidatedCallbackUrl(input, WEBAPP_URL);
+
+    expect(once).not.toBeNull();
+    // The property that matters: anything this function hands back, it will take back. Without it a
+    // value can be validated on the way in and rejected on the way out.
+    expect(getValidatedCallbackUrl(once, WEBAPP_URL)).toBe(once);
+  });
+
   test("leaves room for the widest callback the app actually mints", () => {
     // An invite link, `/invite?token=<jwt>`, is the longest legitimate callback in the app at roughly
     // 640 characters with a long address. If that ever approaches the cap, this fails before users do.

--- a/apps/web/lib/utils/url.ts
+++ b/apps/web/lib/utils/url.ts
@@ -34,12 +34,32 @@ export const testURLmatch = (
   }
 };
 
+/**
+ * Upper bound on a callback URL, in characters (ENG-2783).
+ *
+ * A callback rides in a request line, and nginx's `large_client_header_buffers` defaults to `4 8k` with
+ * the rule that a request line must fit inside ONE buffer — so an over-long callback comes back as a
+ * bare `414 Request-URI Too Large`, a blank page with nothing to act on. Rejecting it here turns that
+ * into something diagnosable instead: `proxy.ts` answers `400 {"error":"Invalid callback URL"}`, and
+ * the auth flows fall back to `WEBAPP_URL` the same way they do for any other invalid callback.
+ *
+ * 2048 is the conventional safe maximum, and it is not a new constraint on this codebase:
+ * `resendVerificationEmailAction` has capped its callback at 2000 since it was written. The widest
+ * legitimate callback in the app is an invite link, `/invite?token=<jwt>`, which measures ~640
+ * characters with a long address — so this leaves roughly threefold headroom.
+ */
+export const MAX_CALLBACK_URL_LENGTH = 2048;
+
 // Helper function to validate callback URLs
 export const getValidatedCallbackUrl = (
   url: string | null | undefined,
   WEBAPP_URL: string
 ): string | null => {
   if (!url) {
+    return null;
+  }
+
+  if (url.length > MAX_CALLBACK_URL_LENGTH) {
     return null;
   }
 

--- a/apps/web/lib/utils/url.ts
+++ b/apps/web/lib/utils/url.ts
@@ -59,10 +59,6 @@ export const getValidatedCallbackUrl = (
     return null;
   }
 
-  if (url.length > MAX_CALLBACK_URL_LENGTH) {
-    return null;
-  }
-
   try {
     const parsedWebAppUrl = new URL(WEBAPP_URL);
     const isAbsoluteUrl = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
@@ -97,7 +93,14 @@ export const getValidatedCallbackUrl = (
       return null;
     }
 
-    return parsedUrl.toString();
+    const validatedCallbackUrl = parsedUrl.toString();
+
+    // Measured on what we RETURN, not on what came in. `toString()` percent-encodes, up to ninefold
+    // for a 3-byte character, so an input under the cap can leave it: 258 characters ending in 227 CJK
+    // characters comes back as 2074. Checking the input instead made the function reject its own
+    // output, so a callback accepted here failed the re-validation in `completeSsoRecovery` and the
+    // user landed on the app root rather than where they were going.
+    return validatedCallbackUrl.length > MAX_CALLBACK_URL_LENGTH ? null : validatedCallbackUrl;
   } catch {
     return null;
   }

--- a/apps/web/modules/auth/lib/verification-links.ts
+++ b/apps/web/modules/auth/lib/verification-links.ts
@@ -1,7 +1,22 @@
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
-import { SSO_RECOVERY_SIGN_IN_PATH } from "@/modules/ee/sso/lib/constants";
 
 const RELATIVE_URL_BASE = "http://localhost";
+
+/**
+ * The two SSO-recovery route paths.
+ *
+ * They live here, not in `modules/ee/sso/lib/constants.ts`, because OSS code needs them — this file
+ * builds the emailed verify link, and `verification-requested/actions.ts` matches an incoming callback
+ * against the completion path — and `.coderabbit.yaml` (`apps/web/modules/ee/**`) forbids OSS importing
+ * from `modules/ee` outside the `license-check` gate. Route paths carry no entitlement, so the fix is
+ * to own them on this side and let the EE modules import them; that direction is fine. This file is
+ * also reachable from a client component (`signup/components/signup-form.tsx`), which is a second
+ * reason not to pull an EE module in from here.
+ */
+export const SSO_RECOVERY_COMPLETION_PATH = "/api/auth/sso/recovery/complete";
+
+/** Better Auth's recovery magic-link endpoint, mounted by `ssoRecoverySignInPlugin` under `/api/auth`. */
+export const SSO_RECOVERY_SIGN_IN_PATH = "/api/auth/sso-recovery/sign-in";
 
 /**
  * Lifetime of the emailed verification / SSO-recovery magic link.

--- a/apps/web/modules/auth/lib/verification-links.ts
+++ b/apps/web/modules/auth/lib/verification-links.ts
@@ -1,4 +1,5 @@
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
+import { SSO_RECOVERY_SIGN_IN_PATH } from "@/modules/ee/sso/lib/constants";
 
 const RELATIVE_URL_BASE = "http://localhost";
 
@@ -88,7 +89,7 @@ export const buildVerificationLinks = ({
   // flow (ENG-1054), so the legacy /auth/verify page is gone. It resolves at Better Auth's
   // /sso-recovery/sign-in endpoint, which verifies the JWT, establishes the session, and redirects to
   // callbackUrl. (`purpose` still distinguishes the verification-request link below.)
-  const verifyLink = new URL("/api/auth/sso-recovery/sign-in", webAppUrl);
+  const verifyLink = new URL(SSO_RECOVERY_SIGN_IN_PATH, webAppUrl);
   verifyLink.searchParams.set("token", token);
 
   const verificationRequestLink = new URL("/auth/verification-requested", webAppUrl);

--- a/apps/web/modules/auth/lib/verification-links.ts
+++ b/apps/web/modules/auth/lib/verification-links.ts
@@ -1,6 +1,18 @@
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
 
 const RELATIVE_URL_BASE = "http://localhost";
+
+/**
+ * Lifetime of the emailed verification / SSO-recovery magic link.
+ *
+ * Exported so the SSO recovery intent can be pinned to the SAME number (ENG-2783). The link and the
+ * intent are two halves of one flow — the link mints the session, the intent says what to do with it —
+ * so a shorter intent is a guaranteed failure for anyone who reads their mail later: they get signed in
+ * by a link that is still valid and then land on "recovery failed". This is a leaf module both
+ * `modules/email` and `modules/ee/sso` already import, which is what keeps that pairing in one place
+ * without closing an import cycle.
+ */
+export const VERIFICATION_LINK_TTL_SECONDS = 60 * 60 * 24;
 export const VERIFICATION_REQUEST_PURPOSES = ["email_verification", "sso_recovery"] as const;
 export type TVerificationRequestPurpose = (typeof VERIFICATION_REQUEST_PURPOSES)[number];
 const DEFAULT_VERIFICATION_REQUEST_PURPOSE: TVerificationRequestPurpose = "email_verification";

--- a/apps/web/modules/auth/lib/verification-links.ts
+++ b/apps/web/modules/auth/lib/verification-links.ts
@@ -19,6 +19,29 @@ export const SSO_RECOVERY_COMPLETION_PATH = "/api/auth/sso/recovery/complete";
 export const SSO_RECOVERY_SIGN_IN_PATH = "/api/auth/sso-recovery/sign-in";
 
 /**
+ * A URL's pathname, normalised the way Next resolves one before routing.
+ *
+ * Two callers compare an incoming callback against the paths above, and any comparison that does less
+ * than the router does leaves a gap: `normalizeRepeatedSlashes` in `next/dist/shared/lib/utils.js`
+ * collapses interior repeats AND backslashes, and with neither trailing-slash option set in
+ * `next.config.mjs` a trailing one is dropped too. So `/api//auth/sso/recovery/complete` and
+ * `…/complete/` both reach the completion route while a stricter `===` says they are something else.
+ *
+ * Split rather than matched with `/\/+$/`: that pattern backtracks super-linearly on a path of many
+ * slashes (Sonar S8786), and this pathname comes from a caller-supplied URL.
+ */
+export const normalizeRoutePathname = (url: string): string | null => {
+  try {
+    const { pathname } = new URL(url, RELATIVE_URL_BASE);
+    const segments = pathname.replaceAll("\\", "/").split("/").filter(Boolean);
+
+    return segments.length === 0 ? "/" : `/${segments.join("/")}`;
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Lifetime of the emailed verification / SSO-recovery magic link.
  *
  * Exported so the SSO recovery intent can be pinned to the SAME number (ENG-2783). The link and the

--- a/apps/web/modules/auth/lib/verification-links.ts
+++ b/apps/web/modules/auth/lib/verification-links.ts
@@ -42,16 +42,34 @@ export const normalizeRoutePathname = (url: string): string | null => {
 };
 
 /**
- * Lifetime of the emailed verification / SSO-recovery magic link.
+ * Lifetime of the emailed SSO-recovery magic link AND of the recovery intent behind it (ENG-2783).
  *
- * Exported so the SSO recovery intent can be pinned to the SAME number (ENG-2783). The link and the
- * intent are two halves of one flow — the link mints the session, the intent says what to do with it —
- * so a shorter intent is a guaranteed failure for anyone who reads their mail later: they get signed in
- * by a link that is still valid and then land on "recovery failed". This is a leaf module both
- * `modules/email` and `modules/ee/sso` already import, which is what keeps that pairing in one place
- * without closing an import cycle.
+ * One clock for the whole flow, deliberately. The link mints the session and the intent says what to do
+ * with it, so the two are halves of one operation and a gap either way is a defect: a link that
+ * outlives its intent signs the user in and then lands them on "recovery failed" with recovery
+ * half-done, and an intent that outlives its link sits there authorising a password-and-second-factor
+ * strip long after the mail is dead. Both halves derive from this number, and
+ * `getSsoRecoveryPairedTtlSeconds` keeps them paired across a resend too.
+ *
+ * Fifteen minutes, not the day this started as. Completing recovery clears the credential password and
+ * deletes the `TwoFactor` row, which makes it the strongest capability we hand out over email — and the
+ * link is a stateless JWT, so it stays replayable for its whole life. The bars for a short-lived
+ * emailed credential all sit at or under an hour: NIST SP 800-63B-4 s3.1.3.2 makes an out-of-band
+ * authentication invalid unless completed "within 10 minutes" (SHALL), RFC 6749 s4.1.2 RECOMMENDS at
+ * most 10 minutes for an authorization code, RFC 9126 s2.2 puts a `request_uri` at "between 5 and 600
+ * seconds", and OWASP WSTG 4.9 says such a link "should rarely be more than an hour". Our own password
+ * reset — a strictly weaker capability, since it leaves 2FA armed — defaults to 30 minutes
+ * (`PASSWORD_RESET_TOKEN_LIFETIME_MINUTES`, hard-capped at 120). Fifteen leaves room for mail delivery
+ * while staying inside all of those, and unlike sign-up verification, recovery starts with the user at
+ * the keyboard mid-sign-in rather than being something they come back to later.
+ *
+ * Scope is narrower than the name: `sendVerificationEmail` is the only consumer, and its only callers
+ * are `startSsoRecovery` and the SSO-recovery branch of `resendVerificationEmailAction`. Sign-up
+ * verification is Better Auth's own flow on `EMAIL_VERIFICATION_TTL_SECONDS` (1 hour) and is untouched.
+ * No email copy quotes a duration, so shortening this needs no rewording — the template already offers
+ * the resend link for an expired one.
  */
-export const VERIFICATION_LINK_TTL_SECONDS = 60 * 60 * 24;
+export const VERIFICATION_LINK_TTL_SECONDS = 60 * 15;
 export const VERIFICATION_REQUEST_PURPOSES = ["email_verification", "sso_recovery"] as const;
 export type TVerificationRequestPurpose = (typeof VERIFICATION_REQUEST_PURPOSES)[number];
 const DEFAULT_VERIFICATION_REQUEST_PURPOSE: TVerificationRequestPurpose = "email_verification";

--- a/apps/web/modules/auth/verification-requested/actions.test.ts
+++ b/apps/web/modules/auth/verification-requested/actions.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
-import { verifySsoRelinkIntent } from "@/lib/jwt";
 import { auth } from "@/modules/auth/lib/auth";
 import { getUserByEmail } from "@/modules/auth/lib/user";
 // Import mocked functions
@@ -53,6 +52,11 @@ const signupIntentMocks = vi.hoisted(() => ({
   createSignupIntentToken: vi.fn(),
 }));
 
+const recoveryIntentMocks = vi.hoisted(() => ({
+  readSsoRecoveryIntent: vi.fn(),
+  refreshSsoRecoveryIntent: vi.fn(),
+}));
+
 vi.mock("@/modules/auth/lib/signup-intent", () => ({
   SIGNUP_INTENT_COOKIE_NAME: "formbricks.signup_intent",
   SIGNUP_INTENT_COOKIE_OPTIONS: { httpOnly: true, secure: false, path: "/", sameSite: "lax", maxAge: 3600 },
@@ -60,8 +64,9 @@ vi.mock("@/modules/auth/lib/signup-intent", () => ({
   createSignupIntentToken: signupIntentMocks.createSignupIntentToken,
 }));
 
-vi.mock("@/lib/jwt", () => ({
-  verifySsoRelinkIntent: vi.fn(),
+vi.mock("@/modules/ee/sso/lib/recovery-intent", () => ({
+  readSsoRecoveryIntent: recoveryIntentMocks.readSsoRecoveryIntent,
+  refreshSsoRecoveryIntent: recoveryIntentMocks.refreshSsoRecoveryIntent,
 }));
 
 vi.mock("@/lib/constants", async (importOriginal) => {
@@ -110,9 +115,8 @@ describe("resendVerificationEmailAction", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(verifySsoRelinkIntent).mockImplementation(() => {
-      throw new Error("invalid");
-    });
+    // Default: no stored intent, so a client-supplied recovery callback proves nothing on its own.
+    recoveryIntentMocks.readSsoRecoveryIntent.mockResolvedValue(null);
     cookieMocks.get.mockReturnValue(undefined);
     signupIntentMocks.classifySignupIntent.mockReturnValue("absent");
     signupIntentMocks.createSignupIntentToken.mockReturnValue("fresh-intent-token");
@@ -261,19 +265,20 @@ describe("resendVerificationEmailAction", () => {
         isActive: true,
       };
       vi.mocked(getUserByEmail).mockResolvedValue(verifiedUserWithLocale);
-      vi.mocked(verifySsoRelinkIntent).mockReturnValue({
+      recoveryIntentMocks.readSsoRecoveryIntent.mockResolvedValue({
         callbackUrl: "http://localhost:3000",
         email: mockVerifiedUser.email,
         provider: "google",
         providerAccountId: "provider_123",
         userId: mockVerifiedUser.id,
+        createdAt: Date.now(),
       });
 
       const result = await resendVerificationEmailAction({
         ctx: mockCtx,
         parsedInput: {
           ...validInput,
-          callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?intent=test-intent",
+          callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?state=test-state",
         },
       } as any);
 
@@ -281,7 +286,7 @@ describe("resendVerificationEmailAction", () => {
         id: mockVerifiedUser.id,
         email: mockVerifiedUser.email,
         locale: "en-US",
-        callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?intent=test-intent",
+        callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?state=test-state",
         purpose: "sso_recovery",
       });
       expect(result).toEqual({ success: true });
@@ -302,7 +307,7 @@ describe("resendVerificationEmailAction", () => {
         ctx: mockCtx,
         parsedInput: {
           ...validInput,
-          callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?intent=forged-intent",
+          callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?state=forged-state",
         },
       } as any);
 
@@ -310,29 +315,30 @@ describe("resendVerificationEmailAction", () => {
       expect(result).toEqual({ success: true });
     });
 
-    test("should fall back to a normal verification email when the relink intent belongs to a different email", async () => {
+    test("should fall back to a normal verification email when the recovery intent belongs to a different email", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
-      vi.mocked(verifySsoRelinkIntent).mockReturnValue({
+      recoveryIntentMocks.readSsoRecoveryIntent.mockResolvedValue({
         callbackUrl: "http://localhost:3000",
         email: "other@example.com",
         provider: "google",
         providerAccountId: "provider_123",
         userId: "user_123",
+        createdAt: Date.now(),
       });
 
       const result = await resendVerificationEmailAction({
         ctx: mockCtx,
         parsedInput: {
           ...validInput,
-          callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?intent=test-intent",
+          callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?state=test-state",
         },
       } as any);
 
       expect(auth.api.sendVerificationEmail).toHaveBeenCalledWith({
         body: {
           email: mockUser.email,
-          callbackURL: "http://localhost:3000/api/auth/sso/recovery/complete?intent=test-intent",
+          callbackURL: "http://localhost:3000/api/auth/sso/recovery/complete?state=test-state",
         },
         headers: expect.any(Headers),
       });

--- a/apps/web/modules/auth/verification-requested/actions.test.ts
+++ b/apps/web/modules/auth/verification-requested/actions.test.ts
@@ -282,6 +282,16 @@ describe("resendVerificationEmailAction", () => {
         },
       } as any);
 
+      // The resend mints a fresh one-day link, so the intent it depends on has to be re-paired with it
+      // — deleting this call left the whole suite green.
+      expect(recoveryIntentMocks.refreshSsoRecoveryIntent).toHaveBeenCalledWith("test-state", {
+        callbackUrl: "http://localhost:3000",
+        email: mockVerifiedUser.email,
+        provider: "google",
+        providerAccountId: "provider_123",
+        userId: mockVerifiedUser.id,
+        createdAt: expect.any(Number),
+      });
       expect(sendVerificationEmail).toHaveBeenCalledWith({
         id: mockVerifiedUser.id,
         email: mockVerifiedUser.email,
@@ -290,6 +300,43 @@ describe("resendVerificationEmailAction", () => {
         purpose: "sso_recovery",
       });
       expect(result).toEqual({ success: true });
+    });
+
+    /**
+     * Next resolves `…/complete/` and `/api//auth/…/complete` to the completion route, so a stricter
+     * comparison here made the resend no-op while this action still answered `{ success: true }` and
+     * the UI toasted success.
+     */
+    test.each([
+      ["a trailing slash", "http://localhost:3000/api/auth/sso/recovery/complete/?state=test-state"],
+      ["an interior repeat", "http://localhost:3000/api//auth/sso/recovery/complete?state=test-state"],
+    ])("treats a recovery callback with %s as recovery", async (_label, callbackUrl) => {
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
+      vi.mocked(getUserByEmail).mockResolvedValue({
+        ...mockVerifiedUser,
+        emailVerified: true,
+        locale: "en-US",
+        identityProvider: "email",
+        isActive: true,
+      } as never);
+      recoveryIntentMocks.readSsoRecoveryIntent.mockResolvedValue({
+        callbackUrl: "http://localhost:3000",
+        email: mockVerifiedUser.email,
+        provider: "google",
+        providerAccountId: "provider_123",
+        userId: mockVerifiedUser.id,
+        createdAt: Date.now(),
+      });
+
+      await resendVerificationEmailAction({
+        ctx: mockCtx,
+        parsedInput: { ...validInput, callbackUrl },
+      } as any);
+
+      expect(sendVerificationEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ purpose: "sso_recovery" })
+      );
+      expect(recoveryIntentMocks.refreshSsoRecoveryIntent).toHaveBeenCalled();
     });
 
     test("should not treat a client-supplied recovery callback as recovery without a valid intent", async () => {

--- a/apps/web/modules/auth/verification-requested/actions.test.ts
+++ b/apps/web/modules/auth/verification-requested/actions.test.ts
@@ -55,6 +55,7 @@ const signupIntentMocks = vi.hoisted(() => ({
 const recoveryIntentMocks = vi.hoisted(() => ({
   readSsoRecoveryIntent: vi.fn(),
   refreshSsoRecoveryIntent: vi.fn(),
+  getSsoRecoveryPairedTtlSeconds: vi.fn(() => 60 * 15),
 }));
 
 vi.mock("@/modules/auth/lib/signup-intent", () => ({
@@ -67,6 +68,7 @@ vi.mock("@/modules/auth/lib/signup-intent", () => ({
 vi.mock("@/modules/ee/sso/lib/recovery-intent", () => ({
   readSsoRecoveryIntent: recoveryIntentMocks.readSsoRecoveryIntent,
   refreshSsoRecoveryIntent: recoveryIntentMocks.refreshSsoRecoveryIntent,
+  getSsoRecoveryPairedTtlSeconds: recoveryIntentMocks.getSsoRecoveryPairedTtlSeconds,
 }));
 
 vi.mock("@/lib/constants", async (importOriginal) => {
@@ -273,6 +275,7 @@ describe("resendVerificationEmailAction", () => {
         userId: mockVerifiedUser.id,
         createdAt: Date.now(),
       });
+      recoveryIntentMocks.getSsoRecoveryPairedTtlSeconds.mockReturnValue(777);
 
       const result = await resendVerificationEmailAction({
         ctx: mockCtx,
@@ -282,9 +285,11 @@ describe("resendVerificationEmailAction", () => {
         },
       } as any);
 
-      // The resend mints a fresh one-day link, so the intent it depends on has to be re-paired with it
-      // — deleting this call left the whole suite green.
-      expect(recoveryIntentMocks.refreshSsoRecoveryIntent).toHaveBeenCalledWith("test-state", {
+      // The link and the intent have to get ONE lifetime, or the survivor of the two ends recovery on
+      // its own: a longer-lived link signs the user in and then reports failure. `777` is not a TTL
+      // either call site could arrive at by itself, so it fails if either computes its own instead of
+      // taking the paired value. Deleting the refresh entirely also left the whole suite green once.
+      expect(recoveryIntentMocks.getSsoRecoveryPairedTtlSeconds).toHaveBeenCalledWith({
         callbackUrl: "http://localhost:3000",
         email: mockVerifiedUser.email,
         provider: "google",
@@ -292,12 +297,14 @@ describe("resendVerificationEmailAction", () => {
         userId: mockVerifiedUser.id,
         createdAt: expect.any(Number),
       });
+      expect(recoveryIntentMocks.refreshSsoRecoveryIntent).toHaveBeenCalledWith("test-state", 777);
       expect(sendVerificationEmail).toHaveBeenCalledWith({
         id: mockVerifiedUser.id,
         email: mockVerifiedUser.email,
         locale: "en-US",
         callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?state=test-state",
         purpose: "sso_recovery",
+        linkTtlSeconds: 777,
       });
       expect(result).toEqual({ success: true });
     });

--- a/apps/web/modules/auth/verification-requested/actions.ts
+++ b/apps/web/modules/auth/verification-requested/actions.ts
@@ -16,11 +16,13 @@ import {
   createSignupIntentToken,
 } from "@/modules/auth/lib/signup-intent";
 import { getUserByEmail } from "@/modules/auth/lib/user";
-import { TVerificationRequestPurpose } from "@/modules/auth/lib/verification-links";
+import {
+  SSO_RECOVERY_COMPLETION_PATH,
+  TVerificationRequestPurpose,
+} from "@/modules/auth/lib/verification-links";
 import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
-import { SSO_RECOVERY_COMPLETION_PATH } from "@/modules/ee/sso/lib/constants";
 import {
   type TSsoRecoveryIntent,
   readSsoRecoveryIntent,

--- a/apps/web/modules/auth/verification-requested/actions.ts
+++ b/apps/web/modules/auth/verification-requested/actions.ts
@@ -6,7 +6,6 @@ import { logger } from "@formbricks/logger";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { ZUserEmail } from "@formbricks/types/user";
 import { WEBAPP_URL } from "@/lib/constants";
-import { verifySsoRelinkIntent } from "@/lib/jwt";
 import { actionClient } from "@/lib/utils/action-client";
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
 import { auth } from "@/modules/auth/lib/auth";
@@ -22,6 +21,11 @@ import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import { SSO_RECOVERY_COMPLETION_PATH } from "@/modules/ee/sso/lib/constants";
+import {
+  type TSsoRecoveryIntent,
+  readSsoRecoveryIntent,
+  refreshSsoRecoveryIntent,
+} from "@/modules/ee/sso/lib/recovery-intent";
 import { sendVerificationEmail } from "@/modules/email";
 
 const ZResendVerificationEmailAction = z.object({
@@ -29,34 +33,43 @@ const ZResendVerificationEmailAction = z.object({
   callbackUrl: z.string().max(2000).optional(),
 });
 
-const getVerificationRequestPurpose = ({
+/**
+ * The SSO-recovery intent this resend is for, or null when it is an ordinary verification resend.
+ *
+ * The email check is not decoration: this action is unauthenticated, so a state id must only unlock a
+ * resend for the address it was minted for. That binding used to come free with the intent JWT's
+ * signature; it is now an explicit comparison against the stored record (ENG-2783).
+ *
+ * The read deliberately does not consume the intent — the resent link points at the very same record.
+ */
+const resolveSsoRecoveryResend = async ({
   callbackUrl,
   userEmail,
 }: {
   callbackUrl?: string;
   userEmail: string;
-}): TVerificationRequestPurpose => {
+}): Promise<{ stateId: string; intent: TSsoRecoveryIntent } | null> => {
   const validatedCallbackUrl = getValidatedCallbackUrl(callbackUrl, WEBAPP_URL);
   if (!validatedCallbackUrl) {
-    return "email_verification";
+    return null;
   }
 
   const parsedCallbackUrl = new URL(validatedCallbackUrl);
   if (parsedCallbackUrl.pathname !== SSO_RECOVERY_COMPLETION_PATH) {
-    return "email_verification";
+    return null;
   }
 
-  const intentToken = parsedCallbackUrl.searchParams.get("intent");
-  if (!intentToken) {
-    return "email_verification";
+  const stateId = parsedCallbackUrl.searchParams.get("state");
+  if (!stateId) {
+    return null;
   }
 
-  try {
-    const intent = verifySsoRelinkIntent(intentToken);
-    return intent.email.toLowerCase() === userEmail.toLowerCase() ? "sso_recovery" : "email_verification";
-  } catch {
-    return "email_verification";
+  const intent = await readSsoRecoveryIntent(stateId);
+  if (intent?.email.toLowerCase() !== userEmail.toLowerCase()) {
+    return null;
   }
+
+  return { stateId, intent };
 };
 
 export const resendVerificationEmailAction = actionClient.inputSchema(ZResendVerificationEmailAction).action(
@@ -68,17 +81,18 @@ export const resendVerificationEmailAction = actionClient.inputSchema(ZResendVer
       throw new ResourceNotFoundError("user", parsedInput.email);
     }
     const validatedCallbackUrl = getValidatedCallbackUrl(parsedInput.callbackUrl, WEBAPP_URL) ?? undefined;
-    const purpose = getVerificationRequestPurpose({
+    const ssoRecoveryResend = await resolveSsoRecoveryResend({
       callbackUrl: validatedCallbackUrl,
       userEmail: user.email,
     });
-    if (user.emailVerified && purpose !== "sso_recovery") {
+    const purpose: TVerificationRequestPurpose = ssoRecoveryResend ? "sso_recovery" : "email_verification";
+    if (user.emailVerified && !ssoRecoveryResend) {
       return {
         success: true,
       };
     }
     ctx.auditLoggingCtx.userId = user.id;
-    if (purpose === "sso_recovery") {
+    if (ssoRecoveryResend) {
       // SSO recovery keeps the app-minted JWT and the recovery magic link (now routed to Better Auth's
       // /sso-recovery/sign-in endpoint via buildVerificationLinks).
       await sendVerificationEmail({
@@ -88,6 +102,14 @@ export const resendVerificationEmailAction = actionClient.inputSchema(ZResendVer
         callbackUrl: validatedCallbackUrl,
         purpose,
       });
+
+      // ENG-2783: re-pair the intent with the link just minted. The resend mints a fresh one-day link
+      // while the intent keeps the clock it started with, so without this the new link outlives the
+      // record it depends on and the user is signed in only to be told recovery failed — the same
+      // pairing bug the sign-up intent cookie's resend refresh exists to avoid. Bounded against the
+      // intent's original createdAt inside the helper, so an unauthenticated caller cannot slide the
+      // window forever. Best-effort: the mail has gone out, so a failure here costs the pairing only.
+      await refreshSsoRecoveryIntent(ssoRecoveryResend.stateId, ssoRecoveryResend.intent);
     } else {
       // Email verification is Better Auth-native (ENG-1054 decommission): BA mints its own verification
       // token and sends the verify link through the emailVerification.sendVerificationEmail callback in

--- a/apps/web/modules/auth/verification-requested/actions.ts
+++ b/apps/web/modules/auth/verification-requested/actions.ts
@@ -7,7 +7,7 @@ import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { ZUserEmail } from "@formbricks/types/user";
 import { WEBAPP_URL } from "@/lib/constants";
 import { actionClient } from "@/lib/utils/action-client";
-import { getValidatedCallbackUrl } from "@/lib/utils/url";
+import { MAX_CALLBACK_URL_LENGTH, getValidatedCallbackUrl } from "@/lib/utils/url";
 import { auth } from "@/modules/auth/lib/auth";
 import {
   SIGNUP_INTENT_COOKIE_NAME,
@@ -30,7 +30,9 @@ import { sendVerificationEmail } from "@/modules/email";
 
 const ZResendVerificationEmailAction = z.object({
   email: ZUserEmail,
-  callbackUrl: z.string().max(2000).optional(),
+  // The same bound `getValidatedCallbackUrl` enforces, so a callback this action accepts is one the
+  // rest of the app would accept too — two independent numbers here drifted once already.
+  callbackUrl: z.string().max(MAX_CALLBACK_URL_LENGTH).optional(),
 });
 
 /**

--- a/apps/web/modules/auth/verification-requested/actions.ts
+++ b/apps/web/modules/auth/verification-requested/actions.ts
@@ -19,6 +19,7 @@ import { getUserByEmail } from "@/modules/auth/lib/user";
 import {
   SSO_RECOVERY_COMPLETION_PATH,
   TVerificationRequestPurpose,
+  normalizeRoutePathname,
 } from "@/modules/auth/lib/verification-links";
 import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
@@ -59,7 +60,10 @@ const resolveSsoRecoveryResend = async ({
   }
 
   const parsedCallbackUrl = new URL(validatedCallbackUrl);
-  if (parsedCallbackUrl.pathname !== SSO_RECOVERY_COMPLETION_PATH) {
+  // Through the shared normaliser, not a bare `!==` on `pathname`: Next resolves `…/complete/` and
+  // `/api//auth/…/complete` to the completion route, and a stricter comparison here would make the
+  // resend silently no-op while this action still reported success.
+  if (normalizeRoutePathname(validatedCallbackUrl) !== SSO_RECOVERY_COMPLETION_PATH) {
     return null;
   }
 

--- a/apps/web/modules/auth/verification-requested/actions.ts
+++ b/apps/web/modules/auth/verification-requested/actions.ts
@@ -26,6 +26,7 @@ import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import {
   type TSsoRecoveryIntent,
+  getSsoRecoveryPairedTtlSeconds,
   readSsoRecoveryIntent,
   refreshSsoRecoveryIntent,
 } from "@/modules/ee/sso/lib/recovery-intent";
@@ -101,6 +102,17 @@ export const resendVerificationEmailAction = actionClient.inputSchema(ZResendVer
     }
     ctx.auditLoggingCtx.userId = user.id;
     if (ssoRecoveryResend) {
+      // ENG-2783: the resent link and the refreshed intent get ONE lifetime, computed once here.
+      //
+      // Both halves are needed to finish recovery, so whichever expires first ends the flow — and if
+      // the link is the survivor the user is signed in and then told recovery failed. A resend is
+      // where they can come apart: the intent's refresh is capped against its original `createdAt`
+      // (the caller is unauthenticated, so the window must not slide forever), while a freshly minted
+      // link would otherwise take the full TTL no matter how close that ceiling is. Deriving the
+      // number twice would also let a clock tick between the two, so it is derived once and passed to
+      // both.
+      const pairedTtlSeconds = getSsoRecoveryPairedTtlSeconds(ssoRecoveryResend.intent);
+
       // SSO recovery keeps the app-minted JWT and the recovery magic link (now routed to Better Auth's
       // /sso-recovery/sign-in endpoint via buildVerificationLinks).
       await sendVerificationEmail({
@@ -109,15 +121,11 @@ export const resendVerificationEmailAction = actionClient.inputSchema(ZResendVer
         locale: user.locale,
         callbackUrl: validatedCallbackUrl,
         purpose,
+        linkTtlSeconds: pairedTtlSeconds,
       });
 
-      // ENG-2783: re-pair the intent with the link just minted. The resend mints a fresh one-day link
-      // while the intent keeps the clock it started with, so without this the new link outlives the
-      // record it depends on and the user is signed in only to be told recovery failed — the same
-      // pairing bug the sign-up intent cookie's resend refresh exists to avoid. Bounded against the
-      // intent's original createdAt inside the helper, so an unauthenticated caller cannot slide the
-      // window forever. Best-effort: the mail has gone out, so a failure here costs the pairing only.
-      await refreshSsoRecoveryIntent(ssoRecoveryResend.stateId, ssoRecoveryResend.intent);
+      // Best-effort: the mail has gone out, so a failure here costs the pairing, not the resend.
+      await refreshSsoRecoveryIntent(ssoRecoveryResend.stateId, pairedTtlSeconds);
     } else {
       // Email verification is Better Auth-native (ENG-1054 decommission): BA mints its own verification
       // token and sends the verify link through the emailVerification.sendVerificationEmail callback in

--- a/apps/web/modules/ee/sso/lib/better-auth-hooks.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-hooks.test.ts
@@ -512,6 +512,41 @@ describe("ssoLicenseGateBefore", () => {
   test("allows a SAML callback when both SSO and SAML are licensed", async () => {
     await expect(ssoLicenseGateBefore(samlCtx as never)).resolves.toBeUndefined();
   });
+
+  /**
+   * Why SSO recovery needs no entitlement check of its own.
+   *
+   * Neither `resendVerificationEmailAction` nor `completeSsoRecovery` calls `getIsSsoEnabled`, which
+   * reads like the "EE feature reachable without an entitlement check" that `.coderabbit.yaml` asks
+   * reviewers to flag. What makes it safe is upstream: recovery has exactly one producer
+   * (`startSsoRecovery`, called only from `ssoRecoveryAfterHandler`), that producer runs in
+   * `hooks.after`, and this gate runs first in `hooks.before` selecting requests by the same
+   * `resolveSsoIdentityProvider` predicate. On an unlicensed instance the callback is rejected before
+   * the endpoint runs, so no intent is ever minted and there is nothing downstream to reach.
+   *
+   * Pinned per provider because that shared predicate IS the argument: narrow one side's selection and
+   * the gate silently stops covering the other.
+   */
+  test.each(["google", "github", "azuread", "azure-ad", "openid", "saml"])(
+    "rejects a %s callback when SSO is unlicensed, so no recovery intent can be minted",
+    async (providerId) => {
+      vi.mocked(getIsSsoEnabled).mockResolvedValue(false);
+
+      await expect(
+        ssoLicenseGateBefore({ path: "/callback/:providerId", params: { providerId } } as never)
+      ).rejects.toThrow("SSO is not enabled");
+    }
+  );
+
+  test("a request this gate ignores is one recovery ignores too", async () => {
+    const nonCallback = { path: "/sign-up/email" } as never;
+
+    await ssoLicenseGateBefore(nonCallback);
+
+    expect(getIsSsoEnabled).not.toHaveBeenCalled();
+    // The other half of the shared predicate: no provider resolved, so recovery declines to act.
+    expect(getSsoProviderFromContext(nonCallback)).toBeNull();
+  });
 });
 
 describe("ssoRecoveryAfter", () => {

--- a/apps/web/modules/ee/sso/lib/better-auth-recovery-signin.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-recovery-signin.integration.test.ts
@@ -22,7 +22,7 @@ describe("SSO recovery sign-in (real Postgres)", () => {
       data: { email: "recover@example.com", name: "Recover", emailVerified: true },
     });
     const token = createToken(user.id, { purpose: "sso_recovery" });
-    const callbackUrl = `${WEBAPP_URL}/api/auth/sso/recovery/complete?intent=test-intent`;
+    const callbackUrl = `${WEBAPP_URL}/api/auth/sso/recovery/complete?state=test-state`;
 
     const res = await auth.api.ssoRecoverySignIn({ query: { token, callbackUrl }, asResponse: true });
 

--- a/apps/web/modules/ee/sso/lib/constants.test.ts
+++ b/apps/web/modules/ee/sso/lib/constants.test.ts
@@ -4,7 +4,15 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
-import { canonicalAccountIssuer, ssoAccountIssuer } from "./constants";
+import {
+  SSO_RECOVERY_COMPLETION_PATH,
+  SSO_RECOVERY_SIGN_IN_PATH,
+  canonicalAccountIssuer,
+  isSsoRecoveryInternalCallbackUrl,
+  ssoAccountIssuer,
+} from "./constants";
+
+const WEBAPP_URL = "https://app.example.com";
 
 /**
  * `Account.issuer` is spelled in four places that cannot import each other, and ENG-2555 happened
@@ -70,6 +78,47 @@ const parsedSources = Object.entries(ISSUER_MIGRATION_SOURCES).map(([label, path
 // One canonical parse for the per-arm assertions below; the cross-copy equality tests prove every
 // other copy is identical to it, so asserting against one is asserting against all.
 const { arms, elseTemplate } = parsedSources[0].cases[0];
+
+describe("isSsoRecoveryInternalCallbackUrl", () => {
+  /**
+   * The predicate had no test of its own — the loop tests only reached it through
+   * `startSsoRecovery`, so nothing pinned the trailing-slash handling that stops
+   * `…/complete/` slipping past a check Next would then route to the real page anyway.
+   */
+  test.each([
+    ["the completion path", `${WEBAPP_URL}${SSO_RECOVERY_COMPLETION_PATH}?state=abc`],
+    ["the recovery sign-in path", `${WEBAPP_URL}${SSO_RECOVERY_SIGN_IN_PATH}?token=abc`],
+    ["a single trailing slash", `${WEBAPP_URL}${SSO_RECOVERY_COMPLETION_PATH}/`],
+    ["many trailing slashes", `${WEBAPP_URL}${SSO_RECOVERY_COMPLETION_PATH}/////`],
+    ["a dot segment that normalises back", `${WEBAPP_URL}/api/auth/sso/recovery/../recovery/complete`],
+    ["a root-relative form", `${SSO_RECOVERY_COMPLETION_PATH}?state=abc`],
+  ])("recognises %s", (_label, callbackUrl) => {
+    expect(isSsoRecoveryInternalCallbackUrl(callbackUrl)).toBe(true);
+  });
+
+  test.each([
+    ["an ordinary app URL", `${WEBAPP_URL}/organizations/org_1/workspaces/ws_1/surveys`],
+    ["a path that merely starts the same", `${WEBAPP_URL}${SSO_RECOVERY_COMPLETION_PATH}-not-really`],
+    ["a path that merely contains it", `${WEBAPP_URL}/x${SSO_RECOVERY_COMPLETION_PATH}`],
+    ["the app root", WEBAPP_URL],
+    ["an unparseable value", "::::"],
+  ])("leaves %s alone", (_label, callbackUrl) => {
+    expect(isSsoRecoveryInternalCallbackUrl(callbackUrl)).toBe(false);
+  });
+
+  test("stays linear on the input shape that made the old regex quadratic", () => {
+    // Deliberately a slash run that does NOT reach the end. `/\/+$/` (Sonar S8786) matches greedily
+    // from every start position, hits the trailing `b`, fails the anchor and backtracks: measured
+    // 34ms at 10k slashes, 2.9s at 100k, 313s at 1M. Trailing slashes would NOT catch this — the old
+    // regex matched those on the first attempt — so the run has to end in a non-slash to bind.
+    const adversarial = `${WEBAPP_URL}/a${"/".repeat(100_000)}b`;
+    const started = Date.now();
+
+    expect(isSsoRecoveryInternalCallbackUrl(adversarial)).toBe(false);
+
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});
 
 describe("canonicalAccountIssuer ↔ every SQL spelling of the mapping", () => {
   // Guard the guard: if the regex silently matched nothing, every assertion below would pass against an

--- a/apps/web/modules/ee/sso/lib/constants.test.ts
+++ b/apps/web/modules/ee/sso/lib/constants.test.ts
@@ -7,10 +7,8 @@ import { describe, expect, test } from "vitest";
 import {
   SSO_RECOVERY_COMPLETION_PATH,
   SSO_RECOVERY_SIGN_IN_PATH,
-  canonicalAccountIssuer,
-  isSsoRecoveryInternalCallbackUrl,
-  ssoAccountIssuer,
-} from "./constants";
+} from "@/modules/auth/lib/verification-links";
+import { canonicalAccountIssuer, isSsoRecoveryInternalCallbackUrl, ssoAccountIssuer } from "./constants";
 
 const WEBAPP_URL = "https://app.example.com";
 

--- a/apps/web/modules/ee/sso/lib/constants.test.ts
+++ b/apps/web/modules/ee/sso/lib/constants.test.ts
@@ -88,6 +88,12 @@ describe("isSsoRecoveryInternalCallbackUrl", () => {
     ["the recovery sign-in path", `${WEBAPP_URL}${SSO_RECOVERY_SIGN_IN_PATH}?token=abc`],
     ["a single trailing slash", `${WEBAPP_URL}${SSO_RECOVERY_COMPLETION_PATH}/`],
     ["many trailing slashes", `${WEBAPP_URL}${SSO_RECOVERY_COMPLETION_PATH}/////`],
+    // Next's `normalizeRepeatedSlashes` collapses interior repeats and backslashes before routing, so
+    // each of these reaches the completion route; a check that missed them left a way back into the loop.
+    ["an interior repeated slash", `${WEBAPP_URL}/api//auth/sso/recovery/complete`],
+    ["several interior repeats", `${WEBAPP_URL}/api///auth//sso/recovery///complete`],
+    ["a backslash separator", `${WEBAPP_URL}/api\\auth/sso/recovery/complete`],
+    ["repeats and a trailing slash together", `${WEBAPP_URL}/api//auth/sso/recovery/complete//`],
     ["a dot segment that normalises back", `${WEBAPP_URL}/api/auth/sso/recovery/../recovery/complete`],
     ["a root-relative form", `${SSO_RECOVERY_COMPLETION_PATH}?state=abc`],
   ])("recognises %s", (_label, callbackUrl) => {

--- a/apps/web/modules/ee/sso/lib/constants.ts
+++ b/apps/web/modules/ee/sso/lib/constants.ts
@@ -1,8 +1,9 @@
-export const OAUTH_ACCOUNT_NOT_LINKED_ERROR = "OAuthAccountNotLinked";
-export const SSO_RECOVERY_COMPLETION_PATH = "/api/auth/sso/recovery/complete";
+import {
+  SSO_RECOVERY_COMPLETION_PATH,
+  SSO_RECOVERY_SIGN_IN_PATH,
+} from "@/modules/auth/lib/verification-links";
 
-/** Better Auth's recovery magic-link endpoint, mounted by `ssoRecoverySignInPlugin` under `/api/auth`. */
-export const SSO_RECOVERY_SIGN_IN_PATH = "/api/auth/sso-recovery/sign-in";
+export const OAUTH_ACCOUNT_NOT_LINKED_ERROR = "OAuthAccountNotLinked";
 
 /**
  * Does this callback URL point back into the recovery flow itself? (ENG-2783)

--- a/apps/web/modules/ee/sso/lib/constants.ts
+++ b/apps/web/modules/ee/sso/lib/constants.ts
@@ -1,6 +1,37 @@
 export const OAUTH_ACCOUNT_NOT_LINKED_ERROR = "OAuthAccountNotLinked";
 export const SSO_RECOVERY_COMPLETION_PATH = "/api/auth/sso/recovery/complete";
 
+/** Better Auth's recovery magic-link endpoint, mounted by `ssoRecoverySignInPlugin` under `/api/auth`. */
+export const SSO_RECOVERY_SIGN_IN_PATH = "/api/auth/sso-recovery/sign-in";
+
+/**
+ * Does this callback URL point back into the recovery flow itself? (ENG-2783)
+ *
+ * `getValidatedCallbackUrl` checks origin, scheme and credentials — never the path — so a recovery URL
+ * is a perfectly valid same-origin callback, and the "log in" link on the verification-requested page
+ * hands one straight back to `/auth/login`. Signing in with the same IdP from there re-enters
+ * `startSsoRecovery` carrying the previous attempt's completion URL, which is the loop that used to
+ * grow the URL past nginx's request line.
+ *
+ * The opaque state id removed the growth, but not the loop: without this check, attempt N's intent
+ * would still store attempt N-1's completion URL, so finishing recovery would redirect into another
+ * completion whose intent is already consumed — dropping the user on "recovery failed" immediately
+ * after a recovery that actually worked.
+ *
+ * Deliberately NOT folded into `getValidatedCallbackUrl`: `buildVerificationLinks` puts the completion
+ * URL on the emailed link *through* that helper, so rejecting the path there would break the mail.
+ */
+export const isSsoRecoveryInternalCallbackUrl = (callbackUrl: string): boolean => {
+  try {
+    // Next normalises a trailing slash away before routing, so compare the same way it does.
+    const pathname = new URL(callbackUrl, "http://localhost").pathname.replace(/\/+$/, "");
+
+    return pathname === SSO_RECOVERY_COMPLETION_PATH || pathname === SSO_RECOVERY_SIGN_IN_PATH;
+  } catch {
+    return false;
+  }
+};
+
 /**
  * The synthetic `Account.issuer` for the providers we configure ourselves (ENG-2343).
  *

--- a/apps/web/modules/ee/sso/lib/constants.ts
+++ b/apps/web/modules/ee/sso/lib/constants.ts
@@ -23,10 +23,22 @@ export const SSO_RECOVERY_SIGN_IN_PATH = "/api/auth/sso-recovery/sign-in";
  */
 export const isSsoRecoveryInternalCallbackUrl = (callbackUrl: string): boolean => {
   try {
-    // Next normalises a trailing slash away before routing, so compare the same way it does.
-    const pathname = new URL(callbackUrl, "http://localhost").pathname.replace(/\/+$/, "");
+    // Next normalises trailing slashes away before routing, so compare the same way it does —
+    // otherwise `…/complete/` slips past this check and still reaches the route.
+    //
+    // Walked by index rather than stripped with `/\/+$/`: that pattern backtracks super-linearly on a
+    // path of many slashes (Sonar S8786), and this pathname comes from a caller-supplied URL. Slicing
+    // in a loop would allocate per slash; finding the end first is one pass and one allocation.
+    const { pathname } = new URL(callbackUrl, "http://localhost");
+    let end = pathname.length;
+    while (end > 0 && pathname.charAt(end - 1) === "/") {
+      end -= 1;
+    }
+    const normalizedPathname = pathname.slice(0, end);
 
-    return pathname === SSO_RECOVERY_COMPLETION_PATH || pathname === SSO_RECOVERY_SIGN_IN_PATH;
+    return (
+      normalizedPathname === SSO_RECOVERY_COMPLETION_PATH || normalizedPathname === SSO_RECOVERY_SIGN_IN_PATH
+    );
   } catch {
     return false;
   }

--- a/apps/web/modules/ee/sso/lib/constants.ts
+++ b/apps/web/modules/ee/sso/lib/constants.ts
@@ -1,6 +1,7 @@
 import {
   SSO_RECOVERY_COMPLETION_PATH,
   SSO_RECOVERY_SIGN_IN_PATH,
+  normalizeRoutePathname,
 } from "@/modules/auth/lib/verification-links";
 
 export const OAUTH_ACCOUNT_NOT_LINKED_ERROR = "OAuthAccountNotLinked";
@@ -21,28 +22,15 @@ export const OAUTH_ACCOUNT_NOT_LINKED_ERROR = "OAuthAccountNotLinked";
  *
  * Deliberately NOT folded into `getValidatedCallbackUrl`: `buildVerificationLinks` puts the completion
  * URL on the emailed link *through* that helper, so rejecting the path there would break the mail.
+ *
+ * Compared through `normalizeRoutePathname` so this agrees with the router rather than with a subset of
+ * it — a check stricter than Next's own resolution leaves exactly the shapes it misses as a way back
+ * into the loop.
  */
 export const isSsoRecoveryInternalCallbackUrl = (callbackUrl: string): boolean => {
-  try {
-    // Next normalises trailing slashes away before routing, so compare the same way it does —
-    // otherwise `…/complete/` slips past this check and still reaches the route.
-    //
-    // Walked by index rather than stripped with `/\/+$/`: that pattern backtracks super-linearly on a
-    // path of many slashes (Sonar S8786), and this pathname comes from a caller-supplied URL. Slicing
-    // in a loop would allocate per slash; finding the end first is one pass and one allocation.
-    const { pathname } = new URL(callbackUrl, "http://localhost");
-    let end = pathname.length;
-    while (end > 0 && pathname.charAt(end - 1) === "/") {
-      end -= 1;
-    }
-    const normalizedPathname = pathname.slice(0, end);
+  const pathname = normalizeRoutePathname(callbackUrl);
 
-    return (
-      normalizedPathname === SSO_RECOVERY_COMPLETION_PATH || normalizedPathname === SSO_RECOVERY_SIGN_IN_PATH
-    );
-  } catch {
-    return false;
-  }
+  return pathname === SSO_RECOVERY_COMPLETION_PATH || pathname === SSO_RECOVERY_SIGN_IN_PATH;
 };
 
 /**

--- a/apps/web/modules/ee/sso/lib/recovery-intent.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.integration.test.ts
@@ -4,6 +4,7 @@ import { cache } from "@/lib/cache";
 import {
   consumeSsoRecoveryIntent,
   createSsoRecoveryIntent,
+  getSsoRecoveryPairedTtlSeconds,
   readSsoRecoveryIntent,
   refreshSsoRecoveryIntent,
 } from "./recovery-intent";
@@ -20,7 +21,7 @@ import {
  * derivation is what the module claims: `fb:sso_recovery:intent:<sha256(stateId)>`.
  */
 
-const LINK_TTL_SECONDS = 60 * 60 * 24;
+const LINK_TTL_SECONDS = 60 * 15;
 
 const intentInput = {
   userId: "cm5q1x2y30000abcdefghijkl",
@@ -60,11 +61,11 @@ describe("SSO recovery intent store (real Redis)", () => {
   test("a resend extends a TTL that has run down", async () => {
     const stateId = await createSsoRecoveryIntent(intentInput);
     const stored = (await readSsoRecoveryIntent(stateId))!;
-    // Stand in for hours having passed since the link was issued.
+    // Stand in for most of the window having passed since the link was issued.
     await (await redisClient()).expire(keyFor(stateId), 60);
     expect(await ttlOf(stateId)).toBeLessThanOrEqual(60);
 
-    await refreshSsoRecoveryIntent(stateId, stored);
+    await refreshSsoRecoveryIntent(stateId, getSsoRecoveryPairedTtlSeconds(stored));
 
     expect(await ttlOf(stateId)).toBeGreaterThan(LINK_TTL_SECONDS - 60);
     // EXPIRE moves the expiry only: the record itself must come back byte-identical.
@@ -79,7 +80,7 @@ describe("SSO recovery intent store (real Redis)", () => {
     await consumeSsoRecoveryIntent(stateId);
     expect(await ttlOf(stateId)).toBe(-2); // gone
 
-    await refreshSsoRecoveryIntent(stateId, stored);
+    await refreshSsoRecoveryIntent(stateId, getSsoRecoveryPairedTtlSeconds(stored));
 
     expect(await ttlOf(stateId)).toBe(-2); // still gone — EXPIRE did not recreate it
     await expect(readSsoRecoveryIntent(stateId)).resolves.toBeNull();

--- a/apps/web/modules/ee/sso/lib/recovery-intent.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.integration.test.ts
@@ -1,0 +1,106 @@
+import crypto from "node:crypto";
+import { beforeEach, describe, expect, test } from "vitest";
+import { cache } from "@/lib/cache";
+import {
+  consumeSsoRecoveryIntent,
+  createSsoRecoveryIntent,
+  readSsoRecoveryIntent,
+  refreshSsoRecoveryIntent,
+} from "./recovery-intent";
+
+/**
+ * The intent store against real Redis (ENG-2783).
+ *
+ * The unit suite fakes `cache.getRedisClient()`, so the one thing it structurally cannot check is the
+ * semantics the resurrection guard rests on: that `EXPIRE` is a no-op on a key that is already gone.
+ * That is Redis behaviour rather than ours, and until this file it had never been executed — the guard
+ * was verified against a hand-written fake of the very command it depends on.
+ *
+ * The key is recomputed here rather than imported, which also makes this an independent check that the
+ * derivation is what the module claims: `fb:sso_recovery:intent:<sha256(stateId)>`.
+ */
+
+const LINK_TTL_SECONDS = 60 * 60 * 24;
+
+const intentInput = {
+  userId: "cm5q1x2y30000abcdefghijkl",
+  email: "store@example.com",
+  provider: "google",
+  providerAccountId: "google-sub-store",
+  callbackUrl: "http://localhost:3000/organizations/org_1/workspaces/ws_1/surveys",
+};
+
+const keyFor = (stateId: string) =>
+  `fb:sso_recovery:intent:${crypto.createHash("sha256").update(stateId).digest("hex")}`;
+
+const redisClient = async () => {
+  const redis = await cache.getRedisClient();
+  expect(redis).not.toBeNull();
+  return redis!;
+};
+
+/** Redis `TTL`: seconds remaining, -2 when the key is gone, -1 when it has no expiry. */
+const ttlOf = async (stateId: string) => (await redisClient()).ttl(keyFor(stateId));
+
+describe("SSO recovery intent store (real Redis)", () => {
+  beforeEach(async () => {
+    await redisClient();
+  });
+
+  test("round-trips through Redis under the hashed key, at the emailed link's TTL", async () => {
+    const stateId = await createSsoRecoveryIntent(intentInput);
+
+    await expect(readSsoRecoveryIntent(stateId)).resolves.toMatchObject(intentInput);
+    // The raw id is the lookup secret; only its digest may be at rest.
+    expect(keyFor(stateId)).not.toContain(stateId);
+    await expect(redisClient().then((r) => r.exists(keyFor(stateId)))).resolves.toBe(1);
+    expect(await ttlOf(stateId)).toBeGreaterThan(LINK_TTL_SECONDS - 60);
+  });
+
+  test("a resend extends a TTL that has run down", async () => {
+    const stateId = await createSsoRecoveryIntent(intentInput);
+    const stored = (await readSsoRecoveryIntent(stateId))!;
+    // Stand in for hours having passed since the link was issued.
+    await (await redisClient()).expire(keyFor(stateId), 60);
+    expect(await ttlOf(stateId)).toBeLessThanOrEqual(60);
+
+    await refreshSsoRecoveryIntent(stateId, stored);
+
+    expect(await ttlOf(stateId)).toBeGreaterThan(LINK_TTL_SECONDS - 60);
+    // EXPIRE moves the expiry only: the record itself must come back byte-identical.
+    await expect(readSsoRecoveryIntent(stateId)).resolves.toEqual(stored);
+  });
+
+  /** The guard the unit test could only assert against a fake of `EXPIRE`. */
+  test("a resend racing a completion cannot resurrect the consumed intent", async () => {
+    const stateId = await createSsoRecoveryIntent(intentInput);
+    const stored = (await readSsoRecoveryIntent(stateId))!;
+
+    await consumeSsoRecoveryIntent(stateId);
+    expect(await ttlOf(stateId)).toBe(-2); // gone
+
+    await refreshSsoRecoveryIntent(stateId, stored);
+
+    expect(await ttlOf(stateId)).toBe(-2); // still gone — EXPIRE did not recreate it
+    await expect(readSsoRecoveryIntent(stateId)).resolves.toBeNull();
+  });
+
+  test("consuming removes the key rather than merely expiring it", async () => {
+    const stateId = await createSsoRecoveryIntent(intentInput);
+
+    await consumeSsoRecoveryIntent(stateId);
+
+    await expect(redisClient().then((r) => r.exists(keyFor(stateId)))).resolves.toBe(0);
+    await expect(readSsoRecoveryIntent(stateId)).resolves.toBeNull();
+  });
+
+  test("two intents never collide, and each is independently consumable", async () => {
+    const first = await createSsoRecoveryIntent(intentInput);
+    const second = await createSsoRecoveryIntent({ ...intentInput, userId: "other-user" });
+
+    await consumeSsoRecoveryIntent(first);
+
+    await expect(readSsoRecoveryIntent(first)).resolves.toBeNull();
+    await expect(readSsoRecoveryIntent(second)).resolves.toMatchObject({ userId: "other-user" });
+  });
+});

--- a/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
@@ -18,7 +18,9 @@ vi.mock("crypto", async () => await vi.importActual<typeof import("crypto")>("cr
 
 vi.mock("@formbricks/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn() } }));
 
-vi.mock("@/lib/cache", () => ({ cache: { get: vi.fn(), set: vi.fn(), del: vi.fn() } }));
+vi.mock("@/lib/cache", () => ({
+  cache: { get: vi.fn(), set: vi.fn(), del: vi.fn(), getRedisClient: vi.fn() },
+}));
 
 const mockCache = vi.mocked(cache);
 
@@ -60,6 +62,16 @@ describe("SSO recovery intent", () => {
       keys.forEach((key) => store.delete(key));
       return { ok: true, data: undefined };
     });
+    // Real EXPIRE semantics, which is the whole point of using it: a no-op returning 0 on a key that is
+    // no longer there. A stub that always "succeeded" would hide the resurrection this guards against.
+    mockCache.getRedisClient.mockResolvedValue({
+      expire: vi.fn(async (key: string, seconds: number) => {
+        const entry = store.get(key);
+        if (!entry) return 0;
+        store.set(key, { ...entry, ttlMs: seconds * 1000 });
+        return 1;
+      }),
+    } as never);
   });
 
   describe("create", () => {
@@ -193,6 +205,28 @@ describe("SSO recovery intent", () => {
     });
 
     /**
+     * A resend and a completion can race. Refresh must extend a live record, never write one back —
+     * otherwise a resend landing just after completion resurrects the intent that completion consumed,
+     * and single use quietly stops holding.
+     */
+    test("cannot resurrect an intent that a completion already consumed", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+      await consumeSsoRecoveryIntent(stateId);
+
+      await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now()));
+
+      expect(store.size).toBe(0);
+      await expect(readSsoRecoveryIntent(stateId)).resolves.toBeNull();
+    });
+
+    test("does nothing when Redis is unavailable, rather than throwing at the caller", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+      mockCache.getRedisClient.mockResolvedValue(null);
+
+      await expect(refreshSsoRecoveryIntent(stateId, storedIntent(Date.now()))).resolves.toBeUndefined();
+    });
+
+    /**
      * `resendVerificationEmailAction` is unauthenticated, so a plain sliding window would let anyone
      * holding a state id keep an intent alive forever. `createdAt` never moves, so the slide is capped.
      */
@@ -210,20 +244,21 @@ describe("SSO recovery intent", () => {
 
     test("writes nothing once the absolute lifetime has elapsed", async () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
-      mockCache.set.mockClear();
+      mockCache.getRedisClient.mockClear();
 
       await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now() - MAX_LIFETIME_MS - 1));
 
-      expect(mockCache.set).not.toHaveBeenCalled();
+      expect(mockCache.getRedisClient).not.toHaveBeenCalled();
     });
 
-    test("keeps createdAt fixed, so repeated refreshes measure from the original start", async () => {
+    test("leaves the stored record untouched, so a refresh cannot write back a stale copy", async () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
-      const createdAt = Date.now() - LINK_TTL_MS;
 
-      await refreshSsoRecoveryIntent(stateId, storedIntent(createdAt));
+      await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now() - LINK_TTL_MS));
 
-      await expect(readSsoRecoveryIntent(stateId)).resolves.toMatchObject({ createdAt });
+      // The intent handed in carries a different createdAt; the record must still hold its own.
+      const stored = await readSsoRecoveryIntent(stateId);
+      expect(stored?.createdAt).toBeGreaterThan(Date.now() - LINK_TTL_MS);
     });
   });
 });

--- a/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { cache } from "@/lib/cache";
+import {
+  type TSsoRecoveryIntent,
+  consumeSsoRecoveryIntent,
+  createSsoRecoveryIntent,
+  readSsoRecoveryIntent,
+  refreshSsoRecoveryIntent,
+} from "./recovery-intent";
+
+/**
+ * `vitestSetup.ts` stubs `crypto.createHash` to the constant `"fake-hash"` for the license checks. This
+ * module derives its cache key from `sha256(stateId)`, so under that stub every state id collapses onto
+ * one key: two intents would overwrite each other and a key-derivation regression would be invisible.
+ * Restore the real implementation for this file — the store below depends on keys actually differing.
+ */
+vi.mock("crypto", async () => await vi.importActual<typeof import("crypto")>("crypto"));
+
+vi.mock("@formbricks/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn() } }));
+
+vi.mock("@/lib/cache", () => ({ cache: { get: vi.fn(), set: vi.fn(), del: vi.fn() } }));
+
+const mockCache = vi.mocked(cache);
+
+/**
+ * A real store rather than assertions on `cache.set` call arguments.
+ *
+ * Reading back through the same key derivation is what makes the round-trip tests bind anything: with
+ * `expect(cache.set).toHaveBeenCalledWith(...)` the key could be the raw state id, or a constant, and
+ * every test would still pass.
+ */
+const store = new Map<string, { value: unknown; ttlMs?: number }>();
+
+const LINK_TTL_MS = 60 * 60 * 24 * 1000;
+const MAX_LIFETIME_MS = 60 * 60 * 24 * 7 * 1000;
+
+const intentInput = {
+  userId: "cm5q1x2y30000abcdefghijkl",
+  email: "matti@formbricks.com",
+  provider: "azuread",
+  providerAccountId: "00000000-1111-2222-3333-444444444444",
+  callbackUrl: "https://test-webapp-url.com/workspaces/abc/surveys",
+};
+
+describe("SSO recovery intent", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    store.clear();
+
+    mockCache.set.mockImplementation(async (key: string, value: unknown, ttlMs?: number) => {
+      store.set(key, { value, ttlMs });
+      return { ok: true, data: undefined };
+    });
+    mockCache.get.mockImplementation(async (key: string) => ({
+      ok: true,
+      // The real service JSON round-trips, so mirror that rather than handing back the same object.
+      data: store.has(key) ? JSON.parse(JSON.stringify(store.get(key)!.value)) : null,
+    }));
+    mockCache.del.mockImplementation(async (keys: string[]) => {
+      keys.forEach((key) => store.delete(key));
+      return { ok: true, data: undefined };
+    });
+  });
+
+  describe("create", () => {
+    test("returns an opaque 43-character base64url state id", async () => {
+      await expect(createSsoRecoveryIntent(intentInput)).resolves.toMatch(/^[A-Za-z0-9_-]{43}$/);
+    });
+
+    test("round-trips the intent", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+
+      await expect(readSsoRecoveryIntent(stateId)).resolves.toEqual({
+        ...intentInput,
+        createdAt: expect.any(Number),
+      });
+    });
+
+    test("mints a distinct state id and key per intent, so two recoveries cannot collide", async () => {
+      const first = await createSsoRecoveryIntent(intentInput);
+      const second = await createSsoRecoveryIntent({ ...intentInput, userId: "other-user" });
+
+      expect(first).not.toBe(second);
+      expect(store.size).toBe(2);
+      await expect(readSsoRecoveryIntent(first)).resolves.toMatchObject({ userId: intentInput.userId });
+      await expect(readSsoRecoveryIntent(second)).resolves.toMatchObject({ userId: "other-user" });
+    });
+
+    test("keys on the hash, never on the state id itself", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+      const [key] = [...store.keys()];
+
+      expect(key).not.toContain(stateId);
+      expect(key).toMatch(/^fb:sso_recovery:intent:[0-9a-f]{64}$/);
+    });
+
+    test("stores nothing the URL used to carry in the clear", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+
+      // The state id is the whole of what travels; it must not encode the identity it stands for.
+      expect(stateId).not.toContain(intentInput.userId);
+      expect(stateId).not.toContain(intentInput.email);
+    });
+
+    test("stores with the verification-link TTL, so the link cannot outlive the intent", async () => {
+      await createSsoRecoveryIntent(intentInput);
+
+      expect([...store.values()][0].ttlMs).toBe(LINK_TTL_MS);
+    });
+
+    test("throws when the write fails, rather than emailing a link that cannot work", async () => {
+      mockCache.set.mockResolvedValue({ ok: false, error: { code: "RedisConnectionError" } });
+
+      await expect(createSsoRecoveryIntent(intentInput)).rejects.toThrow(
+        "Unable to store the SSO recovery intent"
+      );
+    });
+  });
+
+  describe("read", () => {
+    test("returns null for an id that was never issued", async () => {
+      await expect(readSsoRecoveryIntent("a".repeat(43))).resolves.toBeNull();
+    });
+
+    test.each([
+      ["absent", undefined],
+      ["empty", ""],
+      ["too short", "a".repeat(42)],
+      ["too long", "a".repeat(44)],
+      ["not base64url", `${"a".repeat(42)}+`],
+    ])("rejects a %s state id without touching Redis", async (_label, stateId) => {
+      await expect(readSsoRecoveryIntent(stateId)).resolves.toBeNull();
+      expect(mockCache.get).not.toHaveBeenCalled();
+    });
+
+    test("returns null rather than throwing when the cache is unreachable", async () => {
+      mockCache.get.mockResolvedValue({ ok: false, error: { code: "RedisConnectionError" } });
+
+      await expect(readSsoRecoveryIntent("a".repeat(43))).resolves.toBeNull();
+    });
+
+    /**
+     * The check that replaces the JWT signature. A Redis value carries no integrity guarantee, so every
+     * field is validated on the way out — `callbackUrl` becomes a redirect and `providerAccountId`
+     * becomes the SSO identity linked to the account, and a cast would hand both straight through.
+     */
+    test.each([
+      ["a missing userId", { ...intentInput, userId: undefined }],
+      ["a missing email", { ...intentInput, email: undefined }],
+      ["a missing provider", { ...intentInput, provider: undefined }],
+      ["a missing providerAccountId", { ...intentInput, providerAccountId: undefined }],
+      ["a missing callbackUrl", { ...intentInput, callbackUrl: undefined }],
+      ["a non-string callbackUrl", { ...intentInput, callbackUrl: { href: "https://evil.example" } }],
+      ["a non-string providerAccountId", { ...intentInput, providerAccountId: 42 }],
+      ["an empty userId", { ...intentInput, userId: "" }],
+      ["a missing createdAt", { ...intentInput }],
+      ["a non-numeric createdAt", { ...intentInput, createdAt: "yesterday" }],
+    ])("discards a stored record with %s", async (_label, stored) => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+      const [key] = [...store.keys()];
+      store.set(key, { value: stored });
+
+      await expect(readSsoRecoveryIntent(stateId)).resolves.toBeNull();
+    });
+  });
+
+  describe("consume", () => {
+    test("removes the record, so a completed recovery cannot be replayed", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+
+      await consumeSsoRecoveryIntent(stateId);
+
+      await expect(readSsoRecoveryIntent(stateId)).resolves.toBeNull();
+    });
+
+    test("never throws when the delete fails — the account link has already committed", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+      mockCache.del.mockResolvedValue({ ok: false, error: { code: "RedisConnectionError" } });
+
+      await expect(consumeSsoRecoveryIntent(stateId)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("refresh", () => {
+    const storedIntent = (createdAt: number): TSsoRecoveryIntent => ({ ...intentInput, createdAt });
+
+    test("re-pairs a resent link with a full TTL while well inside the absolute lifetime", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+
+      await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now()));
+
+      expect([...store.values()][0].ttlMs).toBe(LINK_TTL_MS);
+    });
+
+    /**
+     * `resendVerificationEmailAction` is unauthenticated, so a plain sliding window would let anyone
+     * holding a state id keep an intent alive forever. `createdAt` never moves, so the slide is capped.
+     */
+    test("clamps the TTL so a refresh cannot push expiry past the absolute lifetime", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+      // Six and a half days in: less than one link TTL of absolute lifetime is left.
+      const createdAt = Date.now() - (MAX_LIFETIME_MS - LINK_TTL_MS / 2);
+
+      await refreshSsoRecoveryIntent(stateId, storedIntent(createdAt));
+
+      const { ttlMs } = [...store.values()][0];
+      expect(ttlMs).toBeLessThan(LINK_TTL_MS);
+      expect(createdAt + ttlMs!).toBeLessThanOrEqual(createdAt + MAX_LIFETIME_MS);
+    });
+
+    test("writes nothing once the absolute lifetime has elapsed", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+      mockCache.set.mockClear();
+
+      await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now() - MAX_LIFETIME_MS - 1));
+
+      expect(mockCache.set).not.toHaveBeenCalled();
+    });
+
+    test("keeps createdAt fixed, so repeated refreshes measure from the original start", async () => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+      const createdAt = Date.now() - LINK_TTL_MS;
+
+      await refreshSsoRecoveryIntent(stateId, storedIntent(createdAt));
+
+      await expect(readSsoRecoveryIntent(stateId)).resolves.toMatchObject({ createdAt });
+    });
+  });
+});

--- a/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
@@ -242,13 +242,15 @@ describe("SSO recovery intent", () => {
       expect(createdAt + ttlMs!).toBeLessThanOrEqual(createdAt + MAX_LIFETIME_MS);
     });
 
-    test("writes nothing once the absolute lifetime has elapsed", async () => {
+    test("leaves the expiry alone once the absolute lifetime has elapsed", async () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
-      mockCache.getRedisClient.mockClear();
+      const before = { ...[...store.values()][0] };
 
       await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now() - MAX_LIFETIME_MS - 1));
 
-      expect(mockCache.getRedisClient).not.toHaveBeenCalled();
+      // The record and its TTL, not the call order: an implementation that reaches Redis and then
+      // declines to extend is equally correct, and asserting "never asked for a client" would fail it.
+      expect([...store.values()][0]).toEqual(before);
     });
 
     test("leaves the stored record untouched, so a refresh cannot write back a stale copy", async () => {

--- a/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
@@ -236,15 +236,21 @@ describe("SSO recovery intent", () => {
      * holding a state id keep an intent alive forever. `createdAt` never moves, so the slide is capped.
      */
     test("clamps the TTL so a refresh cannot push expiry past the absolute lifetime", async () => {
+      const now = Date.now();
       const stateId = await createSsoRecoveryIntent(intentInput);
-      // Six and a half days in: less than one link TTL of absolute lifetime is left.
-      const createdAt = Date.now() - (MAX_LIFETIME_MS - LINK_TTL_MS / 2);
+      // Six and a half days in: half a link TTL of absolute lifetime left. The record keeps the full
+      // TTL it was issued with, so a refresh that does nothing also fails the expiry assertion below.
+      const createdAt = now - (MAX_LIFETIME_MS - LINK_TTL_MS / 2);
 
       await refreshSsoRecoveryIntent(stateId, storedIntent(createdAt));
 
       const { ttlMs } = [...store.values()][0];
+      // The resulting EXPIRY, measured from now — not the TTL in isolation. `createdAt + ttlMs` versus
+      // `createdAt + MAX_LIFETIME_MS` cancels `createdAt` and only says `ttlMs <= MAX_LIFETIME_MS`,
+      // which a full link TTL always satisfies. Elapsed time cannot flake this: any drift after `now`
+      // shrinks the remaining lifetime, so `ttlMs` only ever comes out smaller.
+      expect(now + ttlMs!).toBeLessThanOrEqual(createdAt + MAX_LIFETIME_MS);
       expect(ttlMs).toBeLessThan(LINK_TTL_MS);
-      expect(createdAt + ttlMs!).toBeLessThanOrEqual(createdAt + MAX_LIFETIME_MS);
     });
 
     test("leaves the expiry alone once the absolute lifetime has elapsed", async () => {

--- a/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
@@ -327,6 +327,26 @@ describe("SSO recovery intent", () => {
       expect(store.get(key)!.ttlMs).toBe(agedTtlMs);
     });
 
+    /**
+     * A lifetime that is not a real number must never reach EXPIRE. `NaN` is the one that matters: it
+     * fails every comparison, so a guard written as `ttlSeconds <= 0` lets it straight through — which
+     * is what Sonar's S1940 suggestion would have reintroduced here.
+     */
+    test.each([
+      ["NaN", Number.NaN],
+      ["Infinity", Number.POSITIVE_INFINITY],
+      ["a negative TTL", -1],
+    ])("ignores %s rather than passing it to EXPIRE", async (_label, ttlSeconds) => {
+      const stateId = await createSsoRecoveryIntent(intentInput);
+      const [key] = [...store.keys()];
+      const agedTtlMs = 60 * 1000;
+      store.set(key, { ...store.get(key)!, ttlMs: agedTtlMs });
+
+      await refreshSsoRecoveryIntent(stateId, ttlSeconds);
+
+      expect(store.get(key)!.ttlMs).toBe(agedTtlMs);
+    });
+
     test("leaves the stored record untouched, so a refresh cannot write back a stale copy", async () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
       const issuedCreatedAt = (await readSsoRecoveryIntent(stateId))!.createdAt;

--- a/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
@@ -4,6 +4,7 @@ import {
   type TSsoRecoveryIntent,
   consumeSsoRecoveryIntent,
   createSsoRecoveryIntent,
+  getSsoRecoveryPairedTtlSeconds,
   readSsoRecoveryIntent,
   refreshSsoRecoveryIntent,
 } from "./recovery-intent";
@@ -33,7 +34,7 @@ const mockCache = vi.mocked(cache);
  */
 const store = new Map<string, { value: unknown; ttlMs?: number }>();
 
-const LINK_TTL_MS = 60 * 60 * 24 * 1000;
+const LINK_TTL_MS = 60 * 15 * 1000;
 // One resend's worth of slack past the link TTL — see INTENT_MAX_LIFETIME_MS.
 const MAX_LIFETIME_MS = LINK_TTL_MS * 2;
 
@@ -194,18 +195,73 @@ describe("SSO recovery intent", () => {
     });
   });
 
+  /**
+   * The number a resend gives to BOTH halves of the flow.
+   *
+   * The link and the intent are needed together, so whichever expires first ends recovery — and if the
+   * link is the survivor the user is signed in and then told recovery failed. A resend is the one place
+   * they can come apart, because the intent's refresh is capped against `createdAt` while a freshly
+   * minted link would otherwise take a full TTL however close that ceiling is.
+   */
+  describe("paired ttl for a resend", () => {
+    const LINK_TTL_SECONDS = LINK_TTL_MS / 1000;
+    const intentAged = (ageMs: number): TSsoRecoveryIntent => ({
+      ...intentInput,
+      createdAt: Date.now() - ageMs,
+    });
+
+    test("gives a resend well inside the ceiling the full link TTL", () => {
+      expect(getSsoRecoveryPairedTtlSeconds(intentAged(0))).toBe(LINK_TTL_SECONDS);
+    });
+
+    test("returns nothing to send once the absolute lifetime has passed", () => {
+      expect(getSsoRecoveryPairedTtlSeconds(intentAged(MAX_LIFETIME_MS + 1))).toBe(0);
+    });
+
+    /**
+     * The invariant, swept rather than sampled at one age: whatever the record's age, the lifetime
+     * handed out can never reach past the ceiling. Asserted as an absolute instant — `createdAt + ttl`
+     * against `createdAt + MAX` cancels `createdAt` and would pass for any TTL under the ceiling,
+     * which is the shape that made an earlier assertion here unfalsifiable.
+     */
+    test.each([0, 1, 60, LINK_TTL_MS / 2, LINK_TTL_MS, LINK_TTL_MS + 1, MAX_LIFETIME_MS - 1000])(
+      "aged %ims, expires no later than the ceiling and never beyond one link TTL",
+      (ageMs) => {
+        const intent = intentAged(ageMs);
+        const now = Date.now();
+
+        const ttlSeconds = getSsoRecoveryPairedTtlSeconds(intent);
+
+        expect(now + ttlSeconds * 1000).toBeLessThanOrEqual(intent.createdAt + MAX_LIFETIME_MS);
+        expect(ttlSeconds).toBeLessThanOrEqual(LINK_TTL_SECONDS);
+      }
+    );
+
+    /**
+     * Past one link TTL of age the clamp has to actually bite, or the sweep above is satisfied by a
+     * function that always returns the full TTL.
+     */
+    test("clamps below a full link TTL once the ceiling is nearer than one", () => {
+      expect(getSsoRecoveryPairedTtlSeconds(intentAged(LINK_TTL_MS + 60_000))).toBeLessThan(LINK_TTL_SECONDS);
+    });
+  });
+
   describe("refresh", () => {
     const storedIntent = (createdAt: number): TSsoRecoveryIntent => ({ ...intentInput, createdAt });
+    // Refresh takes the TTL rather than the record, so drive it the way the resend action does: through
+    // `getSsoRecoveryPairedTtlSeconds`. Composing them here keeps these assertions on the behaviour a
+    // resend actually produces, instead of on a number no caller would pass.
+    const pairedTtl = (createdAt: number): number => getSsoRecoveryPairedTtlSeconds(storedIntent(createdAt));
 
     test("re-pairs a resent link with a full TTL while well inside the absolute lifetime", async () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
       const [key] = [...store.keys()];
-      // Age it first, as a link resent hours later would find it. Asserted against a record still
+      // Age it first, as a link resent later in the window would find it. Asserted against a record still
       // carrying its issued TTL, this cannot fail: a refresh that does nothing at all leaves the same
       // value, which is what made an earlier version of this test green against a no-op.
       store.set(key, { ...store.get(key)!, ttlMs: 60 * 1000 });
 
-      await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now()));
+      await refreshSsoRecoveryIntent(stateId, pairedTtl(Date.now()));
 
       expect(store.get(key)!.ttlMs).toBe(LINK_TTL_MS);
     });
@@ -219,7 +275,7 @@ describe("SSO recovery intent", () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
       await consumeSsoRecoveryIntent(stateId);
 
-      await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now()));
+      await refreshSsoRecoveryIntent(stateId, pairedTtl(Date.now()));
 
       expect(store.size).toBe(0);
       await expect(readSsoRecoveryIntent(stateId)).resolves.toBeNull();
@@ -229,7 +285,7 @@ describe("SSO recovery intent", () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
       mockCache.getRedisClient.mockResolvedValue(null);
 
-      await expect(refreshSsoRecoveryIntent(stateId, storedIntent(Date.now()))).resolves.toBeUndefined();
+      await expect(refreshSsoRecoveryIntent(stateId, pairedTtl(Date.now()))).resolves.toBeUndefined();
     });
 
     /**
@@ -239,11 +295,11 @@ describe("SSO recovery intent", () => {
     test("clamps the TTL so a refresh cannot push expiry past the absolute lifetime", async () => {
       const now = Date.now();
       const stateId = await createSsoRecoveryIntent(intentInput);
-      // Six and a half days in: half a link TTL of absolute lifetime left. The record keeps the full
+      // Deep enough in that only half a link TTL of absolute lifetime is left. The record keeps the full
       // TTL it was issued with, so a refresh that does nothing also fails the expiry assertion below.
       const createdAt = now - (MAX_LIFETIME_MS - LINK_TTL_MS / 2);
 
-      await refreshSsoRecoveryIntent(stateId, storedIntent(createdAt));
+      await refreshSsoRecoveryIntent(stateId, pairedTtl(createdAt));
 
       const { ttlMs } = [...store.values()][0];
       // The resulting EXPIRY, measured from now — not the TTL in isolation. `createdAt + ttlMs` versus
@@ -264,7 +320,7 @@ describe("SSO recovery intent", () => {
       const agedTtlMs = 60 * 1000;
       store.set(key, { ...store.get(key)!, ttlMs: agedTtlMs });
 
-      await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now() - MAX_LIFETIME_MS - 1));
+      await refreshSsoRecoveryIntent(stateId, pairedTtl(Date.now() - MAX_LIFETIME_MS - 1));
 
       // The TTL, not the call order: an implementation that reaches Redis and then declines to extend
       // is equally correct, so asserting "never asked for a client" would fail a correct one.
@@ -278,7 +334,7 @@ describe("SSO recovery intent", () => {
       // one the issued value already satisfies.
       const staleCreatedAt = issuedCreatedAt - LINK_TTL_MS;
 
-      await refreshSsoRecoveryIntent(stateId, storedIntent(staleCreatedAt));
+      await refreshSsoRecoveryIntent(stateId, pairedTtl(staleCreatedAt));
 
       expect((await readSsoRecoveryIntent(stateId))?.createdAt).toBe(issuedCreatedAt);
     });

--- a/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
@@ -198,10 +198,15 @@ describe("SSO recovery intent", () => {
 
     test("re-pairs a resent link with a full TTL while well inside the absolute lifetime", async () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
+      const [key] = [...store.keys()];
+      // Age it first, as a link resent hours later would find it. Asserted against a record still
+      // carrying its issued TTL, this cannot fail: a refresh that does nothing at all leaves the same
+      // value, which is what made an earlier version of this test green against a no-op.
+      store.set(key, { ...store.get(key)!, ttlMs: 60 * 1000 });
 
       await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now()));
 
-      expect([...store.values()][0].ttlMs).toBe(LINK_TTL_MS);
+      expect(store.get(key)!.ttlMs).toBe(LINK_TTL_MS);
     });
 
     /**
@@ -261,12 +266,14 @@ describe("SSO recovery intent", () => {
 
     test("leaves the stored record untouched, so a refresh cannot write back a stale copy", async () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
+      const issuedCreatedAt = (await readSsoRecoveryIntent(stateId))!.createdAt;
+      // A createdAt a refresh would visibly overwrite if it wrote the record back at all, rather than
+      // one the issued value already satisfies.
+      const staleCreatedAt = issuedCreatedAt - LINK_TTL_MS;
 
-      await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now() - LINK_TTL_MS));
+      await refreshSsoRecoveryIntent(stateId, storedIntent(staleCreatedAt));
 
-      // The intent handed in carries a different createdAt; the record must still hold its own.
-      const stored = await readSsoRecoveryIntent(stateId);
-      expect(stored?.createdAt).toBeGreaterThan(Date.now() - LINK_TTL_MS);
+      expect((await readSsoRecoveryIntent(stateId))?.createdAt).toBe(issuedCreatedAt);
     });
   });
 });

--- a/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
@@ -34,7 +34,8 @@ const mockCache = vi.mocked(cache);
 const store = new Map<string, { value: unknown; ttlMs?: number }>();
 
 const LINK_TTL_MS = 60 * 60 * 24 * 1000;
-const MAX_LIFETIME_MS = 60 * 60 * 24 * 7 * 1000;
+// One resend's worth of slack past the link TTL — see INTENT_MAX_LIFETIME_MS.
+const MAX_LIFETIME_MS = LINK_TTL_MS * 2;
 
 const intentInput = {
   userId: "cm5q1x2y30000abcdefghijkl",

--- a/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.test.ts
@@ -244,13 +244,19 @@ describe("SSO recovery intent", () => {
 
     test("leaves the expiry alone once the absolute lifetime has elapsed", async () => {
       const stateId = await createSsoRecoveryIntent(intentInput);
-      const before = { ...[...store.values()][0] };
+      const [key] = [...store.keys()];
+      // Age the stored TTL first. Asserted against a record still carrying its issued TTL, "unchanged"
+      // is indistinguishable from "re-set to the same full TTL", and the assertion cannot fail —
+      // dropping the absolute-lifetime guard left it green. A lowered TTL is a value only a real
+      // refresh would overwrite.
+      const agedTtlMs = 60 * 1000;
+      store.set(key, { ...store.get(key)!, ttlMs: agedTtlMs });
 
       await refreshSsoRecoveryIntent(stateId, storedIntent(Date.now() - MAX_LIFETIME_MS - 1));
 
-      // The record and its TTL, not the call order: an implementation that reaches Redis and then
-      // declines to extend is equally correct, and asserting "never asked for a client" would fail it.
-      expect([...store.values()][0]).toEqual(before);
+      // The TTL, not the call order: an implementation that reaches Redis and then declines to extend
+      // is equally correct, so asserting "never asked for a client" would fail a correct one.
+      expect(store.get(key)!.ttlMs).toBe(agedTtlMs);
     });
 
     test("leaves the stored record untouched, so a refresh cannot write back a stale copy", async () => {

--- a/apps/web/modules/ee/sso/lib/recovery-intent.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.ts
@@ -155,6 +155,10 @@ export const readSsoRecoveryIntent = async (
   }
 
   if (result.data === null) {
+    // Logged, though a miss is an ordinary outcome (expired, or already consumed): `completeSsoRecovery`
+    // reports the failure without a correlation id of its own, and the hash is the only handle an
+    // operator can join the two lines on. Recoveries are rare, so this does not add meaningful volume.
+    logger.warn({ stateIdHash }, "No SSO recovery intent stored for this state");
     return null;
   }
 
@@ -210,13 +214,22 @@ export const refreshSsoRecoveryIntent = async (
   }
 
   const stateIdHash = hashStateId(stateId);
-  const result = await cache.set(
-    getIntentCacheKey(stateIdHash),
-    intent,
-    Math.min(INTENT_TTL_MS, remainingLifetimeMs)
-  );
+  const ttlSeconds = Math.floor(Math.min(INTENT_TTL_MS, remainingLifetimeMs) / 1000);
 
-  if (!result.ok) {
-    logger.error({ error: result.error, stateIdHash }, "Failed to refresh the SSO recovery intent");
+  try {
+    const redis = await cache.getRedisClient();
+
+    if (!redis) {
+      logger.error({ stateIdHash }, "Redis is required to refresh the SSO recovery intent");
+      return;
+    }
+
+    // EXPIRE rather than writing the record back, for two reasons. It is a no-op on a key that is
+    // already gone, so a resend racing a completion cannot resurrect the intent that completion just
+    // consumed — a rewrite would, and would quietly undo single use. And it never touches the stored
+    // value, so there is no path by which a stale copy read moments earlier gets written back.
+    await redis.expire(getIntentCacheKey(stateIdHash), ttlSeconds);
+  } catch (error) {
+    logger.error({ error, stateIdHash }, "Failed to refresh the SSO recovery intent");
   }
 };

--- a/apps/web/modules/ee/sso/lib/recovery-intent.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.ts
@@ -196,9 +196,10 @@ export const consumeSsoRecoveryIntent = async (stateId: string): Promise<void> =
  * outlives the intent it depends on and the user is signed in only to be told recovery failed — the
  * same pairing bug the sign-up intent cookie's resend refresh exists to avoid.
  *
- * The record is rewritten unchanged, `createdAt` included, so every refresh is measured against the
- * original start and the window cannot slide past {@link INTENT_MAX_LIFETIME_MS}. Best-effort, never
- * throws: the mail has already gone out, so a failure here costs the pairing, not the resend.
+ * Only the expiry moves — the stored record, `createdAt` included, is never rewritten. So every refresh
+ * is measured against the original start and the window cannot slide past {@link INTENT_MAX_LIFETIME_MS},
+ * which matters because the caller is unauthenticated. Best-effort, never throws: the mail has already
+ * gone out, so a failure here costs the pairing, not the resend.
  */
 export const refreshSsoRecoveryIntent = async (
   stateId: string,

--- a/apps/web/modules/ee/sso/lib/recovery-intent.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.ts
@@ -1,0 +1,222 @@
+import "server-only";
+import crypto from "node:crypto";
+import { z } from "zod";
+import { createCacheKey } from "@formbricks/cache";
+import { logger } from "@formbricks/logger";
+import { cache } from "@/lib/cache";
+import { VERIFICATION_LINK_TTL_SECONDS } from "@/modules/auth/lib/verification-links";
+
+/**
+ * SSO recovery intent storage (ENG-2783) — what a recovery attempt has to remember between the SSO
+ * collision and the moment the user proves control of the mailbox.
+ *
+ * It used to be a JWT in the URL. That URL then became the *next* attempt's `callbackUrl`, so every
+ * retry encrypted the previous attempt's whole URL inside the new one: `symmetricEncrypt` is hex, which
+ * doubles, and the JWT's base64url adds another third — ~2.7x per attempt, measured 79 -> 1092 -> 3793
+ * -> 10996 characters. nginx's `large_client_header_buffers` defaults to `4 8k` and a request line may
+ * not exceed one buffer, so attempt three came back as a bare `414 Request-URI Too Large`. There is no
+ * starting length at which nesting is safe, so the payload has to leave the URL entirely.
+ *
+ * What replaces it is the shape RFC 9126 reached for the same reason — a short opaque reference to
+ * server-side state. RFC 6750 s5.2 ("Bearer tokens SHOULD NOT be passed in page URLs") and RFC 9700
+ * s2.1 (state should be opaque and one-time) point the same way, and it drops the encrypted `userId` /
+ * `email` / `providerAccountId` out of nginx access logs and browser history as a side effect.
+ *
+ * ## Why not a cookie, like `modules/auth/lib/signup-intent.ts`
+ *
+ * Because this state has to survive the *mail* hop. `startSsoRecovery` hands the completion URL to
+ * `sendVerificationEmail`, and `buildVerificationLinks` puts it on the emailed magic link itself, so the
+ * browser that finishes recovery may not be the browser that started it — a different device entirely.
+ * A cookie set at the start would simply be absent there, which is a hard break rather than a
+ * degradation. `signup-intent.ts` is same-browser BY DESIGN (that is the whole of ENG-2562: it exists to
+ * withhold a session from a browser that did not sign up); recovery cannot require the same thing.
+ *
+ * ## Why Redis is an acceptable home for it
+ *
+ * `REDIS_URL` is a required env var — the app does not boot without it — and Better Auth already keeps
+ * sessions, verification records and OAuth state there via `secondaryStorage`. Note what that means for
+ * the trust model: the JWT this replaces was signed, and a Redis value is not, so the integrity of the
+ * record now rests on `parseStoredIntent` below plus the guards in `completeSsoRecovery`. That is a fair
+ * trade rather than a downgrade, because anyone who can write this Redis can mint a Better Auth session
+ * outright and never needs to forge an intent.
+ */
+
+/** 32 bytes, so guessing is out of reach — RFC 9126 s2.2 wants a value "infeasible to predict or guess". */
+const STATE_ENTROPY_BYTES = 32;
+
+/** Exactly what {@link toBase64Url} produces for 32 bytes. Checked before Redis is ever touched. */
+const STATE_ID_REGEX = /^[A-Za-z0-9_-]{43}$/;
+
+const INTENT_TTL_MS = VERIFICATION_LINK_TTL_SECONDS * 1000;
+
+/**
+ * Ceiling on one intent's total life, however many times it is refreshed.
+ *
+ * The refresh exists so a resent link does not outlive the intent it needs (same pairing problem as the
+ * sign-up intent cookie). But `resendVerificationEmailAction` is unauthenticated, so a plain sliding
+ * window would let anyone holding a state id keep a record alive forever. `createdAt` is written once
+ * and never moved, so measuring from it caps the slide.
+ */
+const INTENT_MAX_LIFETIME_MS = 60 * 60 * 24 * 7 * 1000;
+
+const ZStoredSsoRecoveryIntent = z.object({
+  userId: z.string().min(1),
+  email: z.string().min(1),
+  provider: z.string().min(1),
+  providerAccountId: z.string().min(1),
+  callbackUrl: z.string().min(1),
+  createdAt: z.number().int().nonnegative(),
+});
+
+export type TSsoRecoveryIntent = z.infer<typeof ZStoredSsoRecoveryIntent>;
+
+const toBase64Url = (buffer: Buffer) =>
+  buffer.toString("base64").replaceAll("=", "").replaceAll("+", "-").replaceAll("/", "_");
+
+/**
+ * The cache key is the HASH of the state id, never the id itself, so a Redis dump yields nothing
+ * usable — same reasoning as `lib/oauth/integration-state.ts`. It is also the only form of the id that
+ * may appear in a log line.
+ */
+const hashStateId = (stateId: string) => crypto.createHash("sha256").update(stateId).digest("hex");
+
+const getIntentCacheKey = (stateIdHash: string) =>
+  createCacheKey.custom("sso_recovery", "intent", stateIdHash);
+
+/**
+ * Store an intent and return the opaque id that stands for it in the URL.
+ *
+ * Throws when the write fails: without a stored intent the completion route has nothing to act on, so
+ * continuing would send the user an email whose link cannot work. Fail closed — this record decides
+ * whether an SSO identity gets linked to an account.
+ */
+export const createSsoRecoveryIntent = async (
+  intent: Omit<TSsoRecoveryIntent, "createdAt">
+): Promise<string> => {
+  const stateId = toBase64Url(crypto.randomBytes(STATE_ENTROPY_BYTES));
+  const stateIdHash = hashStateId(stateId);
+  const record: TSsoRecoveryIntent = { ...intent, createdAt: Date.now() };
+
+  const result = await cache.set(getIntentCacheKey(stateIdHash), record, INTENT_TTL_MS);
+
+  if (!result.ok) {
+    logger.error(
+      { error: result.error, stateIdHash, userId: intent.userId },
+      "Failed to store the SSO recovery intent"
+    );
+    throw new Error("Unable to store the SSO recovery intent");
+  }
+
+  return stateId;
+};
+
+/**
+ * Validate the stored value field by field rather than casting it.
+ *
+ * This is the check that replaces the JWT's signature. Two fields make it load-bearing rather than
+ * defensive: `callbackUrl` becomes a redirect (its origin is re-checked by `getValidatedCallbackUrl`
+ * downstream, but only if it is a string at all), and `providerAccountId` becomes the SSO identity
+ * linked to the account. A cast would hand both to whatever happened to be under the key.
+ */
+const parseStoredIntent = (value: unknown): TSsoRecoveryIntent | null => {
+  const parsed = ZStoredSsoRecoveryIntent.safeParse(value);
+
+  return parsed.success ? parsed.data : null;
+};
+
+/**
+ * Read an intent WITHOUT consuming it.
+ *
+ * Deliberately non-consuming, and the reason is the inbox: mail security gateways (Defender Safe Links,
+ * Proofpoint, Mimecast) fetch every link in a message before the human sees it, and the emailed link
+ * redirects here. Burning the record on read would let a scanner spend it and lock the real user out —
+ * the classic way one-time email links break in corporate mail. RFC 9126 s4 allows exactly this
+ * latitude: one-time use SHOULD, "but MAY allow for duplicate requests due to a user
+ * reloading/refreshing their user agent." Consumption happens after a completion commits, in
+ * {@link consumeSsoRecoveryIntent}.
+ *
+ * Returns `null` rather than throwing — for a missing record, a malformed one, and an unreachable Redis
+ * alike. The caller is an unauthenticated GET that must degrade to the recovery-failed redirect, never
+ * to a 500.
+ */
+export const readSsoRecoveryIntent = async (
+  stateId: string | null | undefined
+): Promise<TSsoRecoveryIntent | null> => {
+  if (!stateId || !STATE_ID_REGEX.test(stateId)) {
+    return null;
+  }
+
+  const stateIdHash = hashStateId(stateId);
+  const result = await cache.get<unknown>(getIntentCacheKey(stateIdHash));
+
+  if (!result.ok) {
+    logger.error({ error: result.error, stateIdHash }, "Failed to read the SSO recovery intent");
+    return null;
+  }
+
+  if (result.data === null) {
+    return null;
+  }
+
+  const intent = parseStoredIntent(result.data);
+  if (!intent) {
+    logger.error({ stateIdHash }, "Discarded a malformed SSO recovery intent");
+  }
+
+  return intent;
+};
+
+/**
+ * Single-use, applied at the only moment it is safe to: after the account link has committed.
+ *
+ * Best-effort, never throws. The link already happened, so failing here must not turn a completed
+ * recovery into an error — the record expires on its own.
+ */
+export const consumeSsoRecoveryIntent = async (stateId: string): Promise<void> => {
+  if (!STATE_ID_REGEX.test(stateId)) {
+    return;
+  }
+
+  const stateIdHash = hashStateId(stateId);
+  const result = await cache.del([getIntentCacheKey(stateIdHash)]);
+
+  if (!result.ok) {
+    logger.error({ error: result.error, stateIdHash }, "Failed to consume the SSO recovery intent");
+  }
+};
+
+/**
+ * Re-pair the intent with a link that was just resent.
+ *
+ * A resend mints a fresh {@link VERIFICATION_LINK_TTL_SECONDS} link, so without this the new link
+ * outlives the intent it depends on and the user is signed in only to be told recovery failed — the
+ * same pairing bug the sign-up intent cookie's resend refresh exists to avoid.
+ *
+ * The record is rewritten unchanged, `createdAt` included, so every refresh is measured against the
+ * original start and the window cannot slide past {@link INTENT_MAX_LIFETIME_MS}. Best-effort, never
+ * throws: the mail has already gone out, so a failure here costs the pairing, not the resend.
+ */
+export const refreshSsoRecoveryIntent = async (
+  stateId: string,
+  intent: TSsoRecoveryIntent
+): Promise<void> => {
+  if (!STATE_ID_REGEX.test(stateId)) {
+    return;
+  }
+
+  const remainingLifetimeMs = intent.createdAt + INTENT_MAX_LIFETIME_MS - Date.now();
+  if (remainingLifetimeMs <= 0) {
+    return;
+  }
+
+  const stateIdHash = hashStateId(stateId);
+  const result = await cache.set(
+    getIntentCacheKey(stateIdHash),
+    intent,
+    Math.min(INTENT_TTL_MS, remainingLifetimeMs)
+  );
+
+  if (!result.ok) {
+    logger.error({ error: result.error, stateIdHash }, "Failed to refresh the SSO recovery intent");
+  }
+};

--- a/apps/web/modules/ee/sso/lib/recovery-intent.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.ts
@@ -225,8 +225,11 @@ export const getSsoRecoveryPairedTtlSeconds = (intent: TSsoRecoveryIntent): numb
  *
  * Takes the lifetime rather than deriving it, and that is the point: the caller mints the resent link
  * with the same {@link getSsoRecoveryPairedTtlSeconds} value it passes here, so the two halves cannot
- * come apart — not even by the second or two that computing the number twice would cost. Anything not
- * strictly positive is a no-op, `NaN` included, so a miscomputed lifetime can never become an EXPIRE.
+ * come apart — not even by the second or two that computing the number twice would cost.
+ *
+ * `Number.isFinite` before the comparison, not just `<= 0`: a miscomputed lifetime arrives as `NaN`,
+ * which fails EVERY comparison, so `NaN <= 0` is false and an unguarded version would hand `NaN`
+ * straight to EXPIRE. `Infinity` is rejected on the same line for the same reason.
  *
  * Only the expiry moves — the stored record, `createdAt` included, is never rewritten. So every refresh
  * is measured against the original start and the window cannot slide past {@link INTENT_MAX_LIFETIME_MS},
@@ -234,7 +237,7 @@ export const getSsoRecoveryPairedTtlSeconds = (intent: TSsoRecoveryIntent): numb
  * gone out, so a failure here costs the pairing, not the resend.
  */
 export const refreshSsoRecoveryIntent = async (stateId: string, ttlSeconds: number): Promise<void> => {
-  if (!STATE_ID_REGEX.test(stateId) || !(ttlSeconds > 0)) {
+  if (!STATE_ID_REGEX.test(stateId) || !Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
     return;
   }
 

--- a/apps/web/modules/ee/sso/lib/recovery-intent.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.ts
@@ -56,8 +56,13 @@ const INTENT_TTL_MS = VERIFICATION_LINK_TTL_SECONDS * 1000;
  * sign-up intent cookie). But `resendVerificationEmailAction` is unauthenticated, so a plain sliding
  * window would let anyone holding a state id keep a record alive forever. `createdAt` is written once
  * and never moved, so measuring from it caps the slide.
+ *
+ * Two link lifetimes rather than a round number of days: this record authorises clearing a password and
+ * a second factor, so the ceiling is "one resend's worth of slack" — enough that a resent link is never
+ * orphaned, and past that the user restarts recovery, which is one click. Deriving it also means it
+ * cannot drift away from the link TTL it exists to cover.
  */
-const INTENT_MAX_LIFETIME_MS = 60 * 60 * 24 * 7 * 1000;
+const INTENT_MAX_LIFETIME_MS = INTENT_TTL_MS * 2;
 
 const ZStoredSsoRecoveryIntent = z.object({
   userId: z.string().min(1),

--- a/apps/web/modules/ee/sso/lib/recovery-intent.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.ts
@@ -57,10 +57,12 @@ const INTENT_TTL_MS = VERIFICATION_LINK_TTL_SECONDS * 1000;
  * window would let anyone holding a state id keep a record alive forever. `createdAt` is written once
  * and never moved, so measuring from it caps the slide.
  *
- * Two link lifetimes rather than a round number of days: this record authorises clearing a password and
- * a second factor, so the ceiling is "one resend's worth of slack" — enough that a resent link is never
+ * Two link lifetimes rather than an absolute figure: this record authorises clearing a password and a
+ * second factor, so the ceiling is "one resend's worth of slack" — enough that a resent link is never
  * orphaned, and past that the user restarts recovery, which is one click. Deriving it also means it
- * cannot drift away from the link TTL it exists to cover.
+ * cannot drift away from the link TTL it exists to cover. At the current 15-minute link that is a
+ * 30-minute ceiling, which is exactly what `PASSWORD_RESET_TOKEN_LIFETIME_MINUTES` defaults to for the
+ * strictly weaker password-reset link.
  */
 const INTENT_MAX_LIFETIME_MS = INTENT_TTL_MS * 2;
 
@@ -197,30 +199,46 @@ export const consumeSsoRecoveryIntent = async (stateId: string): Promise<void> =
 /**
  * Re-pair the intent with a link that was just resent.
  *
- * A resend mints a fresh {@link VERIFICATION_LINK_TTL_SECONDS} link, so without this the new link
- * outlives the intent it depends on and the user is signed in only to be told recovery failed — the
- * same pairing bug the sign-up intent cookie's resend refresh exists to avoid.
+ * Takes the lifetime rather than deriving it, and that is the point: the caller mints the resent link
+ * with the same {@link getSsoRecoveryPairedTtlSeconds} value it passes here, so the two halves cannot
+ * come apart — not even by the second or two that computing the number twice would cost. Anything not
+ * strictly positive is a no-op, `NaN` included, so a miscomputed lifetime can never become an EXPIRE.
  *
  * Only the expiry moves — the stored record, `createdAt` included, is never rewritten. So every refresh
  * is measured against the original start and the window cannot slide past {@link INTENT_MAX_LIFETIME_MS},
  * which matters because the caller is unauthenticated. Best-effort, never throws: the mail has already
  * gone out, so a failure here costs the pairing, not the resend.
  */
-export const refreshSsoRecoveryIntent = async (
-  stateId: string,
-  intent: TSsoRecoveryIntent
-): Promise<void> => {
-  if (!STATE_ID_REGEX.test(stateId)) {
-    return;
+/**
+ * How long both halves of a resent recovery may live, in seconds — `0` once the intent is spent.
+ *
+ * The link and the intent have to expire together (see {@link VERIFICATION_LINK_TTL_SECONDS}), and a
+ * resend is where they can come apart: the refreshed intent is capped by
+ * {@link INTENT_MAX_LIFETIME_MS} while a freshly minted link would otherwise get a full TTL regardless.
+ * Near the ceiling that hands out a link which outlives the record it needs — the exact "signed in,
+ * then recovery failed" failure the shared constant exists to prevent. So the resend mints its token
+ * with this number too, and the invariant holds by construction rather than by both call sites
+ * happening to agree.
+ *
+ * `0` means the ceiling is reached: there is no honest window left to send, and the caller should make
+ * the user start recovery again instead of mailing a link that is already dead.
+ */
+export const getSsoRecoveryPairedTtlSeconds = (intent: TSsoRecoveryIntent): number => {
+  const remainingLifetimeMs = intent.createdAt + INTENT_MAX_LIFETIME_MS - Date.now();
+
+  if (remainingLifetimeMs <= 0) {
+    return 0;
   }
 
-  const remainingLifetimeMs = intent.createdAt + INTENT_MAX_LIFETIME_MS - Date.now();
-  if (remainingLifetimeMs <= 0) {
+  return Math.floor(Math.min(INTENT_TTL_MS, remainingLifetimeMs) / 1000);
+};
+
+export const refreshSsoRecoveryIntent = async (stateId: string, ttlSeconds: number): Promise<void> => {
+  if (!STATE_ID_REGEX.test(stateId) || !(ttlSeconds > 0)) {
     return;
   }
 
   const stateIdHash = hashStateId(stateId);
-  const ttlSeconds = Math.floor(Math.min(INTENT_TTL_MS, remainingLifetimeMs) / 1000);
 
   try {
     const redis = await cache.getRedisClient();

--- a/apps/web/modules/ee/sso/lib/recovery-intent.ts
+++ b/apps/web/modules/ee/sso/lib/recovery-intent.ts
@@ -197,19 +197,6 @@ export const consumeSsoRecoveryIntent = async (stateId: string): Promise<void> =
 };
 
 /**
- * Re-pair the intent with a link that was just resent.
- *
- * Takes the lifetime rather than deriving it, and that is the point: the caller mints the resent link
- * with the same {@link getSsoRecoveryPairedTtlSeconds} value it passes here, so the two halves cannot
- * come apart — not even by the second or two that computing the number twice would cost. Anything not
- * strictly positive is a no-op, `NaN` included, so a miscomputed lifetime can never become an EXPIRE.
- *
- * Only the expiry moves — the stored record, `createdAt` included, is never rewritten. So every refresh
- * is measured against the original start and the window cannot slide past {@link INTENT_MAX_LIFETIME_MS},
- * which matters because the caller is unauthenticated. Best-effort, never throws: the mail has already
- * gone out, so a failure here costs the pairing, not the resend.
- */
-/**
  * How long both halves of a resent recovery may live, in seconds — `0` once the intent is spent.
  *
  * The link and the intent have to expire together (see {@link VERIFICATION_LINK_TTL_SECONDS}), and a
@@ -233,6 +220,19 @@ export const getSsoRecoveryPairedTtlSeconds = (intent: TSsoRecoveryIntent): numb
   return Math.floor(Math.min(INTENT_TTL_MS, remainingLifetimeMs) / 1000);
 };
 
+/**
+ * Re-pair the intent with a link that was just resent.
+ *
+ * Takes the lifetime rather than deriving it, and that is the point: the caller mints the resent link
+ * with the same {@link getSsoRecoveryPairedTtlSeconds} value it passes here, so the two halves cannot
+ * come apart — not even by the second or two that computing the number twice would cost. Anything not
+ * strictly positive is a no-op, `NaN` included, so a miscomputed lifetime can never become an EXPIRE.
+ *
+ * Only the expiry moves — the stored record, `createdAt` included, is never rewritten. So every refresh
+ * is measured against the original start and the window cannot slide past {@link INTENT_MAX_LIFETIME_MS},
+ * which matters because the caller is unauthenticated. Best-effort, never throws: the mail has already
+ * gone out, so a failure here costs the pairing, not the resend.
+ */
 export const refreshSsoRecoveryIntent = async (stateId: string, ttlSeconds: number): Promise<void> => {
   if (!STATE_ID_REGEX.test(stateId) || !(ttlSeconds > 0)) {
     return;

--- a/apps/web/modules/ee/sso/lib/sso-recovery-loop.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery-loop.integration.test.ts
@@ -47,9 +47,9 @@ const seedUser = () =>
   });
 
 /** The Better Auth endpoint context for an SSO callback that collided with an existing account. */
-const makeCollisionCtx = (redirect: (url: string) => Error) => ({
+const makeCollisionCtx = (redirect: (url: string) => Error, providerId: string) => ({
   path: "/callback/:providerId",
-  params: { providerId: "google" },
+  params: { providerId },
   context: {
     responseHeaders: new Headers({ location: `${WEBAPP_URL}/auth/login?error=account_not_linked` }),
   },
@@ -57,7 +57,11 @@ const makeCollisionCtx = (redirect: (url: string) => Error) => ({
 });
 
 /** One turn of the loop. Returns where the handler redirected the browser. */
-const runOneRecoveryAttempt = async (callbackUrl: string, providerAccountId: string): Promise<string> => {
+const runOneRecoveryAttempt = async (
+  callbackUrl: string,
+  providerAccountId: string,
+  providerId = "google"
+): Promise<string> => {
   mocks.getOAuthState.mockResolvedValue({ callbackURL: callbackUrl });
 
   let redirectedTo = "";
@@ -69,7 +73,9 @@ const runOneRecoveryAttempt = async (callbackUrl: string, providerAccountId: str
   await runWithSsoRequestContext(async () => {
     captureSsoIdentity({ email: VICTIM_EMAIL, providerAccountId });
     // The handler signals its redirect by throwing, exactly as Better Auth expects.
-    await expect(ssoRecoveryAfterHandler(makeCollisionCtx(redirect) as never)).rejects.toBeDefined();
+    await expect(
+      ssoRecoveryAfterHandler(makeCollisionCtx(redirect, providerId) as never)
+    ).rejects.toBeDefined();
   });
 
   expect(redirectedTo).toContain("/auth/verification-requested");
@@ -112,6 +118,38 @@ describe("SSO recovery retry loop (real Postgres + Redis, real Better Auth hook)
     expect(new Set(stateIds).size).toBe(4);
     stateIds.forEach((stateId) => expect(stateId).toMatch(/^[A-Za-z0-9_-]{43}$/));
   });
+
+  /**
+   * The ticket was reported against Microsoft, but nothing on this path is provider-specific:
+   * `ssoRecoveryAfterHandler` fires for any id `normalizeSsoProvider` accepts, and `startSsoRecovery`
+   * carries `provider` as data without branching on it. So every configured provider grew the URL the
+   * same way, and every one of them is fixed by the same change. `azure-ad` is in the list because
+   * Microsoft can arrive under either spelling — the normaliser maps the legacy alias to `azuread`.
+   */
+  test.each(["google", "github", "azuread", "azure-ad", "openid", "saml"])(
+    "the loop is flat for %s too, not just the provider it was reported against",
+    async (providerId) => {
+      await seedUser();
+
+      let callbackUrl = `${WEBAPP_URL}/organizations/org_loop/workspaces/ws_loop/surveys`;
+      const lengths: number[] = [];
+
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const verificationRequestedUrl = await runOneRecoveryAttempt(
+          callbackUrl,
+          `${providerId}-sub-${attempt}`,
+          providerId
+        );
+        const completionUrl = new URL(verificationRequestedUrl).searchParams.get("callbackUrl")!;
+
+        lengths.push(completionUrl.length);
+        expect(loginRequestLineFor(verificationRequestedUrl).length).toBeLessThan(NGINX_REQUEST_LINE_LIMIT);
+        callbackUrl = completionUrl;
+      }
+
+      expect(new Set(lengths).size).toBe(1);
+    }
+  );
 
   test("a recovery callback arriving as the next attempt's destination is dropped, not stored", async () => {
     await seedUser();

--- a/apps/web/modules/ee/sso/lib/sso-recovery-loop.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery-loop.integration.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { resetDb } from "@/integration/reset-db";
+import { WEBAPP_URL } from "@/lib/constants";
+import { ssoRecoveryAfterHandler } from "@/modules/ee/sso/lib/better-auth-hooks";
+import { completeSsoRecovery } from "@/modules/ee/sso/lib/sso-recovery";
+import { captureSsoIdentity, runWithSsoRequestContext } from "@/modules/ee/sso/lib/sso-request-context";
+
+/**
+ * ENG-2783 end to end, through the hook the IdP callback actually runs, against real Postgres and real
+ * Redis.
+ *
+ * The unit growth test proves the arithmetic; this proves the wiring. It starts one level above
+ * `startSsoRecovery` — at `ssoRecoveryAfterHandler`, the Better Auth `hooks.after` middleware that turns
+ * an `error=account_not_linked` callback into recovery — so the callback URL it works from is the one
+ * Better Auth really hands over, and the intent really lands in Redis. Only `getOAuthState` is stubbed,
+ * because reading it needs a live Better Auth request context that no test can supply; every other
+ * participant is real.
+ *
+ * The loop under test is the one from the ticket: the completion URL becomes the `callbackUrl` on the
+ * verification-requested page, whose log-in link hands it to `/auth/login`, and signing in with the same
+ * IdP re-enters this handler carrying it. On the JWT implementation each turn multiplied the URL by
+ * ~2.7 (hex-encoded ciphertext, then base64url) and the third produced a bare 414.
+ */
+
+const mocks = vi.hoisted(() => ({ getOAuthState: vi.fn() }));
+
+// The one stub. `APIError` and `createAuthMiddleware` from the same module stay real.
+vi.mock("better-auth/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("better-auth/api")>()),
+  getOAuthState: mocks.getOAuthState,
+}));
+
+// Fires inside setImmediate and calls getClientIpFromHeaders() outside a request scope.
+vi.mock("@/modules/ee/audit-logs/lib/handler", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/ee/audit-logs/lib/handler")>()),
+  queueAuditEventBackground: vi.fn(async () => undefined),
+}));
+
+/** nginx's `large_client_header_buffers` defaults to `4 8k`, and a request line must fit ONE buffer. */
+const NGINX_REQUEST_LINE_LIMIT = 8192;
+const VICTIM_EMAIL = "loop@example.com";
+
+const seedUser = () =>
+  prisma.user.create({
+    data: { email: VICTIM_EMAIL, name: "Loop Tester", emailVerified: true, locale: "en-US" },
+  });
+
+/** The Better Auth endpoint context for an SSO callback that collided with an existing account. */
+const makeCollisionCtx = (redirect: (url: string) => Error) => ({
+  path: "/callback/:providerId",
+  params: { providerId: "google" },
+  context: {
+    responseHeaders: new Headers({ location: `${WEBAPP_URL}/auth/login?error=account_not_linked` }),
+  },
+  redirect,
+});
+
+/** One turn of the loop. Returns where the handler redirected the browser. */
+const runOneRecoveryAttempt = async (callbackUrl: string, providerAccountId: string): Promise<string> => {
+  mocks.getOAuthState.mockResolvedValue({ callbackURL: callbackUrl });
+
+  let redirectedTo = "";
+  const redirect = (url: string) => {
+    redirectedTo = url;
+    return new Error("redirect");
+  };
+
+  await runWithSsoRequestContext(async () => {
+    captureSsoIdentity({ email: VICTIM_EMAIL, providerAccountId });
+    // The handler signals its redirect by throwing, exactly as Better Auth expects.
+    await expect(ssoRecoveryAfterHandler(makeCollisionCtx(redirect) as never)).rejects.toBeDefined();
+  });
+
+  expect(redirectedTo).toContain("/auth/verification-requested");
+  return redirectedTo;
+};
+
+/** What the browser sends when the user clicks "log in" on the verification-requested page. */
+const loginRequestLineFor = (verificationRequestedUrl: string): string => {
+  const callbackUrl = new URL(verificationRequestedUrl).searchParams.get("callbackUrl") ?? "";
+  return `GET /auth/login?callbackUrl=${encodeURIComponent(callbackUrl)} HTTP/1.1`;
+};
+
+describe("SSO recovery retry loop (real Postgres + Redis, real Better Auth hook)", () => {
+  beforeEach(async () => {
+    await resetDb();
+    vi.clearAllMocks();
+  });
+
+  test("four trips round the loop leave every URL the same length, well inside nginx's buffer", async () => {
+    await seedUser();
+
+    let callbackUrl = `${WEBAPP_URL}/organizations/org_loop/workspaces/ws_loop/surveys`;
+    const lengths: number[] = [];
+    const stateIds: string[] = [];
+
+    for (let attempt = 0; attempt < 4; attempt++) {
+      const verificationRequestedUrl = await runOneRecoveryAttempt(callbackUrl, `google-sub-${attempt}`);
+      const completionUrl = new URL(verificationRequestedUrl).searchParams.get("callbackUrl")!;
+
+      lengths.push(completionUrl.length);
+      stateIds.push(new URL(completionUrl).searchParams.get("state")!);
+      expect(loginRequestLineFor(verificationRequestedUrl).length).toBeLessThan(NGINX_REQUEST_LINE_LIMIT);
+
+      // Round again with what the log-in link carries — the step that used to nest.
+      callbackUrl = completionUrl;
+    }
+
+    expect(new Set(lengths).size).toBe(1);
+    // Every attempt gets its own record; none is reused or overwritten.
+    expect(new Set(stateIds).size).toBe(4);
+    stateIds.forEach((stateId) => expect(stateId).toMatch(/^[A-Za-z0-9_-]{43}$/));
+  });
+
+  test("a recovery callback arriving as the next attempt's destination is dropped, not stored", async () => {
+    await seedUser();
+    const { readSsoRecoveryIntent } = await import("@/modules/ee/sso/lib/recovery-intent");
+
+    const originalDestination = `${WEBAPP_URL}/organizations/org_loop/workspaces/ws_loop/surveys`;
+    const first = await runOneRecoveryAttempt(originalDestination, "google-sub-a");
+    const firstCompletionUrl = new URL(first).searchParams.get("callbackUrl")!;
+
+    const second = await runOneRecoveryAttempt(firstCompletionUrl, "google-sub-b");
+    const secondCompletionUrl = new URL(second).searchParams.get("callbackUrl")!;
+
+    const firstIntent = await readSsoRecoveryIntent(new URL(firstCompletionUrl).searchParams.get("state"));
+    const secondIntent = await readSsoRecoveryIntent(new URL(secondCompletionUrl).searchParams.get("state"));
+
+    expect(firstIntent?.callbackUrl).toBe(originalDestination);
+    // Round two arrived pointing back into recovery, so it falls back rather than nesting.
+    expect(secondIntent?.callbackUrl).toBe(WEBAPP_URL);
+  });
+
+  test("the intent minted by the hook completes and is then spent", async () => {
+    const user = await seedUser();
+    const { readSsoRecoveryIntent } = await import("@/modules/ee/sso/lib/recovery-intent");
+
+    const destination = `${WEBAPP_URL}/organizations/org_loop/workspaces/ws_loop/surveys`;
+    const verificationRequestedUrl = await runOneRecoveryAttempt(destination, "google-sub-complete");
+    const completionUrl = new URL(verificationRequestedUrl).searchParams.get("callbackUrl")!;
+    const stateId = new URL(completionUrl).searchParams.get("state")!;
+
+    const landedOn = await completeSsoRecovery({ stateId, sessionUserId: user.id });
+
+    expect(landedOn).toBe(destination);
+    await expect(readSsoRecoveryIntent(stateId)).resolves.toBeNull();
+
+    const account = await prisma.account.findFirst({ where: { userId: user.id, provider: "google" } });
+    expect(account?.providerAccountId).toBe("google-sub-complete");
+
+    // Replaying the spent state must not relink.
+    await expect(completeSsoRecovery({ stateId, sessionUserId: user.id })).rejects.toThrow(
+      "OAuthAccountNotLinked"
+    );
+  });
+});

--- a/apps/web/modules/ee/sso/lib/sso-recovery-loop.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery-loop.integration.test.ts
@@ -67,15 +67,16 @@ const runOneRecoveryAttempt = async (
   let redirectedTo = "";
   const redirect = (url: string) => {
     redirectedTo = url;
-    return new Error("redirect");
+    return new Error("sso-recovery-redirect");
   };
 
   await runWithSsoRequestContext(async () => {
     captureSsoIdentity({ email: VICTIM_EMAIL, providerAccountId });
-    // The handler signals its redirect by throwing, exactly as Better Auth expects.
-    await expect(
-      ssoRecoveryAfterHandler(makeCollisionCtx(redirect, providerId) as never)
-    ).rejects.toBeDefined();
+    // The handler signals its redirect by throwing, exactly as Better Auth expects. Matched on the
+    // sentinel rather than `toBeDefined()`, so a crash on the way there cannot read as a redirect.
+    await expect(ssoRecoveryAfterHandler(makeCollisionCtx(redirect, providerId) as never)).rejects.toThrow(
+      "sso-recovery-redirect"
+    );
   });
 
   expect(redirectedTo).toContain("/auth/verification-requested");

--- a/apps/web/modules/ee/sso/lib/sso-recovery-url-growth.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery-url-growth.test.ts
@@ -21,7 +21,6 @@ import { startSsoRecovery } from "./sso-recovery";
 const NGINX_REQUEST_LINE_LIMIT = 8192;
 const WEBAPP_URL = "http://localhost:3000";
 
-
 // Hoisted with the mocks that use them: `vi.mock` factories are lifted above every top-level const.
 const mocks = vi.hoisted(() => ({
   createEmailToken: vi.fn(() => "email-token"),
@@ -35,7 +34,12 @@ vi.mock("crypto", async () => await vi.importActual<typeof import("crypto")>("cr
 
 vi.mock("@formbricks/database", () => ({ prisma: { $transaction: vi.fn(), user: { findUnique: vi.fn() } } }));
 vi.mock("@formbricks/logger", () => ({
-  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), withContext: () => ({ info: vi.fn(), error: vi.fn() }) },
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    withContext: () => ({ info: vi.fn(), error: vi.fn() }),
+  },
 }));
 // Real crypto material, so this file runs unchanged against the JWT implementation too — which is what
 // makes "red before, green after" checkable rather than asserted. `vitestSetup.ts` supplies a 19-char
@@ -154,7 +158,9 @@ describe("SSO recovery URL growth (ENG-2783)", () => {
     // Round two, arriving with the previous attempt's completion URL — the shape that used to nest.
     await startRecoveryReturningCompletionUrl(completionUrl);
 
-    const storedCallbackUrls = [...mocks.store.values()].map((intent) => (intent as { callbackUrl: string }).callbackUrl);
+    const storedCallbackUrls = [...mocks.store.values()].map(
+      (intent) => (intent as { callbackUrl: string }).callbackUrl
+    );
     expect(storedCallbackUrls).toEqual([`${WEBAPP_URL}/environments/env_1`, WEBAPP_URL]);
   });
 });

--- a/apps/web/modules/ee/sso/lib/sso-recovery-url-growth.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery-url-growth.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { sendVerificationEmail } from "@/modules/email";
+import { startSsoRecovery } from "./sso-recovery";
+
+/**
+ * The regression test for ENG-2783, and the one the existing suite could not have been.
+ *
+ * `sso-recovery.test.ts` mocks the intent factory to a constant string, so the completion URL is the
+ * same length there whatever the input — which is precisely why a bug about URL length lived in this
+ * function for two releases with the file green. This file therefore drives the REAL intent
+ * construction (only Redis is faked, by an in-memory store) and measures the URL the browser would
+ * actually request.
+ *
+ * On the JWT implementation this replaces, the loop below produced 1092 -> 3793 -> 10996 -> 30204
+ * characters: `symmetricEncrypt` is hex-encoded, so it doubles its input, and the JWT's base64url adds
+ * another third — about 2.7x per attempt. nginx's `large_client_header_buffers` defaults to `4 8k` and
+ * a request line may not exceed a single buffer, so the third attempt came back as a bare
+ * `414 Request-URI Too Large` with no way out but editing the address bar.
+ */
+
+const NGINX_REQUEST_LINE_LIMIT = 8192;
+const WEBAPP_URL = "http://localhost:3000";
+
+
+// Hoisted with the mocks that use them: `vi.mock` factories are lifted above every top-level const.
+const mocks = vi.hoisted(() => ({
+  createEmailToken: vi.fn(() => "email-token"),
+  webAppUrl: "http://localhost:3000",
+  store: new Map<string, unknown>(),
+}));
+
+// vitestSetup.ts stubs `crypto.createHash` to a constant; recovery-intent keys on sha256(stateId), so
+// the stub would collapse every intent onto one key and hide a collision.
+vi.mock("crypto", async () => await vi.importActual<typeof import("crypto")>("crypto"));
+
+vi.mock("@formbricks/database", () => ({ prisma: { $transaction: vi.fn(), user: { findUnique: vi.fn() } } }));
+vi.mock("@formbricks/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), withContext: () => ({ info: vi.fn(), error: vi.fn() }) },
+}));
+// Real crypto material, so this file runs unchanged against the JWT implementation too — which is what
+// makes "red before, green after" checkable rather than asserted. `vitestSetup.ts` supplies a 19-char
+// ENCRYPTION_KEY that `createCipheriv` rejects, and no NEXTAUTH_SECRET at all.
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  WEBAPP_URL: mocks.webAppUrl,
+  ENCRYPTION_KEY: "0".repeat(64),
+  NEXTAUTH_SECRET: "test-nextauth-secret",
+}));
+// Only the email token is stubbed — it is a fixed-size claim either way, and the length under test is
+// the callback's. Everything else stays real, including the intent factory this change removes.
+vi.mock("@/lib/jwt", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/jwt")>()),
+  createEmailToken: mocks.createEmailToken,
+}));
+vi.mock("@/modules/email", () => ({
+  sendVerificationEmail: vi.fn(async () => true),
+  sendSsoRecoveryFactorsRemovedEmail: vi.fn(async () => true),
+}));
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({ queueAuditEventBackground: vi.fn() }));
+
+vi.mock("@/lib/cache", () => ({
+  cache: {
+    set: vi.fn(async (key: string, value: unknown) => {
+      mocks.store.set(key, value);
+      return { ok: true, data: undefined };
+    }),
+    get: vi.fn(async (key: string) => ({ ok: true, data: mocks.store.get(key) ?? null })),
+    del: vi.fn(async () => ({ ok: true, data: undefined })),
+  },
+}));
+
+const existingUser = {
+  id: "cm5q1x2y30000abcdefghijkl",
+  email: "matti@formbricks.com",
+  locale: "en-US" as const,
+  emailVerified: false,
+  isActive: true,
+  identityProvider: "email" as const,
+  identityProviderAccountId: null,
+  twoFactorEnabled: false,
+};
+
+/** One turn of the loop: start recovery, and hand back the completion URL it puts in the email. */
+const startRecoveryReturningCompletionUrl = async (callbackUrl: string): Promise<string> => {
+  await startSsoRecovery({
+    existingUser,
+    provider: "google",
+    account: { type: "oauth", provider: "google", providerAccountId: "provider-account-1" } as never,
+    callbackUrl,
+  });
+
+  return vi.mocked(sendVerificationEmail).mock.calls.at(-1)![0].callbackUrl!;
+};
+
+describe("SSO recovery URL growth (ENG-2783)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.store.clear();
+    mocks.createEmailToken.mockReturnValue("email-token");
+  });
+
+  test("retrying the loop does not grow the URL", async () => {
+    // The user's real destination, and then whatever the previous attempt handed the login link.
+    let callbackUrl = `${WEBAPP_URL}/workspaces/cm5q1x2y30000abcdefghijkl/surveys`;
+    const completionUrlLengths: number[] = [];
+
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const completionUrl = await startRecoveryReturningCompletionUrl(callbackUrl);
+      completionUrlLengths.push(completionUrl.length);
+      // Step 6 of the loop: the verification-requested page's log-in link carries the completion URL
+      // into /auth/login, and signing in with the same IdP re-enters startSsoRecovery with it.
+      callbackUrl = completionUrl;
+    }
+
+    expect(new Set(completionUrlLengths).size).toBe(1);
+  });
+
+  test("keeps every attempt's request line far inside nginx's 8K buffer", async () => {
+    let callbackUrl = `${WEBAPP_URL}/workspaces/cm5q1x2y30000abcdefghijkl/surveys`;
+
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const completionUrl = await startRecoveryReturningCompletionUrl(callbackUrl);
+      // What the browser sends when the user clicks "log in" on the verification-requested page.
+      const requestLine = `GET /auth/login?callbackUrl=${encodeURIComponent(completionUrl)} HTTP/1.1`;
+
+      expect(requestLine.length).toBeLessThan(NGINX_REQUEST_LINE_LIMIT);
+      callbackUrl = completionUrl;
+    }
+  });
+
+  test("the completion URL is a short opaque reference, carrying no part of the intent", async () => {
+    const completionUrl = await startRecoveryReturningCompletionUrl(`${WEBAPP_URL}/environments/env_1`);
+    const stateId = new URL(completionUrl).searchParams.get("state");
+
+    expect(stateId).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(completionUrl.length).toBeLessThan(150);
+    expect(completionUrl).not.toContain(existingUser.id);
+    expect(completionUrl).not.toContain("matti");
+  });
+
+  test("a callback URL sized to survive one nesting still yields the same short URL", async () => {
+    // Length has to stop mattering, not merely be smaller: an 8K callback is what attempt three used to
+    // hand back, and it must not produce an 8K completion URL in turn.
+    const hugeCallbackUrl = `${WEBAPP_URL}/environments/env_1?padding=${"a".repeat(8000)}`;
+
+    const completionUrl = await startRecoveryReturningCompletionUrl(hugeCallbackUrl);
+
+    expect(completionUrl.length).toBeLessThan(150);
+  });
+
+  test("refuses to nest: a recovery callback is dropped rather than stored", async () => {
+    const completionUrl = await startRecoveryReturningCompletionUrl(`${WEBAPP_URL}/environments/env_1`);
+
+    // Round two, arriving with the previous attempt's completion URL — the shape that used to nest.
+    await startRecoveryReturningCompletionUrl(completionUrl);
+
+    const storedCallbackUrls = [...mocks.store.values()].map((intent) => (intent as { callbackUrl: string }).callbackUrl);
+    expect(storedCallbackUrls).toEqual([`${WEBAPP_URL}/environments/env_1`, WEBAPP_URL]);
+  });
+});

--- a/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.integration.test.ts
@@ -3,9 +3,9 @@ import { prisma } from "@formbricks/database";
 import { resetDb } from "@/integration/reset-db";
 import { ENCRYPTION_KEY, WEBAPP_URL } from "@/lib/constants";
 import { symmetricEncrypt } from "@/lib/crypto";
-import { createSsoRelinkIntent } from "@/lib/jwt";
 import { auth } from "@/modules/auth/lib/auth";
 import { getSessionTokenFromCookieHeader } from "@/modules/auth/lib/session-cookie";
+import { createSsoRecoveryIntent } from "@/modules/ee/sso/lib/recovery-intent";
 import { completeSsoRecovery } from "@/modules/ee/sso/lib/sso-recovery";
 import { sendPasswordResetLinkEmail } from "@/modules/email";
 
@@ -109,9 +109,11 @@ const createRecoverySession = async (userId: string): Promise<string> => {
   return session.token;
 };
 
-const runRecovery = (user: { id: string; email: string }, sessionToken: string) =>
+const runRecovery = async (user: { id: string; email: string }, sessionToken: string) =>
   completeSsoRecovery({
-    intentToken: createSsoRelinkIntent({
+    // Through the real store against the real Redis, not a hand-built token: the intent lives there now
+    // (ENG-2783), so anything else would exercise a shape production never produces.
+    stateId: await createSsoRecoveryIntent({
       userId: user.id,
       email: user.email,
       provider: "google",

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -813,6 +813,49 @@ describe("sso-recovery", () => {
     expect(syncSsoIdentityForUser).toHaveBeenCalledOnce();
   });
 
+  /**
+   * The failure redirect must not tell an unauthenticated caller whether a state id exists. Carrying the
+   * stored callback on the pre-session branches did exactly that — a held id got the record's callback
+   * back, an unknown one got a bare redirect — and leaked where that user was headed with it.
+   */
+  test.each([
+    ["missing_session", { stateId: "test-state" }],
+    ["session_user_mismatch", { stateId: "test-state", sessionUserId: "someone-else" }],
+  ])("withholds the stored callback from a caller who is not the intent's user (%s)", async (_r, args) => {
+    await expect(completeSsoRecovery(args)).rejects.toMatchObject({ callbackUrl: undefined });
+  });
+
+  test("withholds the stored callback when the provider is unusable, before any session is checked", async () => {
+    mocks.readSsoRecoveryIntent.mockResolvedValue({
+      userId: "user_1",
+      email: "john.doe@example.com",
+      provider: "unknown-provider",
+      providerAccountId: "provider-account-1",
+      callbackUrl: "http://localhost:3000/environments/env_1",
+      createdAt: Date.now(),
+    });
+
+    await expect(
+      completeSsoRecovery({ stateId: "test-state", sessionUserId: "user_1" })
+    ).rejects.toMatchObject({ callbackUrl: undefined });
+  });
+
+  test("returns the callback once the caller is proven to be the intent's own user", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "someone.else@example.com",
+      locale: "en-US",
+      emailVerified: true,
+      isActive: true,
+      identityProvider: "email",
+      identityProviderAccountId: null,
+    } as any);
+
+    await expect(
+      completeSsoRecovery({ stateId: "test-state", sessionUserId: "user_1" })
+    ).rejects.toMatchObject({ callbackUrl: "http://localhost:3000/environments/env_1" });
+  });
+
   test("preserves only safe callback URLs in the failure redirect", () => {
     expect(getSsoRecoveryFailureRedirectUrl("http://localhost:3000/invite?token=invite-token")).toBe(
       "http://localhost:3000/auth/login?error=OAuthAccountNotLinked&callbackUrl=http%3A%2F%2Flocalhost%3A3000%2Finvite%3Ftoken%3Dinvite-token"

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -534,6 +534,30 @@ describe("sso-recovery", () => {
     expect(mocks.consumeSsoRecoveryIntent).toHaveBeenCalledWith("test-state");
   });
 
+  /**
+   * The link is what the intent pays for, so a transaction that rolls back must leave the intent
+   * spendable — otherwise a transient database fault burns the user's one recovery and the emailed
+   * link they still hold goes nowhere.
+   */
+  test("keeps the intent when the linking transaction rolls back", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "john.doe@example.com",
+      locale: "en-US",
+      emailVerified: false,
+      isActive: true,
+      identityProvider: "email",
+      identityProviderAccountId: null,
+    } as any);
+    vi.mocked(syncSsoIdentityForUser).mockRejectedValue(new Error("deadlock detected"));
+
+    await expect(completeSsoRecovery({ stateId: "test-state", sessionUserId: "user_1" })).rejects.toThrow(
+      "deadlock detected"
+    );
+
+    expect(mocks.consumeSsoRecoveryIntent).not.toHaveBeenCalled();
+  });
+
   test("leaves the intent in place when the recovery is rejected", async () => {
     // A mail scanner reaching the completion URL has no session, so it lands on `missing_session`.
     // Consuming there would spend the record before the real user ever clicked their link.

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -11,8 +11,9 @@ import { completeSsoRecovery, getSsoRecoveryFailureRedirectUrl, startSsoRecovery
 
 const mocks = vi.hoisted(() => ({
   createEmailToken: vi.fn(),
-  createSsoRelinkIntent: vi.fn(),
-  verifySsoRelinkIntent: vi.fn(),
+  createSsoRecoveryIntent: vi.fn(),
+  readSsoRecoveryIntent: vi.fn(),
+  consumeSsoRecoveryIntent: vi.fn(),
   queueAuditEventBackground: vi.fn(),
 }));
 
@@ -35,8 +36,12 @@ vi.mock("@/lib/constants", async (importOriginal) => {
 
 vi.mock("@/lib/jwt", () => ({
   createEmailToken: mocks.createEmailToken,
-  createSsoRelinkIntent: mocks.createSsoRelinkIntent,
-  verifySsoRelinkIntent: mocks.verifySsoRelinkIntent,
+}));
+
+vi.mock("./recovery-intent", () => ({
+  createSsoRecoveryIntent: mocks.createSsoRecoveryIntent,
+  readSsoRecoveryIntent: mocks.readSsoRecoveryIntent,
+  consumeSsoRecoveryIntent: mocks.consumeSsoRecoveryIntent,
 }));
 
 vi.mock("@/modules/auth/lib/session-revocation", () => ({
@@ -145,13 +150,14 @@ describe("sso-recovery", () => {
       "/auth/verification-requested?token=email-token&purpose=sso_recovery"
     );
     mocks.createEmailToken.mockReturnValue("email-token");
-    mocks.createSsoRelinkIntent.mockReturnValue("intent-token");
-    mocks.verifySsoRelinkIntent.mockReturnValue({
+    mocks.createSsoRecoveryIntent.mockResolvedValue("state-id");
+    mocks.readSsoRecoveryIntent.mockResolvedValue({
       userId: "user_1",
       email: "john.doe@example.com",
       provider: "google",
       providerAccountId: "provider-account-1",
       callbackUrl: "http://localhost:3000/environments/env_1",
+      createdAt: Date.now(),
     });
   });
 
@@ -182,12 +188,12 @@ describe("sso-recovery", () => {
       id: "user_1",
       email: "john.doe@example.com",
       locale: "en-US",
-      callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?intent=intent-token",
+      callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?state=state-id",
       purpose: "sso_recovery",
     });
     expect(buildVerificationRequestedPath).toHaveBeenCalledWith({
       token: "email-token",
-      callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?intent=intent-token",
+      callbackUrl: "http://localhost:3000/api/auth/sso/recovery/complete?state=state-id",
       purpose: "sso_recovery",
     });
     expect(result).toBe("/auth/verification-requested?token=email-token&purpose=sso_recovery");
@@ -243,7 +249,7 @@ describe("sso-recovery", () => {
     } as any);
 
     const callbackUrl = await completeSsoRecovery({
-      intentToken: "test-intent",
+      stateId: "test-state",
       sessionUserId: "user_1",
       sessionToken: "current-session-token",
     });
@@ -357,7 +363,7 @@ describe("sso-recovery", () => {
 
     const completeRecovery = () =>
       completeSsoRecovery({
-        intentToken: "test-intent",
+        stateId: "test-state",
         sessionUserId: "user_1",
         sessionToken: "current-session-token",
       });
@@ -512,6 +518,30 @@ describe("sso-recovery", () => {
     });
   });
 
+  test("consumes the intent once the link commits, but never before", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "john.doe@example.com",
+      locale: "en-US",
+      emailVerified: false,
+      isActive: true,
+      identityProvider: "email",
+      identityProviderAccountId: null,
+    } as any);
+
+    await completeSsoRecovery({ stateId: "test-state", sessionUserId: "user_1" });
+
+    expect(mocks.consumeSsoRecoveryIntent).toHaveBeenCalledWith("test-state");
+  });
+
+  test("leaves the intent in place when the recovery is rejected", async () => {
+    // A mail scanner reaching the completion URL has no session, so it lands on `missing_session`.
+    // Consuming there would spend the record before the real user ever clicked their link.
+    await expect(completeSsoRecovery({ stateId: "test-state" })).rejects.toThrow("OAuthAccountNotLinked");
+
+    expect(mocks.consumeSsoRecoveryIntent).not.toHaveBeenCalled();
+  });
+
   test("does not clear local auth material for already verified users", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: "user_1",
@@ -524,7 +554,7 @@ describe("sso-recovery", () => {
     } as any);
 
     await completeSsoRecovery({
-      intentToken: "test-intent",
+      stateId: "test-state",
       sessionUserId: "user_1",
       sessionToken: "current-session-token",
     });
@@ -565,7 +595,7 @@ describe("sso-recovery", () => {
     } as any);
 
     await completeSsoRecovery({
-      intentToken: "test-intent",
+      stateId: "test-state",
       sessionUserId: "user_1",
       sessionToken: "current-session-token",
     });
@@ -597,7 +627,7 @@ describe("sso-recovery", () => {
     vi.mocked(revokeUserSessionsExcept).mockRejectedValue(new Error("redis unavailable"));
 
     const callbackUrl = await completeSsoRecovery({
-      intentToken: "test-intent",
+      stateId: "test-state",
       sessionUserId: "user_1",
       sessionToken: "current-session-token",
     });
@@ -628,7 +658,7 @@ describe("sso-recovery", () => {
   test("rejects recovery when the signed-in user does not match the intent owner", async () => {
     await expect(
       completeSsoRecovery({
-        intentToken: "test-intent",
+        stateId: "test-state",
         sessionUserId: "user_2",
       })
     ).rejects.toThrow("OAuthAccountNotLinked");
@@ -650,7 +680,7 @@ describe("sso-recovery", () => {
   test("rejects recovery when there is no signed-in session", async () => {
     await expect(
       completeSsoRecovery({
-        intentToken: "test-intent",
+        stateId: "test-state",
       })
     ).rejects.toThrow("OAuthAccountNotLinked");
 
@@ -669,7 +699,7 @@ describe("sso-recovery", () => {
   });
 
   test("rejects recovery when the intent provider is invalid", async () => {
-    mocks.verifySsoRelinkIntent.mockReturnValue({
+    mocks.readSsoRecoveryIntent.mockResolvedValue({
       userId: "user_1",
       email: "john.doe@example.com",
       provider: "unknown-provider",
@@ -679,7 +709,7 @@ describe("sso-recovery", () => {
 
     await expect(
       completeSsoRecovery({
-        intentToken: "test-intent",
+        stateId: "test-state",
         sessionUserId: "user_1",
       })
     ).rejects.toThrow("OAuthAccountNotLinked");
@@ -699,13 +729,11 @@ describe("sso-recovery", () => {
   });
 
   test("rejects invalid or expired recovery intents before looking up any user", async () => {
-    mocks.verifySsoRelinkIntent.mockImplementation(() => {
-      throw new Error("expired");
-    });
+    mocks.readSsoRecoveryIntent.mockResolvedValue(null);
 
     await expect(
       completeSsoRecovery({
-        intentToken: "expired-intent",
+        stateId: "expired-state",
         sessionUserId: "user_1",
       })
     ).rejects.toThrow("OAuthAccountNotLinked");
@@ -741,7 +769,7 @@ describe("sso-recovery", () => {
 
     await expect(
       completeSsoRecovery({
-        intentToken: "test-intent",
+        stateId: "test-state",
         sessionUserId: "user_1",
       })
     ).rejects.toThrow("OAuthAccountNotLinked");
@@ -777,7 +805,7 @@ describe("sso-recovery", () => {
 
     await expect(
       completeSsoRecovery({
-        intentToken: "test-intent",
+        stateId: "test-state",
         sessionUserId: "user_1",
       })
     ).resolves.toBe("http://localhost:3000/environments/env_1");

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -931,6 +931,43 @@ describe("sso-recovery", () => {
     ).rejects.toMatchObject({ callbackUrl: "http://localhost:3000/environments/env_1" });
   });
 
+  /**
+   * The last guard between an unsigned Redis record and an open redirect.
+   *
+   * `readSsoRecoveryIntent` type-checks the stored `callbackUrl`, but it cannot vouch for the origin —
+   * the record carries no signature, unlike the JWT it replaced. So completion re-validates before
+   * handing the value back, and this is the test that keeps that line alive: a mutation sweep showed
+   * the whole return could be reduced to `intent.callbackUrl` with the entire suite still green.
+   */
+  test.each([
+    ["an off-origin absolute URL", "https://evil.example/steal"],
+    ["a scheme-relative pathname (ENG-1636)", "http://localhost:3000//evil.example"],
+    ["a non-http scheme", "javascript:alert(1)"],
+    ["credentials in the authority", "http://user:pass@localhost:3000/x"],
+  ])("falls back to the app origin rather than redirecting to %s", async (_label, callbackUrl) => {
+    mocks.readSsoRecoveryIntent.mockResolvedValue({
+      userId: "user_1",
+      email: "john.doe@example.com",
+      provider: "google",
+      providerAccountId: "provider-account-1",
+      callbackUrl,
+      createdAt: Date.now(),
+    });
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "john.doe@example.com",
+      locale: "en-US",
+      emailVerified: true,
+      isActive: true,
+      identityProvider: "email",
+      identityProviderAccountId: null,
+    } as any);
+
+    await expect(completeSsoRecovery({ stateId: "test-state", sessionUserId: "user_1" })).resolves.toBe(
+      "http://localhost:3000"
+    );
+  });
+
   test("preserves only safe callback URLs in the failure redirect", () => {
     expect(getSsoRecoveryFailureRedirectUrl("http://localhost:3000/invite?token=invite-token")).toBe(
       "http://localhost:3000/auth/login?error=OAuthAccountNotLinked&callbackUrl=http%3A%2F%2Flocalhost%3A3000%2Finvite%3Ftoken%3Dinvite-token"

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -94,6 +94,8 @@ vi.mock("./account-linking", () => ({
 }));
 
 describe("sso-recovery", () => {
+  let transactionCommitted = false;
+  let consumedAfterCommit: boolean | null = null;
   const txUserUpdate = vi.fn();
   const txUserUpdateMany = vi.fn();
   // Both legacy writes go through `user.updateMany`, so the stub answers on the FILTER rather than on
@@ -142,10 +144,21 @@ describe("sso-recovery", () => {
     txOauthRefreshUpdateMany.mockResolvedValue({ count: 2 });
     txOauthConsentDeleteMany.mockResolvedValue({ count: 1 });
     vi.mocked(revokeUserSessionsExcept).mockResolvedValue(2);
+    // The mock carries a commit step. Without one, `consumeSsoRecoveryIntent` moved INSIDE the
+    // transaction was indistinguishable from after it — and inside is wrong, because Redis is not part
+    // of the transaction, so a rollback would leave the intent spent with nothing linked.
+    transactionCommitted = false;
+    consumedAfterCommit = null;
     vi.mocked(prisma.$transaction).mockImplementation(
-      async (callback: (txClient: Prisma.TransactionClient) => Promise<unknown>) =>
-        await callback(tx as unknown as Prisma.TransactionClient)
+      async (callback: (txClient: Prisma.TransactionClient) => Promise<unknown>) => {
+        const result = await callback(tx as unknown as Prisma.TransactionClient);
+        transactionCommitted = true;
+        return result;
+      }
     );
+    mocks.consumeSsoRecoveryIntent.mockImplementation(async () => {
+      consumedAfterCommit = transactionCommitted;
+    });
     vi.mocked(buildVerificationRequestedPath).mockReturnValue(
       "/auth/verification-requested?token=email-token&purpose=sso_recovery"
     );
@@ -532,6 +545,9 @@ describe("sso-recovery", () => {
     await completeSsoRecovery({ stateId: "test-state", sessionUserId: "user_1" });
 
     expect(mocks.consumeSsoRecoveryIntent).toHaveBeenCalledWith("test-state");
+    // After the COMMIT, not merely somewhere in the function: Redis is outside the transaction, so
+    // consuming inside it would spend the intent even on a rollback.
+    expect(consumedAfterCommit).toBe(true);
   });
 
   /**

--- a/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.test.ts
@@ -566,6 +566,57 @@ describe("sso-recovery", () => {
     expect(mocks.consumeSsoRecoveryIntent).not.toHaveBeenCalled();
   });
 
+  /**
+   * Single use is hygiene here, not the thing that makes replay safe.
+   *
+   * If `consumeSsoRecoveryIntent` cannot delete — Redis unreachable at exactly that moment — the record
+   * survives to its TTL and a second completion runs. That is harmless by construction rather than by
+   * luck: `syncSsoIdentityForUser` upserts, and the first completion set `emailVerified`, so
+   * `reclaimUnverifiedLocalAuthIfNeeded` finds nothing to strip and the session sweep it guards never
+   * fires. This is the alternative to claiming an `in_progress` state before the transaction, which
+   * would need the same Redis that just failed the delete and would strand the user until TTL if the
+   * process died between claim and commit.
+   */
+  test("a replayed completion relinks idempotently, stripping and sweeping nothing", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "john.doe@example.com",
+      locale: "en-US",
+      emailVerified: false,
+      isActive: true,
+      identityProvider: "email",
+      identityProviderAccountId: null,
+    } as any);
+
+    // First completion: the account is unproven, so this is the one that strips and sweeps.
+    await completeSsoRecovery({ stateId: "test-state", sessionUserId: "user_1" });
+    expect(txUserUpdate).toHaveBeenCalled();
+    expect(revokeUserSessionsExcept).toHaveBeenCalled();
+
+    // The delete failed, so the record is still there and the emailed link is spent again. The user
+    // row is now proven, exactly as the first completion left it.
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user_1",
+      email: "john.doe@example.com",
+      locale: "en-US",
+      emailVerified: true,
+      isActive: true,
+      identityProvider: "email",
+      identityProviderAccountId: null,
+    } as any);
+    txUserUpdate.mockClear();
+    vi.mocked(revokeUserSessionsExcept).mockClear();
+    vi.mocked(syncSsoIdentityForUser).mockClear();
+
+    await expect(completeSsoRecovery({ stateId: "test-state", sessionUserId: "user_1" })).resolves.toBe(
+      "http://localhost:3000/environments/env_1"
+    );
+
+    expect(syncSsoIdentityForUser).toHaveBeenCalledOnce(); // an upsert, so no second identity
+    expect(txUserUpdate).not.toHaveBeenCalled(); // nothing left to strip
+    expect(revokeUserSessionsExcept).not.toHaveBeenCalled(); // and so no second session sweep
+  });
+
   test("does not clear local auth material for already verified users", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: "user_1",

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -301,14 +301,14 @@ const createSsoRecoveryCompletionUrl = (stateId: string): string => {
 };
 
 /**
- * A failed recovery, carrying the callback the caller should bounce back to.
+ * A failed recovery, sometimes carrying the callback the caller should bounce back to.
  *
- * The completion route needs that callback to build its failure redirect, and it used to recover it by
+ * The completion route builds its failure redirect from that callback, and it used to recover one by
  * decoding the intent JWT a second time. With the intent held server-side there is nothing in the URL
- * left to decode, and a second Redis read to answer a question this function already knows the answer
- * to would be wasteful — so the answer travels on the error.
+ * left to decode, so the answer travels on the error instead of costing a second Redis read.
  *
- * `callbackUrl` is only ever set once the caller has proven to be the intent's own user. Attaching it
+ * "Sometimes" is the load-bearing word: `callbackUrl` is set only once the caller has proven to be the
+ * intent's own user, which in practice is the `user_mismatch` branch alone. Attaching it
  * earlier turned the failure redirect into an unauthenticated oracle: a caller holding a state id got
  * back the callback stored against it, while an unknown id got a bare redirect — so the response
  * distinguished "this recovery exists" from "it does not", and leaked where that user was headed. The

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -308,6 +308,13 @@ const createSsoRecoveryCompletionUrl = (stateId: string): string => {
  * left to decode, and a second Redis read to answer a question this function already knows the answer
  * to would be wasteful — so the answer travels on the error.
  *
+ * `callbackUrl` is only ever set once the caller has proven to be the intent's own user. Attaching it
+ * earlier turned the failure redirect into an unauthenticated oracle: a caller holding a state id got
+ * back the callback stored against it, while an unknown id got a bare redirect — so the response
+ * distinguished "this recovery exists" from "it does not", and leaked where that user was headed. The
+ * state id is 256 bits so it cannot be guessed, but it does travel in a URL and therefore in access
+ * logs and history, and nothing about holding one should reveal the record behind it.
+ *
  * The message stays `OAUTH_ACCOUNT_NOT_LINKED_ERROR`, unchanged from the plain `Error` this replaces.
  */
 export class SsoRecoveryError extends Error {
@@ -476,7 +483,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "invalid_provider",
     });
-    throw new SsoRecoveryError(intent.callbackUrl);
+    throw new SsoRecoveryError();
   }
 
   if (!sessionUserId) {
@@ -496,7 +503,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "missing_session",
     });
-    throw new SsoRecoveryError(intent.callbackUrl);
+    throw new SsoRecoveryError();
   }
 
   if (sessionUserId !== intent.userId) {
@@ -517,7 +524,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "session_user_mismatch",
     });
-    throw new SsoRecoveryError(intent.callbackUrl);
+    throw new SsoRecoveryError();
   }
 
   const user = await prisma.user.findUnique({
@@ -544,6 +551,8 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "user_mismatch",
     });
+    // Past the session check, so this caller IS the intent's user — handing back their own callback
+    // discloses nothing they did not already supply.
     throw new SsoRecoveryError(intent.callbackUrl);
   }
 

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -7,7 +7,10 @@ import { createEmailToken } from "@/lib/jwt";
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
 import { revokeUserSessionsExcept } from "@/modules/auth/lib/session-revocation";
 import { finalizeSuccessfulSignIn } from "@/modules/auth/lib/sign-in-tracking";
-import { buildVerificationRequestedPath } from "@/modules/auth/lib/verification-links";
+import {
+  SSO_RECOVERY_COMPLETION_PATH,
+  buildVerificationRequestedPath,
+} from "@/modules/auth/lib/verification-links";
 import { queueAuditEventBackground } from "@/modules/ee/audit-logs/lib/handler";
 import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import { sendSsoRecoveryFactorsRemovedEmail, sendVerificationEmail } from "@/modules/email";
@@ -17,11 +20,7 @@ import {
   TSsoLookupUser,
   syncSsoIdentityForUser,
 } from "./account-linking";
-import {
-  OAUTH_ACCOUNT_NOT_LINKED_ERROR,
-  SSO_RECOVERY_COMPLETION_PATH,
-  isSsoRecoveryInternalCallbackUrl,
-} from "./constants";
+import { OAUTH_ACCOUNT_NOT_LINKED_ERROR, isSsoRecoveryInternalCallbackUrl } from "./constants";
 import { normalizeSsoProvider } from "./provider-normalization";
 import { consumeSsoRecoveryIntent, createSsoRecoveryIntent, readSsoRecoveryIntent } from "./recovery-intent";
 

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -3,7 +3,7 @@ import type { IdentityProvider, Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import type { Account } from "@formbricks/types/auth";
 import { WEBAPP_URL } from "@/lib/constants";
-import { createEmailToken, createSsoRelinkIntent, verifySsoRelinkIntent } from "@/lib/jwt";
+import { createEmailToken } from "@/lib/jwt";
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
 import { revokeUserSessionsExcept } from "@/modules/auth/lib/session-revocation";
 import { finalizeSuccessfulSignIn } from "@/modules/auth/lib/sign-in-tracking";
@@ -17,8 +17,17 @@ import {
   TSsoLookupUser,
   syncSsoIdentityForUser,
 } from "./account-linking";
-import { OAUTH_ACCOUNT_NOT_LINKED_ERROR, SSO_RECOVERY_COMPLETION_PATH } from "./constants";
+import {
+  OAUTH_ACCOUNT_NOT_LINKED_ERROR,
+  SSO_RECOVERY_COMPLETION_PATH,
+  isSsoRecoveryInternalCallbackUrl,
+} from "./constants";
 import { normalizeSsoProvider } from "./provider-normalization";
+import {
+  consumeSsoRecoveryIntent,
+  createSsoRecoveryIntent,
+  readSsoRecoveryIntent,
+} from "./recovery-intent";
 
 const getSsoRecoveryLogger = (
   event: "sso_recovery_started" | "sso_recovery_completed" | "sso_recovery_failed"
@@ -288,11 +297,47 @@ const reclaimUnverifiedLocalAuthIfNeeded = async ({
   };
 };
 
-const createSsoRecoveryCompletionUrl = (intentToken: string): string => {
+const createSsoRecoveryCompletionUrl = (stateId: string): string => {
   const completionUrl = new URL(SSO_RECOVERY_COMPLETION_PATH, WEBAPP_URL);
-  completionUrl.searchParams.set("intent", intentToken);
+  completionUrl.searchParams.set("state", stateId);
 
   return completionUrl.toString();
+};
+
+/**
+ * A failed recovery, carrying the callback the caller should bounce back to.
+ *
+ * The completion route needs that callback to build its failure redirect, and it used to recover it by
+ * decoding the intent JWT a second time. With the intent held server-side there is nothing in the URL
+ * left to decode, and a second Redis read to answer a question this function already knows the answer
+ * to would be wasteful — so the answer travels on the error.
+ *
+ * The message stays `OAUTH_ACCOUNT_NOT_LINKED_ERROR`, unchanged from the plain `Error` this replaces.
+ */
+export class SsoRecoveryError extends Error {
+  readonly callbackUrl?: string;
+
+  constructor(callbackUrl?: string) {
+    super(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
+    this.name = "SsoRecoveryError";
+    this.callbackUrl = callbackUrl;
+  }
+}
+
+/**
+ * Where to send the user once recovery completes — never back into recovery itself (ENG-2783).
+ *
+ * See `isSsoRecoveryInternalCallbackUrl` for why a recovery URL reaches this point at all, and why the
+ * check cannot live in `getValidatedCallbackUrl`.
+ */
+const resolveRecoveryCallbackUrl = (callbackUrl: string): string => {
+  const validatedCallbackUrl = getValidatedCallbackUrl(callbackUrl, WEBAPP_URL);
+
+  if (!validatedCallbackUrl || isSsoRecoveryInternalCallbackUrl(validatedCallbackUrl)) {
+    return WEBAPP_URL;
+  }
+
+  return validatedCallbackUrl;
 };
 
 export const getSsoRecoveryFailureRedirectUrl = (callbackUrl?: string): string => {
@@ -318,17 +363,17 @@ export const startSsoRecovery = async ({
   account: Account;
   callbackUrl: string;
 }): Promise<string> => {
-  const originalCallbackUrl = getValidatedCallbackUrl(callbackUrl, WEBAPP_URL) ?? WEBAPP_URL;
+  const originalCallbackUrl = resolveRecoveryCallbackUrl(callbackUrl);
 
   try {
-    const recoveryIntent = createSsoRelinkIntent({
+    const stateId = await createSsoRecoveryIntent({
       userId: existingUser.id,
       email: existingUser.email,
       provider,
       providerAccountId: account.providerAccountId,
       callbackUrl: originalCallbackUrl,
     });
-    const completionUrl = createSsoRecoveryCompletionUrl(recoveryIntent);
+    const completionUrl = createSsoRecoveryCompletionUrl(stateId);
 
     await sendVerificationEmail({
       id: existingUser.id,
@@ -384,11 +429,11 @@ export const startSsoRecovery = async ({
 };
 
 export const completeSsoRecovery = async ({
-  intentToken,
+  stateId,
   sessionUserId,
   sessionToken,
 }: {
-  intentToken: string;
+  stateId: string;
   sessionUserId?: string;
   /**
    * The recovering user's own session token, so the post-commit revocation can spare it. Everything else
@@ -396,12 +441,16 @@ export const completeSsoRecovery = async ({
    */
   sessionToken?: string;
 }): Promise<string> => {
-  let intent: ReturnType<typeof verifySsoRelinkIntent>;
+  // Reads without consuming. The completion URL sits in an email, and mail security gateways fetch
+  // every link in a message before the human sees it — burning the intent on read would let a scanner
+  // spend it and lock the real user out. It is consumed after the link commits instead.
+  const intent = await readSsoRecoveryIntent(stateId);
 
-  try {
-    intent = verifySsoRelinkIntent(intentToken);
-  } catch (error) {
-    getSsoRecoveryLogger("sso_recovery_failed").error({ error }, "Invalid or expired SSO recovery intent");
+  if (!intent) {
+    getSsoRecoveryLogger("sso_recovery_failed").error(
+      {},
+      "Missing, expired or malformed SSO recovery intent"
+    );
     queueSsoRecoveryAuditEvent({
       action: "sso_recovery_failed",
       status: "failure",
@@ -410,7 +459,7 @@ export const completeSsoRecovery = async ({
       provider: "unknown",
       failureReason: "invalid_or_expired_intent",
     });
-    throw new Error(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
+    throw new SsoRecoveryError();
   }
 
   const provider = normalizeSsoProvider(intent.provider);
@@ -431,7 +480,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "invalid_provider",
     });
-    throw new Error(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
+    throw new SsoRecoveryError(intent.callbackUrl);
   }
 
   if (!sessionUserId) {
@@ -451,7 +500,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "missing_session",
     });
-    throw new Error(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
+    throw new SsoRecoveryError(intent.callbackUrl);
   }
 
   if (sessionUserId !== intent.userId) {
@@ -472,7 +521,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "session_user_mismatch",
     });
-    throw new Error(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
+    throw new SsoRecoveryError(intent.callbackUrl);
   }
 
   const user = await prisma.user.findUnique({
@@ -499,7 +548,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "user_mismatch",
     });
-    throw new Error(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
+    throw new SsoRecoveryError(intent.callbackUrl);
   }
 
   const reclaimed = await prisma.$transaction(async (tx) => {
@@ -523,6 +572,12 @@ export const completeSsoRecovery = async ({
 
     return outcome;
   });
+
+  // Single use, applied at the only point where it is safe to: the link has committed, so the intent
+  // has done its job and a replay would only redo work. Not on read — see the note above the read.
+  // Best-effort inside the helper: the account is already linked, and a Redis hiccup here must not turn
+  // a completed recovery into a failure. The record expires on its own.
+  await consumeSsoRecoveryIntent(stateId);
 
   // Only when factors were actually stripped: this is the account changing hands, so any session the
   // squatter still holds has to go. Reachable in practice because `signUpEmail` writes

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -23,11 +23,7 @@ import {
   isSsoRecoveryInternalCallbackUrl,
 } from "./constants";
 import { normalizeSsoProvider } from "./provider-normalization";
-import {
-  consumeSsoRecoveryIntent,
-  createSsoRecoveryIntent,
-  readSsoRecoveryIntent,
-} from "./recovery-intent";
+import { consumeSsoRecoveryIntent, createSsoRecoveryIntent, readSsoRecoveryIntent } from "./recovery-intent";
 
 const getSsoRecoveryLogger = (
   event: "sso_recovery_started" | "sso_recovery_completed" | "sso_recovery_failed"

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -317,11 +317,22 @@ const createSsoRecoveryCompletionUrl = (stateId: string): string => {
  * The message stays `OAUTH_ACCOUNT_NOT_LINKED_ERROR`, unchanged from the plain `Error` this replaces.
  */
 export class SsoRecoveryError extends Error {
+  /**
+   * `intent_missing` means there was nothing to act on — already completed, or expired. `rejected`
+   * means an intent WAS read and a guard turned it down.
+   *
+   * The route needs the difference because its failure response tears the caller's session down, and
+   * only one of the two is evidence that it should. The emailed link is replayable for a day by design
+   * (`better-auth-recovery-signin.ts`), so without this a second open would sign the user in and then
+   * immediately sign them out claiming the link had failed — after it had in fact succeeded.
+   */
+  readonly failure: "intent_missing" | "rejected";
   readonly callbackUrl?: string;
 
-  constructor(callbackUrl?: string) {
+  constructor(failure: "intent_missing" | "rejected", callbackUrl?: string) {
     super(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
     this.name = "SsoRecoveryError";
+    this.failure = failure;
     this.callbackUrl = callbackUrl;
   }
 }
@@ -461,7 +472,7 @@ export const completeSsoRecovery = async ({
       provider: "unknown",
       failureReason: "invalid_or_expired_intent",
     });
-    throw new SsoRecoveryError();
+    throw new SsoRecoveryError("intent_missing");
   }
 
   const provider = normalizeSsoProvider(intent.provider);
@@ -482,7 +493,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "invalid_provider",
     });
-    throw new SsoRecoveryError();
+    throw new SsoRecoveryError("rejected");
   }
 
   if (!sessionUserId) {
@@ -502,7 +513,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "missing_session",
     });
-    throw new SsoRecoveryError();
+    throw new SsoRecoveryError("rejected");
   }
 
   if (sessionUserId !== intent.userId) {
@@ -523,7 +534,7 @@ export const completeSsoRecovery = async ({
       callbackUrl: intent.callbackUrl,
       failureReason: "session_user_mismatch",
     });
-    throw new SsoRecoveryError();
+    throw new SsoRecoveryError("rejected");
   }
 
   const user = await prisma.user.findUnique({
@@ -552,7 +563,7 @@ export const completeSsoRecovery = async ({
     });
     // Past the session check, so this caller IS the intent's user — handing back their own callback
     // discloses nothing they did not already supply.
-    throw new SsoRecoveryError(intent.callbackUrl);
+    throw new SsoRecoveryError("rejected", intent.callbackUrl);
   }
 
   const reclaimed = await prisma.$transaction(async (tx) => {

--- a/apps/web/modules/ee/sso/lib/sso-recovery.ts
+++ b/apps/web/modules/ee/sso/lib/sso-recovery.ts
@@ -322,7 +322,7 @@ export class SsoRecoveryError extends Error {
    * means an intent WAS read and a guard turned it down.
    *
    * The route needs the difference because its failure response tears the caller's session down, and
-   * only one of the two is evidence that it should. The emailed link is replayable for a day by design
+   * only one of the two is evidence that it should. The emailed link is replayable for its window by design
    * (`better-auth-recovery-signin.ts`), so without this a second open would sign the user in and then
    * immediately sign them out claiming the link had failed — after it had in fact succeeded.
    */

--- a/apps/web/modules/email/index.tsx
+++ b/apps/web/modules/email/index.tsx
@@ -51,7 +51,11 @@ import {
 import { getOrganizationByWorkspaceId } from "@/lib/organization/service";
 import { TElementResponseMappingSurvey, getElementResponseMapping } from "@/lib/responses";
 import { getTranslate } from "@/lingodotdev/server";
-import { TVerificationRequestPurpose, buildVerificationLinks } from "@/modules/auth/lib/verification-links";
+import {
+  TVerificationRequestPurpose,
+  VERIFICATION_LINK_TTL_SECONDS,
+  buildVerificationLinks,
+} from "@/modules/auth/lib/verification-links";
 import { buildVerifiedLinkSurveyUrl } from "@/modules/email/lib/verified-link-survey-url";
 import { resolveStorageUrl } from "@/modules/storage/utils";
 
@@ -161,7 +165,7 @@ export const sendVerificationEmail = async ({
   try {
     const t = await getTranslate(locale);
     const token = createToken(id, {
-      expiresIn: "1d",
+      expiresIn: VERIFICATION_LINK_TTL_SECONDS,
       purpose,
     });
     const { verifyLink, verificationRequestLink } = buildVerificationLinks({

--- a/apps/web/modules/email/index.tsx
+++ b/apps/web/modules/email/index.tsx
@@ -155,17 +155,23 @@ export const sendVerificationEmail = async ({
   locale,
   callbackUrl,
   purpose = "email_verification",
+  linkTtlSeconds = VERIFICATION_LINK_TTL_SECONDS,
 }: {
   id: string;
   email: TUserEmail;
   locale: TUserLocale;
   callbackUrl?: string;
   purpose?: TVerificationRequestPurpose;
+  /**
+   * Overridden only by an SSO-recovery resend, which has to mint a link no longer-lived than the intent
+   * it points at — see `getSsoRecoveryPairedTtlSeconds`. Everything else gets the full window.
+   */
+  linkTtlSeconds?: number;
 }): Promise<boolean> => {
   try {
     const t = await getTranslate(locale);
     const token = createToken(id, {
-      expiresIn: VERIFICATION_LINK_TTL_SECONDS,
+      expiresIn: linkTtlSeconds,
       purpose,
     });
     const { verifyLink, verificationRequestLink } = buildVerificationLinks({

--- a/apps/web/modules/email/verification-link-ttl.test.ts
+++ b/apps/web/modules/email/verification-link-ttl.test.ts
@@ -7,8 +7,13 @@ import { VERIFICATION_LINK_TTL_SECONDS } from "@/modules/auth/lib/verification-l
  *
  * `verification-links.ts` says the constant is shared so the emailed link and the SSO recovery intent
  * cannot drift apart — a link that outlives its intent signs the user in and then tells them recovery
- * failed. Nothing pinned the email half of that: changing `expiresIn` here to `"1h"` left the whole
- * suite green, which is exactly the drift the constant was introduced to prevent.
+ * failed, and an intent that outlives its link keeps authorising a password-and-2FA strip after the
+ * mail is dead. Nothing pinned the email half of that: changing `expiresIn` here to `"1h"` left the
+ * whole suite green, which is exactly the drift the constant was introduced to prevent.
+ *
+ * The absolute number is pinned here too, deliberately and in one place. It is a security window, not
+ * an implementation detail — lengthening it widens the strongest capability the product hands out over
+ * email — so a change to it should have to be a change to a test that says so.
  */
 
 const mocks = vi.hoisted(() => ({
@@ -54,7 +59,28 @@ describe("the emailed verification link's lifetime", () => {
     }
   );
 
-  test("the shared TTL is one day, which is the window the intent is paired to", () => {
-    expect(VERIFICATION_LINK_TTL_SECONDS).toBe(60 * 60 * 24);
+  test("a caller may shorten the link, which is how a resend stays paired with a capped intent", async () => {
+    await sendVerificationEmail({
+      id: "user_1",
+      email: "someone@example.com",
+      locale: "en-US",
+      callbackUrl: "http://localhost:3000/x",
+      purpose: "sso_recovery",
+      linkTtlSeconds: 90,
+    });
+
+    expect(createToken).toHaveBeenCalledWith("user_1", { expiresIn: 90, purpose: "sso_recovery" });
+  });
+
+  /**
+   * Fifteen minutes, and pinned because it is a security window rather than a tuning knob: completing
+   * recovery clears the password and deletes the second factor, and the link stays replayable for its
+   * whole life. Every bar for an emailed credential of this strength sits at or under an hour — NIST
+   * SP 800-63B-4 s3.1.3.2 (10 min, SHALL), RFC 6749 s4.1.2 (10 min RECOMMENDED for an authorization
+   * code), RFC 9126 s2.2 (a `request_uri` at 5-600s), OWASP WSTG 4.9 ("rarely be more than an hour")
+   * — and our own password reset, which leaves 2FA armed, defaults to 30 minutes.
+   */
+  test("the shared TTL is fifteen minutes, which is the window the intent is paired to", () => {
+    expect(VERIFICATION_LINK_TTL_SECONDS).toBe(60 * 15);
   });
 });

--- a/apps/web/modules/email/verification-link-ttl.test.ts
+++ b/apps/web/modules/email/verification-link-ttl.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createToken } from "@/lib/jwt";
+import { VERIFICATION_LINK_TTL_SECONDS } from "@/modules/auth/lib/verification-links";
+
+/**
+ * The one guarantee `VERIFICATION_LINK_TTL_SECONDS` exists to make.
+ *
+ * `verification-links.ts` says the constant is shared so the emailed link and the SSO recovery intent
+ * cannot drift apart — a link that outlives its intent signs the user in and then tells them recovery
+ * failed. Nothing pinned the email half of that: changing `expiresIn` here to `"1h"` left the whole
+ * suite green, which is exactly the drift the constant was introduced to prevent.
+ */
+
+const mocks = vi.hoisted(() => ({
+  sendMail: vi.fn(async () => ({ messageId: "1" })),
+  createToken: vi.fn(() => "recovery-token"),
+  createEmailToken: vi.fn(() => "email-token"),
+}));
+
+vi.mock("nodemailer", () => ({
+  createTransport: () => ({ sendMail: mocks.sendMail, verify: vi.fn(async () => true), close: vi.fn() }),
+}));
+vi.mock("@/lib/jwt", () => ({ createToken: mocks.createToken, createEmailToken: mocks.createEmailToken }));
+vi.mock("@/lingodotdev/server", () => ({ getTranslate: async () => (key: string) => key }));
+vi.mock("@/lib/organization/service", () => ({ getOrganizationByWorkspaceId: vi.fn() }));
+vi.mock("@formbricks/email", () => ({
+  renderVerificationEmail: vi.fn(async () => "<html>verify</html>"),
+}));
+
+const { sendVerificationEmail } = await import("./index");
+
+describe("the emailed verification link's lifetime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createToken.mockReturnValue("recovery-token");
+    mocks.createEmailToken.mockReturnValue("email-token");
+  });
+
+  test.each(["sso_recovery", "email_verification"] as const)(
+    "mints the %s token with the shared link TTL, not a literal",
+    async (purpose) => {
+      await sendVerificationEmail({
+        id: "user_1",
+        email: "someone@example.com",
+        locale: "en-US",
+        callbackUrl: "http://localhost:3000/x",
+        purpose,
+      });
+
+      expect(createToken).toHaveBeenCalledWith("user_1", {
+        expiresIn: VERIFICATION_LINK_TTL_SECONDS,
+        purpose,
+      });
+    }
+  );
+
+  test("the shared TTL is one day, which is the window the intent is paired to", () => {
+    expect(VERIFICATION_LINK_TTL_SECONDS).toBe(60 * 60 * 24);
+  });
+});

--- a/packages/cache/src/types/keys.ts
+++ b/packages/cache/src/types/keys.ts
@@ -16,4 +16,10 @@ export type CacheKey = z.infer<typeof ZCacheKey>;
  * Possible namespaces for custom cache keys
  * Add new namespaces here as they are introduced
  */
-export type CustomCacheNamespace = "account_deletion" | "analytics" | "billing" | "oauth" | "github";
+export type CustomCacheNamespace =
+  | "account_deletion"
+  | "analytics"
+  | "billing"
+  | "oauth"
+  | "github"
+  | "sso_recovery";


### PR DESCRIPTION
Fixes ENG-2783

## What & why

**Was:** Retrying an SSO sign-in that lands in recovery encrypted the previous attempt's whole URL into the next one, growing it ~2.7x each time; the third attempt returned a bare `414 Request-URI Too Large`. Reported against Microsoft; every provider was affected equally.

**Now:** The intent lives in Redis behind a 43-character opaque state id. Measured 1092 / 3793 / 10996 / 30204 chars before, flat 115 after.

<details>
<summary>The same completion URL, attempt 1 and attempt 3</summary>

Before — attempt 1 (1024 chars), the whole intent encrypted into the query string:

```
http://localhost:3010/api/auth/sso/recovery/complete?intent=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI4OTFmZGUwOTA2YmVkMDkxYTYxZWE1ZDMxNDlmZjU1MTo1MmQ0N2JjYzMyNTBmODc1YTZhMzAxOTI2NWFjMDc0OTM1YjU1MDUxYTBiYTQ5NjA6YjFiOGMzN2VlMWEyNzE5Y2Q1YzUzZjNkNTAyMTViYzciLCJlbWFpbCI6IjZjMjFjODU5NTFmY2ZkYzY…
```

Before — attempt 3 (10224 chars), now carrying attempts 1 and 2 nested inside it. nginx's
`large_client_header_buffers` defaults to `4 8k` and a request line must fit one buffer, so this is
the one that came back as `414 Request-URI Too Large`:

```
http://localhost:3010/api/auth/sso/recovery/complete?intent=eyJhbGciOiJIUzI1NiIsInR5cCI6Ik…
```

After — every attempt, 102 chars:

```
http://localhost:3010/api/auth/sso/recovery/complete?state=bTM_nOH9WgdTODC6aTXi8N8AXGcvRCGcD3PemXhFckI
```

</details>

- A callback already pointing into recovery is dropped, so the loop cannot re-enter itself.
- `getValidatedCallbackUrl` bounds length, so an oversized callback 400s instead of 414ing.
- Encrypted `userId` / `email` / `providerAccountId` leave the URL, and so the logs and history.

## Where to look

- [recovery-intent.ts#L142](https://github.com/formbricks/formbricks/blob/6c4fb3b140982deb54fb8103c18620a335436bfe/apps/web/modules/ee/sso/lib/recovery-intent.ts#L142) — every field validated on read; Redis has no signature
- [recovery-intent.ts#L232](https://github.com/formbricks/formbricks/blob/6c4fb3b140982deb54fb8103c18620a335436bfe/apps/web/modules/ee/sso/lib/recovery-intent.ts#L232) — EXPIRE, so a resend cannot resurrect a consumed intent
- [sso-recovery.ts#L320](https://github.com/formbricks/formbricks/blob/6c4fb3b140982deb54fb8103c18620a335436bfe/apps/web/modules/ee/sso/lib/sso-recovery.ts#L320) — failure carries a callback only past the session check

## Breaking changes

- [ ] This PR contains breaking changes

No public API, SDK export, route, env var or config key changes; only our own emailed link calls the completion route. At deploy, recovery links already in inboxes fail on the usual "recovery failed" page — they carry the TTL they were minted with, so that tail runs for up to a day; links minted after the deploy last 15 minutes.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && pnpm vitest run modules/ee/sso lib/utils/url.test.ts app/api/auth/sso/recovery`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Four retries no longer grow the URL | unit (red on main) | `sso-recovery-url-growth.test.ts`: flat 115 chars; on main `expected 10136 to be less than 8192` |
| Same through the real hook, for every provider | unit (red on main) | `sso-recovery-loop.integration.test.ts`, real PG+Redis; google/github/azuread/azure-ad/openid/saml all fail on main at 9854-10012 chars. `pnpm test:integration` |
| Store validates, consumes once, bounds refresh | unit (mutation) | `recovery-intent.test.ts`; 9 mutations, all red (e.g. `recovery-intent.ts:232`) |
| Link and intent cannot drift apart | unit (mutation) | `verification-link-ttl.test.ts` + `actions.test.ts`; 8 mutations on the shared clock, all red, no survivors |
| Failure redirect no longer confirms a state id exists | unit (mutation) | `sso-recovery.test.ts`; red at `sso-recovery.ts:506` |
| Whole chain on a live stack | manual | Emailed link -> session -> completion -> original callback; intent gone, Google account linked |
| Four real IdP round trips through a stub OIDC provider | manual | Completion URL flat at 102 chars where attempt three used to 414; anti-nesting visible in the stored intents |
| Second open of a used link keeps the session | live stack | Link -> completion -> lands on the original callback; re-opening lands on `?error=OAuthAccountNotLinked` with `get-session` still returning the user. The regression Anshuman's Major describes, not reproduced |
| A Redis outage behaves the same way | live stack | Redis stopped mid-flow: log shows `Failed to read the SSO recovery intent {code: redis_connection_error}` reaching the same branch; session still valid once Redis returned |
| Resend past the window tells the truth | live stack | Toast reads "The link you used is no longer valid." through the real action pipeline, where it used to claim the mail was resent |
| Resend inside the window still works | live stack | Success toast, real message in Mailpit, and the intent TTL moved 120s -> 887s, so the paired TTL landed |
| Link and intent share one 15-minute clock | live stack | The emailed JWT decodes to `exp - iat = 900` with `purpose: sso_recovery`; the intent's TTL matches |
| The capability the 15-min window bounds still works | integration (mutation) | `sso-recovery.integration.test.ts`, real Postgres + Redis: the squatter's password signs in before recovery and 401s after, the `TwoFactor` row and legacy columns go, their sessions stop resolving in both stores, and a verified account keeps everything. 4 mutations on the strip, all red, no survivors |
| Oversized callback | manual | `400 {"error":"Invalid callback URL"}` |

**Open gaps**

- Concurrent completions on one state id can both pass the guards before either consumes; `syncSsoIdentityForUser` is an upsert, so the cost is a duplicate audit row.
- The completion route still has no rate limit — pre-existing; ENG-2558 owns rate limiting in this flow.

**Risks**

- Redis becomes a hard dependency of starting recovery, failing closed; ENG-2558's bodiless 500 is how that surfaces today.
- The emailed recovery link shortens from 1 day to 15 min, so the intent it is paired to keeps main's 15-minute window rather than widening. A resend re-pairs both halves on one lifetime, capped at 30 min from `createdAt` (what `PASSWORD_RESET_TOKEN_LIFETIME_MINUTES` already defaults to). Someone who reads a recovery mail later now gets "link expired, request a new one" instead of being signed in and then told recovery failed.
- The 2048-char callback cap is global; the widest the app mints is an invite link at ~640.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.



