### PR TITLE
feat(mobile-core): add the server-delivered mobile core bundle (bridge protocol v1)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
     "@formbricks/js": "5.0.0",
     "@formbricks/js-core": "workspace:*",
     "@formbricks/logger": "workspace:*",
+    "@formbricks/mobile-core": "workspace:*",
     "@formbricks/storage": "workspace:*",
     "@formbricks/survey-ui": "workspace:*",
     "@formbricks/surveys": "workspace:*",

--- a/packages/mobile-core/eslint.config.mjs
+++ b/packages/mobile-core/eslint.config.mjs
@@ -1,0 +1,13 @@
+import library from "@formbricks/config-eslint/library";
+
+export default [
+  ...library({ tsconfigRootDir: import.meta.dirname }),
+  {
+    files: ["**/*.test.ts"],
+    rules: {
+      // vitest assertions (`expect(obj.method).toHaveBeenCalled…`, `vi.mocked(obj.method)`)
+      // reference methods without invoking them, so no `this` can go astray.
+      "@typescript-eslint/unbound-method": "off",
+    },
+  },
+];

--- a/packages/mobile-core/package.json
+++ b/packages/mobile-core/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@formbricks/mobile-core",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "version": "1.0.0",
+  "description": "Server-delivered decision logic (the mobile 'brain') for the Formbricks mobile SDKs. Built as a DOM-free bundle that runs in JavaScriptCore / WebView JS engines and is loaded by the native SDK shells over the Formbricks API.",
+  "homepage": "https://formbricks.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formbricks/formbricks"
+  },
+  "keywords": [
+    "Formbricks",
+    "surveys",
+    "experience management"
+  ],
+  "sideEffects": true,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "dev": "vite build --watch --mode dev",
+    "build": "vite build",
+    "build:dev": "vite build --mode dev",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "clean": "rimraf .turbo node_modules dist coverage",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Formbricks <hola@formbricks.com>",
+  "devDependencies": {
+    "@formbricks/config-typescript": "workspace:*",
+    "@formbricks/config-eslint": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/mobile-core/src/index.ts
+++ b/packages/mobile-core/src/index.ts
@@ -1,0 +1,12 @@
+// Entry point for the mobile core bundle ("the brain"). Built as UMD with the
+// global name `formbricksMobileCore`; the native SDK shells (iOS JavaScriptCore,
+// Android/Flutter WebView engines) evaluate the bundle and then call
+// `globalThis.formbricksMobileCore.selectSurvey(payload)`.
+//
+// Contract with the shells:
+// - `protocolVersion` must equal the shell's bridge protocol version, or the
+//   shell discards the bundle and falls back to its built-in logic.
+// - `selectSurvey` is pure decision logic: state in, decision out. Anything
+//   requiring platform capabilities (storage, networking, presenting UI)
+//   stays on the native side.
+export { PROTOCOL_VERSION as protocolVersion, selectSurvey } from "@/lib/select-survey";

--- a/packages/mobile-core/src/lib/select-survey.test.ts
+++ b/packages/mobile-core/src/lib/select-survey.test.ts
@@ -1,0 +1,263 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import vm from "node:vm";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { SelectSurveyDecision, SelectSurveyPayload, Survey } from "@/types";
+import { getLanguageCode, selectSurvey } from "./select-survey";
+
+const NOW_MS = 1_750_000_000_000;
+
+const buildSurvey = (overrides: Partial<Survey> = {}): Survey => ({
+  id: "survey_1",
+  displayOption: "respondMultiple",
+  triggers: [{ actionClass: { name: "Button Clicked" } }],
+  ...overrides,
+});
+
+const buildPayload = (overrides: Partial<SelectSurveyPayload> = {}): SelectSurveyPayload => ({
+  action: "button_clicked",
+  workspaceState: {
+    data: {
+      data: {
+        surveys: [buildSurvey()],
+        actionClasses: [{ key: "button_clicked", name: "Button Clicked", type: "code" }],
+        settings: {},
+      },
+    },
+  },
+  userState: {},
+  language: "default",
+  nowMs: NOW_MS,
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("selectSurvey", () => {
+  test("selects the survey matching the tracked action", () => {
+    const decision = selectSurvey(buildPayload());
+
+    expect(decision.shouldDisplay).toBe(true);
+    expect(decision.surveyId).toBe("survey_1");
+    expect(decision.delaySeconds).toBe(0);
+    expect(decision.languageCode).toBe("default");
+    expect(decision.v).toBe(1);
+  });
+
+  test("declines unknown actions", () => {
+    const decision = selectSurvey(buildPayload({ action: "unknown_action" }));
+
+    expect(decision.shouldDisplay).toBe(false);
+    expect(decision.reason).toContain("unknown");
+  });
+
+  test("ignores non-code action classes", () => {
+    const payload = buildPayload();
+    payload.workspaceState!.data!.data!.actionClasses = [
+      { key: "button_clicked", name: "Button Clicked", type: "noCode" },
+    ];
+
+    expect(selectSurvey(payload).shouldDisplay).toBe(false);
+  });
+
+  test("passes the survey delay through", () => {
+    const payload = buildPayload();
+    payload.workspaceState!.data!.data!.surveys = [buildSurvey({ delay: 5 })];
+
+    expect(selectSurvey(payload).delaySeconds).toBe(5);
+  });
+
+  describe("display type filtering", () => {
+    test("displayOnce declines when the survey was already displayed", () => {
+      const payload = buildPayload({
+        userState: { displays: [{ surveyId: "survey_1", createdAt: "2026-01-01T00:00:00Z" }] },
+      });
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ displayOption: "displayOnce" })];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+
+    test("displayMultiple declines after a response", () => {
+      const payload = buildPayload({ userState: { responses: ["survey_1"] } });
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ displayOption: "displayMultiple" })];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+
+    test("displaySome respects the display limit", () => {
+      const payload = buildPayload({
+        userState: {
+          displays: [
+            { surveyId: "survey_1", createdAt: "2026-01-01T00:00:00Z" },
+            { surveyId: "survey_1", createdAt: "2026-01-02T00:00:00Z" },
+          ],
+        },
+      });
+      payload.workspaceState!.data!.data!.surveys = [
+        buildSurvey({ displayOption: "displaySome", displayLimit: 2 }),
+      ];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+
+    test("unknown display option declines", () => {
+      const payload = buildPayload();
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ displayOption: "somethingNew" })];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+  });
+
+  describe("recontact days", () => {
+    test("declines when within the survey recontact window", () => {
+      const payload = buildPayload({
+        userState: { lastDisplayedAtMs: NOW_MS - 86_400_000 }, // 1 day ago
+      });
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ recontactDays: 7 })];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+
+    test("falls back to the workspace default recontact days", () => {
+      const payload = buildPayload({
+        userState: { lastDisplayedAtMs: NOW_MS - 86_400_000 },
+      });
+      payload.workspaceState!.data!.data!.settings = { recontactDays: 7 };
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+
+    test("allows display once the window has passed", () => {
+      const payload = buildPayload({
+        userState: { lastDisplayedAtMs: NOW_MS - 8 * 86_400_000 }, // 8 days ago
+      });
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ recontactDays: 7 })];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(true);
+    });
+  });
+
+  describe("segments", () => {
+    test("anonymous users are excluded from surveys whose segment has filters", () => {
+      const payload = buildPayload();
+      payload.workspaceState!.data!.data!.surveys = [
+        buildSurvey({ segment: { id: "seg_1", hasFilters: true } }),
+      ];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+
+    test("identified users without segments see nothing", () => {
+      const payload = buildPayload({ userState: { userId: "user_1", segments: [] } });
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+
+    test("identified users see surveys for their segments", () => {
+      const payload = buildPayload({ userState: { userId: "user_1", segments: ["seg_1"] } });
+      payload.workspaceState!.data!.data!.surveys = [
+        buildSurvey({ segment: { id: "seg_1", hasFilters: true } }),
+      ];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(true);
+    });
+  });
+
+  describe("display percentage", () => {
+    test("declines when the draw exceeds the percentage", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.99);
+      const payload = buildPayload();
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ displayPercentage: 50 })];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+
+    test("displays when the draw is under the percentage", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.1);
+      const payload = buildPayload();
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ displayPercentage: 50 })];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(true);
+    });
+  });
+
+  describe("multi-language surveys", () => {
+    const languages = [
+      { language: { code: "en", alias: null }, default: true, enabled: true },
+      { language: { code: "de", alias: "german" }, default: false, enabled: true },
+      { language: { code: "fr", alias: null }, default: false, enabled: false },
+    ];
+
+    test("resolves an enabled language by code", () => {
+      const payload = buildPayload({ language: "de" });
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ languages })];
+
+      const decision = selectSurvey(payload);
+      expect(decision.shouldDisplay).toBe(true);
+      expect(decision.languageCode).toBe("de");
+    });
+
+    test("resolves an enabled language by alias", () => {
+      const payload = buildPayload({ language: "german" });
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ languages })];
+
+      expect(selectSurvey(payload).languageCode).toBe("de");
+    });
+
+    test("maps the default language to 'default'", () => {
+      const payload = buildPayload({ language: "en" });
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ languages })];
+
+      expect(selectSurvey(payload).languageCode).toBe("default");
+    });
+
+    test("declines when the language is disabled", () => {
+      const payload = buildPayload({ language: "fr" });
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ languages })];
+
+      const decision = selectSurvey(payload);
+      expect(decision.shouldDisplay).toBe(false);
+      expect(decision.reason).toContain("not available in language");
+    });
+
+    test("declines when the language is unknown to the survey", () => {
+      const payload = buildPayload({ language: "es" });
+      payload.workspaceState!.data!.data!.surveys = [buildSurvey({ languages })];
+
+      expect(selectSurvey(payload).shouldDisplay).toBe(false);
+    });
+  });
+});
+
+describe("getLanguageCode", () => {
+  test("returns 'default' for empty or 'default' input", () => {
+    const survey = buildSurvey();
+    expect(getLanguageCode(survey, null)).toBe("default");
+    expect(getLanguageCode(survey, "")).toBe("default");
+    expect(getLanguageCode(survey, "default")).toBe("default");
+  });
+});
+
+// Proves the built bundle runs in a bare JS engine: no DOM, no `window`, no
+// `self` — only `globalThis`, matching the JavaScriptCore environment the iOS
+// shell provides. Skipped when the bundle hasn't been built yet.
+const bundlePath = resolve(__dirname, "../../dist/core.umd.cjs");
+describe.skipIf(!existsSync(bundlePath))("built bundle in a DOM-free engine", () => {
+  test("evaluates and decides via globalThis.formbricksMobileCore", () => {
+    const source = readFileSync(bundlePath, "utf8");
+    const sandbox = vm.createContext(Object.create(null) as Record<string, unknown>);
+
+    vm.runInContext(source, sandbox);
+    const resultJson = vm.runInContext(
+      `JSON.stringify(globalThis.formbricksMobileCore.selectSurvey(${JSON.stringify(buildPayload())}))`,
+      sandbox
+    ) as string;
+
+    const decision = JSON.parse(resultJson) as SelectSurveyDecision;
+    expect(vm.runInContext("globalThis.formbricksMobileCore.protocolVersion", sandbox)).toBe(1);
+    expect(decision.shouldDisplay).toBe(true);
+    expect(decision.surveyId).toBe("survey_1");
+  });
+});

