### PR TITLE
fix(api): stop serving the internal ingestFlags column on v2 responses and webhook payloads [ENG-2955]

### DIFF
--- a/apps/web/integration/db-boolean.ts
+++ b/apps/web/integration/db-boolean.ts
@@ -6,9 +6,13 @@
 //
 // Only the bare specifier is aliased: `@formbricks/database/prisma` (the enums + Prisma namespace) is
 // schema-agnostic at runtime and resolves normally.
+//
+// Constructed with the same options as the app's client (packages/database/src/client.ts), so what a
+// read returns here is what a read returns in production — the global `omit` included.
 import { PrismaClient } from "../../../packages/database/generated/prisma-test/client";
+import { PRISMA_GLOBAL_OMIT } from "../../../packages/database/src/client-options";
 import { createPrismaPgAdapter } from "../../../packages/database/src/prisma-adapter";
 
 const { adapter } = createPrismaPgAdapter();
 
-export const prisma = new PrismaClient({ adapter });
+export const prisma = new PrismaClient({ adapter, omit: PRISMA_GLOBAL_OMIT });

--- a/apps/web/integration/management-response-payload.integration.test.ts
+++ b/apps/web/integration/management-response-payload.integration.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { ZResponse } from "@formbricks/database/zod/responses";
+import { resetDb } from "@/integration/reset-db";
+import { getResponse as getV1Response } from "@/lib/response/service";
+import {
+  getResponse,
+  getResponseForPipeline,
+} from "@/modules/api/v2/management/responses/[responseId]/lib/response";
+import { getResponses } from "@/modules/api/v2/management/responses/lib/response";
+import { ZGetResponsesFilter } from "@/modules/api/v2/management/responses/types/responses";
+
+/**
+ * Which columns the management APIs serve for a response, against real Postgres.
+ *
+ * `Response.ingestFlags` is internal Embedded Data bookkeeping (ENG-1845). The v2 management routes and
+ * the pipeline read whole rows without a `select`, so until the client omitted the column globally
+ * (packages/database/src/client.ts) they handed it to integrators and webhook consumers while no
+ * OpenAPI bundle described it (ENG-2955). The unit harness mocks Prisma, so only a real client can show
+ * what a select-less read returns — and that the one legitimate reader, which selects the column
+ * explicitly, still gets it.
+ *
+ * The shape assertion is the part meant to outlive the ticket: every key a v2 read serves must be a key
+ * `ZResponse` documents, so the next internal column fails here instead of reaching a payload.
+ */
+
+const INGEST_FLAGS = [{ key: "plan", reason: "coercion_failed" }];
+
+const DOCUMENTED_KEYS = Object.keys(ZResponse.shape).sort();
+
+const BLOCKS = [
+  {
+    id: "clbk1234567890123456789013",
+    name: "Main Block",
+    elements: [
+      {
+        id: "satisfaction",
+        type: "openText",
+        headline: { default: "What should we improve?" },
+        required: true,
+        inputType: "text",
+        charLimit: { enabled: false },
+      },
+    ],
+  },
+];
+
+const seedResponse = async () => {
+  const organization = await prisma.organization.create({ data: { name: "Payload Org" } });
+  const workspace = await prisma.workspace.create({
+    data: { name: "Payload Workspace", organizationId: organization.id },
+  });
+  const survey = await prisma.survey.create({
+    data: {
+      name: "Payload Survey",
+      type: "link",
+      status: "inProgress",
+      workspaceId: workspace.id,
+      blocks: BLOCKS,
+    },
+    select: { id: true },
+  });
+  const response = await prisma.response.create({
+    data: { surveyId: survey.id, finished: true, data: { plan: "gold" }, ingestFlags: INGEST_FLAGS },
+    select: { id: true },
+  });
+
+  return { workspaceId: workspace.id, responseId: response.id };
+};
+
+const servedKeys = (row: object): string[] => Object.keys(row).sort();
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("ingestFlags at the Prisma client", () => {
+  test("the column is stored, and an explicit select still reads it", async () => {
+    // The ingest path (lib/response/service.ts `updateResponse`) merges into the stored flags through
+    // exactly this kind of select. A global omit must not take the column away from it.
+    const { responseId } = await seedResponse();
+
+    const stored = await prisma.response.findUniqueOrThrow({
+      where: { id: responseId },
+      select: { ingestFlags: true },
+    });
+
+    expect(stored).toEqual({ ingestFlags: INGEST_FLAGS });
+  });
+
+  test("a read without a select does not return it", async () => {
+    const { responseId } = await seedResponse();
+
+    const row = await prisma.response.findUniqueOrThrow({ where: { id: responseId } });
+
+    expect(row).not.toHaveProperty("ingestFlags");
+    expect(row.finished).toBe(true);
+  });
+});
+
+describe("what the management APIs serve for a response", () => {
+  test("v2 list serves exactly the keys the v2 OpenAPI schema documents", async () => {
+    const { workspaceId } = await seedResponse();
+
+    const result = await getResponses([workspaceId], ZGetResponsesFilter.parse({}));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.data).toHaveLength(1);
+    expect(servedKeys(result.data.data[0])).toEqual(DOCUMENTED_KEYS);
+  });
+
+  test("v2 single read serves exactly the documented keys", async () => {
+    const { responseId } = await seedResponse();
+
+    const result = await getResponse(responseId);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(servedKeys(result.data)).toEqual(DOCUMENTED_KEYS);
+  });
+
+  test("the pipeline read, which becomes the webhook body, does not carry it", async () => {
+    const { responseId } = await seedResponse();
+
+    const result = await getResponseForPipeline(responseId);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).not.toHaveProperty("ingestFlags");
+  });
+
+  test("v1 agrees with v2", async () => {
+    // v1 always selected its columns (`responseSelection`), so this is the baseline v2 now matches.
+    const { responseId } = await seedResponse();
+
+    const served = await getV1Response(responseId);
+
+    expect(served).not.toBeNull();
+    expect(served).not.toHaveProperty("ingestFlags");
+  });
+});

