### PR TITLE
fix(embedded-data): localize the Duration (seconds) filter entry [ENG-2894]

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/lib/utils.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/lib/utils.test.ts
@@ -46,6 +46,7 @@ describe("utils", () => {
       "workspace.surveys.responses.utm_term": "UTM Term",
       "workspace.surveys.responses.viewport_height": "Viewport Height",
       "workspace.surveys.responses.viewport_width": "Viewport Width",
+      "workspace.surveys.responses.duration_seconds": "Duration (seconds)",
     };
     return translations[key] || key;
   }) as unknown as TFunction;
@@ -175,6 +176,14 @@ describe("utils", () => {
         expect(getReservedColumnLabel(name, mockT), name).toBe(label);
         expect(mockT, name).toHaveBeenCalledWith(`workspace.surveys.responses.${key}`);
       }
+    });
+
+    test("routes the filter-only `durationSeconds` entry through `t()` as well", () => {
+      // `display: "none"`, so no column shows it — but the response filter offers it (ENG-1848) through
+      // this same switch, and it was the one offered entry still left to the derived fallback, reading
+      // `Duration Seconds` in every locale (ENG-2894).
+      expect(getReservedColumnLabel("durationSeconds", mockT)).toBe("Duration (seconds)");
+      expect(mockT).toHaveBeenCalledWith("workspace.surveys.responses.duration_seconds");
     });
 
     test("still derives a label for a catalog entry nobody has written a key for yet", () => {

--- a/apps/web/app/lib/surveys/surveys.test.ts
+++ b/apps/web/app/lib/surveys/surveys.test.ts
@@ -156,6 +156,32 @@ describe("surveys", () => {
       expect(utmSource?.fieldDataType).toBe("string");
     });
 
+    test("labels every meta option through `t()`, the filter-only durationSeconds included", () => {
+      const survey = {
+        id: "survey1",
+        name: "Test Survey",
+        blocks: [],
+        questions: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        status: "draft",
+        isCaptureIpEnabled: true,
+      } as unknown as TSurvey;
+
+      const metaOptions =
+        genOptions(survey).elementOptions.find((opt) => opt.header === OptionsType.META)?.option ?? [];
+      expect(metaOptions.length).toBeGreaterThan(20);
+
+      // `t` here is the identity, so each label IS the key it was routed through — a label derived from
+      // the catalog name, such as `Duration Seconds`, carries no key and fails the pattern (ENG-2894).
+      for (const { id, label } of metaOptions) {
+        expect(label, id).toMatch(/^(workspace\.surveys\.responses|common)\.[a-z_]+$/);
+      }
+      expect(metaOptions.find((option) => option.id === "durationSeconds")?.label).toBe(
+        "workspace.surveys.responses.duration_seconds"
+      );
+    });
+
     test("reserved options drop shadowed names and respect the IP capture toggle", () => {
       const survey = {
         id: "survey1",

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -3581,6 +3581,7 @@ checksums:
     workspace/surveys/responses/delete_response_quotas: 6719c90d8019000ca0a74586fb3b6a65
     workspace/surveys/responses/device: c009f849d689c745de9e38ad17644c7a
     workspace/surveys/responses/device_info: b621ff59202f171e232c1910f9236573
+    workspace/surveys/responses/duration_seconds: 3183e260e571ee2d9aac4979709cc953
     workspace/surveys/responses/email: e7f34943a0c2fb849db1839ff6ef5cb5
     workspace/surveys/responses/error_downloading_responses: 97a79108cfc854834d09cf14c300a291
     workspace/surveys/responses/first_name: cf040a5d6a9fd696be400380cc99f54b

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "Die Antwort ist Teil von Kontingenten für diese Umfrage. Wie möchtest du mit den Kontingenten verfahren?",
         "device": "Gerät",
         "device_info": "Geräte-Info",
+        "duration_seconds": "Dauer (Sekunden)",
         "email": "E-Mail",
         "error_downloading_responses": "Beim Herunterladen der Antworten ist ein Fehler aufgetreten",
         "first_name": "Vorname",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "The response is part of quotas for this survey. How do you want to handle the quotas?",
         "device": "Device",
         "device_info": "Device info",
+        "duration_seconds": "Duration (seconds)",
         "email": "Email",
         "error_downloading_responses": "An error occurred while downloading responses",
         "first_name": "First Name",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "La respuesta forma parte de cuotas para esta encuesta. ¿Cómo quieres gestionar las cuotas?",
         "device": "Dispositivo",
         "device_info": "Información del dispositivo",
+        "duration_seconds": "Duración (segundos)",
         "email": "Correo electrónico",
         "error_downloading_responses": "Se produjo un error al descargar las respuestas",
         "first_name": "Nombre",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "La réponse fait partie des quotas pour ce sondage. Comment voulez-vous gérer les quotas ?",
         "device": "Dispositif",
         "device_info": "Informations sur l'appareil",
+        "duration_seconds": "Durée (secondes)",
         "email": "Email",
         "error_downloading_responses": "Une erreur s'est produite lors du téléchargement des réponses",
         "first_name": "Prénom",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "A válasz a kérdőív kvótáinak részét képezik. Hogyan szeretné kezelni a kvótákat?",
         "device": "Eszköz",
         "device_info": "Eszközinformációk",
+        "duration_seconds": "Időtartam (másodperc)",
         "email": "E-mail",
         "error_downloading_responses": "Hiba történt a válaszok letöltése során",
         "first_name": "Keresztnév",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "この回答は、このアンケートの割り当ての一部です。 割り当てをどのように処理しますか？",
         "device": "デバイス",
         "device_info": "デバイス情報",
+        "duration_seconds": "所要時間（秒）",
         "email": "メールアドレス",
         "error_downloading_responses": "回答のダウンロード中にエラーが発生しました",
         "first_name": "名",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "De respons maakt deel uit van de quota voor dit onderzoek. Hoe wilt u omgaan met de quota?",
         "device": "Apparaat",
         "device_info": "Apparaatinformatie",
+        "duration_seconds": "Duur (seconden)",
         "email": "E-mail",
         "error_downloading_responses": "Er is een fout opgetreden bij het downloaden van de antwoorden",
         "first_name": "Voornaam",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "A resposta faz parte das cotas desta pesquisa. Como você quer gerenciar as cotas?",
         "device": "dispositivo",
         "device_info": "Informações do dispositivo",
+        "duration_seconds": "Duração (segundos)",
         "email": "Email",
         "error_downloading_responses": "Ocorreu um erro ao baixar as respostas",
         "first_name": "Primeiro Nome",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "A resposta faz parte das quotas deste inquérito. Como deseja gerir as quotas?",
         "device": "Dispositivo",
         "device_info": "Informações do dispositivo",
+        "duration_seconds": "Duração (segundos)",
         "email": "Email",
         "error_downloading_responses": "Ocorreu um erro ao transferir as respostas",
         "first_name": "Primeiro Nome",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "Răspunsul face parte din cotele pentru acest sondaj. Cum doriți să gestionați cotele?",
         "device": "Dispozitiv",
         "device_info": "Informații despre dispozitiv",
+        "duration_seconds": "Durată (secunde)",
         "email": "Email",
         "error_downloading_responses": "A apărut o eroare la descărcarea răspunsurilor",
         "first_name": "Prenume",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "Ответ входит в квоты для этого опроса. Как вы хотите обработать квоты?",
         "device": "Устройство",
         "device_info": "Информация об устройстве",
+        "duration_seconds": "Длительность (секунды)",
         "email": "Email",
         "error_downloading_responses": "Произошла ошибка при загрузке ответов",
         "first_name": "Имя",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "Svaret är del av kvoter för denna enkät. Hur vill du hantera kvoterna?",
         "device": "Enhet",
         "device_info": "Enhetsinformation",
+        "duration_seconds": "Varaktighet (sekunder)",
         "email": "E-post",
         "error_downloading_responses": "Ett fel uppstod vid nedladdning av svar",
         "first_name": "Förnamn",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "Yanıt bu anket için kotaların bir parçası. Kotaları nasıl işlemek istiyorsun?",
         "device": "Cihaz",
         "device_info": "Cihaz bilgisi",
+        "duration_seconds": "Süre (saniye)",
         "email": "E-posta",
         "error_downloading_responses": "Yanıtlar indirilirken bir hata oluştu",
         "first_name": "Ad",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "该响应是 此 调查配额 的一部分。 您 希望 如何 处理 这些 配额？",
         "device": "设备",
         "device_info": "设备信息",
+        "duration_seconds": "持续时间（秒）",
         "email": "邮件",
         "error_downloading_responses": "下载答复时发生错误",
         "first_name": "名字",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -3708,6 +3708,7 @@
         "delete_response_quotas": "此回應屬於此問卷的配額。你想如何處理配額？",
         "device": "裝置",
         "device_info": "裝置資訊",
+        "duration_seconds": "持續時間（秒）",
         "email": "電子郵件",
         "error_downloading_responses": "下載回應時發生錯誤",
         "first_name": "名字",

--- a/apps/web/modules/analysis/lib/reserved-field-display.ts
+++ b/apps/web/modules/analysis/lib/reserved-field-display.ts
@@ -20,10 +20,12 @@ import { formatFieldNameToTitleCase } from "@formbricks/types/safe-identifier";
 /**
  * The human-readable label for a reserved field (ENG-2540).
  *
- * **Every field either surface displays today has its own key.** All twenty-one `display !== "none"`
- * catalog entries are listed below, so `Page Path`, `UTM Source` and `Timezone` are translated in
- * every locale rather than rendered as English derived from the catalog name — which is what the
- * repo's i18n rule asks for, and what shipping them derived would have quietly broken.
+ * **Every field either surface displays today has its own key, and so does the one filter-only
+ * entry.** All twenty-one `display !== "none"` catalog entries are listed below, plus
+ * `durationSeconds`, which no column shows but the response filter offers (ENG-1848). So `Page Path`,
+ * `UTM Source` and `Duration (seconds)` are translated in every locale rather than rendered as
+ * English derived from the catalog name — which is what the repo's i18n rule asks for, and what
+ * shipping them derived would have quietly broken.
  *
  * `formatFieldNameToTitleCase` — the same helper the recall and logic pickers use — stays as the
  * `default` arm, deliberately, as a **last resort rather than the rule**: ENG-1858's next batch of
@@ -83,6 +85,10 @@ export const getReservedFieldLabel = (name: string, t: TFunction): string => {
       return t("workspace.surveys.responses.viewport_height");
     case "viewportWidth":
       return t("workspace.surveys.responses.viewport_width");
+    // The one `display: "none"` entry the response filter offers (ENG-1848): never a column, so this
+    // key is only ever read by the filter picker (ENG-2894).
+    case "durationSeconds":
+      return t("workspace.surveys.responses.duration_seconds");
     default:
       return formatFieldNameToTitleCase(name);
   }


### PR DESCRIPTION
Ref ENG-2894

## What & why

**Was:** In Responses → Filter → Add filter, the Meta group's duration entry read `Duration Seconds` in every language — the only offered field with no translation key.

**Now:** It goes through `t("workspace.surveys.responses.duration_seconds")` — `Duration (seconds)` in English, `Dauer (Sekunden)` in German.

- `getReservedFieldLabel` only covered `display !== "none"` entries; `durationSeconds` is `display: "none"` yet filter-offered, so it fell through to the title-cased catalog name.

## Where to look

- [reserved-field-display.ts:90](apps/web/modules/analysis/lib/reserved-field-display.ts#L90) — the new switch arm
- [en-US.json:3711](apps/web/locales/en-US.json#L3711) — the key; the other 14 locales and `i18n.lock` come from `pnpm i18n`

## Breaking changes

- [ ] This PR contains breaking changes

None — a label key on an internal helper; no API, env or SDK change.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run app/lib/surveys/surveys.test.ts 'app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/lib/utils.test.ts' lib/response/utils.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Picker labels `durationSeconds` through the new key | unit (red on main) | `surveys.test.ts` › "labels every meta option…": red without the arm (`Duration Seconds`) |
| Every offered Meta option carries a key, none derived | unit (guard) | Same test, identity `t`: all 22 options match a `workspace.surveys.responses.*`/`common.*` key |
| Shared switch routes `durationSeconds` to `duration_seconds` | unit (red on main) | `responses/lib/utils.test.ts` › "routes the filter-only…": red without the arm |
| Export header stays the un-localized `Duration Seconds` | unit (guard) | `lib/response/utils.test.ts`: 95 passed, header assertions untouched |
| Key translated in all 14 locales, lockfile in sync | manual | `pnpm i18n`: Lingo.dev wrote all 14; scan reports every locale complete |
| German picker shows `Dauer (Sekunden)` | manual | Not run — steps under Open gaps |

**Open gaps**

- Not checked in a browser. To check: language → German at `/account/settings/profile`; survey → Responses → Filter → Add filter → field list; the Meta group should read `Dauer (Sekunden)`. Set English back afterwards.

**Risks**

- Only the label changes; operators, values and the `ttc._total` locator are untouched.

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `max`.