--- a/packages/mobile-core/src/lib/select-survey.ts
+++ b/packages/mobile-core/src/lib/select-survey.ts
@@ -1,0 +1,150 @@
+import type { SelectSurveyDecision, SelectSurveyPayload, Survey, UserState, WorkspaceState } from "@/types";
+
+const PROTOCOL_VERSION = 1;
+const MS_PER_DAY = 86_400_000;
+
+const decline = (reason: string): SelectSurveyDecision => ({
+  v: PROTOCOL_VERSION,
+  shouldDisplay: false,
+  surveyId: null,
+  delaySeconds: null,
+  languageCode: null,
+  reason,
+});
+
+const filterByDisplayType = (surveys: Survey[], userState: UserState): Survey[] => {
+  const displays = userState.displays ?? [];
+  const responses = userState.responses ?? [];
+
+  return surveys.filter((survey) => {
+    switch (survey.displayOption) {
+      case "respondMultiple":
+        return true;
+      case "displayOnce":
+        return !displays.some((display) => display.surveyId === survey.id);
+      case "displayMultiple":
+        return !responses.includes(survey.id);
+      case "displaySome": {
+        if (typeof survey.displayLimit !== "number") return true;
+        if (responses.includes(survey.id)) return false;
+        return displays.filter((display) => display.surveyId === survey.id).length < survey.displayLimit;
+      }
+      default:
+        return false;
+    }
+  });
+};
+
+const filterByRecontactDays = (
+  surveys: Survey[],
+  defaultRecontactDays: number | null | undefined,
+  userState: UserState,
+  nowMs: number
+): Survey[] => {
+  const lastDisplayedAtMs = userState.lastDisplayedAtMs;
+  if (typeof lastDisplayedAtMs !== "number") return surveys;
+
+  return surveys.filter((survey) => {
+    const recontactDays = survey.recontactDays ?? defaultRecontactDays;
+    if (typeof recontactDays !== "number") return true;
+    const daysSinceLastDisplay = Math.floor((nowMs - lastDisplayedAtMs) / MS_PER_DAY);
+    return daysSinceLastDisplay >= recontactDays;
+  });
+};
+
+const filterBySegments = (surveys: Survey[], userState: UserState): Survey[] => {
+  // Anonymous users: only surveys without a segment, or whose segment has no filters.
+  if (!userState.userId) {
+    return surveys.filter((survey) => !survey.segment || !survey.segment.hasFilters);
+  }
+
+  const segments = userState.segments ?? [];
+  if (segments.length === 0) return [];
+
+  return surveys.filter((survey) => {
+    const segmentId = survey.segment?.id;
+    return typeof segmentId === "string" && segments.includes(segmentId);
+  });
+};
+
+const shouldDisplayBasedOnPercentage = (displayPercentage: number | null | undefined): boolean => {
+  if (typeof displayPercentage !== "number") return true;
+  const clamped = Math.min(Math.max(displayPercentage, 0), 100);
+  return Math.random() * 100 < clamped;
+};
+
+// Resolves the language the survey should render in, or null when the survey
+// isn't available in the requested language.
+export const getLanguageCode = (survey: Survey, language: string | null | undefined): string | null => {
+  const availableCodes = (survey.languages ?? []).map((entry) => entry.language.code);
+
+  const raw = language?.toLowerCase() ?? "";
+  if (!raw || raw === "default") return "default";
+
+  const selected = (survey.languages ?? []).find(
+    (entry) => entry.language.code.toLowerCase() === raw || entry.language.alias?.toLowerCase() === raw
+  );
+
+  if (selected?.default) return "default";
+
+  if (!selected || !selected.enabled || !availableCodes.includes(selected.language.code)) {
+    return null;
+  }
+
+  return selected.language.code;
+};
+
+export const selectSurvey = (payload: SelectSurveyPayload): SelectSurveyDecision => {
+  const workspaceState: WorkspaceState = payload.workspaceState ?? {};
+  const userState: UserState = payload.userState ?? {};
+  const nowMs = payload.nowMs ?? Date.now();
+
+  const workspaceData = workspaceState.data?.data;
+  const surveys = workspaceData?.surveys ?? [];
+  const actionClasses = workspaceData?.actionClasses ?? [];
+
+  const actionClass = actionClasses.find(
+    (candidate) => candidate.type === "code" && candidate.key === payload.action
+  );
+  if (!actionClass) {
+    return decline(
+      `Action with identifier '${payload.action}' is unknown. Please add this action in Formbricks in order to use it via the SDK action tracking.`
+    );
+  }
+
+  let eligible = filterByDisplayType(surveys, userState);
+  eligible = filterByRecontactDays(eligible, workspaceData?.settings?.recontactDays, userState, nowMs);
+  eligible = filterBySegments(eligible, userState);
+
+  const survey = eligible.find((candidate) =>
+    (candidate.triggers ?? []).some((trigger) => trigger.actionClass?.name === actionClass.name)
+  );
+  if (!survey) {
+    return decline(`No eligible survey found for action '${payload.action}'.`);
+  }
+
+  if (!shouldDisplayBasedOnPercentage(survey.displayPercentage)) {
+    return decline(`Skipping survey ${survey.id} due to display percentage restriction.`);
+  }
+
+  let languageCode: string | null = "default";
+  if ((survey.languages?.length ?? 0) > 1) {
+    languageCode = getLanguageCode(survey, payload.language);
+    if (!languageCode) {
+      return decline(
+        `Survey ${survey.id} is not available in language "${payload.language ?? "default"}". Skipping.`
+      );
+    }
+  }
+
+  return {
+    v: PROTOCOL_VERSION,
+    shouldDisplay: true,
+    surveyId: survey.id,
+    delaySeconds: survey.delay ?? 0,
+    languageCode,
+    reason: `Survey ${survey.id} matched action '${payload.action}'.`,
+  };
+};
+
+export { PROTOCOL_VERSION };

