### PR TITLE
fix(ui): move the last three native date inputs onto the unified picker

### DIFF
--- a/apps/web/lib/utils/datetime.test.ts
+++ b/apps/web/lib/utils/datetime.test.ts
@@ -138,6 +138,17 @@ describe("parseStoredDay", () => {
     expect(parsed && [parsed.getFullYear(), parsed.getMonth(), parsed.getDate()]).toEqual([2026, 0, 31]);
   });
 
+  test.each(["2026-08-05T25:99:99Z", "2026-08-05Tnot-a-time", "2026-08-05T"])(
+    "keeps the day when only the time part is malformed: %s",
+    (value) => {
+      // Deliberate: the day is what the picker shows, and the `<input type="date">` this replaced
+      // split on "T" the same way. Blanking a readable day over a broken suffix would lose data.
+      const parsed = parseStoredDay(value);
+
+      expect(parsed && formatLocalDay(parsed)).toBe("2026-08-05");
+    }
+  );
+
   test("returns null when there is no stored value", () => {
     expect(parseStoredDay("")).toBeNull();
     expect(parseStoredDay(null)).toBeNull();

--- a/apps/web/lib/utils/datetime.test.ts
+++ b/apps/web/lib/utils/datetime.test.ts
@@ -9,6 +9,7 @@ import {
   getFormattedDateTimeString,
   isValidDateString,
   parseLocalDay,
+  parseStoredDay,
 } from "./datetime";
 
 describe("datetime utils", () => {
@@ -119,6 +120,38 @@ describe("formatLocalDay / parseLocalDay", () => {
       expect(formatLocalDay(parseLocalDay(day))).toBe(day);
     }
   );
+});
+
+describe("parseStoredDay", () => {
+  test("reads the calendar day out of a stored ISO timestamp without shifting it", () => {
+    // Segment and contact-attribute values are stored at midnight UTC. Parsing the whole string as an
+    // instant would land on the 4th for viewers west of UTC; the day named in the string must win.
+    const parsed = parseStoredDay("2026-08-05T00:00:00.000Z");
+
+    expect(parsed && formatLocalDay(parsed)).toBe("2026-08-05");
+    expect(parsed && [parsed.getHours(), parsed.getMinutes()]).toEqual([0, 0]);
+  });
+
+  test("parses a bare yyyy-MM-dd day, as validation rules store it", () => {
+    const parsed = parseStoredDay("2026-01-31");
+
+    expect(parsed && [parsed.getFullYear(), parsed.getMonth(), parsed.getDate()]).toEqual([2026, 0, 31]);
+  });
+
+  test("returns null when there is no stored value", () => {
+    expect(parseStoredDay("")).toBeNull();
+    expect(parseStoredDay(null)).toBeNull();
+    expect(parseStoredDay(undefined)).toBeNull();
+  });
+
+  test.each([
+    ["not-a-date", "unparseable text"],
+    ["2026-13-45", "an out-of-range day that Date would roll over to 2027-02-14"],
+    ["05/08/2026", "a non-ISO order"],
+    ["2026-9-7", 'an unpadded day, which an <input type="date"> also rejected'],
+  ])("returns null for %s (%s)", (value) => {
+    expect(parseStoredDay(value)).toBeNull();
+  });
 });
 
 describe("getDateFnsLocale", () => {

--- a/apps/web/lib/utils/datetime.ts
+++ b/apps/web/lib/utils/datetime.ts
@@ -165,6 +165,11 @@ export const parseLocalDay = (value: string): Date => {
  * `<input type="date">` did, so a value that predates the picker still renders, a rolled-over one
  * (`2026-13-45`) is refused rather than silently shown as a different day, and an unparseable one
  * yields `null` instead of the Invalid Date that would break the calendar.
+ *
+ * Only the day is validated, so a well-formed day followed by a malformed time still resolves to that
+ * day. That is deliberate: the day is the part a date picker shows, these values can arrive from the
+ * Management API rather than only from this UI, and the `<input type="date">` this replaced split on
+ * `T` the same way — blanking a readable day over a broken time suffix would lose information.
  */
 export const parseStoredDay = (value: string | null | undefined): Date | null => {
   if (!value) return null;

--- a/apps/web/lib/utils/datetime.ts
+++ b/apps/web/lib/utils/datetime.ts
@@ -154,3 +154,23 @@ export const parseLocalDay = (value: string): Date => {
 
   return new Date(year, month - 1, day);
 };
+
+/**
+ * Parses a stored date value — a bare `yyyy-MM-dd` or a full ISO timestamp — to the local midnight of
+ * the calendar day it names, or `null` when it names none.
+ *
+ * The time part is dropped before parsing rather than handed to `Date`: a stored
+ * `2026-08-05T00:00:00.000Z` is the 5th as written, and reading it as an instant would select the 4th
+ * for any viewer west of UTC. Round-tripping through `formatLocalDay` accepts exactly the values an
+ * `<input type="date">` did, so a value that predates the picker still renders, a rolled-over one
+ * (`2026-13-45`) is refused rather than silently shown as a different day, and an unparseable one
+ * yields `null` instead of the Invalid Date that would break the calendar.
+ */
+export const parseStoredDay = (value: string | null | undefined): Date | null => {
+  if (!value) return null;
+
+  const day = value.split("T")[0];
+  const parsed = parseLocalDay(day);
+
+  return formatLocalDay(parsed) === day ? parsed : null;
+};

--- a/apps/web/modules/ee/contacts/components/attribute-field-row.tsx
+++ b/apps/web/modules/ee/contacts/components/attribute-field-row.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { CalendarIcon, HashIcon, TagIcon, TrashIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { TContactAttributeKey } from "@formbricks/types/contact-attribute-key";
+import { formatLocalDay, parseStoredDay } from "@/lib/utils/datetime";
+import { toUTCDateString } from "@/modules/ee/contacts/segments/lib/date-utils";
 import { Button } from "@/modules/ui/components/button";
+import { DatePicker } from "@/modules/ui/components/date-picker";
 import { FormControl, FormError, FormField, FormItem, FormLabel } from "@/modules/ui/components/form";
 import { Input } from "@/modules/ui/components/input";
 import {
@@ -44,6 +48,9 @@ export const AttributeFieldRow = ({
   onRemove,
   t,
 }: AttributeFieldRowProps) => {
+  // Only the resolved language is read here; `t` stays prop-drilled from the modal that owns the form.
+  const { i18n } = useTranslation();
+  const locale = i18n.resolvedLanguage ?? i18n.language ?? "en-US";
   const availableOptions = getAvailableOptions(index);
 
   return (
@@ -104,16 +111,14 @@ export const AttributeFieldRow = ({
           const renderValueInput = () => {
             if (dataType === "date") {
               return (
-                <Input
-                  type="date"
-                  value={valueField.value ? valueField.value.split("T")[0] : ""}
-                  onChange={(e) => {
-                    const dateValue = e.target.value ? new Date(e.target.value).toISOString() : "";
-                    valueField.onChange(dateValue);
-                  }}
-                  placeholder={t("workspace.contacts.attribute_value_placeholder")}
-                  className="w-full"
-                />
+                <div className="flex-1">
+                  <DatePicker
+                    value={parseStoredDay(valueField.value)}
+                    locale={locale}
+                    triggerClassName="h-10 w-full"
+                    onChange={(date) => valueField.onChange(toUTCDateString(formatLocalDay(date)))}
+                  />
+                </div>
               );
             }
 

--- a/apps/web/modules/ee/contacts/segments/components/date-filter-value.tsx
+++ b/apps/web/modules/ee/contacts/segments/components/date-filter-value.tsx
@@ -4,7 +4,9 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TDateOperator, TSegmentFilterValue, TTimeUnit } from "@formbricks/types/segment";
 import { cn } from "@/lib/cn";
+import { formatLocalDay, parseStoredDay } from "@/lib/utils/datetime";
 import { toUTCDateString } from "@/modules/ee/contacts/segments/lib/date-utils";
+import { DatePicker } from "@/modules/ui/components/date-picker";
 import { Input } from "@/modules/ui/components/input";
 import {
   Select,
@@ -22,7 +24,8 @@ interface DateFilterValueProps {
 }
 
 export function DateFilterValue({ operator, value, onChange, viewOnly }: DateFilterValueProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.resolvedLanguage ?? i18n.language ?? "en-US";
   const [error, setError] = useState("");
 
   // Relative time operators: isOlderThan, isNewerThan
@@ -76,23 +79,23 @@ export function DateFilterValue({ operator, value, onChange, viewOnly }: DateFil
 
     return (
       <div className="flex items-center gap-2">
-        <Input
-          type="date"
-          className="h-9 w-auto bg-white"
+        <DatePicker
+          value={parseStoredDay(betweenValue[0])}
+          locale={locale}
           disabled={viewOnly}
-          value={betweenValue[0] ? betweenValue[0].split("T")[0] : ""}
-          onChange={(e) => {
-            onChange([toUTCDateString(e.target.value), betweenValue[1]]);
+          triggerClassName="h-9 w-[180px]"
+          onChange={(date) => {
+            onChange([toUTCDateString(formatLocalDay(date)), betweenValue[1]]);
           }}
         />
         <span className="text-sm text-slate-600">{t("common.and")}</span>
-        <Input
-          type="date"
-          className="h-9 w-auto bg-white"
+        <DatePicker
+          value={parseStoredDay(betweenValue[1])}
+          locale={locale}
           disabled={viewOnly}
-          value={betweenValue[1] ? betweenValue[1].split("T")[0] : ""}
-          onChange={(e) => {
-            onChange([betweenValue[0], toUTCDateString(e.target.value)]);
+          triggerClassName="h-9 w-[180px]"
+          onChange={(date) => {
+            onChange([betweenValue[0], toUTCDateString(formatLocalDay(date))]);
           }}
         />
       </div>
@@ -104,13 +107,13 @@ export function DateFilterValue({ operator, value, onChange, viewOnly }: DateFil
   const dateValue = typeof value === "string" ? value : "";
 
   return (
-    <Input
-      type="date"
-      className="h-9 w-auto bg-white"
+    <DatePicker
+      value={parseStoredDay(dateValue)}
+      locale={locale}
       disabled={viewOnly}
-      value={dateValue ? dateValue.split("T")[0] : ""}
-      onChange={(e) => {
-        onChange(toUTCDateString(e.target.value));
+      triggerClassName="h-9 w-[180px]"
+      onChange={(date) => {
+        onChange(toUTCDateString(formatLocalDay(date)));
       }}
     />
   );

--- a/apps/web/modules/survey/editor/components/validation-rule-value-input.tsx
+++ b/apps/web/modules/survey/editor/components/validation-rule-value-input.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 import { ALLOWED_FILE_EXTENSIONS, TAllowedFileExtension } from "@formbricks/types/storage";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { TValidationRule, TValidationRuleType } from "@formbricks/types/surveys/validation-rules";
+import { formatLocalDay, parseStoredDay } from "@/lib/utils/datetime";
+import { DatePicker } from "@/modules/ui/components/date-picker";
 import { Input } from "@/modules/ui/components/input";
 import { MultiSelect } from "@/modules/ui/components/multi-select";
 import {
@@ -34,45 +36,46 @@ export const ValidationRuleValueInput = ({
   onFileExtensionChange,
   element,
 }: ValidationRuleValueInputProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.resolvedLanguage ?? i18n.language ?? "en-US";
 
-  // Determine HTML input type for value inputs
-  let htmlInputType: "number" | "date" | "text" = "text";
-  if (config.valueType === "number") {
-    htmlInputType = "number";
-  } else if (
-    ruleType.startsWith("is") &&
-    (ruleType.includes("Later") || ruleType.includes("Earlier") || ruleType.includes("On"))
-  ) {
-    htmlInputType = "date";
-  }
+  // Date rules store the day as `yyyy-MM-dd`, and the two range rules store the pair comma-joined.
+  const [startDay = "", endDay = ""] = (typeof currentValue === "string" ? currentValue : "").split(",");
 
-  // Special handling for date range inputs
   if (ruleType === "isBetween" || ruleType === "isNotBetween") {
     return (
       <div className="flex w-full items-center gap-2">
-        <Input
-          type="date"
-          value={(currentValue as string)?.split(",")?.[0] ?? ""}
-          onChange={(e) => {
-            const currentEndDate = (currentValue as string)?.split(",")?.[1] ?? "";
-            onChange(`${e.target.value},${currentEndDate}`);
-          }}
-          placeholder={t("workspace.surveys.edit.validation.start_date")}
-          className="h-9 flex-1 bg-white"
-        />
+        <div className="flex-1">
+          <DatePicker
+            value={parseStoredDay(startDay)}
+            locale={locale}
+            placeholder={t("workspace.surveys.edit.validation.start_date")}
+            triggerClassName="h-9 w-full"
+            onChange={(date) => onChange(`${formatLocalDay(date)},${endDay}`)}
+          />
+        </div>
         <span className="text-sm text-slate-500">{t("common.and")}</span>
-        <Input
-          type="date"
-          value={(currentValue as string)?.split(",")?.[1] ?? ""}
-          onChange={(e) => {
-            const currentStartDate = (currentValue as string)?.split(",")?.[0] ?? "";
-            onChange(`${currentStartDate},${e.target.value}`);
-          }}
-          placeholder={t("workspace.surveys.edit.validation.end_date")}
-          className="h-9 flex-1 bg-white"
-        />
+        <div className="flex-1">
+          <DatePicker
+            value={parseStoredDay(endDay)}
+            locale={locale}
+            placeholder={t("workspace.surveys.edit.validation.end_date")}
+            triggerClassName="h-9 w-full"
+            onChange={(date) => onChange(`${startDay},${formatLocalDay(date)}`)}
+          />
+        </div>
       </div>
+    );
+  }
+
+  if (ruleType === "isLaterThan" || ruleType === "isEarlierThan") {
+    return (
+      <DatePicker
+        value={parseStoredDay(startDay)}
+        locale={locale}
+        triggerClassName="h-9 w-[200px]"
+        onChange={(date) => onChange(formatLocalDay(date))}
+      />
     );
   }
 
@@ -126,7 +129,7 @@ export const ValidationRuleValueInput = ({
   // Default text/number input
   return (
     <Input
-      type={htmlInputType}
+      type={config.valueType === "number" ? "number" : "text"}
       value={currentValue ?? ""}
       onChange={(e) => onChange(e.target.value)}
       // Browsers accept scientific notation in a number field, so `1e5` would silently store

--- a/apps/web/modules/survey/editor/lib/validation-rules-config.ts
+++ b/apps/web/modules/survey/editor/lib/validation-rules-config.ts
@@ -101,29 +101,26 @@ export const RULE_TYPE_CONFIG: Record<
     valueType: "number",
     valuePlaceholder: "100",
   },
+  // The four date rules render a calendar picker, which labels itself, so they carry no placeholder.
   isLaterThan: {
     labelKey: "is_later_than",
     needsValue: true,
     valueType: "text",
-    valuePlaceholder: "YYYY-MM-DD",
   },
   isEarlierThan: {
     labelKey: "is_earlier_than",
     needsValue: true,
     valueType: "text",
-    valuePlaceholder: "YYYY-MM-DD",
   },
   isBetween: {
     labelKey: "is_between",
     needsValue: true,
     valueType: "text",
-    valuePlaceholder: "YYYY-MM-DD,YYYY-MM-DD",
   },
   isNotBetween: {
     labelKey: "is_not_between",
     needsValue: true,
     valueType: "text",
-    valuePlaceholder: "YYYY-MM-DD,YYYY-MM-DD",
   },
   minRanked: {
     labelKey: "minimum_options_ranked",


### PR DESCRIPTION
Ref ENG-700

## What & why

**Was:** Three surfaces still rendered `<input type="date">`, showing the browser's own calendar in the **OS** locale — `02.03.2026` on a German machine — while the rest of the app showed `Mar 2, 2026`.

**Now:** All three use the shared `DatePicker` — contact attribute editor, segment date filter, survey date validation rules — each still writing back the format it wrote before.

No other unmigrated pickers remain in `apps/web`; `survey-ui` keeps its own by design.

## Where to look

- [`parseStoredDay`](https://github.com/formbricks/formbricks/blob/claude/unified-date-picker-audit-4ebb3f/apps/web/lib/utils/datetime.ts#L157-L176) — the only new logic; both storage shapes, no shift
- [`validation-rule-value-input.tsx`](https://github.com/formbricks/formbricks/blob/claude/unified-date-picker-audit-4ebb3f/apps/web/modules/survey/editor/components/validation-rule-value-input.tsx#L42-L78) — date branch replaces `htmlInputType` sniffing

## Breaking changes

- [ ] This PR contains breaking changes

None — three internal admin components and one helper. Nothing external reaches them; no stored value changes shape.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm test --filter=@formbricks/web -- lib/utils/datetime.test.ts`

Manual rows: seeded data changed in the UI, then read back from Postgres.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Midnight-UTC ISO reads back as the day it names | unit (mutation) | drop `.split("T")[0]` at `datetime.ts:172` to redden |
| Rolled-over or unparseable values yield `null` | unit (guard) | `2026-13-45` refused, not shown as 2027-02-14 |
| Survey date validation rules | manual | Mar 17 → `startDate: "2026-03-17"`, `endDate` untouched |
| Contact date attribute | manual | Apr 23 → `"2026-04-23T00:00:00.000Z"` |
| Segment filter (`isBetween`, `isBefore`) | manual | Feb 20 → `["2026-02-20T…","2026-06-20T…"]` |
| Popover inside a dialog | manual | Both EE modals: above the overlay, right month |

<details>
<summary>Before / after — survey date validation rules</summary>

Same stored values in both shots. Before, the range bounds and the threshold are native inputs in OS format; after, the shared picker in the app locale.

![before](https://raw.githubusercontent.com/formbricks/formbricks/assets/unified-date-picker/before-validation-rules.png)
![after](https://raw.githubusercontent.com/formbricks/formbricks/assets/unified-date-picker/after-validation-rules.png)

</details>

<details>
<summary>Before / after — contact date attribute</summary>

![before](https://raw.githubusercontent.com/formbricks/formbricks/assets/unified-date-picker/before-contact-attribute.png)
![after](https://raw.githubusercontent.com/formbricks/formbricks/assets/unified-date-picker/after-contact-attribute.png)

</details>

<details>
<summary>Before / after — segment date filter</summary>

![before](https://raw.githubusercontent.com/formbricks/formbricks/assets/unified-date-picker/before-segment-filter.png)
![after](https://raw.githubusercontent.com/formbricks/formbricks/assets/unified-date-picker/after-segment-filter.png)

</details>

**Open gaps**

- Only `en-US` driven in the browser; other locales rest on `getDateFnsLocale`.
- No E2E — a control swap inside existing features, not a new journey.

**Risks**

- No clear button — an empty date fails validation on all three surfaces; removal is the delete button.
- Removed the date rules' now-unreachable `valuePlaceholder` entries.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown` (this client does not expose it).
