### PR TITLE
fix(surveys): style the scroll indicator as the primary action [ENG-1783]

### DIFF
--- a/packages/survey-ui/src/styles/globals.css
+++ b/packages/survey-ui/src/styles/globals.css
@@ -160,8 +160,8 @@
   /* ── Page backdrop ─────────────────────────────────────────────────── */
   /* The gray the link-survey shell paints behind the widget when no survey
      background is configured (MediaBackground's default, slate-200). The
-     cardless layout blends its scroll fades and scroll-to-bottom button into
-     it; the shell can override this token if its default ever changes. */
+     cardless layout blends its scroll fades into it; the shell can override
+     this token if its default ever changes. */
   --fb-page-bg-color: #e2e8f0;
 }
 

--- a/packages/surveys/src/components/buttons/scroll-to-bottom-button.tsx
+++ b/packages/surveys/src/components/buttons/scroll-to-bottom-button.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from "react-i18next";
+import { ChevronDownIcon } from "@/components/icons/chevron-down-icon";
+import { cn } from "@/lib/utils";
+
+interface ScrollToBottomButtonProps {
+  onClick: () => void;
+  className?: string;
+}
+
+/**
+ * The floating affordance that scrolls an overflowing card to its end.
+ *
+ * While it is visible the submit button is below the fold, so this *is* the primary next action
+ * (ENG-1783) — hence it borrows the primary button's themed colors (`--fb-button-bg-color` /
+ * `--fb-button-text-color`) instead of blending into the card or page background. It deliberately
+ * does not use the `.button-custom` class: that class also applies the button height, radius and
+ * padding a survey may have customised, which would stretch this circle out of shape.
+ */
+export function ScrollToBottomButton({ onClick, className }: Readonly<ScrollToBottomButtonProps>) {
+  const { t } = useTranslation();
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        transform: "translateX(-50%)",
+        backgroundColor: "var(--fb-button-bg-color)",
+        color: "var(--fb-button-text-color)",
+      }}
+      className={cn(
+        "border-submit-button-border focus:ring-focus absolute bottom-2 left-1/2 z-20 flex h-11 w-11 items-center justify-center rounded-full border shadow-md transition-opacity hover:opacity-90 focus:ring-2 focus:ring-offset-2 focus:outline-hidden",
+        className
+      )}
+      aria-label={t("common.scroll_to_bottom")}>
+      <ChevronDownIcon className="h-5 w-5" />
+    </button>
+  );
+}

--- a/packages/surveys/src/components/wrappers/cardless-survey-layout.tsx
+++ b/packages/surveys/src/components/wrappers/cardless-survey-layout.tsx
@@ -1,11 +1,10 @@
 import { type JSX } from "preact";
 import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
-import { useTranslation } from "react-i18next";
 import { type TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TSurveyStyling } from "@formbricks/types/surveys/types";
 import { TWorkspaceStyling } from "@formbricks/types/workspace";
+import { ScrollToBottomButton } from "@/components/buttons/scroll-to-bottom-button";
 import { ProgressBar } from "@/components/general/progress-bar";