--- a/packages/mobile-core/src/serving-wiring.test.ts
+++ b/packages/mobile-core/src/serving-wiring.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+// The brain bundle reaches production only as a side effect of the web app's
+// build graph: apps/web declares this package as a dependency, so turbo's
+// `^build` builds it and the copy plugin drops the bundle into
+// apps/web/public/js/mobile/v1/. Nothing fails loudly if that edge is removed
+// — deployed servers just 404 the bundle and every mobile shell silently falls
+// back to native logic. These assertions make that removal a red test instead.
+
+const repoRoot = resolve(__dirname, "../../..");
+
+const readJson = <T>(relativePath: string): T =>
+  JSON.parse(readFileSync(resolve(repoRoot, relativePath), "utf8")) as T;
+
+describe("mobile-core serving wiring", () => {
+  test("apps/web depends on this package so ^build produces the bundle", () => {
+    const webPackage = readJson<{ dependencies?: Record<string, string> }>("apps/web/package.json");
+    expect(webPackage.dependencies?.["@formbricks/mobile-core"]).toBe("workspace:*");
+  });
+
+  test("this package has a build script for turbo to run", () => {
+    const ownPackage = readJson<{ scripts?: Record<string, string> }>("packages/mobile-core/package.json");
+    expect(ownPackage.scripts?.build).toBeDefined();
+  });
+});

