### PR TITLE
fix(editor): seed the note when an ending card switches back to "Ending card" [ENG-2595]

### DIFF
--- a/apps/web/modules/survey/editor/components/edit-ending-card.tsx
+++ b/apps/web/modules/survey/editor/components/edit-ending-card.tsx
@@ -13,10 +13,12 @@ import { TSurvey, TSurveyEndScreenCard, TSurveyRedirectUrlCard } from "@formbric
 import { getTextContent } from "@formbricks/types/surveys/validation";
 import { TUserLocale } from "@formbricks/types/user";
 import { cn } from "@/lib/cn";
+import { extractLanguageCodes } from "@/lib/i18n/utils";
 import { recallToHeadline } from "@/lib/utils/recall";
 import { EditorCardMenu } from "@/modules/survey/editor/components/editor-card-menu";
 import { EndScreenForm } from "@/modules/survey/editor/components/end-screen-form";
 import { RedirectUrlForm } from "@/modules/survey/editor/components/redirect-url-form";
+import { getEndingCardTypeChangePatch } from "@/modules/survey/editor/lib/ending-card";
 import {
   findEndingCardUsedInLogic,
   formatTextWithSlashes,
@@ -282,11 +284,13 @@ export const EditEndingCard = ({
               handleOptionChange={(newType) => {
                 const selectedOption = endingCardTypes.find((option) => option.value === newType);
                 if (!selectedOption?.disabled) {
-                  if (newType === "redirectToUrl") {
-                    updateSurvey({ type: "redirectToUrl" });
-                  } else {
-                    updateSurvey({ type: "endScreen" });
-                  }
+                  updateSurvey(
+                    getEndingCardTypeChangePatch(
+                      endingCard,
+                      newType === "redirectToUrl" ? "redirectToUrl" : "endScreen",
+                      extractLanguageCodes(localSurvey.languages)
+                    )
+                  );
                 }
               }}
             />

--- a/apps/web/modules/survey/editor/lib/ending-card.test.ts
+++ b/apps/web/modules/survey/editor/lib/ending-card.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { TSurveyEnding } from "@formbricks/types/surveys/types";
+import { getEndingCardTypeChangePatch } from "./ending-card";
+
+const redirectCard: TSurveyEnding = {
+  id: "ending1",
+  type: "redirectToUrl",
+  url: "https://example.com",
+  label: "Go",
+};
+
+const endScreenCard: TSurveyEnding = {
+  id: "ending1",
+  type: "endScreen",
+  headline: { default: "Thanks!" },
+};
+
+describe("getEndingCardTypeChangePatch", () => {
+  test("seeds an empty headline when a persisted redirect card switches back to endScreen", () => {
+    const patch = getEndingCardTypeChangePatch(redirectCard, "endScreen", ["default"]);
+
+    expect(patch).toEqual({ type: "endScreen", headline: { default: "" } });
+  });
+
+  test("seeds the headline for every survey language", () => {
+    const patch = getEndingCardTypeChangePatch(redirectCard, "endScreen", ["default", "de"]);
+
+    expect(patch).toEqual({ type: "endScreen", headline: { default: "", de: "" } });
+  });
+
+  test("keeps an existing headline instead of blanking it", () => {
+    const patch = getEndingCardTypeChangePatch(endScreenCard, "endScreen", ["default"]);
+
+    expect(patch).toEqual({ type: "endScreen" });
+  });
+
+  test("keeps the headline a round trip without a save left on the card", () => {
+    // The type switch patches only `type`, so an unsaved endScreen -> redirect -> endScreen round
+    // trip reaches this call as a redirect card that still carries its original headline.
+    const unsavedRoundTrip = { ...redirectCard, headline: { default: "Thanks!" } } as TSurveyEnding;
+
+    expect(getEndingCardTypeChangePatch(unsavedRoundTrip, "endScreen", ["default"])).toEqual({
+      type: "endScreen",
+    });
+  });
+
+  test("seeds a headline when the card has an empty one", () => {
+    const patch = getEndingCardTypeChangePatch({ ...endScreenCard, headline: undefined }, "endScreen", [
+      "default",
+    ]);
+
+    expect(patch).toEqual({ type: "endScreen", headline: { default: "" } });
+  });
+
+  test("switching to redirectToUrl only changes the type", () => {
+    expect(getEndingCardTypeChangePatch(endScreenCard, "redirectToUrl", ["default"])).toEqual({
+      type: "redirectToUrl",
+    });
+  });
+});

--- a/apps/web/modules/survey/editor/lib/ending-card.ts
+++ b/apps/web/modules/survey/editor/lib/ending-card.ts
@@ -1,0 +1,30 @@
+import { TSurveyEndScreenCard, TSurveyEnding, TSurveyRedirectUrlCard } from "@formbricks/types/surveys/types";
+import { createI18nString } from "@/lib/i18n/utils";
+
+/**
+ * The patch to merge into an ending card when its type switch changes the card's type.
+ *
+ * Saving a card as "redirectToUrl" runs it through `ZSurveyRedirectUrlCard`, which strips every
+ * endScreen-only field — so once the survey has been persisted, the card carries no `headline` key
+ * at all. Switching it back to "endScreen" has to seed one, because the note editor drops keystrokes
+ * for a field the card does not already carry: the field looks filled while `localSurvey` never
+ * receives the text, and saving then rejects the note as missing.
+ */
+export const getEndingCardTypeChangePatch = (
+  ending: TSurveyEnding,
+  newType: TSurveyEnding["type"],
+  languageCodes: string[]
+): Partial<TSurveyEndScreenCard> | Partial<TSurveyRedirectUrlCard> => {
+  if (newType === "redirectToUrl") {
+    return { type: "redirectToUrl" };
+  }
+
+  // Switching type only patches `type`, so a card switched back and forth without an intervening
+  // save still carries the headline it started with — keep that rather than blanking it. Hence the
+  // `in` check: the card reads as a redirect card here, but may still hold the field.
+  if ("headline" in ending && ending.headline) {
+    return { type: "endScreen" };
+  }
+
+  return { type: "endScreen", headline: createI18nString("", languageCodes) };
+};


### PR DESCRIPTION
Fixes ENG-2595

## What & why

**Was:** After a survey was saved with a "Redirect to URL" ending, switching that card back to "Ending card" and typing a note left the field looking filled, but saving refused: note missing.

**Now:** The note is accepted and the survey saves. Saving a redirect ending strips the `headline` key, and the editor drops keystrokes for a field the card lacks.

## Where to look

- [ending-card.ts](apps/web/modules/survey/editor/lib/ending-card.ts) — the patch and the `in` check
- [edit-ending-card.tsx:284](apps/web/modules/survey/editor/components/edit-ending-card.tsx#L284) — the call site

## Before

Both recordings start where the ticket does: a **published** survey whose ending was saved as "Redirect to URL", then switched back. The field visibly holds the typed text, yet saving fails: "The note on the Ending card 1 is missing".

https://github.com/user-attachments/assets/fd5c8e95-236a-42f6-bf02-4b655de3b5d3

## After

Same steps, now saved; the card header picks up the note.

https://github.com/user-attachments/assets/e0c5cbb1-239c-4740-8779-2f3aa8fb0b4d

## Breaking changes

- [ ] This PR contains breaking changes

None — confined to editor state in `apps/web`. No API, SDK, route, env var or schema.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm test --filter=@formbricks/web -- modules/survey/editor/lib/ending-card.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Stored redirect ending → "Ending card" → note → Save | manual | Red on main, green after (recordings) |
| Seeds an empty note when the card carries none | unit (mutation) | Mutate `apps/web/modules/survey/editor/lib/ending-card.ts:29` → `return { type: "endScreen" }` → 3 red |
| Seeds the note for every survey language | unit (guard) | `{ default: "", de: "" }` |
| Keeps the note across an unsaved type round trip | unit (guard) | Patch carries `type` only |
| Switching to "Redirect to URL" only changes the type | unit (guard) | Unchanged |

<details>
<summary>Manual repro state</summary>

The repro needs a *persisted* redirect ending, which is what the ticket's publish step produces. Seeded that row on a local published survey, then drove the editor:

```
{"id": "…", "type": "redirectToUrl", "url": "https://example.com", "label": "Go to example"}
```

After the fix, Save reported "Changes saved." and the row held the typed note:

```
{"id": "…", "type": "endScreen", "headline": {"default": "<p …>Thanks again!</span></p>"}}
```

</details>

**Open gaps**

- The preserved-note round trip is unit-tested only; redirect is paywalled locally.
- Multi-language surveys were not driven in the browser.

**Risks**

- The switch now sends a field alongside `type`; `updateSurvey` filters only `subheader`.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.

