### PR TITLE
fix(security): pin brace-expansion to close 2 advisories [ENG-2234]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ overrides:
   qs: 6.16.0
   '@faker-js/faker': 10.5.0
   fflate: 0.4.9
+  brace-expansion@1: 1.1.18
+  brace-expansion@2: 2.1.4
+  brace-expansion@5: 5.0.9
 
 patchedDependencies:
   '@better-auth/oauth-provider@1.7.0': c902485a86bcc6e01946ff9b5339866f3dcd2bbf84369e1c10cc4608e8e2ebd4
@@ -7401,14 +7404,14 @@ packages:
   bowser@2.13.1:
     resolution: {integrity: sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -19896,16 +19899,16 @@ snapshots:
 
   bowser@2.13.1: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -22515,19 +22518,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -341,32 +341,23 @@ overrides:
   # all resolve to the patched version on their own now.
   # js-cookie, shell-quote and form-data@4 were retired by bumping react-use to 17.6.1 (js-cookie ^3),
   # concurrently to 9.2.4 (shell-quote 1.9.0) and @redocly/cli to 1.34.17 (form-data 4.0.6) instead.
-  # === Fixable, deferred to its own PR (ENG-2234) — brace-expansion ===
-  # NOT in the list above: every brace-expansion line we resolve (1.1.16, 2.1.2, 5.0.8) is still
-  # vulnerable, and all three are closable by re-pinning. Re-verified 2026-08-05. Two advisories now:
-  # - GHSA-mh99-v99m-4gvg (unbounded expansion length → OOM), re-split upstream into per-major ranges:
-  #   `<1.1.17` and `>=2.0.0 <2.1.3`. The 5.x line is clear of this one.
-  # - GHSA-rgw5-rvv9-x895 (unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation) covers
-  #   all three: `<1.1.18`, `>=2.0.0 <2.1.4` and `>=4.0.0 <5.0.9`.
-  # Pinning the current maintenance releases — 1.1.18 / 2.1.4 / 5.0.9, all published 2026-07-30 and all
-  # past the `minimumReleaseAge` cooldown below — closes both advisories on all three lines. That is a
-  # dependency change needing its own lockfile and test run, so it is deferred to ENG-2234 rather than
-  # folded into an audit-comment sweep; the note here goes away with that PR. (An earlier version of this
-  # note claimed no patch was coming and that a pin could not close it. Both stopped being true on
-  # 2026-07-28.)
-  # Until then the residual risk stays acceptable — but NOT for the "devDependency-only" reason this note
-  # used to give, which was wrong. Every line reaches brace-expansion via minimatch, and they are rooted
-  # in production chains, not only dev ones: the 2.x line through `googleapis` and `@boxyhq/saml-jackson`
-  # (both apps/web `dependencies`, via gaxios>rimraf>glob and typeorm>glob) and `@ai-sdk/google-vertex`
-  # (a packages/ai `dependency`); the 1.x line through node-gyp under that same saml-jackson's
-  # typeorm>sqlite3. `pnpm audit` marks these findings `dev: false`. By contributor, the 1.x line is
-  # dominated by the eslint plugin graph (typescript-eslint, @vitest/eslint-plugin, eslint-config-next,
-  # eslint-plugin-storybook) and the 2.x line by vite-plugin-dts>@vue/language-core across six workspace
-  # packages, plus both prettier plugins. Two roots sit on both lines: @redocly/cli (mostly 2.x) and
-  # @boxyhq/saml-jackson (mostly 1.x, via the node-gyp chain above).
-  # What makes it tolerable is the input, not the dependency type: every one of these call sites expands
-  # glob patterns supplied by library code or developer config (gaxios' cache cleanup, typeorm's entity
-  # discovery, build and lint globs), never by request data.
+  # ENG-2234 / GHSA-mh99-v99m-4gvg + GHSA-rgw5-rvv9-x895: brace-expansion's recursive expansion has no
+  # bound on total output length, so a crafted `{a,b}{c,d}...` pattern grows the result set exponentially
+  # (DoS). GHSA-rgw5-rvv9-x895 (unbounded intermediate arrays) bypasses the CVE-2026-14257 mitigation and
+  # covers all three lines we resolve; GHSA-mh99-v99m-4gvg covers only the 1.x and 2.x lines. Every line
+  # reaches brace-expansion via minimatch. Pinned to the lowest maintenance release closing both
+  # advisories on each line.
+  # load-bearing: @boxyhq/saml-jackson's typeorm>sqlite3>node-gyp chain (runtime) resolves the vulnerable
+  # 1.x line; the eslint plugin graph (dev) is on the same line.
+  brace-expansion@1: 1.1.18
+  # load-bearing: @boxyhq/saml-jackson resolves the vulnerable 2.x line both directly (typeorm>glob) and
+  # via googleapis/@googleapis/admin (runtime, apps/web and packages/ai `dependencies`); @redocly/cli and
+  # vite-plugin-dts>@vue/language-core (dev) are on the same line.
+  brace-expansion@2: 2.1.4
+  # load-bearing: @sentry/nextjs (runtime, apps/web `dependencies`, via @fastify/otel>@sentry/node) and
+  # react-email (runtime, @formbricks/email `dependencies`) resolve the vulnerable 5.x line, alongside
+  # vite-plugin-dts, typescript-eslint and storybook (dev).
+  brace-expansion@5: 5.0.9
   # === Closed by ENG-2343 (kept as a record, like the section above) ===
   # GHSA-p2fr-6hmx-4528 (@better-auth/oauth-provider RFC 8707 resource-indicator confusion) was carried
   # here as an accepted risk for as long as the only patched line was a pre-release. It is fixed as of


### PR DESCRIPTION
Fixes ENG-2234

## What & why

**Was:** every `brace-expansion` line resolved in the tree (1.x, 2.x, 5.x) was still vulnerable to GHSA-mh99-v99m-4gvg and/or GHSA-rgw5-rvv9-x895 — the latter bypasses the earlier CVE-2026-14257 mitigation and was deferred to this ticket rather than folded into the batch that closed the other six advisories in #9148.

**Now:** all three lines resolve to the lowest maintenance release that closes both advisories; the deferral note in `pnpm-workspace.yaml` is replaced with real pins. No application code changed.

| Package | Old | New | GHSA/CVE | Severity | Linear issue | Direct/override |
| --- | --- | --- | --- | --- | --- | --- |
| `brace-expansion@1` | 1.1.16 | 1.1.18 | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 | high | ENG-2234 | override |
| `brace-expansion@2` | 2.1.2 | 2.1.4 | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 | high | ENG-2234 | override |
| `brace-expansion@5` | 5.0.8 | 5.0.9 | GHSA-rgw5-rvv9-x895 | high | ENG-2234 | override |

## Where to look

- [pnpm-workspace.yaml overrides block](../../blob/HEAD/pnpm-workspace.yaml) — three new pins, deferral note removed

## Breaking changes

- [ ] This PR contains breaking changes

None — patch/point releases of a transitive dependency pinned via `overrides`; no API surface changes.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm install && pnpm audit --prod`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| GHSA-mh99-v99m-4gvg (1.x/2.x OOM) closed | manual | `pnpm audit --prod` → 0 findings (was 2 high) |
| GHSA-rgw5-rvv9-x895 (all 3 lines) closed | manual | `pnpm why brace-expansion` → single resolved version per line (1.1.18/2.1.4/5.0.9) |
| existing suites unaffected by the pin | unit | `pnpm test` — 750 test files / 10,108 tests passed |

Also ran, all green: `pnpm lint` (0 errors, pre-existing warnings only), `pnpm format` (no diff).

**Open gaps**

- No e2e/manual app boot — a pure dependency-version change with no application-code path to exercise beyond what the full unit suite already covers.

**Risks**

- `brace-expansion` is reached from production chains (via `minimatch`, e.g. `@boxyhq/saml-jackson`'s `typeorm`/`sqlite3` and `googleapis` paths), not only dev tooling; this is a patch release on each line, covered by the existing suite but not manually re-exercised.

### Needs a human

None — the advisory closed with a version pin; no major upgrade or application-code change was required.

---

> [!NOTE]
> **AI model used** — claude-sonnet-5, reasoning effort unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHN8rUmGS7VD974AFdWrdp

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHN8rUmGS7VD974AFdWrdp)_