### PR TITLE
fix(analysis): label AI example responses with the survey's default language [ENG-2838]

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
@@ -630,6 +630,65 @@ describe("generateExampleResponseDataset", () => {
   });
 });
 
+describe("response language", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const withLanguages = (survey: TSurvey, languages: TSurvey["languages"]): TSurvey =>
+    ({ ...survey, languages }) as TSurvey;
+
+  const language = (code: string, isDefault: boolean, enabled = true) =>
+    ({ default: isDefault, enabled, language: { code } }) as unknown as TSurvey["languages"][number];
+
+  const generate = async (survey: TSurvey) => {
+    mockOpenTextAnswers(survey);
+    const result = await generateExampleResponseDataset({
+      survey,
+      organizationId: "org_1",
+      workspaceId: "workspace_1",
+      userId: "user_1",
+    });
+    return result.responses.map((response) => response.language);
+  };
+
+  const ratingSurvey = () =>
+    makeSurvey([
+      { ...baseQuestion, id: "q_rating", type: TSurveyElementTypeEnum.Rating, scale: "number", range: 5 },
+    ] as unknown as TSurvey["questions"]);
+
+  test("labels every response with a language the survey declares", async () => {
+    const survey = withLanguages(ratingSurvey(), [language("en-US", true), language("de-DE", false)]);
+
+    const languages = await generate(survey);
+
+    expect(languages).toHaveLength(EXAMPLE_RESPONSE_COUNT);
+    expect(languages.every((code) => code === "en-US" || code === "de-DE")).toBe(true);
+  });
+
+  test("uses the default language when it is the survey's only one", async () => {
+    const survey = withLanguages(ratingSurvey(), [language("ar-AE", true)]);
+
+    const languages = await generate(survey);
+
+    expect(new Set(languages)).toEqual(new Set(["ar-AE"]));
+  });
+
+  test("ignores a disabled language, falling back to the default", async () => {
+    const survey = withLanguages(ratingSurvey(), [language("en-US", true), language("fr-FR", false, false)]);
+
+    const languages = await generate(survey);
+
+    expect(new Set(languages)).toEqual(new Set(["en-US"]));
+  });
+
+  test("asserts no language for a survey that declares none", async () => {
+    const survey = withLanguages(ratingSurvey(), []);
+
+    const languages = await generate(survey);
+
+    expect(new Set(languages)).toEqual(new Set([null]));
+  });
+});
+
 describe("toExampleResponseInput", () => {
   const createdAt = new Date("2026-05-20T10:00:00Z");
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
@@ -524,13 +524,22 @@ const buildRespondentProfiles = (count: number): TExampleRespondentProfile[] =>
     (_, index) => RESPONDENT_PROFILE_PRESETS[index % RESPONDENT_PROFILE_PRESETS.length]
   );
 
-// Picks an enabled non-default survey language at random ~30% of the time;
-// otherwise leaves it null so the response uses the survey default. Mirrors a
-// real distribution where most respondents use the default language.
+// Picks an enabled non-default survey language ~30% of the time, otherwise the survey's default
+// language code. Mirrors a real distribution where most respondents answer in the default.
+//
+// The default's code rather than null: a real respondent's answer carries it too, because the
+// renderer resolves its "default" sentinel to that code before the response is created. Leaving
+// null here published the feedback record with no language, so generated responses landed in the
+// dashboard's "Not specified" bucket and skewed the Language breakdown (ENG-2838).
+//
+// A survey with no configured languages keeps returning null: it declares no language, so there is
+// no code to assert - the same rule the renderer applies.
 const pickResponseLanguage = (survey: TSurvey): string | null => {
-  const enabledNonDefault = (survey.languages ?? []).filter((l) => l.enabled && !l.default);
-  if (enabledNonDefault.length === 0) return null;
-  if (randomInt(10) >= 3) return null;
+  const languages = survey.languages ?? [];
+  const defaultCode = languages.find((l) => l.default)?.language.code ?? null;
+  const enabledNonDefault = languages.filter((l) => l.enabled && !l.default);
+
+  if (enabledNonDefault.length === 0 || randomInt(10) >= 3) return defaultCode;
   return pickFrom(enabledNonDefault).language.code;
 };
 


### PR DESCRIPTION
Fixes ENG-2838

## What & why

**Was:** AI-generated example responses were mostly stored with no language, so the dashboard's Language breakdown filed them under "Not specified" — sitting next to real responses, which always carry a code.

**Now:** They carry the survey's default language code, and the breakdown groups them under it.

- The generator picked an enabled non-default language ~30% of the time and returned `null` otherwise — always `null` when the survey had no non-default language.
- Real responses never hit this: the renderer resolves its `"default"` sentinel to the default code before the response is created.
- A survey that declares no languages still asserts none, matching the renderer.

## Where to look

- [`example-responses.ts` `pickResponseLanguage`](https://github.com/formbricks/formbricks/blob/dhruwang/eng-2838-example-response-language/apps/web/app/(app)/workspaces/%5BworkspaceId%5D/surveys/%5BsurveyId%5D/(analysis)/summary/lib/example-responses.ts#L526-L543) — the pick, and why the default's code replaces `null`

## Before

A generated response's feedback record, on a survey whose default language is `en-US`: the `Language` field is empty, which is what the dashboard reads as "Not specified".

<img width="373" height="192" alt="Screenshot 2026-09-07 at 4 00 22 PM" src="https://github.com/user-attachments/assets/c9bc2880-dc45-4109-902a-0e181a538611" />

## After

The same field on a record generated from this branch: `en-US`, the survey's default language, so it groups with the real responses instead of beside them.

<img width="439" height="128" alt="Screenshot 2026-09-07 at 4 06 20 PM" src="https://github.com/user-attachments/assets/74d89ab0-07d2-409c-91f3-5bb172543d38" />

## Breaking changes

- [ ] This PR contains breaking changes

None — this only fills in a field on newly generated example responses, which no external consumer reads.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter=@formbricks/web exec vitest run "app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts"`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Every generated response gets a language the survey declares (`en-US` default + `de-DE`) | unit (red on main) | Passes; fails on `main` |
| A survey with only a default language labels all of them with it (`ar-AE`) | unit (red on main) | Passes; fails on `main` |
| A disabled non-default language is never picked | unit (red on main) | Passes; fails on `main` |
| A survey declaring no languages still asserts none | unit (guard) | Passes |

`red on main`: `git stash push "apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts"` then rerun — 3 failed, 20 passed.

**Open gaps**

- Example responses generated before this keep their empty language: the column is `null`, so a Hub re-import copies that across. Clearing an existing chart needs the survey's example data regenerated, or a backfill of responses tagged `AI-generated example response`.
- Not exercised in a running app — generating examples needs an AI-entitled org and a survey with zero responses.

**Risks**

- A chart already grouped by language shifts: generated rows move out of "Not specified" into the survey's default code.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.