--- a/packages/mobile-core/src/types.ts
+++ b/packages/mobile-core/src/types.ts
@@ -1,0 +1,84 @@
+// Shapes of the state the native shells hand across the bridge. The workspace
+// state mirrors the /api/v2/client/{workspaceId}/environment response as cached
+// (and re-encoded) by the shells, so every field is optional and the brain must
+// stay defensive: an old shell may send less than a new brain expects.
+
+export interface SurveyLanguage {
+  language: {
+    code: string;
+    alias?: string | null;
+  };
+  default?: boolean;
+  enabled?: boolean;
+}
+
+export interface SurveyTrigger {
+  actionClass?: {
+    name?: string | null;
+  } | null;
+}
+
+export interface SurveySegment {
+  id?: string | null;
+  hasFilters?: boolean;
+}
+
+export interface Survey {
+  id: string;
+  displayOption?: string | null;
+  displayLimit?: number | null;
+  displayPercentage?: number | null;
+  recontactDays?: number | null;
+  delay?: number | null;
+  languages?: SurveyLanguage[] | null;
+  triggers?: SurveyTrigger[] | null;
+  segment?: SurveySegment | null;
+}
+
+export interface ActionClass {
+  key?: string | null;
+  name?: string | null;
+  type?: string | null;
+}
+
+export interface WorkspaceState {
+  data?: {
+    data?: {
+      surveys?: Survey[] | null;
+      actionClasses?: ActionClass[] | null;
+      settings?: {
+        recontactDays?: number | null;
+      } | null;
+    } | null;
+  } | null;
+}
+
+export interface Display {
+  surveyId?: string | null;
+  createdAt?: string | null;
+}
+
+export interface UserState {
+  userId?: string | null;
+  segments?: string[] | null;
+  displays?: Display[] | null;
+  responses?: string[] | null;
+  lastDisplayedAtMs?: number | null;
+}
+
+export interface SelectSurveyPayload {
+  action: string;
+  workspaceState?: WorkspaceState | null;
+  userState?: UserState | null;
+  language?: string | null;
+  nowMs?: number | null;
+}
+
+export interface SelectSurveyDecision {
+  v: number;
+  shouldDisplay: boolean;
+  surveyId: string | null;
+  delaySeconds: number | null;
+  languageCode: string | null;
+  reason: string;
+}

