### PR TITLE
fix(navigation): stop link prefetches from repointing the active workspace

### DIFF
--- a/apps/web/playwright/workspace-delete.spec.ts
+++ b/apps/web/playwright/workspace-delete.spec.ts
@@ -133,13 +133,11 @@ test("stays in the same organization when deleting a workspace as a member of mu
   // This lands on a /workspaces/:id path, so the proxy refreshes that cookie on its own — the spec
   // below covers the branch where it does not.
   await page.goto("/account/settings/profile", { waitUntil: "domcontentloaded" });
-  // `domcontentloaded` returns before the settings shell has resolved its organization, and this
-  // route compiles cold on CI, so the default 5s expect timeout is not enough under worker
-  // contention. The positive assertion has to settle first: it is what proves the sidebar rendered
-  // at all, and without it the `toHaveCount(0)` below would pass on an empty page.
+  // The positive assertion has to settle first: it is what proves the sidebar rendered at all, and
+  // without it the `toHaveCount(0)` below would pass on an empty page.
   await expect(
     page.locator(`a[href^="/organizations/${user.organizationId}/settings/"]`).first()
-  ).toBeVisible({ timeout: 30000 });
+  ).toBeVisible();
   await expect(page.locator(`a[href^="/organizations/${otherOrganization.id}/"]`)).toHaveCount(0);
 });
 
@@ -259,12 +257,10 @@ test("keeps the organization in account settings when the delete lands on the on
   // The cookie still named the workspace we just deleted until the delete action started repointing
   // it, which sent account settings to the *other* organization via the organizations[0] fallback.
   await page.goto("/account/settings/profile", { waitUntil: "domcontentloaded" });
-  // `domcontentloaded` returns before the settings shell has resolved its organization, and this
-  // route compiles cold on CI, so the default 5s expect timeout is not enough under worker
-  // contention. The positive assertion has to settle first: it is what proves the sidebar rendered
-  // at all, and without it the `toHaveCount(0)` below would pass on an empty page.
+  // The positive assertion has to settle first: it is what proves the sidebar rendered at all, and
+  // without it the `toHaveCount(0)` below would pass on an empty page.
   await expect(
     page.locator(`a[href^="/organizations/${user.organizationId}/settings/"]`).first()
-  ).toBeVisible({ timeout: 30000 });
+  ).toBeVisible();
   await expect(page.locator(`a[href^="/organizations/${otherOrganization.id}/"]`)).toHaveCount(0);
 });

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -152,6 +152,41 @@ describe("proxy", () => {
     expect(response.cookies.get("formbricks-workspace-id")?.value).toBe("ws-456");
   });
 