--- a/apps/web/integration/management-response-payload.integration.test.ts
+++ b/apps/web/integration/management-response-payload.integration.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { prisma } from "@formbricks/database";
 import { ZResponse } from "@formbricks/database/zod/responses";
+import { ZResponse as ZV1Response } from "@formbricks/types/responses";
 import { resetDb } from "@/integration/reset-db";
 import { getResponse as getV1Response } from "@/lib/response/service";
 import {
@@ -27,6 +28,9 @@ import { ZGetResponsesFilter } from "@/modules/api/v2/management/responses/types
 const INGEST_FLAGS = [{ key: "plan", reason: "coercion_failed" }];
 
 const DOCUMENTED_KEYS = Object.keys(ZResponse.shape).sort();
+
+// v1 documents its own shape — `tags` and `contact` included — so it is pinned to that, not to v2's.
+const V1_DOCUMENTED_KEYS = Object.keys(ZV1Response.shape).sort();
 
 const BLOCKS = [
   {
@@ -130,13 +134,14 @@ describe("what the management APIs serve for a response", () => {
     expect(result.data).not.toHaveProperty("ingestFlags");
   });
 
-  test("v1 agrees with v2", async () => {
+  test("v1 serves exactly its own documented keys, which never included the column", async () => {
     // v1 always selected its columns (`responseSelection`), so this is the baseline v2 now matches.
     const { responseId } = await seedResponse();
 
     const served = await getV1Response(responseId);
 
     expect(served).not.toBeNull();
-    expect(served).not.toHaveProperty("ingestFlags");
+    expect(servedKeys(served as object)).toEqual(V1_DOCUMENTED_KEYS);
+    expect(V1_DOCUMENTED_KEYS).not.toContain("ingestFlags");
   });
 });

--- a/packages/database/src/client-options.ts
+++ b/packages/database/src/client-options.ts
@@ -1,0 +1,13 @@
+/**
+ * Columns a read without a `select` must not return — passed as `omit` to every Prisma client that
+ * stands in for the app's: the real one in `client.ts` and the integration harness's Boolean-shaped
+ * one (apps/web/integration/db-boolean.ts). One constant, so the two cannot drift.
+ *
+ * `Response.ingestFlags` is Embedded Data ingest bookkeeping (ENG-1845) with one reader — the response
+ * update in apps/web/lib/response/service.ts — which selects it explicitly, and an explicit `select`
+ * still returns an omitted column. Every other read is a consumer: without this, the v2 management
+ * responses routes and the pipeline payload served an internal column that no OpenAPI bundle describes
+ * (ENG-2955). Omitted at the client rather than per query so the next internal column is one line here,
+ * not a hunt through every route that forgot a `select`.
+ */
+export const PRISMA_GLOBAL_OMIT = { response: { ingestFlags: true } } as const;

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -1,3 +1,4 @@
+import { PRISMA_GLOBAL_OMIT } from "./client-options";
 import { PrismaClient } from "./prisma";
 import { createPrismaPgAdapter } from "./prisma-adapter";
 
@@ -6,6 +7,7 @@ const prismaClientSingleton = (): PrismaClient => {
 
   return new PrismaClient({
     adapter,
+    omit: PRISMA_GLOBAL_OMIT,
     ...(process.env.DEBUG === "1" && {
       log: ["query", "info"],
     }),

--- a/packages/database/zod/responses.ts
+++ b/packages/database/zod/responses.ts
@@ -119,8 +119,10 @@ export const ZResponse = z.object({
   displayId: z.string().nullable().describe("The display ID of the response"),
   // `ingestFlags` is deliberately omitted rather than described: this schema is the management API's
   // public shape and the OpenAPI document, and the column is internal Embedded Data bookkeeping
-  // (ENG-1845) that no route selects. Documenting it would advertise a field the API never returns;
-  // exposing it belongs to the release that surfaces coercion failures in the UI.
+  // (ENG-1845) that the Prisma client omits from every read without a `select`
+  // (`PRISMA_GLOBAL_OMIT`, ENG-2955) — so a payload built from a whole row matches this shape exactly.
+  // Documenting it would advertise a field the API never returns; exposing it belongs to the release
+  // that surfaces coercion failures in the UI.
 }) satisfies z.ZodType<Omit<Response, "ingestFlags">>;
 
 ZResponse.meta({


### PR DESCRIPTION
Fixes ENG-2955

## What & why

**Was:** every v2 management response route (`GET` list and single, `PUT`, `DELETE`) returned an `ingestFlags` key on each response, and so did the webhook body built from the v2 create path — an internal Embedded Data column that no OpenAPI bundle describes and that v1 never returned.

**Now:** no read without an explicit `select` returns the column. v1 and v2 serve the same keys, and a v2 response is exactly the shape `ZResponse` documents.

- One `omit` on the Prisma client (`PRISMA_GLOBAL_OMIT`) rather than a `select` per route, so the next internal column is one line there and not a hunt through every route.
- The one legitimate reader — the ingest merge in `lib/response/service.ts` — selects the column explicitly, and an explicit `select` still returns an omitted column.

## Where to look

- [`client-options.ts`](https://github.com/formbricks/formbricks/blob/1084414f2b3781d5f9993d60d388196a175673c5/packages/database/src/client-options.ts#L13) — the omit, shared by the app's client and the integration harness's client
- [`db-boolean.ts`](https://github.com/formbricks/formbricks/blob/1084414f2b3781d5f9993d60d388196a175673c5/apps/web/integration/db-boolean.ts#L18) — the harness client now takes the same options; before this the suite could only ever test a client the app never runs

## Breaking changes

- [ ] This PR contains breaking changes

None — the key only ever appeared on the epic branch; no release has served it, so no external consumer has seen it.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web test:integration integration/management-response-payload.integration.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| A read without a `select` omits `ingestFlags`; v2 list and single read serve exactly `ZResponse`'s keys; the pipeline row omits it | unit (red on main) | 4 of 6 fail with the omit removed (16 keys served vs 15 documented), 6/6 with it |
| An explicit `select` still reads the column, so the ingest merge keeps working | unit (guard) | pass — the seeded flags read back unchanged |
| v1 serves exactly its own documented keys (`@formbricks/types/responses`), which never included the column | unit (guard) | pass |
| The production client (not only the harness's) applies the omit | manual | select-less `findFirst` through `dist` returned the 15 documented keys |
| Nothing else reads the column off a select-less row | manual | `git grep ingestFlags`: one reader, explicit select at `lib/response/service.ts` |

**Open gaps**

- The suite runs the harness's Boolean-shaped client, not `client.ts`; both take `PRISMA_GLOBAL_OMIT`, and `client.ts` itself is covered only by the manual probe above.

**Risks**

- The exported `prisma` keeps the wide `PrismaClient` type, so a future `row.ingestFlags` read off a select-less result compiles but is `undefined` at runtime. Read it through an explicit `select`, as `service.ts` does.

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
