### PR TITLE
fix(security): bump fflate to 0.4.9, patch 1 advisory [ENG-2887]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,7 @@ overrides:
   fast-uri@3: 3.1.5
   deepmerge-ts@7: 8.0.1
   mysql2: 3.23.1
+  fflate: 0.4.9
 
 patchedDependencies:
   '@better-auth/oauth-provider@1.7.0': c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4
@@ -8516,8 +8517,8 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fflate@0.4.8:
-    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -21172,7 +21173,7 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  fflate@0.4.8: {}
+  fflate@0.4.9: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -23254,7 +23255,7 @@ snapshots:
       '@posthog/types': 1.369.5
       core-js: 3.48.0
       dompurify: 3.4.13
-      fflate: 0.4.8
+      fflate: 0.4.9
       preact: 10.29.1
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -279,6 +279,13 @@ overrides:
   # load-bearing: prisma resolves 3.15.3 (dev-only Prisma CLI, mysql adapter) and better-auth /
   # @boxyhq/saml-jackson / typeorm resolve 3.20.0 (runtime, optional mysql adapters).
   mysql2: 3.23.1
+  # ENG-2887 / GHSA-px8p-9vwx-vf98 (CVE-2026-45820): fflate's unzipSync() can loop indefinitely on a
+  # malformed ZIP archive whose central-directory entry declares the ZIP64 sentinel
+  # (compressed_size=0xFFFFFFFF) but omits the required ZIP64 extra field; the out-of-bounds read that
+  # should supply the real size returns undefined, which coerces to 0 and keeps the loop condition true
+  # forever (DoS). Affects the 0.4.x line from 0.4.5; patched in 0.4.9.
+  # load-bearing: posthog-js (browser, apps/web) resolves 0.4.8.
+  fflate: 0.4.9
   # === Removed once upstream caught up (kept as a record of what no longer needs a pin) ===
   # ajv@6, @babel/core, body-parser, engine.io@6, linkify-it, protobufjs@7 and uuid@11
   # all resolve to the patched version on their own now.


### PR DESCRIPTION
Fixes ENG-2887

## What & why

**Was:** `fflate` resolved to 0.4.8 (via `posthog-js`, browser bundle) — `unzipSync()` loops indefinitely on a malformed ZIP archive whose central-directory entry declares the ZIP64 sentinel (`compressed_size=0xFFFFFFFF`) without the required ZIP64 extra field.

**Now:** `fflate` is overridden to 0.4.9, the lowest version closing the advisory.

| Package | Old | New | GHSA/CVE | Severity | Linear issue | Direct/override |
| --- | --- | --- | --- | --- | --- | --- |
| `fflate` | 0.4.8 | 0.4.9 | GHSA-px8p-9vwx-vf98 / CVE-2026-45820 | medium | ENG-2887 | override (new) |

## Where to look

- [pnpm-workspace.yaml overrides block](../../blob/HEAD/pnpm-workspace.yaml) — new `fflate` pin with its advisory note

## Breaking changes

- [ ] This PR contains breaking changes

None — a patch-level pin on a transitive, browser-bundle-only dependency; no application code changed.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm install && pnpm audit --prod`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| fflate unzipSync ZIP64 infinite-loop DoS closed | manual | `pnpm why fflate` → single resolved version 0.4.9; GHSA-px8p-9vwx-vf98 gone from `pnpm audit --prod` |

Also ran, all green: `pnpm lint` (0 errors, pre-existing warnings only), `pnpm test` (749 test files / 10,092 tests passed), `pnpm format` (no changes, `format:check`-clean).

**Open gaps**

- No e2e/manual app boot — pure dependency-version change with no application-code path beyond what the unit suite covers.

**Risks**

- none — transitive, browser-bundle-only dependency of `posthog-js`; not on any server request path.

### Needs a human

None — the one advisory in scope closed with a version pin.

### Out of scope (this sweep)

Of the 13 open `[Dependabot #...]` issues on the Engineering team, 12 (fast-uri ×4, browserslist ×2, qs ×2, sanitize-html ×2, `@xmldom/xmldom`, `@faker-js/faker`) already have an open, non-draft PR covering them (#9148, `fix(security): bump 6 packages, patch 12 advisories`) — left untouched here to avoid a competing change. `brace-expansion` (5 advisories, tracked in ENG-2234 alongside fflate) has no open `[Dependabot #...]` Linear issue, so it stays out of this sweep's scope; ENG-2234 remains open for it.

---

> [!NOTE]
> **AI model used** — `claude-sonnet-5`, reasoning effort `unknown`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ji3Ja5ex4gbvXBh9GfMFzX)_