### PR TITLE
fix(security): rate-limit token-consuming auth actions

### DIFF
--- a/apps/web/modules/auth/forgot-password/reset/actions.test.ts
+++ b/apps/web/modules/auth/forgot-password/reset/actions.test.ts
@@ -8,6 +8,8 @@ import {
   PASSWORD_COMPROMISED_ERROR_CODE,
 } from "@formbricks/types/errors";
 import { auth } from "@/modules/auth/lib/auth";
+import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { resetPasswordAction } from "./actions";
 
 const constantsState = vi.hoisted(() => ({
@@ -18,6 +20,10 @@ const constantsState = vi.hoisted(() => ({
 // auth.ts (onPasswordReset + revokeSessionsOnPasswordReset), not this action (ENG-1054).
 vi.mock("@/modules/auth/lib/auth", () => ({
   auth: { api: { resetPassword: vi.fn() } },
+}));
+
+vi.mock("@/modules/core/rate-limit/helpers", () => ({
+  applyIPRateLimit: vi.fn(),
 }));
 
 vi.mock("next/headers", () => ({
@@ -64,6 +70,26 @@ describe("resetPasswordAction", () => {
     });
   });
 
+  test("applies the reset-password IP limit before calling Better Auth", async () => {
+    vi.mocked(auth.api.resetPassword).mockResolvedValue({ status: true } as never);
+
+    await resetPasswordAction({ parsedInput } as never);
+
+    expect(applyIPRateLimit).toHaveBeenCalledWith(rateLimitConfigs.auth.resetPassword);
+    expect(applyIPRateLimit).toHaveBeenCalledBefore(vi.mocked(auth.api.resetPassword));
+  });
+
+  test("short-circuits before Better Auth when the IP limit is exceeded", async () => {
+    vi.mocked(applyIPRateLimit).mockRejectedValue(
+      new Error("Maximum number of requests reached. Please try again later.")
+    );
+
+    await expect(resetPasswordAction({ parsedInput } as never)).rejects.toThrow(
+      "Maximum number of requests reached. Please try again later."
+    );
+    expect(auth.api.resetPassword).not.toHaveBeenCalled();
+  });
+
   test("maps a Better Auth APIError (invalid/expired/used token) to the invalid-reset-token error", async () => {
     vi.mocked(auth.api.resetPassword).mockRejectedValue(
       new APIError("BAD_REQUEST", { message: "invalid token", code: "INVALID_TOKEN" })
@@ -101,6 +127,7 @@ describe("resetPasswordAction", () => {
     constantsState.passwordResetDisabled = true;
 
     await expect(resetPasswordAction({ parsedInput } as any)).rejects.toThrow(OperationNotAllowedError);
+    expect(applyIPRateLimit).not.toHaveBeenCalled();
     expect(auth.api.resetPassword).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/modules/auth/forgot-password/reset/actions.ts
+++ b/apps/web/modules/auth/forgot-password/reset/actions.ts
@@ -15,6 +15,8 @@ import { PASSWORD_RESET_DISABLED } from "@/lib/constants";
 import { actionClient } from "@/lib/utils/action-client";
 import { auth } from "@/modules/auth/lib/auth";
 import { isPasswordCompromisedError } from "@/modules/auth/lib/better-auth-hibp";
+import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 
 const ZResetPasswordAction = z.object({
   token: z.string().min(1),
@@ -27,6 +29,8 @@ export const resetPasswordAction = actionClient
     if (PASSWORD_RESET_DISABLED) {
       throw new OperationNotAllowedError("Password reset is disabled");
     }
+
+    await applyIPRateLimit(rateLimitConfigs.auth.resetPassword);
 
     try {
       await auth.api.resetPassword({

--- a/apps/web/modules/auth/verify-email-change/actions.test.ts
+++ b/apps/web/modules/auth/verify-email-change/actions.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { verifyEmailChangeToken } from "@/lib/jwt";
+import { updateBrevoCustomer } from "@/modules/auth/lib/brevo";
+import { getUser, updateUser } from "@/modules/auth/lib/user";
+import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import { verifyEmailChangeAction } from "./actions";
+
+type VerifyEmailChangeHandler = (args: {
+  ctx: { auditLoggingCtx: { userId?: string; oldObject?: unknown; newObject?: unknown } };
+  parsedInput: { token: string };
+}) => Promise<unknown>;
+
+vi.mock("@/lib/jwt", () => ({
+  verifyEmailChangeToken: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  actionClient: {
+    inputSchema: vi.fn().mockReturnThis(),
+    action: vi.fn((handler: VerifyEmailChangeHandler) => handler),
+  },
+}));
+
+vi.mock("@/modules/auth/lib/brevo", () => ({
+  updateBrevoCustomer: vi.fn(),
+}));
+
+vi.mock("@/modules/auth/lib/user", () => ({
+  getUser: vi.fn(),
+  updateUser: vi.fn(),
+}));
+
+vi.mock("@/modules/core/rate-limit/helpers", () => ({
+  applyIPRateLimit: vi.fn(),
+}));
+
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_action: string, _object: string, handler: VerifyEmailChangeHandler) => handler),
+}));
+
+describe("verifyEmailChangeAction", () => {
+  const parsedInput = { token: "opaque-email-change-token" };
+  const mockCtx = { auditLoggingCtx: {} };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
+    vi.mocked(verifyEmailChangeToken).mockResolvedValue({ id: "user-123", email: "new@example.com" });
+    vi.mocked(getUser).mockResolvedValue({ id: "user-123", email: "old@example.com" } as never);
+    vi.mocked(updateUser).mockResolvedValue({ id: "user-123", email: "new@example.com" } as never);
+    vi.mocked(updateBrevoCustomer).mockResolvedValue(undefined);
+  });
+
+  test("applies the verification IP limit before verifying the token", async () => {
+    await verifyEmailChangeAction({ ctx: mockCtx, parsedInput } as never);
+
+    expect(applyIPRateLimit).toHaveBeenCalledWith(rateLimitConfigs.auth.verifyEmail);
+    expect(applyIPRateLimit).toHaveBeenCalledBefore(vi.mocked(verifyEmailChangeToken));
+  });
+
+  test("short-circuits before token processing and side effects when the IP limit is exceeded", async () => {
+    vi.mocked(applyIPRateLimit).mockRejectedValue(
+      new Error("Maximum number of requests reached. Please try again later.")
+    );
+
+    await expect(verifyEmailChangeAction({ ctx: mockCtx, parsedInput } as never)).rejects.toThrow(
+      "Maximum number of requests reached. Please try again later."
+    );
+    expect(verifyEmailChangeToken).not.toHaveBeenCalled();
+    expect(getUser).not.toHaveBeenCalled();
+    expect(updateUser).not.toHaveBeenCalled();
+    expect(updateBrevoCustomer).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/auth/verify-email-change/actions.ts
+++ b/apps/web/modules/auth/verify-email-change/actions.ts
@@ -5,10 +5,14 @@ import { verifyEmailChangeToken } from "@/lib/jwt";
 import { actionClient } from "@/lib/utils/action-client";
 import { updateBrevoCustomer } from "@/modules/auth/lib/brevo";
 import { getUser, updateUser } from "@/modules/auth/lib/user";
+import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 
 export const verifyEmailChangeAction = actionClient.inputSchema(z.object({ token: z.string() })).action(
   withAuditLogging("updated", "user", async ({ ctx, parsedInput }) => {
+    await applyIPRateLimit(rateLimitConfigs.auth.verifyEmail);
+
     // Unauthenticated on purpose — the link is clicked from the new mailbox, often in another browser.
     // What makes that safe is the token's binding to the credential state it was issued under
     // (verifyEmailChangeToken), so a password reset or a prior email change kills it (ENG-2106).

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
@@ -64,7 +64,19 @@ describe("rateLimitConfigs", () => {
 
     test("should have all auth configurations", () => {
       const authConfigs = Object.keys(rateLimitConfigs.auth);
-      expect(authConfigs).toEqual(["login", "signup", "forgotPassword", "verifyEmail", "emailToken"]);
+      expect(authConfigs).toEqual([
+        "login",
+        "signup",
+        "forgotPassword",
+        "resetPassword",
+        "verifyEmail",
+        "emailToken",
+      ]);
+      expect(rateLimitConfigs.auth.resetPassword).toEqual({
+        interval: 3600,
+        allowedPerInterval: 5,
+        namespace: "auth:reset-password",
+      });
       // The values, not just the key: emailToken throttles an unauthenticated endpoint that also
       // reveals whether an address is registered, so a loosened quota is a security regression.
       expect(rateLimitConfigs.auth.emailToken).toEqual({

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.ts
@@ -4,6 +4,8 @@ export const rateLimitConfigs = {
     login: { interval: 900, allowedPerInterval: 10, namespace: "auth:login" }, // 10 per 15 minutes
     signup: { interval: 3600, allowedPerInterval: 30, namespace: "auth:signup" }, // 30 per hour
     forgotPassword: { interval: 3600, allowedPerInterval: 5, namespace: "auth:forgot" }, // 5 per hour
+    // Keep redemption independent so requesting an email cannot exhaust the budget to use its token.
+    resetPassword: { interval: 3600, allowedPerInterval: 5, namespace: "auth:reset-password" }, // 5 per hour
     verifyEmail: { interval: 3600, allowedPerInterval: 10, namespace: "auth:verify" }, // 10 per hour
     emailToken: { interval: 3600, allowedPerInterval: 10, namespace: "auth:email-token" }, // 10 per hour — unauthenticated, tells the caller whether an email is registered
   },


### PR DESCRIPTION
Fixes ENG-2478

## What & why

**Was:** Email-change verification and password-reset redemption accepted unlimited token attempts from one IP.

**Now:** Both actions reject excess attempts before token processing or downstream writes.

## Where to look

- [Password-reset ordering](https://github.com/formbricks/formbricks/blob/4e389350f87b06c698eeec460dd568e2ac7e9e1b/apps/web/modules/auth/forgot-password/reset/actions.ts#L29-L36)
- [Email-change ordering](https://github.com/formbricks/formbricks/blob/4e389350f87b06c698eeec460dd568e2ac7e9e1b/apps/web/modules/auth/verify-email-change/actions.ts#L12-L19)
- [Independent reset quota](https://github.com/formbricks/formbricks/blob/4e389350f87b06c698eeec460dd568e2ac7e9e1b/apps/web/modules/core/rate-limit/rate-limit-configs.ts#L3-L10)

## Breaking changes

- [ ] This PR contains breaking changes

None. This adds internal rate-limit enforcement without changing an external contract.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web test modules/auth/forgot-password/reset/actions.test.ts modules/auth/verify-email-change/actions.test.ts modules/core/rate-limit/rate-limit-configs.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Email change stops before token verification | unit (mutation) | Removing `verify-email-change/actions.ts:14` fails ordering and short-circuit checks |
| Password reset stops before Better Auth | unit (mutation) | Removing `forgot-password/reset/actions.ts:33` fails both limiter checks |
| Reset redemption has an independent quota | unit (mutation) | Changing `rate-limit-configs.ts:8` fails exact config checks |
| Disabled password reset consumes no quota | unit (guard) | Disabled state skipped limiter and Better Auth |

**Open gaps**

- none

**Risks**

- Shared-IP users can collectively exhaust the reset-redemption quota.
- Redis outages preserve the existing fail-open limiter behavior.

---

> [!NOTE]
> **AI model used** — `unknown`, reasoning effort `unknown`.