### PR TITLE
fix(survey-link): preserve the requested language through the verify-email gate [ENG-2584]

### DIFF
--- a/apps/web/modules/email/index.tsx
+++ b/apps/web/modules/email/index.tsx
@@ -52,6 +52,7 @@ import { getOrganizationByWorkspaceId } from "@/lib/organization/service";
 import { TElementResponseMappingSurvey, getElementResponseMapping } from "@/lib/responses";
 import { getTranslate } from "@/lingodotdev/server";
 import { TVerificationRequestPurpose, buildVerificationLinks } from "@/modules/auth/lib/verification-links";
+import { buildVerifiedLinkSurveyUrl } from "@/modules/email/lib/verified-link-survey-url";
 import { resolveStorageUrl } from "@/modules/storage/utils";
 
 export { IS_SMTP_CONFIGURED };
@@ -459,19 +460,14 @@ export const sendLinkSurveyToVerifiedEmail = async (data: TLinkSurveyEmailData):
   const logoUrl = data.logoUrl ? resolveStorageUrl(data.logoUrl) : "";
   const token = createTokenForLinkSurvey(surveyId, email);
   const t = await getTranslate(data.locale);
-  const getSurveyLink = (): string => {
-    if (singleUseId) {
-      const surveyLink = new URL(`${getPublicDomain()}/s/${surveyId}`);
-      surveyLink.searchParams.set("verify", token);
-      surveyLink.searchParams.set("suId", singleUseId);
-      if (singleUseToken) {
-        surveyLink.searchParams.set("suToken", singleUseToken);
-      }
-      return surveyLink.toString();
-    }
-    return `${getPublicDomain()}/s/${surveyId}?verify=${encodeURIComponent(token)}`;
-  };
-  const surveyLink = getSurveyLink();
+  const surveyLink = buildVerifiedLinkSurveyUrl({
+    publicDomain: getPublicDomain(),
+    surveyId,
+    token,
+    singleUseId,
+    singleUseToken,
+    surveyLanguageCode: data.surveyLanguageCode,
+  });
 
   const html = await renderLinkSurveyEmail({ surveyName, surveyLink, logoUrl, t, ...legalProps });
   return await sendEmail({

--- a/apps/web/modules/email/lib/verified-link-survey-url.test.ts
+++ b/apps/web/modules/email/lib/verified-link-survey-url.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import { buildVerifiedLinkSurveyUrl } from "./verified-link-survey-url";
+
+const baseParams = {
+  publicDomain: "https://app.formbricks.com",
+  surveyId: "survey-1",
+  token: "verify-token",
+};
+
+const paramsOf = (url: string): URLSearchParams => new URL(url).searchParams;
+
+describe("buildVerifiedLinkSurveyUrl", () => {
+  test("carries the requested survey language back into the link", () => {
+    const url = buildVerifiedLinkSurveyUrl({ ...baseParams, surveyLanguageCode: "de-DE" });
+
+    expect(paramsOf(url).get("lang")).toBe("de-DE");
+    expect(paramsOf(url).get("verify")).toBe("verify-token");
+  });
+
+  test("omits lang when the respondent chose nothing or stayed on the survey default", () => {
+    expect(paramsOf(buildVerifiedLinkSurveyUrl(baseParams)).has("lang")).toBe(false);
+    expect(
+      paramsOf(buildVerifiedLinkSurveyUrl({ ...baseParams, surveyLanguageCode: "default" })).has("lang")
+    ).toBe(false);
+  });
+
+  test("keeps single-use parameters intact alongside the language", () => {
+    const params = paramsOf(
+      buildVerifiedLinkSurveyUrl({
+        ...baseParams,
+        singleUseId: "su-1",
+        singleUseToken: "su-token",
+        surveyLanguageCode: "de-DE",
+      })
+    );
+
+    expect(params.get("suId")).toBe("su-1");
+    expect(params.get("suToken")).toBe("su-token");
+    expect(params.get("verify")).toBe("verify-token");
+    expect(params.get("lang")).toBe("de-DE");
+  });
+
+  test("omits suToken when there is none, and suId when the link is not single-use", () => {
+    const withoutToken = paramsOf(buildVerifiedLinkSurveyUrl({ ...baseParams, singleUseId: "su-1" }));
+    expect(withoutToken.get("suId")).toBe("su-1");
+    expect(withoutToken.has("suToken")).toBe(false);
+
+    // A single-use token without an id is meaningless — the id is what gets validated.
+    const withoutId = paramsOf(buildVerifiedLinkSurveyUrl({ ...baseParams, singleUseToken: "su-token" }));
+    expect(withoutId.has("suId")).toBe(false);
+    expect(withoutId.has("suToken")).toBe(false);
+  });
+
+  test("points at the survey and encodes values that need it", () => {
+    const url = buildVerifiedLinkSurveyUrl({
+      ...baseParams,
+      token: "a+b/c=",
+      surveyLanguageCode: "zh-Hans-CN",
+    });
+
+    expect(url.startsWith("https://app.formbricks.com/s/survey-1?")).toBe(true);
+    // The raw token would otherwise be read back as a space and a path separator.
+    expect(url).not.toContain("a+b/c=");
+    expect(paramsOf(url).get("verify")).toBe("a+b/c=");
+    expect(paramsOf(url).get("lang")).toBe("zh-Hans-CN");
+  });
+});

--- a/apps/web/modules/email/lib/verified-link-survey-url.ts
+++ b/apps/web/modules/email/lib/verified-link-survey-url.ts
@@ -1,0 +1,44 @@
+interface VerifiedLinkSurveyUrlParams {
+  publicDomain: string;
+  surveyId: string;
+  /** Verification token minted for the respondent's email address. */
+  token: string;
+  singleUseId?: string;
+  singleUseToken?: string;
+  /** Survey language the respondent arrived with; omitted when they made no explicit choice. */
+  surveyLanguageCode?: string;
+}
+
+/**
+ * Builds the survey link that goes into the email-verification email.
+ *
+ * Every parameter the respondent needs to land where they left off is set here, in one place:
+ * `verify` always, `suId`/`suToken` for single-use links, and `lang` when the respondent picked a
+ * language — without it the emailed link drops back to the survey default (ENG-2584).
+ */
+export const buildVerifiedLinkSurveyUrl = ({
+  publicDomain,
+  surveyId,
+  token,
+  singleUseId,
+  singleUseToken,
+  surveyLanguageCode,
+}: VerifiedLinkSurveyUrlParams): string => {
+  const surveyLink = new URL(`${publicDomain}/s/${surveyId}`);
+  surveyLink.searchParams.set("verify", token);
+
+  if (singleUseId) {
+    surveyLink.searchParams.set("suId", singleUseId);
+    if (singleUseToken) {
+      surveyLink.searchParams.set("suToken", singleUseToken);
+    }
+  }
+
+  // "default" is the survey's own default language, which is what a link with no `lang` already
+  // resolves to — so it is left off rather than pinned into the URL.
+  if (surveyLanguageCode && surveyLanguageCode !== "default") {
+    surveyLink.searchParams.set("lang", surveyLanguageCode);
+  }
+
+  return surveyLink.toString();
+};

--- a/apps/web/modules/survey/link/actions.ts
+++ b/apps/web/modules/survey/link/actions.ts
@@ -10,6 +10,7 @@ import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { getOrganizationLogoUrl } from "@/modules/ee/whitelabel/email-customization/lib/organization";
 import { sendLinkSurveyToVerifiedEmail } from "@/modules/email";
 import { getSurveyWithMetadata } from "@/modules/survey/link/lib/data";
+import { resolveSurveyLanguageCode } from "@/modules/survey/link/lib/language";
 import { createLinkSurveyPinToken } from "@/modules/survey/link/lib/pin-token";
 
 export const sendLinkSurveyEmailAction = actionClient
@@ -26,7 +27,16 @@ export const sendLinkSurveyEmailAction = actionClient
     const organizationId = await getOrganizationIdFromSurveyId(parsedInput.surveyId);
     const organizationLogoUrl = await getOrganizationLogoUrl(organizationId);
 
-    await sendLinkSurveyToVerifiedEmail({ ...parsedInput, logoUrl: organizationLogoUrl || "" });
+    // The language arrives from the client, and it ends up as `?lang=` in the link we email out — so
+    // resolve it against this survey's own enabled languages here rather than trusting the payload.
+    // Anything that names no enabled language becomes "default" and is left out of the link entirely.
+    const surveyLanguageCode = resolveSurveyLanguageCode(parsedInput.surveyLanguageCode, survey);
+
+    await sendLinkSurveyToVerifiedEmail({
+      ...parsedInput,
+      surveyLanguageCode,
+      logoUrl: organizationLogoUrl || "",
+    });
     return { success: true };
   });
 

