### PR TITLE
fix(survey-list): hold a survey out of the list until its removal settles [ENG-2583]

### DIFF
--- a/apps/web/modules/survey/list/hooks/use-archive-survey.test.ts
+++ b/apps/web/modules/survey/list/hooks/use-archive-survey.test.ts
@@ -7,7 +7,9 @@ import { type ReactNode, createElement } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { surveyKeys } from "@/modules/survey/list/lib/query";
 import { TSurveyListPage } from "@/modules/survey/list/lib/v3-surveys-client";
+import type { TSurveyOverviewFilters } from "@/modules/survey/list/types/survey-overview";
 import { useArchiveSurvey } from "./use-archive-survey";
+import { useSurveys } from "./use-surveys";
 
 function createWrapper(queryClient: QueryClient) {
   const Wrapper = ({ children }: Readonly<{ children: ReactNode }>) =>
@@ -51,10 +53,12 @@ function createQueryData(): { pages: TSurveyListPage[]; pageParams: (string | nu
   };
 }
 
+const listFilters: TSurveyOverviewFilters = { name: "", status: [], type: [], sortBy: "relevance" };
+
 const queryKey = surveyKeys.list({
   workspaceId: "env_1",
   limit: 20,
-  filters: { name: "", status: [], type: [], sortBy: "relevance" },
+  filters: listFilters,
 });
 
 describe("useArchiveSurvey", () => {
@@ -141,5 +145,142 @@ describe("useArchiveSurvey", () => {
     ).rejects.toThrow("You are not authorized to access this resource");
 
     expect(queryClient.getQueryData<{ pages: TSurveyListPage[] }>(queryKey)?.pages[0]?.data).toHaveLength(1);
+  });
+});
+
+// ENG-2583: the optimistic patch alone lasts only until the next list fetch resolves. These drive the
+// list the way the page does — `useSurveys` beside the mutation — because the regression is only
+// visible in what the list renders, not in the cache the mutation patched.
+describe("useArchiveSurvey with the list mounted", () => {
+  const listUrlPattern = "/api/v3/surveys?";
+  const archiveUrlPattern = "/archive";
+
+  function createListResponse() {
+    return new Response(
+      JSON.stringify({
+        data: [
+          {
+            id: "survey_1",
+            name: "Survey 1",
+            workspaceId: "env_1",
+            type: "link",
+            status: "inProgress",
+            publishOn: null,
+            archivedAt: null,
+            createdAt: "2026-04-15T10:00:00.000Z",
+            updatedAt: "2026-04-15T10:00:00.000Z",
+            responseCount: 0,
+            completedResponseCount: 0,
+            creator: { name: "Alice" },
+            singleUse: null,
+          },
+        ],
+        meta: { limit: 20, nextCursor: null, totalCount: 1, workspaceSurveyCount: 4 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  function renderListWithArchive(queryClient: QueryClient) {
+    return renderHook(
+      () => {
+        const list = useSurveys({ workspaceId: "env_1", limit: 20, filters: listFilters });
+        const archive = useArchiveSurvey({ queryKey: list.queryKey });
+
+        return { archive, list };
+      },
+      { wrapper: createWrapper(queryClient) }
+    );
+  }
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("keeps the survey out of the list when a refetch lands before the archive does", async () => {
+    let resolveArchive: ((value: Response) => void) | undefined;
+    const archiveResponse = new Promise<Response>((resolve) => {
+      resolveArchive = resolve;
+    });
+
+    vi.mocked(global.fetch).mockImplementation((input) =>
+      String(input).includes(archiveUrlPattern) ? archiveResponse : Promise.resolve(createListResponse())
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    });
+
+    const { result } = renderListWithArchive(queryClient);
+
+    await waitFor(() => expect(result.current.list.surveys).toHaveLength(1));
+
+    result.current.archive.mutate({ surveyId: "survey_1" });
+
+    await waitFor(() => expect(result.current.list.surveys).toHaveLength(0));
+
+    // The archive write has not landed, so the server still lists the survey. Anything that starts a
+    // list fetch in this window — a remount, a window-focus refetch, the pagination page — writes
+    // that stale page over the optimistic patch.
+    await queryClient.refetchQueries({ queryKey: surveyKeys.lists() });
+
+    // Wait for the refetched page to reach the render, so the assertion below cannot pass on a render
+    // that predates it: the patch set totalCount to 0 and only the server page carries 1 again.
+    await waitFor(() => expect(result.current.list.data?.pages[0]?.meta.totalCount).toBe(1));
+
+    expect(result.current.archive.isPending).toBe(true);
+    expect(result.current.list.surveys).toHaveLength(0);
+
+    resolveArchive?.(
+      new Response(JSON.stringify({ data: { id: "survey_1", status: "paused", archivedAt: "2026-04-16" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await waitFor(() => expect(result.current.archive.isSuccess).toBe(true));
+  });
+
+  test("puts the survey back once the archive fails, even after a mid-flight refetch", async () => {
+    let rejectArchive: ((reason: Error) => void) | undefined;
+    const archiveResponse = new Promise<Response>((_resolve, reject) => {
+      rejectArchive = reject;
+    });
+
+    vi.mocked(global.fetch).mockImplementation((input) =>
+      String(input).includes(archiveUrlPattern) ? archiveResponse : Promise.resolve(createListResponse())
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    });
+
+    const { result } = renderListWithArchive(queryClient);
+
+    await waitFor(() => expect(result.current.list.surveys).toHaveLength(1));
+
+    result.current.archive.mutate({ surveyId: "survey_1" });
+
+    await waitFor(() => expect(result.current.list.surveys).toHaveLength(0));
+
+    await queryClient.refetchQueries({ queryKey: surveyKeys.lists() });
+    await waitFor(() => expect(result.current.list.data?.pages[0]?.meta.totalCount).toBe(1));
+    expect(result.current.list.surveys).toHaveLength(0);
+
+    rejectArchive?.(new Error("network down"));
+
+    // A failed archive has to hand the survey back, and the fetch mock proves the list request the
+    // rollback settles on is the one that still carries it.
+    await waitFor(() => expect(result.current.archive.isError).toBe(true));
+    await waitFor(() => expect(result.current.list.surveys.map((survey) => survey.id)).toEqual(["survey_1"]));
+    expect(
+      vi.mocked(global.fetch).mock.calls.filter((call) => String(call[0]).includes(listUrlPattern)).length
+    ).toBeGreaterThan(1);
   });
 });

--- a/apps/web/modules/survey/list/hooks/use-pending-survey-removals.ts
+++ b/apps/web/modules/survey/list/hooks/use-pending-survey-removals.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMutationState } from "@tanstack/react-query";
+import { surveyMutationKeys } from "@/modules/survey/list/lib/query";
+
+function getRemovedSurveyId(variables: unknown): string | undefined {
+  if (typeof variables !== "object" || variables === null) {
+    return undefined;
+  }
+
+  const { surveyId } = variables as { surveyId?: unknown };
+
+  return typeof surveyId === "string" ? surveyId : undefined;
+}
+
+/**
+ * Survey ids whose removal (archive, restore or delete) is still in flight.
+ *
+ * The optimistic cache patch in `useSurveyRemovalMutation` cannot keep such a survey out of the list
+ * on its own: `cancelQueries` only covers fetches already running when the mutation starts, so any
+ * list fetch that begins after the patch — a remount, a window-focus refetch, a pagination page, or
+ * a filter change swapping in another cache entry — resolves with server data that still contains
+ * the survey, and the row flashes back while the operation runs (ENG-2583).
+ *
+ * Reading the pending removals at render time closes that window regardless of which refetch wrote
+ * the cache. The mutation stays pending until its `onSettled` invalidation has landed, so the
+ * suppression is released only once the cache holds server truth — on success the survey is gone,
+ * and on failure the rollback puts it back exactly once.
+ */
+export const usePendingSurveyRemovals = (): string[] => {
+  const pendingRemovals = useMutationState({
+    filters: { mutationKey: surveyMutationKeys.removal(), status: "pending" },
+    select: (mutation) => getRemovedSurveyId(mutation.state.variables),
+  });
+
+  return pendingRemovals.filter((surveyId): surveyId is string => surveyId !== undefined);
+};

--- a/apps/web/modules/survey/list/hooks/use-survey-removal-mutation.ts
+++ b/apps/web/modules/survey/list/hooks/use-survey-removal-mutation.ts
@@ -1,13 +1,23 @@
 "use client";
 
 import { InfiniteData, useMutation, useQueryClient } from "@tanstack/react-query";
-import { removeSurveyFromInfiniteData, surveyKeys } from "@/modules/survey/list/lib/query";
+import {
+  removeSurveyFromInfiniteData,
+  surveyKeys,
+  surveyMutationKeys,
+} from "@/modules/survey/list/lib/query";
 import { TSurveyListPage } from "@/modules/survey/list/lib/v3-surveys-client";
 
 // Shared optimistic-mutation hook for survey actions that remove a survey from the current list view
 // (delete, archive, restore). Each optimistically drops the survey from the cached infinite data,
 // rolls back on error, and re-fetches on settle so mixed-filter views reconcile. Callers supply only
 // the v3 client request for their specific action.
+//
+// The cache patch is the immediate half of the removal; it is not enough on its own, because a list
+// fetch starting after the patch resolves with server data that still lists the survey (ENG-2583).
+// `mutationKey` is what lets `usePendingSurveyRemovals` suppress the row for the whole in-flight
+// window, so `onSettled` must keep awaiting its invalidation — that await is what holds the mutation
+// pending until the cache carries server truth again.
 export const useSurveyRemovalMutation = ({
   queryKey,
   mutationFn,
@@ -21,6 +31,7 @@ export const useSurveyRemovalMutation = ({
   const queryClient = useQueryClient();
 
   return useMutation({
+    mutationKey: surveyMutationKeys.removal(),
     mutationFn: async ({ surveyId }: { surveyId: string }) => mutationFn(surveyId),
     onMutate: async ({ surveyId }) => {
       await queryClient.cancelQueries({ queryKey });

--- a/apps/web/modules/survey/list/hooks/use-surveys.test.ts
+++ b/apps/web/modules/survey/list/hooks/use-surveys.test.ts
@@ -5,7 +5,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { type ReactNode, createElement } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { surveyKeys } from "@/modules/survey/list/lib/query";
 import type { TSurveyOverviewFilters } from "@/modules/survey/list/types/survey-overview";
+import { useDeleteSurvey } from "./use-delete-survey";
+import { useRestoreSurvey } from "./use-restore-survey";
 import { useSurveys } from "./use-surveys";
 
 function createWrapper(queryClient: QueryClient) {
@@ -244,5 +247,72 @@ describe("useSurveys", () => {
     );
 
     await waitFor(() => expect(result.current.surveys[0]?.name).toBe("Survey 2"));
+  });
+
+  // ENG-2583: archive, restore and delete all run through `useSurveyRemovalMutation`, so the list
+  // suppresses the row for whichever of them is in flight. Archive's own file drives the full
+  // reappear-mid-flight scenario; this covers the other two inheriting it.
+  test.each([
+    ["delete", useDeleteSurvey],
+    ["restore", useRestoreSurvey],
+  ] as const)("leaves out a survey whose %s is still running", async (_action, useRemoval) => {
+    const fetchMock = vi.mocked(global.fetch);
+    fetchMock.mockImplementation((input) =>
+      String(input).includes("/api/v3/surveys?")
+        ? Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: [
+                  {
+                    id: "survey_1",
+                    name: "Survey 1",
+                    workspaceId: "env_1",
+                    type: "link",
+                    status: "inProgress",
+                    createdAt: "2026-04-15T10:00:00.000Z",
+                    updatedAt: "2026-04-15T10:00:00.000Z",
+                    responseCount: 0,
+                    completedResponseCount: 0,
+                    creator: { name: "Alice" },
+                    singleUse: null,
+                  },
+                ],
+                meta: { limit: 20, nextCursor: null, totalCount: 1, workspaceSurveyCount: 3 },
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } }
+            )
+          )
+        : new Promise<Response>(() => {
+            // The removal request never settles, so the whole assertion runs inside its window.
+          })
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    });
+
+    const { result } = renderHook(
+      () => {
+        const list = useSurveys({
+          workspaceId: "env_1",
+          limit: 20,
+          filters: { name: "", status: [], type: [], sortBy: "relevance" },
+        });
+        const removal = useRemoval({ queryKey: list.queryKey });
+
+        return { list, removal };
+      },
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.list.surveys).toHaveLength(1));
+
+    result.current.removal.mutate({ surveyId: "survey_1" });
+
+    await waitFor(() => expect(result.current.removal.isPending).toBe(true));
+    await queryClient.refetchQueries({ queryKey: surveyKeys.lists() });
+    await waitFor(() => expect(result.current.list.data?.pages[0]?.meta.totalCount).toBe(1));
+
+    expect(result.current.list.surveys).toHaveLength(0);
   });
 });

--- a/apps/web/modules/survey/list/hooks/use-surveys.ts
+++ b/apps/web/modules/survey/list/hooks/use-surveys.ts
@@ -4,6 +4,7 @@ import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { flattenSurveyPages, surveyKeys } from "@/modules/survey/list/lib/query";
 import { TSurveyOverviewFilters } from "@/modules/survey/list/types/survey-overview";
 import { listSurveys } from "../lib/v3-surveys-client";
+import { usePendingSurveyRemovals } from "./use-pending-survey-removals";
 
 export const useSurveys = ({
   workspaceId,
@@ -39,7 +40,10 @@ export const useSurveys = ({
     getNextPageParam: (lastPage) => lastPage.meta.nextCursor ?? undefined,
   });
 
-  const surveys = flattenSurveyPages(query.data);
+  // A survey being archived, restored or deleted stays out of the list for the whole operation, even
+  // if a refetch lands first and writes it back into the cache (ENG-2583).
+  const pendingRemovals = usePendingSurveyRemovals();
+  const surveys = flattenSurveyPages(query.data).filter((survey) => !pendingRemovals.includes(survey.id));
   // Read from page one: cursor pages are requested with includeTotalCount=false and carry null.
   const workspaceSurveyCount = query.data?.pages[0]?.meta.workspaceSurveyCount ?? null;
 

--- a/apps/web/modules/survey/list/lib/query.ts
+++ b/apps/web/modules/survey/list/lib/query.ts
@@ -14,6 +14,11 @@ export const surveyKeys = {
   list: (input: TSurveyListKeyInput) => [...surveyKeys.lists(), input] as const,
 };
 
+export const surveyMutationKeys = {
+  /** Shared by archive, restore and delete so the list can see a removal that is still in flight. */
+  removal: () => [...surveyKeys.all, "removal"] as const,
+};
+
 export function flattenSurveyPages(data?: InfiniteData<TSurveyListPage>): TSurveyListItem[] {
   return data?.pages.flatMap((page) => page.data) ?? [];
 }


### PR DESCRIPTION
Fixes ENG-2583

## What & why

**Was:** Archiving a survey removed its card, then let it flash back into the list while the request was still running, so the action read as failed.

**Now:** The card goes and stays gone for the whole operation, however slow the request, and comes back exactly once if it fails.

- `cancelQueries` in `onMutate` only covers fetches already running, so a later list fetch overwrote the optimistic patch.
- Archive, restore and delete now share one `mutationKey`, and the list reads the in-flight removals at render time.
- The mutation stays pending until its `onSettled` invalidation lands, so the row is released only once the cache holds server truth.

## Where to look

- [`usePendingSurveyRemovals`](https://github.com/formbricks/formbricks/blob/178de78/apps/web/modules/survey/list/hooks/use-pending-survey-removals.ts): the whole suppression, and why the cache patch cannot do it
- [`use-surveys.ts`](https://github.com/formbricks/formbricks/blob/178de78/apps/web/modules/survey/list/hooks/use-surveys.ts#L43): the one read-time filter
- [`use-survey-removal-mutation.ts`](https://github.com/formbricks/formbricks/blob/178de78/apps/web/modules/survey/list/hooks/use-survey-removal-mutation.ts#L34): `onSettled` must keep awaiting, and that await sets the release point

## Breaking changes

- [ ] This PR contains breaking changes

None. One added mutation key and one added client-side hook, both internal to the survey list; no API, env var or SDK surface changes.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm build --filter=@formbricks/web^... && (cd apps/web && pnpm exec vitest run modules/survey/list)`, plus `pnpm exec playwright test survey-archive --project=chromium`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| A list refetch landing before the archive does no longer brings the row back | unit (red on main) | passed; `use-archive-survey.test.ts` → "keeps the survey out of the list when a refetch lands before the archive does" |
| A failed archive hands the survey back, after a mid-flight refetch too | unit (red on main) | passed; `use-archive-survey.test.ts` → "puts the survey back once the archive fails" |
| Restore and delete inherit the same suppression through the shared hook | unit (mutation) | passed; `use-surveys.test.ts`, mutate `use-surveys.ts:45` to drop the filter |
| Archive keeps the workspace count, so archiving the last live survey does not flip the page to onboarding | unit (guard) | passed; `use-archive-survey.test.ts`, existing assertion on `workspaceSurveyCount` |
| A tab switch during a slow archive refetches the list; the row stays out, and returns once the archive lands | manual | Clips and stills below: on `main` the row comes back mid-flight, here it stays out |
| Archive → filter → restore → archive → delete forever, end to end | e2e | passed; `survey-archive.spec.ts`, both tests |

<details>
<summary>Screencast and screenshots: a tab switch while the archive is still running</summary>

Same seeded workspace and the same scripted flow in both clips: the archive request is held open for 4.5 s, and a `visibilitychange` on the window fires while it is pending, so react-query refetches the list mid-flight. Watch the third row after the refetch lands.

| Before (`main`) | After |
| --- | --- |
| ![Clip: after the tab-focus refetch, "Q4 Customer Feedback" reappears as the third row under the "Archiving survey…" toast, then leaves again once the archive completes](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2583/archive-midflight-before.gif) | ![Clip: the same refetch lands, the list keeps its two remaining rows, and "Survey archived" arrives with the row still gone](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2583/archive-midflight-after.gif) |
| [MP4, full frame rate](https://github.com/formbricks/formbricks/blob/assets-pr-screenshots/ENG-2583/archive-midflight-before.mp4) | [MP4, full frame rate](https://github.com/formbricks/formbricks/blob/assets-pr-screenshots/ENG-2583/archive-midflight-after.mp4) |

Stills of the mid-flight moment, from an earlier run with the request held open for 6 s and the frame taken once the refetched list response had landed. The toast is still "Archiving survey…" in both frames.

| Before (`main`) | After |
| --- | --- |
| ![Survey list with "Q4 Customer Feedback" back as the third row while the "Archiving survey…" toast is still showing](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2583/archive-midflight-before.png) | ![Same moment with only the two remaining surveys listed under the "Archiving survey…" toast](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2583/archive-midflight-after.png) |

And the outcome is unchanged, since the suppression is released when the request settles rather than held:

| Before (`main`) | After |
| --- | --- |
| ![Two surveys listed with a "Survey archived" success toast](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2583/archive-settled-before.png) | ![Identical list and "Survey archived" toast after the fix](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2583/archive-settled-after.png) |

</details>

**Open gaps**

- Restore and delete-forever were not watched mid-flight in a browser; they run through the same hook as the pair above.
- The ticket's second suspect, a `hasArchived` cleanup effect in `survey-list.tsx`, no longer exists, so only the refetch path was reproduced.

**Risks**

- Deleting the last survey in a workspace can still flash the onboarding empty state. Count only, pre-existing, and `onSettled` corrects it.
- The suppression is keyed by survey id alone, so a removal hides that id in any other list mounted at the same time, which is the same survey.

<details>
<summary>Why suppress at read time rather than patch every cache entry</summary>

The ticket suggests patching all `surveyKeys.lists()` entries as an alternative. That fixes the filter-swap path but not the one actually reproduced here: a refetch of the *active* key resolves after the patch and overwrites it, whichever entries were patched. Re-applying the patch on every cache update would mean writing to the cache from a cache subscription, which re-enters itself. Filtering at the read closes both paths with no cache writes at all, and the release point falls out of the mutation's own lifecycle rather than needing to be timed.

The reproduction: with the archive request held open, `refetchQueries` on the list key puts `survey_1` and `totalCount: 1` back into the cache while the mutation is still `pending`, and the hook re-renders with the row. Both `red on main` rows above assert on what the list renders, after waiting for the refetched page to reach the render, so neither can pass on a stale snapshot.

</details>

<details>
<summary>How the browser pair and the clips were produced</summary>

A throwaway Playwright spec against a local stack, on a fixture user with three seeded surveys: `page.route` holds `/api/v3/surveys/*/archive` open, the survey is archived, then `window.dispatchEvent(new Event("visibilitychange"))` triggers react-query's focus refetch. The stills were taken once that list response had landed, with the hold at 6 s. The clips use the same spec with the hold at 4.5 s, recorded from a fresh page after login so the video starts at the list, trimmed at the first frame with all three rows, and converted with ffmpeg to a 12 fps GIF plus an H.264 MP4. Each pair was run with one variable: the four source files at `origin/main`, then at this branch. The mid-flight row count recorded by the spec is 1 on `main` and 0 here, in the stills run and in the clips run alike.

</details>

---

> [!NOTE]
> **AI model used** — `unknown` (this session does not expose the serving model or effort level to the run), reasoning effort `unknown`.

<!-- claude-routine
ticket: ENG-2583
opened: 2026-09-07T12:44Z
last_run: 2026-09-09T10:05Z
runs: 11
ci_fixes: 0
review_rounds: 1
status: clean
-->
