### PR TITLE
fix(embedded-data): refuse a variable taking a hidden field's name at the v1 write boundary [ENG-2933]

### DIFF
--- a/apps/web/integration/api-back-compat.integration.test.ts
+++ b/apps/web/integration/api-back-compat.integration.test.ts
@@ -480,4 +480,60 @@ describe("grandfathering at the v1 / v2 write boundary (updateSurvey)", () => {
     expect(served.variables).toHaveLength(1);
     await expectNoDrift(survey.id);
   });
+
+  // ENG-2933: the one write this boundary accepted and no other surface did. The reconcile cannot see
+  // it — a variable is stored under its cuid, a hidden field under its name — so the name guard is
+  // where it is refused, grandfathered exactly like a reserved name.
+  test("a PUT that gives a variable an existing hidden field's name is refused", async () => {
+    const survey = await seedSurvey({ hiddenFields: { enabled: true, fieldIds: ["plan"] } });
+
+    expect(
+      await putOutcome(survey, { variables: [{ id: VARIABLE_ID, name: "plan", type: "text", value: "" }] })
+    ).toEqual({ refused: "InvalidInputError" });
+
+    // Refused before the transaction opened: nothing was written.
+    expect((await readAsLegacyApi(survey.id)).variables).toEqual([]);
+  });
+
+  test("a PUT that gives a hidden field an existing variable's name is refused", async () => {
+    const survey = await seedSurvey({
+      variables: [{ id: VARIABLE_ID, name: "score", type: "number", value: 7 }],
+    });
+
+    expect(await putOutcome(survey, { hiddenFields: { enabled: true, fieldIds: ["score"] } })).toEqual({
+      refused: "InvalidInputError",
+    });
+  });
+
+  test("a full PUT that resends a clash the survey already holds is accepted", async () => {
+    // The 46 production surveys: written straight into the columns before any surface checked. Their
+    // read-modify-write PUT resends both sides and must keep working.
+    const survey = await seedSurvey({
+      variables: [{ id: VARIABLE_ID, name: "first_name", type: "text", value: "" }],
+      hiddenFields: { enabled: true, fieldIds: ["first_name"] },
+    });
+
+    expect(await putOutcome(survey, { name: "Renamed via PUT" })).toBe("accepted");
+
+    const served = await readAsLegacyApi(survey.id);
+    expect(served.variables.map((variable) => variable.name)).toEqual(["first_name"]);
+    expect(served.hiddenFields.fieldIds).toEqual(["first_name"]);
+    await expectNoDrift(survey.id);
+  });
+
+  test("a grandfathered clash does not license a new one", async () => {
+    const survey = await seedSurvey({
+      variables: [{ id: VARIABLE_ID, name: "first_name", type: "text", value: "" }],
+      hiddenFields: { enabled: true, fieldIds: ["first_name", "plan"] },
+    });
+
+    expect(
+      await putOutcome(survey, {
+        variables: [
+          ...survey.variables,
+          { id: "clvar123456789012345678903", name: "plan", type: "text", value: "" },
+        ],
+      })
+    ).toEqual({ refused: "InvalidInputError" });
+  });
 });

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -19,9 +19,9 @@ import {
 } from "@formbricks/types/segment";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import {
-  collectDeclaredFieldNames,
+  type TDeclaredFieldSource,
   describeDeclaredFieldNameErrors,
-  validateNewDeclaredFieldNames,
+  validateNewDeclaredFields,
 } from "@formbricks/types/surveys/declared-field-guard";
 import { TSurvey, TSurveyCreateInput, ZSurvey, ZSurveyCreateInput } from "@formbricks/types/surveys/types";
 import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
@@ -52,16 +52,20 @@ import {
 } from "./utils";
 
 /**
- * ENG-1839: refuse reserved names for newly declared fields, as an `InvalidInputError` — which
- * `handleApiError` maps to a 400 carrying this message, and the editor surfaces as a toast. Thrown
- * before any transaction is opened, so a refusal never fails inside an interactive transaction.
+ * ENG-1839 / ENG-2933: refuse a reserved name, or a name shared by a variable and a hidden field,
+ * for newly declared fields — as an `InvalidInputError`, which `handleApiError` maps to a 400
+ * carrying this message, and the editor surfaces as a toast. Thrown before any transaction is
+ * opened, so a refusal never fails inside an interactive transaction.
  *
  * Deliberately NOT inside `reconcileEmbeddedData`: that runs in the transaction, and the survey copy
  * flow feeds a whole survey's fields to it as "new" against zero existing rows — guarding there
  * would make duplicating a grandfathered survey fail.
  */
