### PR TITLE
fix(analysis): rename the Dashboards tab to Overview

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -223,7 +223,7 @@ checksums:
     common/customer_success: 9b8100f7cc9078702012617237f5b884
     common/dark_overlay: 173e84b526414dbc70dbf9737e443b60
     common/dashboard: c9380ea68c8c76ea451bd9613329a07c
-    common/dashboards: 4bc47e48559a6b688684dcb7ac4babc9
+    common/dashboards: 30c54e4dc4ce599b87d94be34a8617f5
     common/data_refreshed_successfully: 85728c61a9e1a16e46af69ddf0dbcda6
     common/date: 56f41c5d30a76295bb087b20b7bee4c3
     common/days: c95fe8aedde21a0b5653dbd0b3c58b48

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -252,7 +252,7 @@
     "customer_success": "Kundenerlebnis",
     "dark_overlay": "Dunkle Überlagerung",
     "dashboard": "Dashboard",
-    "dashboards": "Dashboards",
+    "dashboards": "Übersicht",
     "data_refreshed_successfully": "Daten erfolgreich aktualisiert",
     "date": "Datum",
     "days": "Tage",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -252,7 +252,7 @@
     "customer_success": "Customer Experience",
     "dark_overlay": "Dark overlay",
     "dashboard": "Dashboard",
-    "dashboards": "Dashboards",
+    "dashboards": "Overview",
     "data_refreshed_successfully": "Data refreshed successfully",
     "date": "Date",
     "days": "days",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -252,7 +252,7 @@
     "customer_success": "Experiencia del cliente",
     "dark_overlay": "Superposición oscura",
     "dashboard": "Panel de control",
-    "dashboards": "Paneles",
+    "dashboards": "Resumen",
     "data_refreshed_successfully": "Datos actualizados correctamente",
     "date": "Fecha",
     "days": "días",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -252,7 +252,7 @@
     "customer_success": "Expérience client",
     "dark_overlay": "Foncée",
     "dashboard": "Tableau de bord",
-    "dashboards": "Tableaux de bord",
+    "dashboards": "Vue d'ensemble",
     "data_refreshed_successfully": "Données actualisées avec succès",
     "date": "Date",
     "days": "jours",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -252,7 +252,7 @@
     "customer_success": "Ügyfélélmény",
     "dark_overlay": "Sötét rávetítés",
     "dashboard": "Vezérlőpult",
-    "dashboards": "Vezérlőpultok",
+    "dashboards": "Áttekintés",
     "data_refreshed_successfully": "Az adatok sikeresen frissítve",
     "date": "Dátum",
     "days": "nap",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -252,7 +252,7 @@
     "customer_success": "カスタマーエクスペリエンス",
     "dark_overlay": "暗いオーバーレイ",
     "dashboard": "ダッシュボード",
-    "dashboards": "ダッシュボード",
+    "dashboards": "概要",
     "data_refreshed_successfully": "データが正常に更新されました",
     "date": "日付",
     "days": "日",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -252,7 +252,7 @@
     "customer_success": "Klantervaring",
     "dark_overlay": "Donkere overlay",
     "dashboard": "Dashboard",
-    "dashboards": "Dashboards",
+    "dashboards": "Overzicht",
     "data_refreshed_successfully": "Gegevens succesvol vernieuwd",
     "date": "Datum",
     "days": "dagen",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -252,7 +252,7 @@
     "customer_success": "Experiência do Cliente",
     "dark_overlay": "sobreposição escura",
     "dashboard": "Painel",
-    "dashboards": "Painéis",
+    "dashboards": "Visão Geral",
     "data_refreshed_successfully": "Dados atualizados com sucesso",
     "date": "Encontro",
     "days": "dias",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -252,7 +252,7 @@
     "customer_success": "Experiência do Cliente",
     "dark_overlay": "Sobreposição escura",
     "dashboard": "Painel",
-    "dashboards": "Dashboards",
+    "dashboards": "Visão Geral",
     "data_refreshed_successfully": "Dados atualizados com sucesso",
     "date": "Data",
     "days": "dias",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -252,7 +252,7 @@
     "customer_success": "Experiența Clienților",
     "dark_overlay": "Suprapunere întunecată",
     "dashboard": "Tablou de bord",