--- a/packages/mobile-core/tsconfig.json
+++ b/packages/mobile-core/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "baseUrl": ".",
+    "isolatedModules": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "resolveJsonModule": true,
+    "strict": true
+  },
+  "extends": "@formbricks/config-typescript/js-library.json",
+  "include": ["src", "package.json"]
+}

--- a/packages/mobile-core/vite.config.ts
+++ b/packages/mobile-core/vite.config.ts
@@ -1,0 +1,54 @@
+/// <reference types="vitest" />
+import { resolve } from "path";
+import { defineConfig } from "vitest/config";
+import type { ViteUserConfig } from "vitest/config";
+import webPackageJson from "../../apps/web/package.json";
+import { copyCompiledAssetsPlugin } from "../vite-plugins/copy-compiled-assets";
+
+type VitestPluginOption = NonNullable<ViteUserConfig["plugins"]>[number];
+
+// The bundle must run in JavaScriptCore (iOS) and bare WebView JS engines:
+// no DOM, no `window`, no `self`. The UMD wrapper resolves the global via
+// `globalThis`, which all target engines provide.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "src"),
+    },
+  },
+  define: {
+    "import.meta.env.VERSION": JSON.stringify(webPackageJson.version),
+  },
+  build: {
+    rollupOptions: {
+      output: { inlineDynamicImports: true },
+    },
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      name: "formbricksMobileCore",
+      formats: ["umd"],
+      fileName: "core",
+    },
+  },
+  plugins: [
+    copyCompiledAssetsPlugin({
+      filename: "core",
+      distDir: resolve(__dirname, "dist"),
+      skipDirectoryCheck: true,
+      // Bridge-protocol-versioned path: a v1 native shell requests
+      // /js/mobile/v1/core.umd.cjs and must always receive a v1-compatible brain.
+      outputSubDir: "mobile/v1",
+    }) as VitestPluginOption,
+  ],
+  test: {
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.ts"],
+      exclude: ["**/*.test.*", "**/*.spec.*"],
+    },
+  },
+});