-const assertNoReservedNewDeclaredFieldNames = (params: { existing: string[]; incoming: string[] }): void => {
-  const errors = validateNewDeclaredFieldNames(params);
+const assertValidNewDeclaredFields = (params: {
+  existing: TDeclaredFieldSource;
+  incoming: TDeclaredFieldSource;
+}): void => {
+  const errors = validateNewDeclaredFields(params);
   if (errors.length > 0) {
     throw new InvalidInputError(describeDeclaredFieldNameErrors(errors));
   }
@@ -379,17 +383,16 @@ export const updateSurveyInternal = async (
     // tenant's language. Mirrors the create path guard (covers drafts too — runs before validation).
     await assertSurveyLanguagesBelongToWorkspace(currentSurvey.workspaceId, languages);
 
-    // ENG-1839: a newly declared field may not take a reserved name. Runs here — before the
-    // transaction, and regardless of `skipValidation` — because this is an input-boundary check, not
-    // schema validation: `ZSurveyHiddenFields` stays lenient by design (the same schema parses
-    // surveys loaded from the database), so without this `PUT /api/v1/management/surveys/<id>` can
-    // still create a hidden field named `country` or `lang` that can never receive a value.
-    // Grandfathering is what makes it safe: `existing` carries everything this survey already
-    // declares, and any name in it passes untouched.
-    assertNoReservedNewDeclaredFieldNames({
-      existing: collectDeclaredFieldNames(currentSurvey),
-      incoming: collectDeclaredFieldNames(updatedSurvey),
-    });
+    // ENG-1839: a newly declared field may not take a reserved name. ENG-2933: nor may a variable and
+    // a hidden field newly share one — the reconcile cannot see that clash, because a variable is
+    // stored under its id and a hidden field under its name. Runs here — before the transaction, and
+    // regardless of `skipValidation` — because this is an input-boundary check, not schema
+    // validation: `ZSurveyHiddenFields` stays lenient by design (the same schema parses surveys
+    // loaded from the database), so without this `PUT /api/v1/management/surveys/<id>` can still
+    // create a hidden field named `country` or `lang` that can never receive a value, or a variable
+    // named after an existing hidden field. Grandfathering is what makes it safe: `existing` is
+    // everything this survey already declares, and any name — or clash — in it passes untouched.
+    assertValidNewDeclaredFields({ existing: currentSurvey, incoming: updatedSurvey });
 
     // ENG-1939/ENG-2115: validation may only be skipped for a draft-to-draft write, so BOTH sides of
     // the transition are gated. The lenient draft schema (ZSurveyDraft) does not validate elements at
@@ -884,10 +887,7 @@ export const createSurvey = async (
     // grandfather yet. Covers templates, `POST /api/v1/management/surveys` and the v3 create route.
     // The survey COPY flow does its own `tx.survey.create` and never reaches here, which is what
     // keeps duplicating a survey that already declares `country` working.
-    assertNoReservedNewDeclaredFieldNames({
-      existing: [],
-      incoming: collectDeclaredFieldNames(restSurveyBody),
-    });
+    assertValidNewDeclaredFields({ existing: {}, incoming: restSurveyBody });
 
     // An app survey can never be shown without a trigger, so block creating one directly in a
     // non-draft status with zero triggers (mirrors the editor's publish guard).

--- a/docs/surveys/general-features/hidden-fields.mdx
+++ b/docs/surveys/general-features/hidden-fields.mdx
@@ -24,13 +24,14 @@ Field ids follow one rule everywhere — the editor and the management API refus
 - A **new** field id must start with a lowercase letter and then contain only lowercase letters, numbers and underscores: `^[a-z][a-z0-9_]*$`. So `page_type`, not `pageType` or `Page Type`.
 - **Reserved names are refused in any casing.** These are the link-survey system params and internal ids: `userId`, `source`, `suid`, `end`, `start`, `welcomeCard`, `hidden`, `verifiedEmail`, `multiLanguage`, `embed`, `verify`, `suToken`, `lang`, `preview`, `startAt`, `skipPrefilled`, `offlineSupport`. A field named exactly like one of them is never filled from a survey URL, whatever the casing of the parameter: that parameter belongs to the survey link. An older survey that declares a case variant such as `Source` keeps being filled by that exact spelling (`?Source=`), never by the reserved one (`?source=`); the mismatch logs a browser console warning naming the spelling that fills the field.
 - **Auto-captured field names are refused too**: every survey can already read those by name without declaring them, and a second field under the same name would be ambiguous in recall and logic. The full list: `source`, `url`, `country`, `action`, `browser`, `os`, `deviceType`, `ipAddress`, `finished`, `language`, `locale`, `responseId`, `surveyId`, `durationSeconds`, `startedAt`, `finishedAt`, `pagePath`, `pageReferrer`, `utmSource`, `utmMedium`, `utmCampaign`, `utmTerm`, `utmContent`, `screenWidth`, `screenHeight`, `viewportWidth`, `viewportHeight`, `timezone`.
+- **A hidden field and a variable may not share a name**, in any casing, for the same reason: recall and logic address both by name. Adding a variable `plan` to a survey with a hidden field `plan` (or the reverse) is refused.
 
 <Note>
   Ids a survey **already declares keep working**: they load, collect values and can be re-saved unchanged —
-  only adding such a name as a *new* field is refused. Deleting a grandfathered field spends the reprieve:
-  once it is gone from the saved survey, the name can no longer be re-added. One consequence: re-creating a
-  survey from an exported document fails with a 400 when the export declares a refused name. Rename that field
-  in the payload before importing.
+  only adding such a name as a *new* field is refused. The same goes for a hidden field and a variable that
+  already share a name. Deleting a grandfathered field spends the reprieve: once it is gone from the saved
+  survey, the name can no longer be re-added. One consequence: re-creating a survey from an exported document
+  fails with a 400 when the export declares a refused name. Rename that field in the payload before importing.
 </Note>
 
 ## Set Hidden Field via URL

--- a/packages/types/surveys/declared-field-guard.test.ts
+++ b/packages/types/surveys/declared-field-guard.test.ts
@@ -1,14 +1,26 @@
 import { describe, expect, test } from "vitest";
 import {
+  type TDeclaredFieldSource,
   collectDeclaredFieldNames,
   describeDeclaredFieldNameError,
   describeDeclaredFieldNameErrors,
+  validateNewDeclaredFieldClashes,
   validateNewDeclaredFieldNames,
+  validateNewDeclaredFields,
 } from "./declared-field-guard";
 import { TValidateIdErrorCode } from "./validation";
 
 const refusedNames = (params: { existing: string[]; incoming: string[] }): string[] =>
   validateNewDeclaredFieldNames(params).map((error) => error.field);
+
+/** A survey's declared fields, spelled the way `TSurvey` carries them. */
+const declared = (fields: { variables?: string[]; hiddenFields?: string[] }): TDeclaredFieldSource => ({
+  variables: fields.variables?.map((name) => ({ id: `var_${name}`, name, type: "text", value: "" })),
+  hiddenFields: fields.hiddenFields === undefined ? undefined : { fieldIds: fields.hiddenFields },
+});
+
+const clashes = (params: { existing: TDeclaredFieldSource; incoming: TDeclaredFieldSource }): string[] =>
+  validateNewDeclaredFieldClashes(params).map((error) => error.field);
 
 describe("validateNewDeclaredFieldNames", () => {
   describe("grandfathering", () => {
@@ -241,5 +253,223 @@ describe("describeDeclaredFieldNameErrors", () => {
     expect(message).toContain('"country"');
     expect(message).toContain('"url"');
     expect(message).toContain("newly added names only");
+  });
+});
+
+// ENG-2933: `PUT /api/v1/management/surveys/{id}` accepted a variable named after one of the survey's
+// hidden fields. The editor and v3 both refuse it, and the reconcile cannot catch it (a variable is
+// stored under its id, a hidden field under its name), so the name guard is where it belongs.
+describe("validateNewDeclaredFieldClashes", () => {
+  describe("a new clash is refused", () => {
+    test("a variable may not take an existing hidden field's name", () => {
+      expect(
+        clashes({
+          existing: declared({ hiddenFields: ["plan"] }),
+          incoming: declared({ hiddenFields: ["plan"], variables: ["plan"] }),
+        })
+      ).toEqual(["plan"]);
+    });
+
+    test("a hidden field may not take an existing variable's name", () => {
+      expect(
+        clashes({
+          existing: declared({ variables: ["score"] }),
+          incoming: declared({ variables: ["score"], hiddenFields: ["score"] }),
+        })
+      ).toEqual(["score"]);
+    });
+
+    test("a create may not declare both sides under one name", () => {
+      expect(
+        clashes({
+          existing: {},
+          incoming: declared({ variables: ["plan"], hiddenFields: ["plan"] }),
+        })
+      ).toEqual(["plan"]);
+    });
+
+    test("matching is case-insensitive, as in the editor and v3", () => {
+      expect(
+        clashes({
+          existing: declared({ hiddenFields: ["Plan"] }),
+          incoming: declared({ hiddenFields: ["Plan"], variables: ["plan"] }),
+        })
+      ).toEqual(["plan"]);
+    });
+
+    test("reports the Duplicate code the editor's hidden-fields card reports for the same clash", () => {
+      expect(
+        validateNewDeclaredFieldClashes({
+          existing: declared({ hiddenFields: ["plan"] }),
+          incoming: declared({ hiddenFields: ["plan"], variables: ["plan"] }),
+        })
+      ).toEqual([{ code: TValidateIdErrorCode.Duplicate, field: "plan" }]);
+    });
+
+    test("the error names the side the write introduces", () => {
+      // The variable already existed, so the hidden field is the newcomer — and the message should
+      // echo the spelling the caller just sent, not the one already stored.
+      expect(
+        clashes({
+          existing: declared({ variables: ["plan"] }),
+          incoming: declared({ variables: ["plan"], hiddenFields: ["Plan"] }),
+        })
+      ).toEqual(["Plan"]);
+      expect(
+        clashes({
+          existing: declared({ hiddenFields: ["plan"] }),
+          incoming: declared({ hiddenFields: ["plan"], variables: ["PLAN"] }),
+        })
+      ).toEqual(["PLAN"]);
+    });
+  });
+
+  describe("grandfathering", () => {
+    // 46 production surveys hold this state (`first_name`, `brand`, `score`, ...). Their plain
+    // read-modify-write PUT resends both sides, and a blanket refusal would break every one of them.
+    const holdsClash = declared({ variables: ["first_name", "score"], hiddenFields: ["first_name", "plan"] });
+
+    test("a survey that already holds the clash may resend it", () => {
+      expect(clashes({ existing: holdsClash, incoming: holdsClash })).toEqual([]);
+    });
+
+    test("grandfathering survives a case change on either side", () => {
+      expect(
+        clashes({
+          existing: declared({ variables: ["First_Name"], hiddenFields: ["first_name"] }),
+          incoming: declared({ variables: ["first_name"], hiddenFields: ["FIRST_NAME"] }),
+        })
+      ).toEqual([]);
+    });
+
+    test("a grandfathered clash does not license a new one", () => {
+      expect(
+        clashes({
+          existing: holdsClash,
+          incoming: declared({
+            variables: ["first_name", "score", "plan"],
+            hiddenFields: ["first_name", "plan"],
+          }),
+        })
+      ).toEqual(["plan"]);
+    });
+
+    test("the reprieve is per pair: a name that is only a variable today is not grandfathered as a clash", () => {
+      // `score` is declared (as a variable), so the reserved-name guard would grandfather it — but
+      // no hidden field shares it yet, so adding one is a NEW clash.
+      expect(
+        clashes({
+          existing: holdsClash,
+          incoming: declared({
+            variables: ["first_name", "score"],
+            hiddenFields: ["first_name", "plan", "score"],
+          }),
+        })
+      ).toEqual(["score"]);
+    });
+
+    test("dropping one side spends the reprieve", () => {
+      // The save that drops the variable passes; after it the survey no longer holds the clash, so
+      // adding the variable back is refused like any new clash.
+      expect(
+        clashes({
+          existing: holdsClash,
+          incoming: declared({ variables: ["score"], hiddenFields: ["first_name", "plan"] }),
+        })
+      ).toEqual([]);
+      expect(
+        clashes({
+          existing: declared({ variables: ["score"], hiddenFields: ["first_name", "plan"] }),
+          incoming: declared({ variables: ["score", "first_name"], hiddenFields: ["first_name", "plan"] }),
+        })
+      ).toEqual(["first_name"]);
+    });
+  });
+
+  describe("what the write leaves in place", () => {
+    test("a carrier the payload never mentions is the survey's current one", () => {
+      // The reconcile carries an unmentioned carrier's rows over unchanged, so a payload that sends
+      // only `variables` still ends up beside the hidden fields it did not mention.
+      expect(
+        clashes({
+          existing: declared({ hiddenFields: ["plan"] }),
+          incoming: declared({ variables: ["plan"] }),
+        })
+      ).toEqual(["plan"]);
+      expect(
+        clashes({
+          existing: declared({ variables: ["plan"] }),
+          incoming: declared({ hiddenFields: ["plan"] }),
+        })
+      ).toEqual(["plan"]);
+    });
+
+    test("a null carrier is treated as unmentioned, not as empty", () => {
+      expect(
+        clashes({
+          existing: declared({ hiddenFields: ["plan"] }),
+          incoming: { variables: declared({ variables: ["plan"] }).variables, hiddenFields: null },
+        })
+      ).toEqual(["plan"]);
+    });
+
+    test("moving a name across namespaces in one write is not a clash", () => {
+      // Hidden field `plan` becomes variable `plan`: after the write only one field carries the name.
+      expect(
+        clashes({
+          existing: declared({ hiddenFields: ["plan"] }),
+          incoming: declared({ hiddenFields: [], variables: ["plan"] }),
+        })
+      ).toEqual([]);
+    });
+
+    test("distinct names never clash", () => {
+      expect(
+        clashes({
+          existing: {},
+          incoming: declared({ variables: ["score", "tier"], hiddenFields: ["plan", "user_region"] }),
+        })
+      ).toEqual([]);
+    });
+  });
+});
+
+describe("validateNewDeclaredFields", () => {
+  test("reports reserved names and clashes together", () => {
+    expect(
+      validateNewDeclaredFields({
+        existing: {},
+        incoming: declared({ variables: ["country", "plan"], hiddenFields: ["plan"] }),
+      })
+    ).toEqual([
+      { code: TValidateIdErrorCode.Reserved, field: "country" },
+      { code: TValidateIdErrorCode.Duplicate, field: "plan" },
+    ]);
+  });
+
+  test("a name refused as reserved is not reported a second time as a clash", () => {
+    const errors = validateNewDeclaredFields({
+      existing: {},
+      incoming: declared({ variables: ["country"], hiddenFields: ["country"] }),
+    });
+
+    expect(errors).toEqual([{ code: TValidateIdErrorCode.Reserved, field: "country" }]);
+  });
+
+  test("grandfathers a reserved name and a clash the survey already holds", () => {
+    const survey = declared({ variables: ["country", "first_name"], hiddenFields: ["first_name"] });
+
+    expect(validateNewDeclaredFields({ existing: survey, incoming: survey })).toEqual([]);
+  });
+
+  test("the clash sentence says what is wrong without claiming the other side came first", () => {
+    const [error] = validateNewDeclaredFields({
+      existing: {},
+      incoming: declared({ variables: ["plan"], hiddenFields: ["plan"] }),
+    });
+
+    expect(describeDeclaredFieldNameError(error)).toBe(
+      'Field name "plan" cannot be used: a second field in this survey would carry that name, and recall and logic address fields by name.'
+    );
   });
 });

--- a/packages/types/surveys/declared-field-guard.ts
+++ b/packages/types/surveys/declared-field-guard.ts
@@ -111,14 +111,114 @@ export const validateNewDeclaredFieldNames = ({
 
     // Delegated rather than reimplemented so this guard and the editor card can never drift apart:
     // `validateId`'s strict branch is the single definition of what a new declared name may be. The
-    // id lists are empty on purpose — a collision with an existing name is a *duplicate*, which the
-    // reconcile's `assertNoDuplicateStorageKeys` and the v3 reference validation already own, and
-    // reporting it here would turn a grandfathered name into an error.
+    // id lists are empty on purpose — passing the survey's names would report every grandfathered
+    // name as a duplicate. A name shared across the two namespaces is a different check, with its
+    // own grandfather rule: `validateNewDeclaredFieldClashes`.
     const error = validateId(name, [], [], [], [], { requireSafeIdentifier: true });
     if (error) errors.push(error);
   }
 
   return errors;
+};
+
+const isDeclared = <T>(carrier: T | null | undefined): carrier is T =>
+  carrier !== undefined && carrier !== null;
+
+/** Lower-cased name → the spelling the payload used, per namespace, for what a source declares. */
+const namesByNamespace = (
+  source: TDeclaredFieldSource
+): { variables: Map<string, string>; hiddenFields: Map<string, string> } => ({
+  variables: new Map(
+    isDeclared(source.variables)
+      ? source.variables.map((variable) => [variable.name.toLowerCase(), variable.name])
+      : []
+  ),
+  hiddenFields: new Map(
+    isDeclared(source.hiddenFields)
+      ? (source.hiddenFields.fieldIds ?? []).map((id) => [id.toLowerCase(), id])
+      : []
+  ),
+});
+
+/**
+ * Refuses a name that a variable and a hidden field would share after the write — unless the survey
+ * already holds that exact clash.
+ *
+ * Recall and logic address variables and hidden fields *by name*, so two fields under one name are
+ * ambiguous by construction. The editor refuses this in both directions and the v3 reference
+ * validation refuses it as `duplicate_identifier`; the v1 management API had no check at all (ENG-2933).
+ * Nothing further down catches it either: the reconcile's `assertNoDuplicateStorageKeys` compares
+ * storage keys, and a variable is stored under its `id` while a hidden field is stored under its
+ * name, so the two never collide there.
+ *
+ * Grandfathered like reserved names, and per-save for the same reasons ({@link validateNewDeclaredFieldNames}):
+ * surveys in production already hold `first_name` as both, and their read-modify-write PUT must keep
+ * working. A clash is refused only when the survey did not already hold it — so adding a variable
+ * `plan` beside an existing hidden field `plan` is refused, resending an existing pair is not, and
+ * dropping one side spends the reprieve. Case-insensitive, matching the editor and v3.
+ *
+ * A carrier the payload never mentions (`undefined`/`null`) is the survey's current one, exactly as
+ * the reconcile carries those rows over — so a payload that sends only `variables` is still checked
+ * against the hidden fields it leaves in place.
+ *
+ * The error names the side the write introduces (the hidden field, when the variable already
+ * existed; the variable otherwise), with the code the editor's hidden-fields card reports for the
+ * same clash.
+ */
+export const validateNewDeclaredFieldClashes = ({
+  existing,
+  incoming,
+}: {
+  existing: TDeclaredFieldSource;
+  incoming: TDeclaredFieldSource;
+}): TValidateIdError[] => {
+  const current = namesByNamespace(existing);
+  const next = namesByNamespace({
+    variables: isDeclared(incoming.variables) ? incoming.variables : existing.variables,
+    hiddenFields: isDeclared(incoming.hiddenFields) ? incoming.hiddenFields : existing.hiddenFields,
+  });
+
+  const errors: TValidateIdError[] = [];
+  for (const [lowered, variableName] of next.variables) {
+    const hiddenFieldId = next.hiddenFields.get(lowered);
+    if (hiddenFieldId === undefined) continue;
+    if (current.variables.has(lowered) && current.hiddenFields.has(lowered)) continue;
+
+    errors.push({
+      code: TValidateIdErrorCode.Duplicate,
+      field: current.variables.has(lowered) ? hiddenFieldId : variableName,
+    });
+  }
+
+  return errors;
+};
+
+/**
+ * Everything a write's declared field names must satisfy, for the write seams that hold a whole
+ * survey on both sides (`updateSurvey`, `createSurvey`): no new reserved name, and no new clash
+ * between a variable and a hidden field. One error per bad name — a name refused as reserved is not
+ * reported a second time as a clash.
+ *
+ * The v3 patch route calls {@link validateNewDeclaredFieldNames} on its own: its reference validation
+ * already refuses the clash as `duplicate_identifier`, so running this there would report it twice.
+ */
+export const validateNewDeclaredFields = ({
+  existing,
+  incoming,
+}: {
+  existing: TDeclaredFieldSource;
+  incoming: TDeclaredFieldSource;
+}): TValidateIdError[] => {
+  const reserved = validateNewDeclaredFieldNames({
+    existing: collectDeclaredFieldNames(existing),
+    incoming: collectDeclaredFieldNames(incoming),
+  });
+  const refused = new Set(reserved.map((error) => error.field.toLowerCase()));
+  const clashes = validateNewDeclaredFieldClashes({ existing, incoming }).filter(
+    (error) => !refused.has(error.field.toLowerCase())
+  );
+
+  return [...reserved, ...clashes];
 };
 
 /**
@@ -175,10 +275,11 @@ const DECLARED_FIELD_NAME_REASONS: Record<Exclude<TValidateIdErrorCode, "reserve
   [TValidateIdErrorCode.InvalidChars]: "it may contain only letters, numbers, underscores and hyphens",
   [TValidateIdErrorCode.NotSafeIdentifier]:
     "it must start with a lowercase letter and contain only lowercase letters, numbers and underscores",
-  // Unreachable from `validateNewDeclaredFieldNames`, which passes empty id lists so a collision is
-  // never reported here. Spelled out anyway: the map is exhaustive over the enum, so a caller that
-  // does pass id lists gets a true sentence instead of falling through to a wrong one.
-  [TValidateIdErrorCode.Duplicate]: "another field in this survey already uses that name",
+  // Reached from `validateNewDeclaredFieldClashes` (a variable and a hidden field under one name),
+  // never from `validateNewDeclaredFieldNames`, which passes empty id lists. Worded for that case
+  // without assuming it — on a create both sides are new, so "already uses" would be false there.
+  [TValidateIdErrorCode.Duplicate]:
+    "a second field in this survey would carry that name, and recall and logic address fields by name",
 };
 
 /** The client-facing sentence for one refused name: `Field name "x" cannot be used: <reason>.` */


### PR DESCRIPTION
Ref ENG-2933

## What & why

**Was:** `PUT /api/v1/management/surveys/{id}` accepted a variable named after one of the survey's hidden fields, or the reverse. The editor and v3 refuse it; v1 was the only surface that did not, so surveys with an ambiguous name could keep appearing through a supported API.

**Now:** the write is refused with a 400 naming the field. Surveys that already hold the clash keep working: a read-modify-write PUT that resends both sides is accepted, and only a *new* pair is refused — the per-save grandfathering reserved names already have.

- Nothing further down could catch it: a variable is stored under its cuid and a hidden field under its name, so the reconcile's duplicate check never sees them collide.
- v3 and the editor are untouched; v3 already refuses the clash as `duplicate_identifier`.

## Where to look

- [`validateNewDeclaredFieldClashes`](https://github.com/formbricks/formbricks/blob/60aa821416d03d330c6cd85c9ddc0d7dbfb7f9d7/packages/types/surveys/declared-field-guard.ts#L168) — refused unless the survey already holds the pair
- [`updateSurvey` call site](https://github.com/formbricks/formbricks/blob/60aa821416d03d330c6cd85c9ddc0d7dbfb7f9d7/apps/web/lib/survey/service.ts#L395) — both hand the guard whole surveys, not flat name lists

## Breaking changes

- [ ] This PR contains breaking changes

None — a write no other surface accepted now returns 400; every existing survey re-saves unchanged.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/types test surveys/declared-field-guard.test.ts && pnpm --filter @formbricks/web test:integration integration/api-back-compat.integration.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| A variable may not take an existing hidden field's name, nor the reverse; case-insensitive | unit (red on main) | 19 new tests fail on the epic, pass here |
| A survey already holding the clash re-saves; dropping one side spends the reprieve | unit (guard) | pass |
| A carrier the payload omits counts as the survey's current one, as in the reconcile | unit (guard) | pass |
| A name that is both reserved and a clash is reported once | unit (guard) | pass |
| `updateSurvey` refuses a new clash and accepts a resent one, on real Postgres | unit (red on main) | 3 refusals read `accepted` on the epic; 28/28 with the fix — four rows in `api-back-compat.integration.test.ts` |
| Editor refuses the clash in both cards | manual | code unchanged; add variable `plan` beside hidden field `plan` to re-check |

**Open gaps**

- The 46 production surveys already holding a clash are left as they are; what they should become is a separate call on the ticket.

**Risks**

- `createSurvey` also serves templates: one declaring a variable and a hidden field under one name would now fail to create. None does today.

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