-    "dashboards": "Tablouri de bord",
+    "dashboards": "Prezentare generală",
     "data_refreshed_successfully": "Datele au fost actualizate cu succes",
     "date": "Dată",
     "days": "zile",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -252,7 +252,7 @@
     "customer_success": "Клиентский опыт",
     "dark_overlay": "Тёмный оверлей",
     "dashboard": "Панель управления",
-    "dashboards": "Дашборды",
+    "dashboards": "Обзор",
     "data_refreshed_successfully": "Данные успешно обновлены",
     "date": "Дата",
     "days": "дни",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -252,7 +252,7 @@
     "customer_success": "Kundupplevelse",
     "dark_overlay": "Mörkt överlägg",
     "dashboard": "Instrumentpanel",
-    "dashboards": "Instrumentpaneler",
+    "dashboards": "Översikt",
     "data_refreshed_successfully": "Data uppdaterades",
     "date": "Datum",
     "days": "dagar",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -252,7 +252,7 @@
     "customer_success": "Müşteri Deneyimi",
     "dark_overlay": "Koyu kaplama",
     "dashboard": "Pano",
-    "dashboards": "Panolar",
+    "dashboards": "Genel Bakış",
     "data_refreshed_successfully": "Veriler başarıyla yenilendi",
     "date": "Tarih",
     "days": "gün",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -252,7 +252,7 @@
     "customer_success": "客户体验",
     "dark_overlay": "深色遮罩层",
     "dashboard": "Dashboard",
-    "dashboards": "仪表盘",
+    "dashboards": "概览",
     "data_refreshed_successfully": "数据刷新成功",
     "date": "日期",
     "days": "天",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -252,7 +252,7 @@
     "customer_success": "客戶體驗",
     "dark_overlay": "深色覆蓋",
     "dashboard": "儀表板",
-    "dashboards": "儀表板",
+    "dashboards": "總覽",
     "data_refreshed_successfully": "資料已成功重新整理",
     "date": "日期",
     "days": "天",


### PR DESCRIPTION
No ticket — asked for directly in chat as a follow-up to the ANALYZE nav rename (ENG-2742, shipped).

## What & why

**Was:** The section header read "Analysis" while its first tab still read "Dashboards", repeating the noun the sidebar had already dropped.

**Now:** That tab reads "Overview", so the pair under "Analysis" is Overview | Charts.

Only the `common.dashboards` string value changed. Nothing was renamed in code: the key, the `/dashboards` route and the separate `common.dashboard` string used inside the feature are untouched.

## Where to look

- [en-US.json:255](apps/web/locales/en-US.json#L255) — the one hand-edited line; every other locale is Lingo output.

## Breaking changes

- [ ] This PR contains breaking changes

None — a UI label in a locale file. No API or SDK shape, route, env var or config key moves, and no upgrade action.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm i18n`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Tab renders "Overview" next to "Charts" under the "Analysis" header | manual | Real `SecondaryNavigation` + `PageHeader` rendered off this branch; before/after below |
| The 15 non-English locales carry a translated value, not the English one | manual | e.g. de `Übersicht`, fr `Vue d'ensemble`, ja `概要` |
| No key drift from the rename | manual | `pnpm i18n` validation: 0 missing, 0 unused, all locales complete |

**Before**

![before](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/analysis-overview-tab/before.png)

**After**

![after](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/analysis-overview-tab/after.png)

<details>
<summary>How the shots were taken</summary>

Not a live capture — the Analysis page needs a seeded tenant and an enterprise licence, neither reachable from this worktree. Instead the real `PageHeader` and `SecondaryNavigation` components were mounted in a throwaway Vite harness with `apps/web/modules/ui/globals.css`, fed the `common.*` strings straight out of `en-US.json` at `HEAD~1` (before) and `HEAD` (after), and shot with Playwright. The harness is deleted; the assets branch is deletable once this merges.

</details>

**Open gaps**

- Not seen in the running app; the label is the only difference, so the render carries it.
- Dashboards has no Playwright spec to extend (ENG-2314).

**Risks**

- The key `common.dashboards` now reads "Overview". It has exactly one call site, so the mismatch is cosmetic, but it will look odd to the next person who greps for it.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.