--- a/packages/vite-plugins/copy-compiled-assets/index.test.ts
+++ b/packages/vite-plugins/copy-compiled-assets/index.test.ts
@@ -1,0 +1,65 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { ResolvedConfig } from "vite";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { copyCompiledAssetsPlugin } from "./index";
+
+// The plugin's contract is a build side effect (files appearing under
+// apps/web/public/js), so nothing else in the test suites exercises it.
+// These tests pin both halves of that contract: existing consumers
+// (js-core, surveys) keep writing to the js root when `outputSubDir` is
+// omitted, and consumers that pass it (mobile-core) write only to the
+// subdirectory.
+
+const runPlugin = async (
+  root: string,
+  options: Parameters<typeof copyCompiledAssetsPlugin>[0]
+): Promise<void> => {
+  const plugin = copyCompiledAssetsPlugin(options);
+  const configResolved = plugin.configResolved as unknown as (config: ResolvedConfig) => void;
+  const writeBundle = plugin.writeBundle as unknown as () => Promise<void>;
+  configResolved({ root } as ResolvedConfig);
+  await writeBundle();
+};
+
+describe("copyCompiledAssetsPlugin", () => {
+  let tmp: string;
+  let packageRoot: string;
+  let jsRoot: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), "copy-compiled-assets-"));
+    // Mirrors the monorepo shape the plugin assumes: <root>/packages/<pkg>
+    // resolving "../../apps/web/public/js" relative to the package root.
+    packageRoot = path.join(tmp, "packages", "fake-package");
+    jsRoot = path.join(tmp, "apps", "web", "public", "js");
+    await mkdir(path.join(packageRoot, "dist"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("without outputSubDir, copies into the js root and renames index to the filename", async () => {
+    await writeFile(path.join(packageRoot, "dist", "index.umd.cjs"), "umd-bundle");
+    await writeFile(path.join(packageRoot, "dist", "index.js"), "esm-bundle");
+
+    await runPlugin(packageRoot, { filename: "formbricks", distDir: "dist" });
+
+    await expect(readFile(path.join(jsRoot, "formbricks.umd.cjs"), "utf8")).resolves.toBe("umd-bundle");
+    await expect(readFile(path.join(jsRoot, "formbricks.js"), "utf8")).resolves.toBe("esm-bundle");
+  });
+
+  test("with outputSubDir, copies only into the subdirectory", async () => {
+    await writeFile(path.join(packageRoot, "dist", "core.umd.cjs"), "brain-bundle");
+
+    await runPlugin(packageRoot, { filename: "core", distDir: "dist", outputSubDir: "mobile/v1" });
+
+    await expect(readFile(path.join(jsRoot, "mobile", "v1", "core.umd.cjs"), "utf8")).resolves.toBe(
+      "brain-bundle"
+    );
+    // The js root must not receive a stray copy alongside the subdirectory one.
+    await expect(readdir(jsRoot)).resolves.toEqual(["mobile"]);
+  });
+});

