### PR TITLE
fix(email): render RTL follow-up emails right-to-left [ENG-2593]

### DIFF
--- a/packages/email/emails/survey/follow-up-email.tsx
+++ b/packages/email/emails/survey/follow-up-email.tsx
@@ -28,7 +28,7 @@ export function FollowUpEmail({
   return (
     <EmailTemplate logoUrl={logoUrl} t={t} {...legalProps}>
       <>
-        <div dangerouslySetInnerHTML={{ __html: body }} />
+        <div dangerouslySetInnerHTML={{ __html: body }} dir="auto" />
 
         {responseData.length > 0 ? (
           <>
@@ -42,7 +42,9 @@ export function FollowUpEmail({
           return (
             <Row key={e.element}>
               <Column className="w-full">
-                <Text className="mb-2 text-sm font-semibold text-slate-900">{e.element}</Text>
+                <Text className="mb-2 text-sm font-semibold text-slate-900" dir="auto">
+                  {e.element}
+                </Text>
                 {renderEmailResponseValue(e.response, e.type, t, true)}
               </Column>
             </Row>
@@ -52,12 +54,12 @@ export function FollowUpEmail({
         {variables.map((variable) => (
           <Row key={variable.id}>
             <Column className="w-full">
-              <Text className="mb-2 text-sm font-semibold text-slate-900">
+              <Text className="mb-2 text-sm font-semibold text-slate-900" dir="auto">
                 {variable.type === "number"
                   ? `${t("emails.number_variable")}: ${variable.name}`
                   : `${t("emails.text_variable")}: ${variable.name}`}
               </Text>
-              <Text className="mt-0 text-sm break-words whitespace-pre-wrap text-slate-700">
+              <Text className="mt-0 text-sm break-words whitespace-pre-wrap text-slate-700" dir="auto">
                 {variable.value}
               </Text>
             </Column>
@@ -67,10 +69,10 @@ export function FollowUpEmail({
         {hiddenFields.map((hiddenField) => (
           <Row key={hiddenField.id}>
             <Column className="w-full">
-              <Text className="mb-2 text-sm font-semibold text-slate-900">
+              <Text className="mb-2 text-sm font-semibold text-slate-900" dir="auto">
                 {t("emails.hidden_field")}: {hiddenField.id}
               </Text>
-              <Text className="mt-0 text-sm break-words whitespace-pre-wrap text-slate-700">
+              <Text className="mt-0 text-sm break-words whitespace-pre-wrap text-slate-700" dir="auto">
                 {hiddenField.value}
               </Text>
             </Column>

--- a/packages/email/emails/survey/follow-up-email.tsx
+++ b/packages/email/emails/survey/follow-up-email.tsx
@@ -55,9 +55,8 @@ export function FollowUpEmail({
           <Row key={variable.id}>
             <Column className="w-full">
               <Text className="mb-2 text-sm font-semibold text-slate-900" dir="auto">
-                {variable.type === "number"
-                  ? `${t("emails.number_variable")}: ${variable.name}`
-                  : `${t("emails.text_variable")}: ${variable.name}`}
+                {variable.type === "number" ? t("emails.number_variable") : t("emails.text_variable")}:{" "}
+                <span dir="auto">{variable.name}</span>
               </Text>
               <Text className="mt-0 text-sm break-words whitespace-pre-wrap text-slate-700" dir="auto">
                 {variable.value}

--- a/packages/email/src/components/email-template.tsx
+++ b/packages/email/src/components/email-template.tsx
@@ -61,7 +61,7 @@ export function EmailTemplate({
               />
             )}
           </Section>
-          <Container className="mx-auto my-8 max-w-xl rounded-md bg-white p-4 text-left">
+          <Container className="mx-auto my-8 max-w-xl rounded-md bg-white p-4 text-start">
             {children}
           </Container>
 

--- a/packages/email/src/lib/email-utils.tsx
+++ b/packages/email/src/lib/email-utils.tsx
@@ -76,6 +76,10 @@ export const renderEmailResponseValue = (
       );
 
     default:
-      return <Text className="mt-0 text-sm break-words whitespace-pre-wrap">{response as string}</Text>;
+      return (
+        <Text className="mt-0 text-sm break-words whitespace-pre-wrap" dir="auto">
+          {response as string}
+        </Text>
+      );
   }
 };

--- a/packages/email/src/lib/render.test.ts
+++ b/packages/email/src/lib/render.test.ts
@@ -210,6 +210,46 @@ describe("custom branding", () => {
   });
 });
 
+describe("follow-up email direction", () => {
+  test("marks the follow-up body and the response/variable/hidden-field text for automatic direction detection", async () => {
+    const html = await renderFollowUpEmail({
+      ...exampleData.followUpEmail,
+      body: "<p>شكرا لملاحظاتك! لقد استلمنا ردك وسنراجعه قريبا.</p>",
+      ...legal,
+      t,
+    });
+
+    // The follow-up body is per-survey authored content in any script, so it gets
+    // dir="auto" rather than a hard rtl/ltr — this is the element from the bug report.
+    expect(html).toMatch(/<div dir="auto">[\s\S]*?شكرا لملاحظاتك/);
+    // Response element labels, variable name/value and hidden-field id/value all carry
+    // their own dir="auto" too, since each can hold independently-directioned content.
+    expect(html.match(/dir="auto"/g)?.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test("keeps an LTR-embedded run (a URL) intact inside RTL variable content", async () => {
+    const mixedValue = "شكرا على الرابط https://example.com/survey/123 وملاحظاتك";
+    const html = await renderFollowUpEmail({
+      ...exampleData.followUpEmail,
+      variables: [{ id: "var-1", name: "Link", type: "text", value: mixedValue }],
+      ...legal,
+      t,
+    });
+
+    // dir="auto" lets the mail client's bidi algorithm keep the LTR URL readable; the
+    // server must not reorder or otherwise mangle the raw text.
+    expect(html).toContain(mixedValue);
+  });
+
+  test("renders LTR follow-ups exactly as before", async () => {
+    const html = await renderFollowUpEmail({ ...exampleData.followUpEmail, ...legal, t });
+
+    expect(html).toContain(exampleData.followUpEmail.responseData[0].element);
+    expect(html).toContain(exampleData.followUpEmail.variables[0].value);
+    expect(html).toContain(exampleData.followUpEmail.hiddenFields[0].value);
+  });
+});
+
 describe("Tailwind render engine", () => {
   // `@react-email/tailwind` — not anything configured in this package — decides which
   // Tailwind version compiles the template classes. Pin that contract: these utilities

--- a/packages/email/src/lib/render.test.ts
+++ b/packages/email/src/lib/render.test.ts
@@ -241,6 +241,35 @@ describe("follow-up email direction", () => {
     expect(html).toContain(mixedValue);
   });
 
+  test("marks the open-text response value for automatic direction detection", async () => {
+    const html = await renderFollowUpEmail({
+      ...exampleData.followUpEmail,
+      responseData: [
+        {
+          element: "ما أكثر ما أعجبك؟",
+          response: "كانت خدمة العملاء ممتازة!",
+          type: TSurveyElementTypeEnum.OpenText,
+        },
+      ],
+      ...legal,
+      t,
+    });
+
+    // The value is rendered by renderEmailResponseValue rather than by the template, so a
+    // dir="auto" on the label alone would leave the answer under it resolved as LTR.
+    expect(html).toMatch(/<p[^>]*dir="auto"[^>]*>كانت خدمة العملاء ممتازة!<\/p>/);
+  });
+
+  test("lets the card alignment follow the direction of each element", async () => {
+    const html = await renderFollowUpEmail({ ...exampleData.followUpEmail, ...legal, t });
+
+    // dir="auto" only sets `direction`; an inherited `text-align:left` from the card would still
+    // pin RTL paragraphs to the left edge. The card uses `text-start`, which resolves per element.
+    // Asserting the declaration also proves the email Tailwind engine compiles the utility.
+    expect(html).toContain("text-align:start");
+    expect(html).not.toContain("text-align:left");
+  });
+
   test("renders LTR follow-ups exactly as before", async () => {
     const html = await renderFollowUpEmail({ ...exampleData.followUpEmail, ...legal, t });
 


### PR DESCRIPTION
Fixes ENG-2593

## What & why

**Was:** The follow-up email declared no text direction, so an Arabic or Hebrew body and the labels and values under it rendered left-to-right: punctuation sat at the visual start of the sentence and mixed LTR runs reversed the reading order. The card's `text-left` also pinned every paragraph to the left edge.

**Now:** The body, every per-content `<Text>` and the open-text response value carry `dir="auto"`, and the shared email card aligns with `text-start`, so each element reads and aligns in the direction of its own content. LTR emails render pixel-identical to before.

## Where to look

- [follow-up-email.tsx](```''https://github.com/formbricks/formbricks/blob/javier/eng-2593-email-follow-up-rtl-text-displays-ltr/packages/email/emails/survey/follow-up-email.tsx):''``` `dir="auto"` on the body div and the response, variable and hidden-field text
- [email-template.tsx](```''https://github.com/formbricks/formbricks/blob/javier/eng-2593-email-follow-up-rtl-text-displays-ltr/packages/email/src/components/email-template.tsx#L64):''``` the shared card goes from `text-left` to `text-start`; every email shares it, see the LTR check below
- [email-utils.tsx](https://github.com/formbricks/formbricks/blob/javier/eng-2593-email-follow-up-rtl-text-displays-ltr/packages/email/src/lib/email-utils.tsx#L80): `dir="auto"` on the open-text response value rendered through `renderEmailResponseValue`

## Breaking changes

- [ ] This PR contains breaking changes

None. Additive `dir` attributes; `text-start` resolves to left for LTR content.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/email test` (all unit rows live in `packages/email/src/lib/render.test.ts`)

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Follow-up body and field text carry `dir="auto"` | unit (red on main) | "marks the follow-up body…" |
| Open-text response value carries `dir="auto"` | unit (red on main) | "marks the open-text response value…" |
| Card alignment follows each element's direction; the email Tailwind engine emits `text-align:start` | unit (red on main) | "lets the card alignment follow…" |
| Embedded LTR run (URL) inside RTL variable text stays unmangled | unit (guard) | "keeps an LTR-embedded run…" |
| LTR follow-ups render exactly as before | unit (guard) + manual | "renders LTR follow-ups exactly as before"; English card pixel-identical to `main`, see fold |
| Arabic follow-up renders right-to-left with correct punctuation and mixed runs | manual | Before/after pairs in the fold, headless Chromium |
| Variable label's translated prefix no longer forces an RTL variable name to LTR | unit (guard) | `render.test.ts` `dir="auto"` count assertion covers the extra wrapper on `variable.name` |

<details>
<summary>Screenshots (main vs this PR, same fixture, viewport and clip)</summary>

| Before | After |
| --- | --- |
| ![Arabic follow-up card with every paragraph left-aligned and punctuation at the visual start of each sentence](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2593/follow-up-rtl-before.png) | ![Arabic follow-up card with Arabic paragraphs right-aligned and punctuation at the end of each sentence](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2593/follow-up-rtl-after-2.png) |
| ![Body paragraphs hugging the left edge with the full stop and colon before the first word](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2593/body-punctuation-before-2.png) | ![Body paragraphs right-aligned with the full stop and colon after the last word](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2593/body-punctuation-after-2.png) |
| ![Question label and answer left-aligned, exclamation mark before the first word of the answer](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2593/open-text-answer-before-2.png) | ![Question label and answer right-aligned, exclamation mark after the last word](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2593/open-text-answer-after-2.png) |
| ![Left-aligned sentence with the Arabic fragments in reversed order around the URL](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2593/mixed-url-run-before-2.png) | ![Right-aligned sentence starting on the right, URL in the middle, last word on the left](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2593/mixed-url-run-after-2.png) |

English follow-up, pixel-identical before and after:

![English follow-up card, unchanged](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2593/follow-up-ltr-unchanged.png)

</details>

**Open gaps**

- Not spot-checked in a real mail client; rendered HTML in headless Chromium only. Outlook's Word engine ignores `text-align:start` and falls back to left, as today.
- Labels with a translated English prefix (`Text variable:`, `Hidden field:`) resolve LTR under an English UI locale and stay left.

**Risks**

- `text-start` changes the shared card for every email; guarded by the pixel-identical LTR check and the `text-align:start` assertion.

---

> [!NOTE]
> **AI model used**: `Fable 5.1`

<!-- claude-routine
ticket: ENG-2593
opened: 2026-09-04T09:32Z
last_run: 2026-09-04T12:17Z
runs: 2
ci_fixes: 0
review_rounds: 1
status: awaiting-ci
-->