-import { ChevronDownIcon } from "@/components/icons/chevron-down-icon";
 import { cn } from "@/lib/utils";
 
 interface CardlessSurveyLayoutProps {
@@ -32,7 +31,6 @@ export function CardlessSurveyLayout({
   showCardlessPreviewLogoSlot,
   linkSurveyCardMaxWidth,
 }: Readonly<CardlessSurveyLayoutProps>) {
-  const { t } = useTranslation();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isScrollAtTop, setIsScrollAtTop] = useState(true);
   const [isScrollAtBottom, setIsScrollAtBottom] = useState(false);
@@ -120,7 +118,7 @@ export function CardlessSurveyLayout({
           <div
             className={cn(
               // Extra bottom padding keeps the last card clear of the floating scroll-to-bottom button.
-              "mx-auto flex w-full flex-col items-center px-4 pb-12 sm:px-6",
+              "mx-auto flex w-full flex-col items-center px-4 pb-14 sm:px-6",
               showCardlessPreviewLogoSlot ? "pt-6" : "pt-10 sm:pt-12"
             )}
             style={cardMaxWidthStyle}>
@@ -135,20 +133,7 @@ export function CardlessSurveyLayout({
                 style={{ background: `linear-gradient(to top, ${fadeColor}, transparent)` }}
               />
             )}
-            <button
-              type="button"
-              onClick={scrollToBottom}
-              style={{
-                transform: "translateX(-50%)",
-                ...(isSolidColorBackground ? { backgroundColor: fadeColor } : undefined),
-              }}
-              className={cn(
-                "hover:border-border focus:ring-brand absolute bottom-2 left-1/2 z-20 flex h-8 w-8 items-center justify-center rounded-full border border-transparent shadow-lg transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-hidden",
-                !isSolidColorBackground && "bg-survey-bg/90 backdrop-blur-sm"
-              )}
-              aria-label={t("common.scroll_to_bottom")}>
-              <ChevronDownIcon className="text-heading h-5 w-5" />
-            </button>
+            <ScrollToBottomButton onClick={scrollToBottom} />
           </>
         )}
       </div>

--- a/packages/surveys/src/components/wrappers/scrollable-container.tsx
+++ b/packages/surveys/src/components/wrappers/scrollable-container.tsx
@@ -1,7 +1,7 @@
 import type { JSX, Ref } from "preact";
 import { forwardRef } from "preact/compat";
 import { useEffect, useImperativeHandle, useRef, useState } from "preact/hooks";
-import { ChevronDownIcon } from "@/components/icons/chevron-down-icon";
+import { ScrollToBottomButton } from "@/components/buttons/scroll-to-bottom-button";
 import { cn } from "@/lib/utils";
 
 interface ScrollableContainerProps {
@@ -94,14 +94,7 @@ export const ScrollableContainer = forwardRef<ScrollableContainerHandle, Scrolla
         {!disableInternalScroll && !isAtBottom && (
           <>
             <div className="from-survey-bg absolute right-4 bottom-0 left-4 h-4 bg-linear-to-t to-transparent" />
-            <button
-              type="button"
-              onClick={scrollToBottom}
-              style={{ transform: "translateX(-50%)" }}
-              className="bg-survey-bg hover:border-border focus:ring-brand absolute bottom-2 left-1/2 z-20 flex h-8 w-8 items-center justify-center rounded-full border border-transparent shadow-lg transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
-              aria-label="Scroll to bottom">
-              <ChevronDownIcon className="text-heading h-5 w-5" />
-            </button>
+            <ScrollToBottomButton onClick={scrollToBottom} />
           </>
         )}
       </div>


### PR DESCRIPTION
Fixes ENG-1783

## What & why

**Was:** while a survey card overflowed, the scroll-to-bottom indicator was a 32px neutral circle that blended into the card (or, in cardless surveys, into the page background) — respondents missed it and stalled.

**Now:** the indicator carries the primary button's themed colors and is 44px, so it reads as the primary next action, then hands off to the real submit button once you reach the end.

- While the indicator is visible the submit button is below the fold, so it *is* the primary action.
- 44px also clears the runtime's 44pt touch-target minimum; the old 32px did not.
- Both indicators (in-card and cardless) now share one component; the in-card one gains the translated `aria-label` the cardless one already had.

## Where to look

- [scroll-to-bottom-button.tsx](packages/surveys/src/components/buttons/scroll-to-bottom-button.tsx) — why it takes the button vars but not `.button-custom`
- [cardless-survey-layout.tsx:118](packages/surveys/src/components/wrappers/cardless-survey-layout.tsx#L118) — bottom padding raised for the taller button

## Before
<img width="636" height="542" alt="Screenshot 2026-09-08 at 11 30 27 AM" src="https://github.com/user-attachments/assets/51b9d0fb-4fef-4578-a42a-4e51dd327fb8" />


## After
<img width="636" height="542" alt="Screenshot 2026-09-08 at 11 29 49 AM" src="https://github.com/user-attachments/assets/7eb4a63d-1955-4fff-8ecc-22e686c924e7" />


## Breaking changes

- [ ] This PR contains breaking changes

None — the changed components are internal to `packages/surveys`, and no exported signature moves.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm turbo run typecheck lint test --filter=@formbricks/surveys --filter=@formbricks/survey-ui`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Indicator uses the survey's button colors | manual | Computed `bg rgb(190,18,60)` / `color #fff` — identical to the `Finish` button under `buttonBgColor #be123c` |
| Indicator is 44×44 and circular under a custom theme | manual | 44px × 44px, fully rounded, unaffected by custom button height/radius/padding |
| Clicking it scrolls to the end and reveals the submit button | manual | Card scrolled to bottom, indicator hid, `Finish` appeared in the same crimson |
| Existing surveys suite still green | unit (guard) | 733 tests in `packages/surveys`, 113 in `survey-ui` |

<details>
<summary>How the manual rows were driven</summary>

The three manual rows were checked against the freshly built UMD bundle (`apps/web/public/js/surveys.umd.cjs`) rendered inline via `formbricksSurveys.renderSurvey`, with an open-text card whose subheader overflows the card, under `styling.buttonBgColor = #be123c`. Colors and box metrics were read off `getComputedStyle` rather than eyeballed. The before/after image above is the same harness against a bundle built from this branch's base commit.

</details>

**Open gaps**

- Not checked against a media/image survey background: that path previously used `bg-survey-bg/90 backdrop-blur-sm` and now gets the solid brand color, which should only improve contrast.
- Cardless layout verified by reading the shared component, not rendered on its own — it renders the same button as the in-card path.

**Risks**

- A survey whose brand button color is close to its card background makes the indicator quieter again; it is still bordered and shadowed.
- The 44px button overlaps 12px more content than the old 32px one; cardless bottom padding was raised to match, the in-card path floats over scrollable content as before.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.