--- a/packages/vite-plugins/copy-compiled-assets/index.ts
+++ b/packages/vite-plugins/copy-compiled-assets/index.ts
@@ -6,6 +6,7 @@ interface CopyCompiledAssetsPluginOptions {
   filename: string;
   distDir: string;
   skipDirectoryCheck?: boolean; // New option to skip checking non-existent directories
+  outputSubDir?: string; // Optional subdirectory below apps/web/public/js (e.g. "mobile/v1")
 }
 
 const ensureDirectoryExists = async (dirPath: string): Promise<void> => {
@@ -33,7 +34,7 @@ export function copyCompiledAssetsPlugin(options: CopyCompiledAssetsPluginOption
 
     async writeBundle() {
       try {
-        const outputDir = path.resolve(config.root, "../../apps/web/public/js");
+        const outputDir = path.resolve(config.root, "../../apps/web/public/js", options.outputSubDir ?? "");
         const distDir = path.resolve(config.root, options.distDir);
 
         // Create the output directory if it doesn't exist

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,9 @@ importers:
       '@formbricks/logger':
         specifier: workspace:*
         version: link:../../packages/logger
+      '@formbricks/mobile-core':
+        specifier: workspace:*
+        version: link:../../packages/mobile-core
       '@formbricks/storage':
         specifier: workspace:*
         version: link:../../packages/storage
@@ -1326,6 +1329,24 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.5(@types/node@25.4.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@7.3.5(@types/node@25.4.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+
+  packages/mobile-core:
+    devDependencies:
+      '@formbricks/config-eslint':
+        specifier: workspace:*
+        version: link:../config-eslint
+      '@formbricks/config-typescript':
+        specifier: workspace:*
+        version: link:../config-typescript
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.6(vitest@4.1.6)
       vite:
         specifier: 'catalog:'
         version: 7.3.5(@types/node@25.4.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)

--- a/turbo.json
+++ b/turbo.json
@@ -102,6 +102,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "@formbricks/mobile-core#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
     "@formbricks/storage#build": {
       "dependsOn": ["@formbricks/logger#build"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
Fixes ENG-2906

## What & why

**Was:** Every mobile SDK (iOS, Android, RN, Flutter) compiles its own copy of the survey display-decision logic; fixes wait for SDK + app store releases and the four copies drift.

**Now:** The decision logic exists once as `packages/mobile-core`, built into a 2.5 kB DOM-free bundle served at `/js/mobile/v1/core.umd.cjs`; native shells fetch and run it, so logic ships with a server release.

- First PR of the JS-brain epic; SDK-side hosts land in the SDK repos against their own `epic/js-brain` branches.

## Where to look

- [`packages/mobile-core/src/lib/select-survey.ts`](https://github.com/formbricks/formbricks/blob/anshuman/eng-2906-brain-merge-packagesmobile-core-into-main/packages/mobile-core/src/lib/select-survey.ts) — the ported decision pipeline
- [`packages/vite-plugins/copy-compiled-assets/index.ts`](https://github.com/formbricks/formbricks/blob/anshuman/eng-2906-brain-merge-packagesmobile-core-into-main/packages/vite-plugins/copy-compiled-assets/index.ts) — shared plugin gains optional `outputSubDir`
- [`turbo.json`](https://github.com/formbricks/formbricks/blob/anshuman/eng-2906-brain-merge-packagesmobile-core-into-main/turbo.json) + `apps/web/package.json` — build-graph wiring so deploys produce the bundle

## Breaking changes

- [ ] This PR contains breaking changes

None — purely additive: a new workspace package nothing imports, a new served static file, and an optional plugin parameter defaulting to existing behaviour.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm turbo run build test lint typecheck --filter=@formbricks/mobile-core --filter=@formbricks/vite-plugins`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Decision pipeline (display types, recontact, segments, percentage, language) | unit (mutation) | 22 tests in `select-survey.test.ts`; flip `!displays.some` at `select-survey.ts:30` → red |
| Bundle runs in a DOM-free engine (no `window`/`self`, JSC-equivalent) | unit (guard) | `select-survey.test.ts` "built bundle in a DOM-free engine" passes against the real build |
| Copy plugin: `outputSubDir` copies only there; default path unchanged for js-core/surveys | unit (mutation) | `copy-compiled-assets/index.test.ts`; drop `outputSubDir` at `index.ts:37` → red |
| Serving wiring: web dep edge + build script get the bundle into deploys | unit (mutation) | `serving-wiring.test.ts`; remove dep at `apps/web/package.json:48` → red |
| Bundle lands at `apps/web/public/js/mobile/v1/core.umd.cjs` | manual | build log shows copy; file present, 2.53 kB |
| Production builds include the bundle | manual | `turbo run build --filter='@formbricks/web^...' --dry` lists `@formbricks/mobile-core#build` |

**Open gaps**

- Native shells consuming the bundle are verified in the SDK repos' `epic/js-brain` PRs, not in this repo's CI; shared cross-repo contract tests come with ENG-2911.
- No integrity hash or brain version stamping yet (ENG-2907, ENG-2908).

**Risks**

- `copyCompiledAssetsPlugin` is shared with js-core/surveys; if `outputSubDir` defaulting regressed, their bundles would land in the wrong directory — re-check `apps/web/public/js/` contents after their builds.

---

> [!NOTE]
> **AI model used** — `claude-fable-5`, reasoning effort `unknown`.