--- a/apps/web/modules/survey/link/components/pin-screen.tsx
+++ b/apps/web/modules/survey/link/components/pin-screen.tsx
@@ -65,7 +65,7 @@ export const PinScreen = (props: Readonly<PinScreenProps>) => {
   const [localPinEntry, setLocalPinEntry] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const { t } = useTranslation();
-  useAppLocale(locale);
+  const isLocaleReady = useAppLocale(locale);
   const [error, setError] = useState("");
   const [survey, setSurvey] = useState<TSurvey>();
   const [pinAuthToken, setPinAuthToken] = useState<string | undefined>();
@@ -111,6 +111,10 @@ export const PinScreen = (props: Readonly<PinScreenProps>) => {
   }, [localPinEntry, surveyId]);
 
   if (!survey) {
+    // The gate is nothing but translated chrome, so it waits for its locale instead of asking for the
+    // PIN in the browser's language and switching a frame later.
+    if (!isLocaleReady) return null;
+
     return (
       <div
         className={cn(

--- a/apps/web/modules/survey/link/components/pin-screen.tsx
+++ b/apps/web/modules/survey/link/components/pin-screen.tsx
@@ -38,7 +38,7 @@ interface PinScreenProps {
   styling: TWorkspaceStyling | TSurveyStyling;
 }
 
-export const PinScreen = (props: PinScreenProps) => {
+export const PinScreen = (props: Readonly<PinScreenProps>) => {
   const {
     surveyId,
     workspace,

--- a/apps/web/modules/survey/link/components/pin-screen.tsx
+++ b/apps/web/modules/survey/link/components/pin-screen.tsx
@@ -5,11 +5,13 @@ import { useTranslation } from "react-i18next";
 import { Response, Workspace } from "@formbricks/database/prisma-browser";
 import { getLinkSurveyCardMaxWidth } from "@formbricks/types/styling";
 import { TSurvey, TSurveyStyling } from "@formbricks/types/surveys/types";
+import { TUserLocale } from "@formbricks/types/user";
 import { TWorkspaceStyling } from "@formbricks/types/workspace";
 import { cn } from "@/lib/cn";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { validateSurveyPinAction } from "@/modules/survey/link/actions";
 import { SurveyClientWrapper } from "@/modules/survey/link/components/survey-client-wrapper";
+import { useAppLocale } from "@/modules/survey/link/hooks/use-app-locale";
 import { OTPInput } from "@/modules/ui/components/otp-input";
 
 interface PinScreenProps {
@@ -24,6 +26,8 @@ interface PinScreenProps {
   IS_FORMBRICKS_CLOUD: boolean;
   verifiedEmail?: string;
   languageCode: string;
+  /** Locale for the gate's own chrome, resolved server-side from `?lang=` or Accept-Language. */
+  locale: TUserLocale;
   isEmbed: boolean;
   isPreview: boolean;
   contactId?: string;
@@ -47,6 +51,7 @@ export const PinScreen = (props: PinScreenProps) => {
     IS_FORMBRICKS_CLOUD,
     verifiedEmail,
     languageCode,
+    locale,
     isEmbed,
     isPreview,
     contactId,
@@ -60,6 +65,7 @@ export const PinScreen = (props: PinScreenProps) => {
   const [localPinEntry, setLocalPinEntry] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const { t } = useTranslation();
+  useAppLocale(locale);
   const [error, setError] = useState("");
   const [survey, setSurvey] = useState<TSurvey>();
   const [pinAuthToken, setPinAuthToken] = useState<string | undefined>();

--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -2,7 +2,6 @@
 
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { Workspace } from "@formbricks/database/prisma-browser";
 import { TResponseData } from "@formbricks/types/responses";
 import { TSurvey, TSurveyStyling } from "@formbricks/types/surveys/types";
@@ -12,6 +11,7 @@ import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { CustomScriptsInjector } from "@/modules/survey/link/components/custom-scripts-injector";
 import { LinkSurveyWrapper } from "@/modules/survey/link/components/link-survey-wrapper";
 import { OfflineAlert } from "@/modules/survey/link/components/offline-alert";
+import { useAppLocale } from "@/modules/survey/link/hooks/use-app-locale";
 import { buildSurveyDocumentTitle } from "@/modules/survey/link/lib/document-title";
 import { getPrefillValue } from "@/modules/survey/link/lib/prefill";
 import { getUserIdFromSearchParams } from "@/modules/survey/link/lib/user-id";
@@ -67,7 +67,6 @@ export const SurveyClientWrapper = ({
   pinAuthToken,
 }: SurveyClientWrapperProps) => {
   const searchParams = useSearchParams();
-  const { i18n } = useTranslation();
 
   // The survey's active language: starts at the server-provided code, then follows the
   // in-survey language switch (via onLanguageChange). The whole shell (i18n strings, logo
@@ -77,14 +76,7 @@ export const SurveyClientWrapper = ({
     setCurrentLanguageCode(languageCode);
   }, [languageCode]);
 
-  useEffect(() => {
-    const webAppLocale = getWebAppLocale(currentLanguageCode, survey);
-    if (i18n.language !== webAppLocale) {
-      i18n.changeLanguage(webAppLocale).catch(() => {
-        i18n.changeLanguage("en-US");
-      });
-    }
-  }, [currentLanguageCode, survey, i18n]);
+  useAppLocale(getWebAppLocale(currentLanguageCode, survey));
 
   const skipPrefilled = searchParams.get("skipPrefilled") === "true";
   const offlineSupport = searchParams.get("offlineSupport") === "true";

--- a/apps/web/modules/survey/link/components/survey-renderer.tsx
+++ b/apps/web/modules/survey/link/components/survey-renderer.tsx
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
 import { type Response } from "@formbricks/database/prisma-browser";
-import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { TSurvey, TSurveyStyling } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
 import { TWorkspaceStyling } from "@formbricks/types/workspace";
@@ -20,8 +19,10 @@ import { SurveyCompletedMessage } from "@/modules/survey/link/components/survey-
 import { SurveyInactive } from "@/modules/survey/link/components/survey-inactive";
 import { VerifyEmail } from "@/modules/survey/link/components/verify-email";
 import { getEmailVerificationDetails } from "@/modules/survey/link/lib/helper";
+import { resolveSurveyLanguageCode } from "@/modules/survey/link/lib/language";
 import type { TLinkSurveySearchParams } from "@/modules/survey/link/lib/types";
 import { hasUserIdSearchParam } from "@/modules/survey/link/lib/user-id";
+import { getGateLocale } from "@/modules/survey/link/lib/utils";
 import { TWorkspaceContextForLinkSurvey } from "@/modules/survey/link/lib/workspace";
 
 interface SurveyRendererProps {
@@ -63,6 +64,11 @@ export const renderSurvey = async ({
 }: SurveyRendererProps) => {
   const langParam = searchParams.lang;
   const isEmbed = searchParams.embed === "true";
+
+  // The survey's content language, and the locale everything around that content is translated in.
+  // Both are resolved once, here, so a gate screen can never disagree with the survey behind it.
+  const languageCode = resolveSurveyLanguageCode(langParam, survey);
+  const gateLocale = getGateLocale({ langParam, languageCode, survey, fallbackLocale: locale });
 
   // Archived surveys are absent from the workspace for respondents — treat the public link as a
   // missing survey (same as a draft or non-link survey) rather than showing an inactive/scheduled state.
@@ -117,9 +123,9 @@ export const renderSurvey = async ({
         <VerifyEmail
           survey={publicSurvey}
           isErrorComponent={true}
-          languageCode={getLanguageCode(langParam, survey)}
+          languageCode={languageCode}
           styling={workspace.styling}
-          locale={locale}
+          locale={gateLocale}
         />
       );
     }
@@ -128,16 +134,15 @@ export const renderSurvey = async ({
         singleUseId={searchParams.suId ?? ""}
         singleUseToken={searchParams.suToken}
         survey={publicSurvey}
-        languageCode={getLanguageCode(langParam, survey)}
+        languageCode={languageCode}
         styling={workspace.styling}
-        locale={locale}
+        locale={gateLocale}
       />
     );
   }
 
   // Compute final styling based on workspace and survey settings
   const styling = computeStyling(workspace.styling, survey.styling);
-  const languageCode = getLanguageCode(langParam, survey);
   const publicDomain = getPublicDomain();
   const canReadUserIdFromUrl =
     allowUrlUserIdLookup && !contactId && hasUserIdSearchParam(searchParams)
@@ -160,6 +165,7 @@ export const renderSurvey = async ({
         IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
         verifiedEmail={verifiedEmail}
         languageCode={languageCode}
+        locale={gateLocale}
         isEmbed={isEmbed}
         isPreview={isPreview}
         contactId={contactId}
@@ -209,39 +215,4 @@ function computeStyling(
     return workspaceStyling;
   }
   return surveyStyling?.overwriteThemeStyling ? surveyStyling : workspaceStyling;
-}
-
-/**
- * Determines the language code to use for the survey.
- * Checks URL parameter against available survey languages and returns
- * "default" if language is not found or disabled.
- */
-function getLanguageCode(langParam: string | undefined, survey: TSurvey): string {
-  if (!langParam) return "default";
-
-  // Match the URL `?lang=` value against the survey's languages in strict precedence so selection is
-  // deterministic regardless of array order: (1) an exact stored `code`, then (2) a custom `alias`, then
-  // (3) canonical equivalence. Code beats alias because an exact code always lines up with the survey's
-  // i18n content keys — without this, one row's alias could shadow another row's exact code. The canonical
-  // pass lets a shared link with a legacy code (`?lang=pt`) still resolve to a migrated language (`pt-BR`).
-  // Returns the survey's stored code so it lines up with its content keys.
-  const langParamLower = langParam.toLowerCase();
-  const langParamCanonical = normalizeLanguageCode(langParam);
-  const selectedLanguage =
-    survey.languages.find(
-      (surveyLanguage) => surveyLanguage.language.code.toLowerCase() === langParamLower
-    ) ??
-    survey.languages.find(
-      (surveyLanguage) => surveyLanguage.language.alias?.toLowerCase() === langParamLower
-    ) ??
-    (langParamCanonical
-      ? survey.languages.find(
-          (surveyLanguage) => normalizeLanguageCode(surveyLanguage.language.code) === langParamCanonical
-        )
-      : undefined);
-
-  if (!selectedLanguage || selectedLanguage?.default || !selectedLanguage?.enabled) {
-    return "default";
-  }
-  return selectedLanguage.language.code;
 }

--- a/apps/web/modules/survey/link/components/verify-email.tsx
+++ b/apps/web/modules/survey/link/components/verify-email.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowLeft, MailIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Toaster, toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -17,7 +17,7 @@ import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { replaceHeadlineRecall } from "@/lib/utils/recall";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { sendLinkSurveyEmailAction } from "@/modules/survey/link/actions";
-import { getWebAppLocale } from "@/modules/survey/link/lib/utils";
+import { useAppLocale } from "@/modules/survey/link/hooks/use-app-locale";
 import { Button } from "@/modules/ui/components/button";
 import { FormControl, FormError, FormField, FormItem } from "@/modules/ui/components/form";
 import { Input } from "@/modules/ui/components/input";
@@ -47,18 +47,9 @@ export const VerifyEmail = ({
   styling,
   locale,
 }: VerifyEmailProps) => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
+  useAppLocale(locale);
 
-  // Set i18n language based on survey language
-  useEffect(() => {
-    const webAppLocale = getWebAppLocale(languageCode, survey);
-    if (i18n.language !== webAppLocale) {
-      i18n.changeLanguage(webAppLocale).catch(() => {
-        // If changeLanguage fails, fallback to default locale
-        i18n.changeLanguage("en-US");
-      });
-    }
-  }, [languageCode, survey, i18n]);
   const form = useForm<TVerifyEmailInput>({
     defaultValues: {
       email: "",
@@ -91,6 +82,8 @@ export const VerifyEmail = ({
       suId: singleUseId ?? "",
       suToken: singleUseToken,
       locale,
+      // The language the respondent is reading the survey in, so the emailed link comes back to it.
+      surveyLanguageCode: languageCode,
     };
 
     const actionResult = await sendLinkSurveyEmailAction(data);

--- a/apps/web/modules/survey/link/components/verify-email.tsx
+++ b/apps/web/modules/survey/link/components/verify-email.tsx
@@ -48,7 +48,7 @@ export const VerifyEmail = ({
   locale,
 }: VerifyEmailProps) => {
   const { t } = useTranslation();
-  useAppLocale(locale);
+  const isLocaleReady = useAppLocale(locale);
 
   const form = useForm<TVerifyEmailInput>({
     defaultValues: {
@@ -103,6 +103,10 @@ export const VerifyEmail = ({
     setShowPreviewQuestions(false);
     setEmailSent(false);
   };
+
+  // The gate is nothing but translated chrome, so it waits for its locale instead of asking for an
+  // email address in the browser's language and switching a frame later.
+  if (!isLocaleReady) return null;
 
   if (isErrorComponent) {
     return (

--- a/apps/web/modules/survey/link/hooks/use-app-locale.test.ts
+++ b/apps/web/modules/survey/link/hooks/use-app-locale.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { useAppLocale } from "./use-app-locale";
+
+const i18n = {
+  language: "en-US",
+  changeLanguage: vi.fn(),
+};
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ i18n }),
+}));
+
+/** Resolves like i18next does: the language is live only once the promise settles. */
+const changeLanguageSucceeds = () => {
+  i18n.changeLanguage.mockImplementation(async (next: string) => {
+    i18n.language = next;
+  });
+};
+
+beforeEach(() => {
+  i18n.language = "en-US";
+  i18n.changeLanguage.mockReset();
+  changeLanguageSucceeds();
+});
+
+describe("useAppLocale", () => {
+  test("waits for the requested locale before reporting ready", async () => {
+    let applyLocale: (() => void) | undefined;
+    i18n.changeLanguage.mockImplementation(
+      (next: string) =>
+        new Promise<void>((resolve) => {
+          applyLocale = () => {
+            i18n.language = next;
+            resolve();
+          };
+        })
+    );
+
+    const { result } = renderHook(() => useAppLocale("de-DE"));
+
+    expect(result.current).toBe(false);
+    expect(i18n.changeLanguage).toHaveBeenCalledWith("de-DE");
+
+    applyLocale?.();
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+    expect(i18n.language).toBe("de-DE");
+  });
+
+  test("is ready on the first render when i18n already sits on the locale", () => {
+    const { result } = renderHook(() => useAppLocale("en-US"));
+
+    expect(result.current).toBe(true);
+    expect(i18n.changeLanguage).not.toHaveBeenCalled();
+  });
+
+  test("reports ready after falling back, so a waiting caller is never left blank", async () => {
+    i18n.changeLanguage.mockImplementation(async (next: string) => {
+      if (next === "he") throw new Error("no bundle for he");
+      i18n.language = next;
+    });
+
+    const { result } = renderHook(() => useAppLocale("he"));
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+    expect(i18n.changeLanguage).toHaveBeenNthCalledWith(2, "en-US");
+  });
+
+  test("stays ready across a later switch, so the survey shell does not blank", async () => {
+    const { result, rerender } = renderHook(({ locale }) => useAppLocale(locale), {
+      initialProps: { locale: "en-US" },
+    });
+
+    expect(result.current).toBe(true);
+
+    rerender({ locale: "fr-FR" });
+
+    expect(result.current).toBe(true);
+    await waitFor(() => {
+      expect(i18n.changeLanguage).toHaveBeenCalledWith("fr-FR");
+    });
+  });
+});

--- a/apps/web/modules/survey/link/hooks/use-app-locale.ts
+++ b/apps/web/modules/survey/link/hooks/use-app-locale.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Switches the app's i18n language for a link survey.
+ *
+ * The i18n instance is initialised once in the root layout from the Accept-Language locale, which is
+ * the right default for a respondent who asked for nothing. A link survey knows better: it also knows
+ * the language the respondent asked for, so every screen in the flow — the gates as much as the survey
+ * — re-points i18n at the locale resolved for it.
+ *
+ * @param locale The locale to translate in, already resolved by the caller
+ */
+export const useAppLocale = (locale: string): void => {
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    if (i18n.language === locale) return;
+    i18n.changeLanguage(locale).catch(() => {
+      // A locale with no bundle would otherwise leave the UI on the previous language mid-render.
+      i18n.changeLanguage("en-US");
+    });
+  }, [locale, i18n]);
+};

--- a/apps/web/modules/survey/link/hooks/use-app-locale.ts
+++ b/apps/web/modules/survey/link/hooks/use-app-locale.ts
@@ -1,26 +1,56 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 /**
- * Switches the app's i18n language for a link survey.
+ * Switches the app's i18n language for a link survey, and reports when that language is live.
  *
  * The i18n instance is initialised once in the root layout from the Accept-Language locale, which is
  * the right default for a respondent who asked for nothing. A link survey knows better: it also knows
  * the language the respondent asked for, so every screen in the flow — the gates as much as the survey
  * — re-points i18n at the locale resolved for it.
  *
+ * Re-pointing it is asynchronous (the locale bundle is fetched), so a caller whose whole surface is
+ * translated chrome — a gate screen — holds its first paint on the returned flag rather than painting
+ * once in the root locale and again in the resolved one. It starts `true` in the common case where
+ * i18n already sits on the requested locale, so nothing waits when the link asked for nothing.
+ *
+ * Once the first requested locale is live the flag stays `true`: a later switch (the in-survey
+ * language picker) re-points i18n without blanking the screen behind it.
+ *
  * @param locale The locale to translate in, already resolved by the caller
+ * @returns Whether a locale has been applied, so a gate screen can wait for it
  */
-export const useAppLocale = (locale: string): void => {
+export const useAppLocale = (locale: string): boolean => {
   const { i18n } = useTranslation();
+  const [isLocaleReady, setIsLocaleReady] = useState(() => i18n.language === locale);
 
   useEffect(() => {
-    if (i18n.language === locale) return;
-    i18n.changeLanguage(locale).catch(() => {
-      // A locale with no bundle would otherwise leave the UI on the previous language mid-render.
-      i18n.changeLanguage("en-US");
-    });
+    if (i18n.language === locale) {
+      setIsLocaleReady(true);
+      return;
+    }
+
+    let isCurrent = true;
+    const applyLocale = async () => {
+      try {
+        await i18n.changeLanguage(locale);
+      } catch {
+        // A locale with no bundle would otherwise leave the UI on the previous language mid-render.
+        await i18n.changeLanguage("en-US").catch(() => undefined);
+      } finally {
+        // Settled either way: a caller waiting on this must not be left with nothing to paint.
+        if (isCurrent) setIsLocaleReady(true);
+      }
+    };
+
+    void applyLocale();
+
+    return () => {
+      isCurrent = false;
+    };
   }, [locale, i18n]);
+
+  return isLocaleReady;
 };

--- a/apps/web/modules/survey/link/lib/language.test.ts
+++ b/apps/web/modules/survey/link/lib/language.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { TSurvey } from "@formbricks/types/surveys/types";
+import { resolveSurveyLanguageCode } from "./language";
+
+const language = (
+  code: string,
+  { alias = null as string | null, isDefault = false, enabled = true } = {}
+) => ({
+  language: {
+    id: `l-${code}`,
+    code,
+    alias,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    workspaceId: "p1",
+  },
+  default: isDefault,
+  enabled,
+});
+
+const surveyWith = (languages: ReturnType<typeof language>[]): TSurvey =>
+  ({ languages }) as unknown as TSurvey;
+
+const survey = surveyWith([
+  language("en-US", { isDefault: true }),
+  language("de-DE"),
+  language("pt-BR", { alias: "brasil" }),
+  language("fr-FR", { enabled: false }),
+]);
+
+describe("resolveSurveyLanguageCode", () => {
+  test("returns the survey's stored code for an enabled language", () => {
+    expect(resolveSurveyLanguageCode("de-DE", survey)).toBe("de-DE");
+    expect(resolveSurveyLanguageCode("de-de", survey)).toBe("de-DE");
+  });
+
+  test("resolves a legacy or bare code through its canonical tag", () => {
+    expect(resolveSurveyLanguageCode("de", survey)).toBe("de-DE");
+  });
+
+  test("resolves a custom alias", () => {
+    expect(resolveSurveyLanguageCode("brasil", survey)).toBe("pt-BR");
+  });
+
+  test("falls back to 'default' rather than erroring on a language the survey does not offer", () => {
+    expect(resolveSurveyLanguageCode("it-IT", survey)).toBe("default");
+    expect(resolveSurveyLanguageCode("not-a-language", survey)).toBe("default");
+    expect(resolveSurveyLanguageCode(undefined, survey)).toBe("default");
+  });
+
+  test("treats a disabled language, and the default language itself, as 'default'", () => {
+    expect(resolveSurveyLanguageCode("fr-FR", survey)).toBe("default");
+    expect(resolveSurveyLanguageCode("en-US", survey)).toBe("default");
+  });
+
+  test("prefers an exact code over another language's alias", () => {
+    // Without the precedence, the alias row could shadow the row whose code was asked for.
+    const shadowed = surveyWith([
+      language("en-US", { isDefault: true }),
+      language("sv-SE", { alias: "de-DE" }),
+      language("de-DE"),
+    ]);
+    expect(resolveSurveyLanguageCode("de-DE", shadowed)).toBe("de-DE");
+  });
+});

--- a/apps/web/modules/survey/link/lib/language.ts
+++ b/apps/web/modules/survey/link/lib/language.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { TSurvey } from "@formbricks/types/surveys/types";
 

--- a/apps/web/modules/survey/link/lib/language.ts
+++ b/apps/web/modules/survey/link/lib/language.ts
@@ -1,0 +1,42 @@
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
+import { TSurvey } from "@formbricks/types/surveys/types";
+
+/**
+ * Resolves a `?lang=` value to one of the survey's own language codes, or "default".
+ *
+ * Kept out of `link/lib/utils.ts` on purpose: the canonical language table this pulls in is large, and
+ * `utils.ts` is imported by the link survey's client components — a public, latency-sensitive page.
+ * Server callers only.
+ *
+ * @param langParam The raw `?lang=` value, or a code being fed back in from a client payload
+ * @returns The survey's stored language code, or "default" when the value names no enabled language
+ */
+export function resolveSurveyLanguageCode(langParam: string | undefined, survey: TSurvey): string {
+  if (!langParam) return "default";
+
+  // Match the URL `?lang=` value against the survey's languages in strict precedence so selection is
+  // deterministic regardless of array order: (1) an exact stored `code`, then (2) a custom `alias`, then
+  // (3) canonical equivalence. Code beats alias because an exact code always lines up with the survey's
+  // i18n content keys — without this, one row's alias could shadow another row's exact code. The canonical
+  // pass lets a shared link with a legacy code (`?lang=pt`) still resolve to a migrated language (`pt-BR`).
+  // Returns the survey's stored code so it lines up with its content keys.
+  const langParamLower = langParam.toLowerCase();
+  const langParamCanonical = normalizeLanguageCode(langParam);
+  const selectedLanguage =
+    survey.languages.find(
+      (surveyLanguage) => surveyLanguage.language.code.toLowerCase() === langParamLower
+    ) ??
+    survey.languages.find(
+      (surveyLanguage) => surveyLanguage.language.alias?.toLowerCase() === langParamLower
+    ) ??
+    (langParamCanonical
+      ? survey.languages.find(
+          (surveyLanguage) => normalizeLanguageCode(surveyLanguage.language.code) === langParamCanonical
+        )
+      : undefined);
+
+  if (!selectedLanguage || selectedLanguage?.default || !selectedLanguage?.enabled) {
+    return "default";
+  }
+  return selectedLanguage.language.code;
+}

--- a/apps/web/modules/survey/link/lib/utils.test.ts
+++ b/apps/web/modules/survey/link/lib/utils.test.ts
@@ -5,10 +5,12 @@ import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/survey
 import { TSurvey } from "@formbricks/types/surveys/types";
 import {
   getElementsFromSurveyBlocks,
+  getGateLocale,
   getSurveyLanguageTag,
   getWebAppLocale,
   isRTL,
   isRTLLanguage,
+  resolveWebAppLocale,
 } from "./utils";
 
 const createMockSurvey = (languages: TSurvey["languages"] = []): TSurvey =>
@@ -103,6 +105,85 @@ describe("getWebAppLocale", () => {
   test("matches base language code for variants", () => {
     expect(getWebAppLocale("pt-PT", createMockSurvey())).toBe("pt-PT");
     expect(getWebAppLocale("es-MX", createMockSurvey())).toBe("es-ES");
+  });
+});
+
+const createLanguage = (code: string, isDefault = false, enabled = true) => ({
+  language: {
+    id: `l-${code}`,
+    code,
+    alias: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    workspaceId: "p1",
+  },
+  default: isDefault,
+  enabled,
+});
+
+describe("resolveWebAppLocale", () => {
+  test("returns null instead of English when the app has no translation for the language", () => {
+    // A Hebrew survey must not drag the chrome to English — the caller keeps its own fallback.
+    expect(resolveWebAppLocale("he", createMockSurvey())).toBeNull();
+    expect(resolveWebAppLocale("xx", createMockSurvey())).toBeNull();
+    expect(resolveWebAppLocale("default", createMockSurvey())).toBeNull();
+  });
+
+  test("keeps a variant the app ships rather than collapsing to the base language", () => {
+    expect(resolveWebAppLocale("pt-PT", createMockSurvey())).toBe("pt-PT");
+    expect(resolveWebAppLocale("pt", createMockSurvey())).toBe("pt-BR");
+    expect(resolveWebAppLocale("pt-BR", createMockSurvey())).toBe("pt-BR");
+  });
+
+  test("distinguishes the Chinese scripts, which share a base code", () => {
+    expect(resolveWebAppLocale("zh-Hant", createMockSurvey())).toBe("zh-Hant-TW");
+    expect(resolveWebAppLocale("zh-Hans", createMockSurvey())).toBe("zh-Hans-CN");
+    expect(resolveWebAppLocale("zh", createMockSurvey())).toBe("zh-Hans-CN");
+  });
+
+  test("matches survey language codes regardless of case", () => {
+    expect(resolveWebAppLocale("DE-de", createMockSurvey())).toBe("de-DE");
+    expect(resolveWebAppLocale("zh-hant-tw", createMockSurvey())).toBe("zh-Hant-TW");
+  });
+
+  test("resolves 'default' through the survey's default language", () => {
+    expect(resolveWebAppLocale("default", createMockSurvey([createLanguage("de", true)]))).toBe("de-DE");
+  });
+});
+
+describe("getGateLocale", () => {
+  const survey = createMockSurvey([createLanguage("en", true), createLanguage("de")]);
+
+  test("uses the requested language, so the gate matches the survey behind it", () => {
+    expect(getGateLocale({ langParam: "de-DE", languageCode: "de", survey, fallbackLocale: "en-US" })).toBe(
+      "de-DE"
+    );
+  });
+
+  test("keeps the Accept-Language locale when the link requests no language", () => {
+    expect(
+      getGateLocale({ langParam: undefined, languageCode: "default", survey, fallbackLocale: "fr-FR" })
+    ).toBe("fr-FR");
+    // An empty `?lang=` is no request either.
+    expect(getGateLocale({ langParam: "", languageCode: "default", survey, fallbackLocale: "fr-FR" })).toBe(
+      "fr-FR"
+    );
+  });
+
+  test("keeps the Accept-Language locale when the requested language is not one the app speaks", () => {
+    // `?lang=` was given but resolves to a language with no app translation (Hebrew here): the
+    // respondent's own browser locale is a better guess than forcing English on them.
+    expect(getGateLocale({ langParam: "he", languageCode: "he", survey, fallbackLocale: "fr-FR" })).toBe(
+      "fr-FR"
+    );
+  });
+
+  test("follows the survey default for a language the survey has not enabled", () => {
+    // getLanguageCode resolves an unknown or disabled `?lang=` to "default", and the content will
+    // render in the survey's default language — so the gate reads that language, not the browser's.
+    expect(
+      getGateLocale({ langParam: "it-IT", languageCode: "default", survey, fallbackLocale: "fr-FR" })
+    ).toBe("en-US");
   });
 });
 

--- a/apps/web/modules/survey/link/lib/utils.ts
+++ b/apps/web/modules/survey/link/lib/utils.ts
@@ -2,6 +2,7 @@ import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { TUserLocale, ZUserLocale } from "@formbricks/types/user";
 
 export function isRTL(text: string): boolean {
   const rtlCharRegex = /[\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC]/;
@@ -70,56 +71,87 @@ export const getSurveyLanguageTag = (
 };
 
 /**
+ * Survey language codes that do not name a web app locale outright. Bare language codes pick the
+ * variant we ship ("pt" -> Brazilian Portuguese), and the Chinese script codes pick their region
+ * because "zh-Hant" shares its base code with "zh-Hans".
+ */
+const SURVEY_LANGUAGE_ALIASES: Record<string, TUserLocale> = {
+  en: "en-US",
+  de: "de-DE",
+  es: "es-ES",
+  fr: "fr-FR",
+  hu: "hu-HU",
+  ja: "ja-JP",
+  nl: "nl-NL",
+  pt: "pt-BR",
+  ro: "ro-RO",
+  ru: "ru-RU",
+  sv: "sv-SE",
+  tr: "tr-TR",
+  zh: "zh-Hans-CN",
+  "zh-hans": "zh-Hans-CN",
+  "zh-hant": "zh-Hant-TW",
+};
+
+/**
+ * Maps a survey language code to the web app locale its chrome should be translated in, or null when
+ * the app ships no translation for it (a Hebrew survey, say) so the caller can keep its own fallback
+ * rather than being forced to English.
+ *
+ * @param languageCode A survey language code, or "default" for the survey's default language
+ */
+export const resolveWebAppLocale = (languageCode: string, survey: TSurvey): TUserLocale | null => {
+  let codeToMap = languageCode;
+
+  if (languageCode === "default") {
+    const defaultLanguage = survey.languages?.find((lang) => lang.default);
+    if (!defaultLanguage) return null;
+    codeToMap = defaultLanguage.language.code;
+  }
+
+  const codeToMapLower = codeToMap.toLowerCase();
+
+  // An exact locale first, so a survey language that already names one ("pt-PT") keeps its variant
+  // instead of collapsing into the base language's default ("pt" -> "pt-BR").
+  const exactLocale = ZUserLocale.options.find((locale) => locale.toLowerCase() === codeToMapLower);
+  if (exactLocale) return exactLocale;
+
+  return (
+    SURVEY_LANGUAGE_ALIASES[codeToMapLower] ?? SURVEY_LANGUAGE_ALIASES[codeToMapLower.split("-")[0]] ?? null
+  );
+};
+
+/**
  * Maps survey language codes to web app locale codes.
  * Falls back to "en-US" if the language is not available in web app locales.
  */
-export const getWebAppLocale = (languageCode: string, survey: TSurvey): string => {
-  // Map of common 2-letter language codes to web app locale codes
-  const languageToLocaleMap: Record<string, string> = {
-    en: "en-US",
-    de: "de-DE",
-    pt: "pt-BR", // Default to Brazilian Portuguese
-    "pt-BR": "pt-BR",
-    "pt-PT": "pt-PT",
-    fr: "fr-FR",
-    hu: "hu-HU",
-    nl: "nl-NL",
-    zh: "zh-Hans-CN", // Default to Simplified Chinese
-    "zh-Hans": "zh-Hans-CN",
-    "zh-Hans-CN": "zh-Hans-CN",
-    "zh-Hant": "zh-Hant-TW",
-    "zh-Hant-TW": "zh-Hant-TW",
-    ro: "ro-RO",
-    ja: "ja-JP",
-    es: "es-ES",
-    sv: "sv-SE",
-    tr: "tr-TR",
-    ru: "ru-RU",
-  };
+export const getWebAppLocale = (languageCode: string, survey: TSurvey): string =>
+  resolveWebAppLocale(languageCode, survey) ?? "en-US";
 
-  let codeToMap = languageCode;
+interface GateLocaleParams {
+  /** The raw `?lang=` value, present only when the respondent asked for a language. */
+  langParam: string | undefined;
+  /** That value resolved against the survey's enabled languages, or "default". */
+  languageCode: string;
+  survey: TSurvey;
+  /** The locale negotiated from the Accept-Language header. */
+  fallbackLocale: TUserLocale;
+}
 
-  // If languageCode is "default", get the default language from survey
-  if (languageCode === "default") {
-    const defaultLanguage = survey.languages?.find((lang) => lang.default);
-    if (defaultLanguage) {
-      codeToMap = defaultLanguage.language.code;
-    } else {
-      return "en-US";
-    }
-  }
-
-  // Check if it's already a web app locale code
-  if (languageToLocaleMap[codeToMap]) {
-    return languageToLocaleMap[codeToMap];
-  }
-
-  // Try to find a match by base language code (e.g., "pt-BR" -> "pt")
-  const baseCode = codeToMap.split("-")[0].toLowerCase();
-  if (languageToLocaleMap[baseCode]) {
-    return languageToLocaleMap[baseCode];
-  }
-
-  // Fallback to English if language is not supported
-  return "en-US";
+/**
+ * The locale the gate screens in front of a survey (PIN entry, email verification) translate their own
+ * chrome in, and the one the verification email is written in.
+ *
+ * Precedence is deliberate and narrow: an explicit `?lang=` that resolves to a language we translate
+ * the app into wins, because that is the language the survey content itself will render in. Everything
+ * else — no `lang` at all, or one the app has no translation for — keeps the Accept-Language locale.
+ */
+export const getGateLocale = ({
+  langParam,
+  languageCode,
+  survey,
+  fallbackLocale,
+}: GateLocaleParams): TUserLocale => {
+  if (!langParam) return fallbackLocale;
+  return resolveWebAppLocale(languageCode, survey) ?? fallbackLocale;
 };

--- a/packages/types/email.ts
+++ b/packages/types/email.ts
@@ -8,7 +8,12 @@ export const ZLinkSurveyEmailData = z.object({
   suId: z.string().optional(),
   suToken: z.string().optional(),
   surveyName: z.string(),
+  // The language the email's own copy is rendered in.
   locale: ZUserLocale,
+  // The survey language the respondent arrived with, as stored on the survey (e.g. "de-DE"). Carried
+  // back into the emailed link as `?lang=` so passing the gate does not drop the requested language.
+  // Absent when the respondent made no explicit choice, so the link stays on the survey default.
+  surveyLanguageCode: z.string().optional(),
   logoUrl: ZStorageUrl.optional(),
 });
 


### PR DESCRIPTION
Fixes ENG-2584

## What & why

**Was:** A respondent opening `/s/<id>?lang=de-DE` met an English PIN screen, and the link in the verification email dropped `lang` — so passing the gate landed them back on the survey in its default language.

**Now:** Gate screens read in the language the link asked for, and the emailed link carries that language back alongside `verify` / `suId` / `suToken`. The verification email itself is written in it too.

- The gate locale is resolved once, server-side, beside the survey's content language, so a gate can no longer disagree with the survey behind it.
- An explicit `?lang=` wins; no param, or one the app has no translation for, keeps the Accept-Language locale.
- `pin-screen` had no language switch at all. It now shares one hook with the verify gate and the survey shell, and both gates hold their first paint until that locale is live.

## Where to look

- [`getGateLocale`](https://github.com/formbricks/formbricks/blob/83a7883/apps/web/modules/survey/link/lib/utils.ts#L143) — the whole precedence, in one place
- [`actions.ts`](https://github.com/formbricks/formbricks/blob/83a7883/apps/web/modules/survey/link/actions.ts#L33) — client-supplied language re-resolved before it reaches an emailed URL
- [`use-app-locale.ts`](https://github.com/formbricks/formbricks/blob/83a7883/apps/web/modules/survey/link/hooks/use-app-locale.ts) — the switch is async, so it reports readiness and settles on the fallback path too

## Breaking changes

- [ ] This PR contains breaking changes

None. One optional field added to an internal server-action payload, and one added `lang` on a link we generate ourselves; no external consumer reaches either.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm build --filter=@formbricks/web^... && (cd apps/web && pnpm exec vitest run modules/survey/link modules/email/lib/verified-link-survey-url.test.ts)`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| An explicit `?lang=` sets the gate locale; no param keeps Accept-Language | unit (mutation) | passed; `link/lib/utils.test.ts`, mutate `link/lib/utils.ts:155` |
| A `?lang=` the app ships no translation for keeps the browser locale, not English | unit (mutation) | passed; `link/lib/utils.test.ts`, mutate the `?? null` at `link/lib/utils.ts:120` |
| The emailed link carries `lang` beside `verify`/`suId`/`suToken` | unit (mutation) | passed; `verified-link-survey-url.test.ts`, mutate `verified-link-survey-url.ts:39` |
| A gate waits for its locale rather than painting in the browser's, and still paints if that locale has no bundle | unit (mutation) | passed; `hooks/use-app-locale.test.ts`, mutate `hooks/use-app-locale.ts:27` to `useState(true)` |
| A `?lang=` naming no enabled language still resolves to the survey default, so the gate matches the content | unit (guard) | passed; `link/lib/language.test.ts`, `link/lib/utils.test.ts` |
| `pt-PT` keeps its variant; `zh-Hant` does not collapse into `zh-Hans` | unit (guard) | passed; `link/lib/utils.test.ts` |

**Open gaps**

- No browser pass: this sandbox has neither Docker nor Postgres, so the German PIN screen, its wait for the locale bundle and the gate were not seen rendered, and there are no screenshots. Worth a look on staging with the survey from the ticket.
- The email was not sent end to end here — the link the respondent receives is covered at the builder, not through SMTP.

**Risks**

- The verification email now follows the requested language rather than Accept-Language. Intended, but it is a visible change for a respondent whose browser and `?lang=` disagree.
- A gate whose `?lang=` differs from the browser locale now shows nothing until that locale's bundle resolves, in place of a frame in the wrong language.
- `resolveWebAppLocale` returning null is a behaviour change for anything reading it through `getWebAppLocale`; that wrapper still pins `en-US`, so the survey shell is untouched.

---

> [!NOTE]
> **AI model used** — `unknown` (this session does not expose the serving model or effort level to the run), reasoning effort `unknown`.

<!-- claude-routine
ticket: ENG-2584
opened: 2026-09-07T06:44Z
last_run: 2026-09-08T06:06Z
runs: 6
ci_fixes: 0
review_rounds: 2
status: clean
-->


---
_Generated by [Claude Code](https://claude.ai/code)_