### PR TITLE
fix(surveys): settle navigation from an off-block blockId instead of throwing [ENG-2818]

### DIFF
--- a/packages/surveys/src/components/general/survey.test.tsx
+++ b/packages/surveys/src/components/general/survey.test.tsx
@@ -51,29 +51,51 @@ vi.mock("@/lib/recall", () => ({
 }));
 
 vi.mock("@/components/general/block-conditional", () => ({
-  BlockConditional: ({ block, onSubmit }: any) => (
-    <button
-      data-testid={`submit-${block.id}`}
-      onClick={() =>
-        onSubmit(
-          { [block.elements[0].id]: `${block.id}-answer` },
-          {
-            [block.elements[0].id]: 123,
-          }
-        )
-      }>
-      Submit {block.id}
-    </button>
+  BlockConditional: ({ block, onSubmit, onBack }: any) => (
+    <>
+      <button
+        data-testid={`submit-${block.id}`}
+        onClick={() =>
+          onSubmit(
+            { [block.elements[0].id]: `${block.id}-answer` },
+            {
+              [block.elements[0].id]: 123,
+            }
+          )
+        }>
+        Submit {block.id}
+      </button>
+      <button data-testid={`back-${block.id}`} onClick={() => onBack()}>
+        Back {block.id}
+      </button>
+    </>
   ),
 }));
 
-vi.mock("@/components/wrappers/stacked-cards-container", () => ({
-  StackedCardsContainer: ({ currentBlockId, getCardContent, survey }: any) => {
-    const blockIndex =
-      currentBlockId === "start" ? -1 : survey.blocks.findIndex((block: any) => block.id === currentBlockId);
-    return <div data-testid="survey-root">{getCardContent(blockIndex, 0)}</div>;
-  },
-}));
+vi.mock("@/components/wrappers/stacked-cards-container", () => {
+  // Mirrors the real container's index math: a `currentBlockId` that is not a block — an ending id,
+  // the "end" sentinel, or a block deleted since progress was saved — maps past the end of the
+  // array, and the card the respondent came from stays mounted behind the current one. That
+  // peeking card keeps its submit and back controls live, which is how a navigation is reachable
+  // from a position that no longer resolves to a block.
+  const resolveBlockIndex = (survey: any, currentBlockId: string): number => {
+    if (currentBlockId === "start") return -1;
+    const blockIndex = survey.blocks.findIndex((block: any) => block.id === currentBlockId);
+    return blockIndex === -1 ? survey.blocks.length : blockIndex;
+  };
+
+  return {
+    StackedCardsContainer: ({ currentBlockId, getCardContent, survey }: any) => {
+      const blockIndex = resolveBlockIndex(survey, currentBlockId);
+      return (
+        <div data-testid="survey-root">
+          {getCardContent(blockIndex, 0)}
+          {blockIndex > 0 ? getCardContent(blockIndex - 1, 1) : null}
+        </div>
+      );
+    },
+  };
+});
 
 vi.mock("@/components/wrappers/auto-close-wrapper", () => ({
   AutoCloseWrapper: ({ children }: any) => <>{children}</>,
@@ -367,6 +389,54 @@ describe("Survey offline restore", () => {
     });
 
     expect(apiClientMocks.getResponseIdByDisplayId).not.toHaveBeenCalled();
+  });
+
+  test("queues the answer instead of throwing when submitted from the ending card", async () => {
+    offlineStorageMocks.getSurveyProgress.mockResolvedValue(makeProgress());
+
+    renderSurvey();
+
+    // Finish the survey, which moves the pointer onto the ending card while the last block's card
+    // stays mounted behind it.
+    fireEvent.click(await screen.findByTestId("submit-block-2"));
+
+    await waitFor(() => {
+      expect(apiClientMocks.createResponse).toHaveBeenCalled();
+    });
+
+    expect(await screen.findByTestId("ending-card")).toBeTruthy();
+
+    // Submitting again from that still-live card used to throw "Block not found" as an unhandled
+    // rejection, dropping the answer entirely (ENG-2818).
+    fireEvent.click(await screen.findByTestId("submit-block-2"));
+
+    await waitFor(() => {
+      expect(apiClientMocks.updateResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseId: "response-created",
+          finished: true,
+          endingId: "ending-1",
+        })
+      );
+    });
+
+    expect(screen.queryByTestId("ending-card")).toBeTruthy();
+  });
+
+  test("back from the first block with no history is a no-op instead of throwing", async () => {
+    offlineStorageMocks.getSurveyProgress.mockResolvedValue(
+      makeProgress({ blockId: "block-1", history: [] })
+    );
+
+    renderSurvey();
+
+    fireEvent.click(await screen.findByTestId("back-block-1"));
+
+    // Still on the first block, and nothing was submitted — the previous behaviour threw
+    // "Block not found" while reading blocks[-1] (ENG-2818).
+    expect(await screen.findByTestId("submit-block-1")).toBeTruthy();
+    expect(apiClientMocks.createResponse).not.toHaveBeenCalled();
+    expect(apiClientMocks.updateResponse).not.toHaveBeenCalled();
   });
 
   test("clears stale finished progress instead of restoring the ending card", async () => {

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -39,6 +39,12 @@ import {
 } from "@/lib/offline-storage";
 import { parseRecallInformation, replaceRecallInfo } from "@/lib/recall";
 import { ResponseQueue } from "@/lib/response-queue";
+import {
+  END_BLOCK_ID,
+  getForwardTargetFromOffBlockId,
+  getPreviousBlockId,
+  isFinishedBlockId,
+} from "@/lib/survey-navigation";
 import { SURVEY_INSTRUCTIONS_ID, getSurveyPagePosition, hasSurveyInstructions } from "@/lib/survey-page";
 import { SurveyState } from "@/lib/survey-state";
 import { useOnlineStatus } from "@/lib/use-online-status";
@@ -516,7 +522,9 @@ export function Survey({
       // If the survey is fully complete (no pending responses + finished), discard stale
       // progress and start fresh instead of restoring to the ending card.
       if (pendingCount === 0) {
-        const isEndingCard = localSurvey.endings.some((e) => e.id === progress.blockId);
+        // The "end" sentinel counts as an ending card here: a survey with no endings defined
+        // finishes on it, so restoring onto it would resume a session that is already over.
+        const isEndingCard = isFinishedBlockId(localSurvey, progress.blockId);
         const isResponseFinished = progress.surveyStateSnapshot?.responseAcc?.finished === true;
 
         if (isEndingCard || isResponseFinished) {
@@ -765,13 +773,28 @@ export function Survey({
       };
 
     if (!currentBlock) {
-      console.error(
-        "Block not found. blockId:",
-        blockId,
-        "available blocks:",
-        localSurvey.blocks.map((b) => b.id)
-      );
-      throw new Error("Block not found");
+      // `blockId` is not a block: an ending id (the survey already finished), the "end" sentinel,
+      // or a block that no longer exists because the survey was edited after progress was saved.
+      // None of those leaves anything to advance through, so finish rather than throw — throwing
+      // escaped as an unhandled rejection, which dropped the answer in hand and left the Next
+      // button spinning (ENG-2818).
+      const offBlockTarget = getForwardTargetFromOffBlockId(localSurvey, blockId);
+
+      // An ending or the sentinel is an expected position to submit from. A `blockId` that matches
+      // neither is survey drift, and the only remaining signal that it happened.
+      if (!offBlockTarget && blockId !== END_BLOCK_ID) {
+        console.warn(
+          "Formbricks: blockId no longer resolves to a block, finishing the survey. blockId:",
+          blockId,
+          "available blocks:",
+          localSurvey.blocks.map((b) => b.id)
+        );
+      }
+
+      return {
+        nextBlockId: offBlockTarget,
+        calculatedVariables: { ...currentVariables },
+      };
     }
 
     const localResponseData = { ...responseData, ...data };
@@ -1092,22 +1115,22 @@ export function Survey({
   };
 
   const onBack = (): void => {
+    const prevBlockId = getPreviousBlockId(localSurvey, blockId, history);
+
+    // Nothing precedes the current card — the respondent is on the first block, or `blockId` is an
+    // ending / a block that no longer exists and no history was saved. Back is a no-op rather than
+    // a throw (ENG-2818), and nothing is consumed: neither the history nor the variable stack is
+    // popped for a navigation that does not happen.
+    if (!prevBlockId) return;
+
     isNavigatingBackRef.current = true;
     hasUserNavigatedRef.current = true;
     blurOutgoingCard();
 
-    let prevBlockId: string | undefined;
-    // use history if available
     if (history.length > 0) {
-      const newHistory = [...history];
-      prevBlockId = newHistory.pop();
-      setHistory(newHistory);
-    } else {
-      // otherwise go back to previous block in array
-      prevBlockId = localSurvey.blocks[currentBlockIndex - 1]?.id;
+      setHistory(history.slice(0, -1));
     }
     popVariableState();
-    if (!prevBlockId) throw new Error("Block not found");
 
     // Revert required changes by the first element in the previous block
     const prevBlock = localSurvey.blocks.find((b) => b.id === prevBlockId);

--- a/packages/surveys/src/lib/survey-navigation.test.ts
+++ b/packages/surveys/src/lib/survey-navigation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import {
+  END_BLOCK_ID,
+  START_BLOCK_ID,
+  getForwardTargetFromOffBlockId,
+  getPreviousBlockId,
+  isFinishedBlockId,
+} from "./survey-navigation";
+
+const survey = {
+  blocks: [{ id: "block-1" }, { id: "block-2" }],
+  endings: [{ id: "ending-1" }, { id: "ending-2" }],
+};
+
+const surveyWithoutEndings = { blocks: [{ id: "block-1" }], endings: [] };
+
+describe("isFinishedBlockId", () => {
+  test("treats every ending card as a finished position", () => {
+    expect(isFinishedBlockId(survey, "ending-1")).toBe(true);
+    expect(isFinishedBlockId(survey, "ending-2")).toBe(true);
+  });
+
+  test("treats the 'end' sentinel as finished, for a survey that defines no endings", () => {
+    expect(isFinishedBlockId(surveyWithoutEndings, END_BLOCK_ID)).toBe(true);
+  });
+
+  test("a block, the welcome card, and a stale id are not finished positions", () => {
+    expect(isFinishedBlockId(survey, "block-1")).toBe(false);
+    expect(isFinishedBlockId(survey, START_BLOCK_ID)).toBe(false);
+    expect(isFinishedBlockId(survey, "deleted-block")).toBe(false);
+  });
+});
+
+describe("getForwardTargetFromOffBlockId", () => {
+  test("keeps the ending already on screen, so the persisted endingId matches it", () => {
+    expect(getForwardTargetFromOffBlockId(survey, "ending-2")).toBe("ending-2");
+  });
+
+  test("returns no target for the 'end' sentinel, so the caller finishes on the first ending", () => {
+    expect(getForwardTargetFromOffBlockId(survey, END_BLOCK_ID)).toBeUndefined();
+  });
+
+  test("returns no target for a block deleted since progress was saved", () => {
+    expect(getForwardTargetFromOffBlockId(survey, "deleted-block")).toBeUndefined();
+  });
+});
+
+describe("getPreviousBlockId", () => {
+  test("returns the last visited card, which branching logic makes authoritative over array order", () => {
+    // From block-2 the array order would say block-1; history says the respondent jumped in.
+    expect(getPreviousBlockId(survey, "block-2", ["block-1", "block-2"])).toBe("block-2");
+  });
+
+  test("returns the welcome card when that is what the respondent came from", () => {
+    expect(getPreviousBlockId(survey, "block-1", [START_BLOCK_ID])).toBe(START_BLOCK_ID);
+  });
+
+  test("returns the previous block by array order when there is no history", () => {
+    expect(getPreviousBlockId(survey, "block-2", [])).toBe("block-1");
+  });
+
+  test("returns nothing from the first block, which has nothing before it", () => {
+    expect(getPreviousBlockId(survey, "block-1", [])).toBeUndefined();
+  });
+
+  test.each([
+    ["an ending card", "ending-1"],
+    ["the 'end' sentinel", END_BLOCK_ID],
+    ["the welcome card", START_BLOCK_ID],
+    ["a block deleted since progress was saved", "deleted-block"],
+  ])("returns nothing from %s with no history, rather than reading blocks[-2]", (_label, blockId) => {
+    expect(getPreviousBlockId(survey, blockId, [])).toBeUndefined();
+  });
+});

--- a/packages/surveys/src/lib/survey-navigation.ts
+++ b/packages/surveys/src/lib/survey-navigation.ts
@@ -1,0 +1,78 @@
+/**
+ * Resolving the renderer's card pointer, `blockId`, against the survey.
+ *
+ * `blockId` is a union: the `"start"` sentinel for the welcome card, a block id while the
+ * respondent is answering, an ending id once the survey is over, and the `"end"` sentinel for a
+ * survey that has no endings at all. A *block*, though, is only resolvable against
+ * `survey.blocks` — so `blocks.findIndex(...)` returns `-1` for every other member of that union
+ * and `blocks[-1]` is `undefined`.
+ *
+ * That disagreement used to surface as a thrown `Block not found` on navigation (ENG-2818). The
+ * throw escaped as an unhandled rejection, so on a link survey the answer in hand was never
+ * queued and the Next button was left spinning. These helpers hold the two resolutions the
+ * navigation paths need, so "`blockId` is not a block" has one defined answer per direction.
+ */
+
+/** The `blockId` sentinel for a finished survey that defines no ending cards. */
+export const END_BLOCK_ID = "end";
+
+/** The `blockId` sentinel for the welcome card. */
+export const START_BLOCK_ID = "start";
+
+interface TNavigableSurvey {
+  blocks: readonly { readonly id: string }[];
+  endings: readonly { readonly id: string }[];
+}
+
+/**
+ * Whether `blockId` means "this survey is over" — an ending card, or the `"end"` sentinel used
+ * when the survey defines none.
+ *
+ * Restored offline progress is validated against this: a saved position that is already an
+ * ending is a finished session, not somewhere to resume.
+ */
+export const isFinishedBlockId = (survey: TNavigableSurvey, blockId: string): boolean =>
+  blockId === END_BLOCK_ID || survey.endings.some((ending) => ending.id === blockId);
+
+/**
+ * The target a forward navigation should settle on when `blockId` does not resolve to a block.
+ *
+ * Reached from three states, all of them normal: `blockId` is an ending id (the survey already
+ * finished), it is the `"end"` sentinel, or it names a block that no longer exists because the
+ * creator edited the survey after progress was saved. None of them leaves anything to advance
+ * through, so the survey finishes:
+ *
+ * - an ending id returns itself, keeping the ending already on screen and the persisted
+ *   `endingId` in agreement with it;
+ * - anything else returns `undefined`, which the caller reads as "no target" and falls back to
+ *   the first ending, exactly as it does when a respondent runs off the last block.
+ */
+export const getForwardTargetFromOffBlockId = (
+  survey: TNavigableSurvey,
+  blockId: string
+): string | undefined => survey.endings.find((ending) => ending.id === blockId)?.id;
+
+/**
+ * The card a Back navigation should return to, or `undefined` when nothing precedes the current
+ * one — in which case Back is a no-op.
+ *
+ * Visited cards are the source of truth: branching logic means the block sitting before the
+ * current one in the array is not necessarily the one the respondent came from. `history` may
+ * hold the `"start"` sentinel, which correctly returns the respondent to the welcome card.
+ *
+ * With no history there is only the array order to fall back on, and an index of `0` (the first
+ * block) or `-1` (an ending, a sentinel, or a block deleted since progress was saved) both mean
+ * there is nowhere to go back to.
+ */
+export const getPreviousBlockId = (
+  survey: TNavigableSurvey,
+  blockId: string,
+  history: readonly string[]
+): string | undefined => {
+  if (history.length > 0) return history[history.length - 1];
+
+  const currentBlockIndex = survey.blocks.findIndex((block) => block.id === blockId);
+  if (currentBlockIndex <= 0) return undefined;
+
+  return survey.blocks[currentBlockIndex - 1].id;
+};


### PR DESCRIPTION
Fixes ENG-2818

## What & why

**Was:** Pressing Next or Back once the survey pointer sat on an ending card — or on a block deleted since offline progress was saved — threw `Block not found`. It escaped as an unhandled rejection, so on a link survey the answer in hand was never queued, the Next button kept spinning, and nothing server-side recorded that the respondent was lost.

**Now:** Both directions have a defined answer. Forward navigation settles on the ending already showing (or the first ending) and the response is submitted; Back does nothing when no card precedes the current one.

- The pointer, `blockId`, is a union of block ids, ending ids and the `"start"`/`"end"` sentinels — but a block only ever resolved against `survey.blocks`.
- That resolution now lives in a pure `survey-navigation` module, one function per direction.
- Restored progress treats `"end"` as finished, so a survey with no endings starts fresh instead of resuming onto a blank card.

## Where to look

- ``https://github.com/formbricks/formbricks/blob/claude/eng-2818-block-not-found-off-block-navigation/packages/surveys/src/components/general/survey.tsx#L775-L797`` — off-block submit now finishes
- ``https://github.com/formbricks/formbricks/blob/claude/eng-2818-block-not-found-off-block-navigation/packages/surveys/src/components/general/survey.tsx#L1117-L1133`` — Back consumes nothing when it does not navigate
- https://github.com/formbricks/formbricks/blob/claude/eng-2818-block-not-found-off-block-navigation/packages/surveys/src/lib/survey-navigation.ts — the two resolutions

## Breaking changes

- [ ] This PR contains breaking changes

None. `@formbricks/surveys` exports no changed signature — `survey-navigation` is internal to the package, and the `Survey` component's props are untouched. The behaviour change replaces a throw with a defined outcome, so no consumer was relying on it.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm test --filter=@formbricks/surveys`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Submit from a still-mounted block card after the survey reached its ending | unit (red on main) | `survey.test.tsx` "queues the answer instead of throwing when submitted from the ending card" — response updated with `finished: true`, `endingId: "ending-1"` |
| Back from the first block with no saved history | unit (red on main) | `survey.test.tsx` "back from the first block with no history is a no-op" — stays on block-1, nothing submitted |
| Back from an ending, `"end"`, the welcome card or a deleted block with no history | unit (mutation) | `survey-navigation.test.ts` — mutate `packages/surveys/src/lib/survey-navigation.ts:75` to `< 0` |
| Forward target for an ending id vs. `"end"` vs. a deleted block | unit (mutation) | `survey-navigation.test.ts` — mutate `getForwardTargetFromOffBlockId` to return `blockId` unconditionally |
| Restored progress sitting on the `"end"` sentinel is discarded | unit (mutation) | `survey-navigation.test.ts` — mutate `packages/surveys/src/lib/survey-navigation.ts:35` to drop the `END_BLOCK_ID` term |

<details>
<summary>Red on main: both rows above, against the pre-fix <code>survey.tsx</code></summary>

```
git stash push -- packages/surveys/src/components/general/survey.tsx
pnpm vitest run src/components/general/survey.test.tsx   # from packages/surveys
git stash pop
```

```
Block not found. blockId: ending-1 available blocks: [ 'block-1', 'block-2' ]
     × queues the answer instead of throwing when submitted from the ending card 1062ms
     × back from the first block with no history is a no-op instead of throwing 4ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
Error: Block not found
    1110|     if (!prevBlockId) throw new Error("Block not found");
Error: Block not found
 Test Files  1 failed (1)
      Tests  2 failed | 6 passed (8)
```

Both reproduce the verbatim production message, and the other six tests in the file stay green.

</details>

<details>
<summary>Verification output</summary>

```
$ pnpm test --filter=@formbricks/surveys
 Test Files  30 passed (30)
      Tests  749 passed (749)

$ pnpm dev:setup && pnpm test          # whole workspace, .env created as test.yml does
 Test Files  749 passed (749)
 Tasks:    26 successful, 26 total

$ pnpm typecheck --filter=@formbricks/surveys
@formbricks/surveys:typecheck: $ tsc --noEmit
 Tasks:    3 successful, 3 total

$ pnpm lint --filter=@formbricks/surveys
 Tasks:    21 successful, 21 total
✓ catalog check passed (64 catalogued dependencies)

$ pnpm format:check
All matched files use Prettier code style!
```

</details>

**Open gaps**

- The component test reaches the off-block submit through a `StackedCardsContainer` mock mirroring the real index math; the peeking card staying clickable is read from source, not a browser.
- Which off-block state produced each Sentry event is still unknown. All three are handled, so it does not gate the fix.
- The quota path (`setBlockId(quotaInfo.endingCardId)`) reaches the same state under the same guard, with no test of its own.

**Risks**

- Submitting from an ending card now re-submits the finished response. The queue updates the existing `responseId` rather than creating a second one; re-check for duplicate responses.
- Restored progress on `"end"` is discarded instead of resumed. Only a survey with no endings defined reaches that state.