+  test.each([
+    ["next-router-prefetch"],
+    ["next-router-segment-prefetch"],
+    ["next-instant-navigation-testing-prefetch"],
+  ])("leaves the active-workspace cookie alone on a %s request", async (prefetchHeader) => {
+    mockGetProxySession.mockResolvedValue(null);
+
+    // The router keeps prefetching the links of a tree it rendered earlier, so after a workspace is
+    // deleted it still prefetches that workspace's links. Honouring one would overwrite the
+    // surviving workspace the delete action stored with a workspace that no longer exists.
+    const request = new NextRequest("http://localhost:3000/workspaces/ws-deleted/settings/workspace/tags", {
+      headers: { [prefetchHeader]: "1" },
+    });
+    request.cookies.set("formbricks-workspace-id", "ws-surviving");
+
+    const response = await proxy(request);
+
+    expect(response.cookies.get("formbricks-workspace-id")).toBeUndefined();
+  });
+
+  test("still sets the active-workspace cookie on a client-side navigation to a workspace", async () => {
+    mockGetProxySession.mockResolvedValue(null);
+
+    // A soft navigation is an RSC request too; only the prefetch headers separate it from a
+    // prefetch, so excluding prefetches must not stop the cookie from following a real route change.
+    const request = new NextRequest("http://localhost:3000/workspaces/ws-456/surveys", {
+      headers: { rsc: "1", "next-router-state-tree": "%5B%22%22%5D" },
+    });
+    request.cookies.set("formbricks-workspace-id", "ws-123");
+
+    const response = await proxy(request);
+
+    expect(response.cookies.get("formbricks-workspace-id")?.value).toBe("ws-456");
+  });
+
   test("overwrites a caller-supplied private IP header with the canonical trusted hop", async () => {
     mockGetProxySession.mockResolvedValue(null);
     const request = new NextRequest("http://localhost:3000/api/auth/sign-in/email", {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -59,6 +59,20 @@ const handleDomainAwareRouting = (request: NextRequest): NextResponse | null => 
   }
 };
 
+/**
+ * Request headers Next.js sets only on prefetches (`next/dist/client/components/app-router-headers`).
+ * A prefetch is speculative — the router issues one for every link it has rendered, whether or not
+ * the user ever opens it — so it must never be read as "the user is here now".
+ */
+const NEXT_PREFETCH_HEADERS = [
+  "next-router-prefetch",
+  "next-router-segment-prefetch",
+  "next-instant-navigation-testing-prefetch",
+] as const;
+
+const isPrefetchRequest = (request: NextRequest): boolean =>
+  NEXT_PREFETCH_HEADERS.some((header) => request.headers.has(header));
+
 export const proxy = async (originalRequest: NextRequest) => {
   // Handle domain-aware routing first
   const domainResponse = handleDomainAwareRouting(originalRequest);
@@ -97,9 +111,17 @@ export const proxy = async (originalRequest: NextRequest) => {
   // Only set the cookie when the value actually changes: a Set-Cookie on a server-action POST makes
   // Next.js treat the action as revalidated, forcing a router refresh after every action — on pages
   // that call an action on mount this becomes an infinite POST/refresh loop.
+  //
+  // Prefetches are excluded because they are not visits. The router re-prefetches the links of a
+  // tree it rendered earlier, so after deleting a workspace it still prefetches that workspace's
+  // now-stale links — and letting one write this cookie overwrote the surviving workspace the
+  // delete action had just stored, pointing it at a workspace that no longer exists. The
+  // org-settings shell then cannot trust the cookie and falls back to `organizations[0]`, dropping
+  // a member of several organizations into an unrelated one.
   const workspaceMatch = /^\/workspaces\/([^/]+)/.exec(request.nextUrl.pathname);
   if (
     workspaceMatch?.[1] &&
+    !isPrefetchRequest(request) &&
     request.cookies.get(FORMBRICKS_WORKSPACE_ID_COOKIE)?.value !== workspaceMatch[1]
   ) {
     nextResponseWithCustomHeader.cookies.set(FORMBRICKS_WORKSPACE_ID_COOKIE, workspaceMatch[1], {


### PR DESCRIPTION
<!-- No ticket: unticketed CI flake, found while triaging the E2E failure on #9100. -->

## What & why

**Was:** Deleting a workspace could land a member of several organizations in an unrelated organization — account settings rendered the wrong organization's sidebar, banners and billing links.

**Now:** Only real navigations move the active-workspace cookie, so account settings stays in the organization you deleted from.

The delete action repoints the cookie at a surviving workspace. But `proxy.ts` treated *any* `/workspaces/:id` request as a visit, and Next.js re-prefetches the links of a tree it rendered earlier — including the deleted workspace's links. A stale prefetch overwrote the cookie with a workspace that no longer exists, so the org-settings shell could not trust it and fell back to `organizations[0]`.

<details>
<summary>How the cookie flipped, from the failing run's Playwright trace</summary>

| Time | Request | `formbricks-workspace-id` |
| --- | --- | --- |
| 21:21:48.963 | delete action `POST` | **sets** `cmthqua4f…` (surviving workspace) |
| 21:21:49.486 | prefetch of `/workspaces/cmthqua3e…/settings/workspace/user-actions` — the **deleted** workspace | **overwrites** back to `cmthqua3e…` |
| 21:21:49.580 | `goto /account/settings/profile` | sends the deleted id → falls back to `organizations[0]` |

The clobbering requests carry `next-router-prefetch: 1`; real navigations send only `rsc` + `next-router-state-tree` (`next/dist/client/components/router-reducer/fetch-server-response.js`). No PPR here, so a navigation always re-requests and still updates the cookie.

</details>

## Where to look

- [proxy.ts:124](apps/web/proxy.ts#L124) — prefetch guard on the cookie write
- [proxy.test.ts:155](apps/web/proxy.test.ts#L155) — prefetch vs. navigation
- [workspace-delete.spec.ts:257](apps/web/playwright/workspace-delete.spec.ts#L257) — 30s timeout reverted

## Breaking changes

- [ ] This PR contains breaking changes

None — internal proxy behaviour. No API, SDK, route, env or config surface changes, and no upgrade action.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && node ../../node_modules/.bin/vitest run proxy.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| A prefetch of a deleted workspace leaves the cookie alone | unit (red on main) | Cookie keeps the surviving workspace, for all three prefetch headers |
| A client-side navigation still repoints the cookie | unit (guard) | `ws-123` → `ws-456` on an `rsc` request with no prefetch header |
| Deleting a workspace keeps account settings in that organization | e2e | `workspace-delete.spec.ts:187` green on the restored 5s timeout; 116 passed, 0 flaky |

**Open gaps**

- E2E ran only in CI: port 3000 and the Postgres/SpiceDB stack belong to another worktree.
- One green run does not disprove an intermittent fault; the unit rows pin the mechanism.

**Risks**

- If a workspace page ever became fully static, its navigation would stop refreshing the cookie.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (not exposed in this non-interactive session).
