### PR TITLE
feat(surveys): add Rename to the survey list context menu

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -416,6 +416,7 @@ checksums:
     common/refresh: c0aec3f31be4c984bae9a482572d2857
     common/remove: dba2fe5fe9f83f8078c687f28cba4b52
     common/remove_from_team: 69bcc7a1001c3017f9de578ee22cffd6
+    common/rename: 6f9413e4606e8d83a010685008fb2931
     common/reorder_and_hide_columns: a5e3d7c0c7ef879211d05a37be1c5069
     common/replace: 98b2268975b1a737b2e4ad837df96703
     common/report_survey: 147dd05db52e35f5d1f837460fb720f5
@@ -3539,6 +3540,7 @@ checksums:
     workspace/surveys/edit/zip: 228fedb7d75304d2a3fcd9f1d1aaccee
     workspace/surveys/error_archiving_survey: c73e729832407531134213ce2aa69a4d
     workspace/surveys/error_deleting_survey: 5a113f1cc0a430b54b21dd1fd4e65e00
+    workspace/surveys/error_renaming_survey: 87084d08efc4121d5d6d83e3bb74ca4f
     workspace/surveys/error_restoring_survey: a070c5b584187d4f1308943d6b378bea
     workspace/surveys/error_updating_status: f163ee51d64903a0c994d39008bf7fe4
     workspace/surveys/featured_templates/churn_description: 095b315526140f3633b3da354b766ed4
@@ -3559,6 +3561,9 @@ checksums:
     workspace/surveys/preview_survey_in_a_new_tab: 0d9b3b93c233543d25ccb49263d7024d
     workspace/surveys/read_only_user_not_allowed_to_create_survey_warning: d6c53a50c939c547f081b53d489958bb
     workspace/surveys/relevance: 9a5655d1d14efdd35052a8ed09bed127
+    workspace/surveys/rename_survey: 442ed6f0b7fa47eb9b3c10d5648bef1b
+    workspace/surveys/rename_survey_description: 2462513dddf89743ca60581c3ae153a1
+    workspace/surveys/rename_survey_placeholder: 22ccf86a882d68184d3acfccf7608f4d
     workspace/surveys/responses/address_line_1: 44788358e7a7c25b0b79bc3090ed15f5
     workspace/surveys/responses/address_line_2: fc4b5a87de46ac4a28a6616f47a34135
     workspace/surveys/responses/an_error_occurred_adding_the_tag: f211ea1ceb8a93b415d88a8deed874ef
@@ -3829,6 +3834,8 @@ checksums:
     workspace/surveys/survey_archived_successfully: de6e34f200a13cf43a7ca684f57d5fec
     workspace/surveys/survey_deleted_successfully: a6b654cc914b344a4475fd2fd4a98cc5
     workspace/surveys/survey_duplicated_successfully: 91e244f1e7a33640bb4817166a01ff46
+    workspace/surveys/survey_name_required: b72531f00e0896ae2c82d39b4e79b70c
+    workspace/surveys/survey_renamed_successfully: 395c4f0a28fa3b7190f396ff50fd7f68
     workspace/surveys/survey_restored_successfully: 2033ab806864f98fabb5d4ed3c945626
     workspace/surveys/templates/all_channels: 6be67a82fc7326dc2304b23ab3348b87
     workspace/surveys/templates/all_industries: c7354412fe34585526ff2232aadace41

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -445,6 +445,7 @@
     "refresh": "Aktualisieren",
     "remove": "Entfernen",
     "remove_from_team": "Aus Team entfernen",
+    "rename": "Umbenennen",
     "reorder_and_hide_columns": "Spalten neu anordnen und ausblenden",
     "replace": "Ersetzen",
     "report_survey": "Umfrage melden",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Umfrage konnte nicht archiviert werden, versuch es noch mal",
       "error_deleting_survey": "Beim Löschen der Umfrage ist ein Fehler aufgetreten",
+      "error_renaming_survey": "Fehler beim Umbenennen der Umfrage",
       "error_restoring_survey": "Umfrage konnte nicht wiederhergestellt werden, versuch es noch mal",
       "error_updating_status": "Beim Aktualisieren des Umfragestatus ist ein Fehler aufgetreten",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Umfrage in neuem Tab in der Vorschau anzeigen",
       "read_only_user_not_allowed_to_create_survey_warning": "Als Nutzer mit Lesezugriff darfst du keine Umfragen erstellen. Bitte einen Nutzer mit Schreibzugriff, eine Umfrage zu erstellen, oder einen Manager, deine Rolle zu erweitern.",
       "relevance": "Relevanz",
+      "rename_survey": "Umfrage umbenennen",
+      "rename_survey_description": "Gib dieser Umfrage einen neuen Namen.",
+      "rename_survey_placeholder": "Umfragename",
       "responses": {
         "address_line_1": "Adresszeile 1",
         "address_line_2": "Adresszeile 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Umfrage archiviert",
       "survey_deleted_successfully": "Umfrage erfolgreich gelöscht",
       "survey_duplicated_successfully": "Umfrage erfolgreich dupliziert",
+      "survey_name_required": "Bitte gib einen Umfragenamen ein.",
+      "survey_renamed_successfully": "Umfrage erfolgreich umbenannt",
       "survey_restored_successfully": "Umfrage wiederhergestellt",
       "templates": {
         "all_channels": "Alle Kanäle",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -445,6 +445,7 @@
     "refresh": "Refresh",
     "remove": "Remove",
     "remove_from_team": "Remove from team",
+    "rename": "Rename",
     "reorder_and_hide_columns": "Reorder and hide columns",
     "replace": "Replace",
     "report_survey": "Report Survey",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Couldn't archive survey, try again",
       "error_deleting_survey": "An error occurred while deleting survey",
+      "error_renaming_survey": "Error renaming survey",
       "error_restoring_survey": "Couldn't restore survey, try again",
       "error_updating_status": "An error occurred while updating survey status",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Preview survey in a new tab",
       "read_only_user_not_allowed_to_create_survey_warning": "As a Read-Only user you are not allowed to create surveys. Please ask a user with write access to create a survey or a manager to upgrade your role.",
       "relevance": "Relevance",
+      "rename_survey": "Rename survey",
+      "rename_survey_description": "Give this survey a new name.",
+      "rename_survey_placeholder": "Survey name",
       "responses": {
         "address_line_1": "Address Line 1",
         "address_line_2": "Address Line 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Survey archived",
       "survey_deleted_successfully": "Survey deleted successfully",
       "survey_duplicated_successfully": "Survey duplicated successfully",
+      "survey_name_required": "Please enter a survey name.",
+      "survey_renamed_successfully": "Survey renamed successfully",
       "survey_restored_successfully": "Survey restored",
       "templates": {
         "all_channels": "All channels",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -445,6 +445,7 @@
     "refresh": "Actualizar",
     "remove": "Eliminar",
     "remove_from_team": "Eliminar del equipo",
+    "rename": "Renombrar",
     "reorder_and_hide_columns": "Reordenar y ocultar columnas",
     "replace": "Reemplazar",
     "report_survey": "Reportar encuesta",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "No se pudo archivar la encuesta, inténtalo de nuevo",
       "error_deleting_survey": "Se produjo un error al eliminar la encuesta",
+      "error_renaming_survey": "Error al renombrar la encuesta",
       "error_restoring_survey": "No se pudo restaurar la encuesta, inténtalo de nuevo",
       "error_updating_status": "Se produjo un error al actualizar el estado de la encuesta",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Vista previa de la encuesta en una nueva pestaña",
       "read_only_user_not_allowed_to_create_survey_warning": "Como usuario de solo lectura no se te permite crear encuestas. Por favor, pide a un usuario con acceso de escritura que cree una encuesta o a un administrador que mejore tu rol.",
       "relevance": "Relevancia",
+      "rename_survey": "Renombrar encuesta",
+      "rename_survey_description": "Dale un nuevo nombre a esta encuesta.",
+      "rename_survey_placeholder": "Nombre de la encuesta",
       "responses": {
         "address_line_1": "Línea de dirección 1",
         "address_line_2": "Línea de dirección 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Encuesta archivada",
       "survey_deleted_successfully": "¡Encuesta eliminada correctamente!",
       "survey_duplicated_successfully": "Encuesta duplicada correctamente.",
+      "survey_name_required": "Por favor, introduce un nombre para la encuesta.",
+      "survey_renamed_successfully": "Encuesta renombrada correctamente",
       "survey_restored_successfully": "Encuesta restaurada",
       "templates": {
         "all_channels": "Todos los canales",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -445,6 +445,7 @@
     "refresh": "Actualiser",
     "remove": "Retirer",
     "remove_from_team": "Retirer de l'équipe",
+    "rename": "Renommer",
     "reorder_and_hide_columns": "Réorganiser et masquer des colonnes",
     "replace": "Remplacer",
     "report_survey": "Rapport d'enquête",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Impossible d'archiver le sondage, réessaye",
       "error_deleting_survey": "Une erreur s'est produite lors de la suppression du sondage",
+      "error_renaming_survey": "Erreur lors du renommage de l'enquête",
       "error_restoring_survey": "Impossible de restaurer le sondage, réessaye",
       "error_updating_status": "Une erreur s'est produite lors de la mise à jour du statut de l'enquête",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Aperçu de l'enquête dans un nouvel onglet",
       "read_only_user_not_allowed_to_create_survey_warning": "En tant qu'utilisateur en lecture seule, vous n'êtes pas autorisé à créer des enquêtes. Veuillez demander à un utilisateur ayant un accès en écriture de créer une enquête ou à un responsable de mettre à jour votre rôle.",
       "relevance": "Pertinence",
+      "rename_survey": "Renommer l'enquête",
+      "rename_survey_description": "Donne un nouveau nom à cette enquête.",
+      "rename_survey_placeholder": "Nom de l'enquête",
       "responses": {
         "address_line_1": "Ligne d'adresse 1",
         "address_line_2": "Ligne d'adresse 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Sondage archivé",
       "survey_deleted_successfully": "Enquête supprimée avec succès !",
       "survey_duplicated_successfully": "Enquête dupliquée avec succès.",
+      "survey_name_required": "Merci de saisir un nom d'enquête.",
+      "survey_renamed_successfully": "Enquête renommée avec succès",
       "survey_restored_successfully": "Sondage restauré",
       "templates": {
         "all_channels": "Tous les canaux",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -445,6 +445,7 @@
     "refresh": "Frissítés",
     "remove": "Eltávolítás",
     "remove_from_team": "Eltávolítás a csapatból",
+    "rename": "Átnevezés",
     "reorder_and_hide_columns": "Oszlopok átrendezése és elrejtése",
     "replace": "Csere",
     "report_survey": "Kérdőív jelentése",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "A felmérés archiválása sikertelen, kérjük, próbálja újra",
       "error_deleting_survey": "Hiba történt a kérdőív törlése során",
+      "error_renaming_survey": "Hiba történt a felmérés átnevezése során",
       "error_restoring_survey": "A felmérés visszaállítása sikertelen, kérjük, próbálja újra",
       "error_updating_status": "Hiba történt a felmérés állapotának frissítése során",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Kérdőív előnézete új lapon",
       "read_only_user_not_allowed_to_create_survey_warning": "Csak olvasási jogosultságú felhasználóként nem hozhat létre kérdőíveket. Kérjen meg egy írási jogosultsággal rendelkező felhasználót, hogy hozzon létre egy kérdőívet, vagy egy vezetőt, hogy frissítse az Ön szerepét.",
       "relevance": "Fontosság",
+      "rename_survey": "Felmérés átnevezése",
+      "rename_survey_description": "Adjon új nevet ennek a felmérésnek.",
+      "rename_survey_placeholder": "Felmérés neve",
       "responses": {
         "address_line_1": "Cím 1. sora",
         "address_line_2": "Cím 2. sora",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Felmérés archiválva",
       "survey_deleted_successfully": "A kérdőív sikeresen törölve",
       "survey_duplicated_successfully": "A kérdőív sikeresen megkettőzve",
+      "survey_name_required": "Kérem, adja meg a felmérés nevét.",
+      "survey_renamed_successfully": "A felmérés sikeresen átnevezésre került",
       "survey_restored_successfully": "Felmérés visszaállítva",
       "templates": {
         "all_channels": "Összes csatorna",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -445,6 +445,7 @@
     "refresh": "更新",
     "remove": "削除",
     "remove_from_team": "チームから削除",
+    "rename": "名前を変更",
     "reorder_and_hide_columns": "列の並び替えと非表示",
     "replace": "置き換え",
     "report_survey": "フォームを報告",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "アンケートをアーカイブできませんでした。もう一度お試しください",
       "error_deleting_survey": "アンケートの削除中にエラーが発生しました",
+      "error_renaming_survey": "アンケートの名前変更エラー",
       "error_restoring_survey": "アンケートを復元できませんでした。もう一度お試しください",
       "error_updating_status": "アンケートのステータス更新中にエラーが発生しました",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "新しいタブでフォームをプレビュー",
       "read_only_user_not_allowed_to_create_survey_warning": "読み取り専用ユーザーはフォームを作成できません。書き込みアクセスを持つユーザーにフォームの作成を依頼するか、管理者にあなたの役割をアップグレードするように依頼してください。",
       "relevance": "関連性",
+      "rename_survey": "アンケート名を変更",
+      "rename_survey_description": "このアンケートに新しい名前を付けてください。",
+      "rename_survey_placeholder": "アンケート名",
       "responses": {
         "address_line_1": "住所1",
         "address_line_2": "住所2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "アンケートをアーカイブしました",
       "survey_deleted_successfully": "フォームを正常に削除しました！",
       "survey_duplicated_successfully": "フォームを正常に複製しました。",
+      "survey_name_required": "アンケート名を入力してください。",
+      "survey_renamed_successfully": "アンケート名を変更しました",
       "survey_restored_successfully": "アンケートを復元しました",
       "templates": {
         "all_channels": "すべてのチャネル",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -445,6 +445,7 @@
     "refresh": "Vernieuwen",
     "remove": "Verwijderen",
     "remove_from_team": "Verwijderen uit team",
+    "rename": "Hernoemen",
     "reorder_and_hide_columns": "Kolommen opnieuw rangschikken en verbergen",
     "replace": "Vervangen",
     "report_survey": "Enquête melden",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Kan enquête niet archiveren, probeer het opnieuw",
       "error_deleting_survey": "Er is een fout opgetreden bij het verwijderen van de enquête",
+      "error_renaming_survey": "Fout bij hernoemen van enquête",
       "error_restoring_survey": "Kan enquête niet herstellen, probeer het opnieuw",
       "error_updating_status": "Er is een fout opgetreden bij het bijwerken van de enquêtestatus",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Bekijk een voorbeeld van de enquête op een nieuw tabblad",
       "read_only_user_not_allowed_to_create_survey_warning": "Als Read-Only-gebruiker mag u geen enquêtes maken. Vraag een gebruiker met schrijftoegang om een ​​enquête te maken of vraag een manager om uw rol te upgraden.",
       "relevance": "Relevantie",
+      "rename_survey": "Enquête hernoemen",
+      "rename_survey_description": "Geef deze enquête een nieuwe naam.",
+      "rename_survey_placeholder": "Naam van enquête",
       "responses": {
         "address_line_1": "Adresregel 1",
         "address_line_2": "Adresregel 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Enquête gearchiveerd",
       "survey_deleted_successfully": "Enquête succesvol verwijderd!",
       "survey_duplicated_successfully": "Enquête is succesvol gedupliceerd.",
+      "survey_name_required": "Voer een naam voor de enquête in.",
+      "survey_renamed_successfully": "Enquête succesvol hernoemd",
       "survey_restored_successfully": "Enquête hersteld",
       "templates": {
         "all_channels": "Alle kanalen",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -445,6 +445,7 @@
     "refresh": "Atualizar",
     "remove": "remover",
     "remove_from_team": "Remover da equipe",
+    "rename": "Renomear",
     "reorder_and_hide_columns": "Reordenar e ocultar colunas",
     "replace": "Substituir",
     "report_survey": "Relatório de Pesquisa",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Não foi possível arquivar a pesquisa, tente novamente",
       "error_deleting_survey": "Ocorreu um erro ao excluir a pesquisa",
+      "error_renaming_survey": "Erro ao renomear pesquisa",
       "error_restoring_survey": "Não foi possível restaurar a pesquisa, tente novamente",
       "error_updating_status": "Ocorreu um erro ao atualizar o status da pesquisa",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Visualizar pesquisa em uma nova aba",
       "read_only_user_not_allowed_to_create_survey_warning": "Como um usuário somente leitura, você não tem permissão para criar pesquisas. Peça a um usuário com acesso de gravação para criar uma pesquisa ou a um gerente para atualizar sua função.",
       "relevance": "Relevância",
+      "rename_survey": "Renomear pesquisa",
+      "rename_survey_description": "Dê um novo nome para esta pesquisa.",
+      "rename_survey_placeholder": "Nome da pesquisa",
       "responses": {
         "address_line_1": "Endereço Linha 1",
         "address_line_2": "Complemento",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Pesquisa arquivada",
       "survey_deleted_successfully": "Pesquisa deletada com sucesso!",
       "survey_duplicated_successfully": "Pesquisa duplicada com sucesso.",
+      "survey_name_required": "Por favor, insira um nome para a pesquisa.",
+      "survey_renamed_successfully": "Pesquisa renomeada com sucesso",
       "survey_restored_successfully": "Pesquisa restaurada",
       "templates": {
         "all_channels": "Todos os canais",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -445,6 +445,7 @@
     "refresh": "Atualizar",
     "remove": "Remover",
     "remove_from_team": "Remover da equipa",
+    "rename": "Renomear",
     "reorder_and_hide_columns": "Reordenar e ocultar colunas",
     "replace": "Substituir",
     "report_survey": "Relatório de Inquérito",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Não foi possível arquivar o inquérito, tenta novamente",
       "error_deleting_survey": "Ocorreu um erro ao eliminar o inquérito",
+      "error_renaming_survey": "Erro ao renomear inquérito",
       "error_restoring_survey": "Não foi possível restaurar o inquérito, tenta novamente",
       "error_updating_status": "Ocorreu um erro ao atualizar o estado do inquérito",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Pré-visualizar inquérito num novo separador",
       "read_only_user_not_allowed_to_create_survey_warning": "Como utilizador de leitura apenas, não tem permissão para criar questionários. Por favor, peça a um utilizador com acesso de escrita para criar um questionário ou a um gestor para atualizar o seu papel.",
       "relevance": "Relevância",
+      "rename_survey": "Renomear inquérito",
+      "rename_survey_description": "Dá um novo nome a este inquérito.",
+      "rename_survey_placeholder": "Nome do inquérito",
       "responses": {
         "address_line_1": "Endereço Linha 1",
         "address_line_2": "Endereço Linha 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Inquérito arquivado",
       "survey_deleted_successfully": "Inquérito eliminado com sucesso!",
       "survey_duplicated_successfully": "Inquérito duplicado com sucesso.",
+      "survey_name_required": "Por favor, introduz um nome para o inquérito.",
+      "survey_renamed_successfully": "Inquérito renomeado com sucesso",
       "survey_restored_successfully": "Inquérito restaurado",
       "templates": {
         "all_channels": "Todos os canais",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -445,6 +445,7 @@
     "refresh": "Reîmprospătează",
     "remove": "Șterge",
     "remove_from_team": "Elimină din echipă",
+    "rename": "Redenumește",
     "reorder_and_hide_columns": "Reordonați și ascundeți coloanele",
     "replace": "Înlocuiește",
     "report_survey": "Raportează chestionarul",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Nu s-a putut arhiva sondajul, încearcă din nou",
       "error_deleting_survey": "A apărut o eroare la ștergerea sondajului",
+      "error_renaming_survey": "Eroare la redenumirea sondajului",
       "error_restoring_survey": "Nu s-a putut restaura sondajul, încearcă din nou",
       "error_updating_status": "A apărut o eroare la actualizarea statusului sondajului",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Previzualizare chestionar în alt tab",
       "read_only_user_not_allowed_to_create_survey_warning": "\"Ca utilizator cu acces doar pentru citire, nu aveți voie să creați sondaje. Vă rugăm să solicitați unui utilizator cu acces de editare să creeze un sondaj sau unui manager să vă upgradeze rolul.\"",
       "relevance": "Relevanță",
+      "rename_survey": "Redenumește sondajul",
+      "rename_survey_description": "Oferă un nume nou acestui sondaj.",
+      "rename_survey_placeholder": "Numele sondajului",
       "responses": {
         "address_line_1": "Adresă Linie 1",
         "address_line_2": "Adresă Linie 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Sondaj arhivat",
       "survey_deleted_successfully": "\"Sondaj șters cu succes!\"",
       "survey_duplicated_successfully": "\"Sondaj duplicat cu succes!\"",
+      "survey_name_required": "Te rugăm să introduci un nume pentru sondaj.",
+      "survey_renamed_successfully": "Sondaj redenumit cu succes",
       "survey_restored_successfully": "Sondaj restaurat",
       "templates": {
         "all_channels": "Toate canalele",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -445,6 +445,7 @@
     "refresh": "Обновить",
     "remove": "Удалить",
     "remove_from_team": "Удалить из команды",
+    "rename": "Переименовать",
     "reorder_and_hide_columns": "Изменить порядок и скрыть столбцы",
     "replace": "Заменить",
     "report_survey": "Пожаловаться на опрос",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Не удалось архивировать опрос, попробуй ещё раз",
       "error_deleting_survey": "Произошла ошибка при удалении опроса",
+      "error_renaming_survey": "Ошибка при переименовании опроса",
       "error_restoring_survey": "Не удалось восстановить опрос, попробуй ещё раз",
       "error_updating_status": "Произошла ошибка при обновлении статуса опроса",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Просмотреть опрос в новой вкладке",
       "read_only_user_not_allowed_to_create_survey_warning": "Пользователям с правами только для чтения нельзя создавать опросы. Попросите пользователя с правами на запись создать опрос или обратитесь к менеджеру для повышения вашей роли.",
       "relevance": "Актуальность",
+      "rename_survey": "Переименовать опрос",
+      "rename_survey_description": "Дайте этому опросу новое название.",
+      "rename_survey_placeholder": "Название опроса",
       "responses": {
         "address_line_1": "Адрес, строка 1",
         "address_line_2": "Адрес, строка 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Опрос архивирован",
       "survey_deleted_successfully": "Опрос успешно удалён!",
       "survey_duplicated_successfully": "Опрос успешно продублирован.",
+      "survey_name_required": "Пожалуйста, введите название опроса.",
+      "survey_renamed_successfully": "Опрос успешно переименован",
       "survey_restored_successfully": "Опрос восстановлен",
       "templates": {
         "all_channels": "Все каналы",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -445,6 +445,7 @@
     "refresh": "Uppdatera",
     "remove": "Ta bort",
     "remove_from_team": "Ta bort från teamet",
+    "rename": "Byt namn",
     "reorder_and_hide_columns": "Ordna om och dölj kolumner",
     "replace": "Ersätt",
     "report_survey": "Rapportera enkät",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Kunde inte arkivera undersökningen, försök igen",
       "error_deleting_survey": "Ett fel uppstod vid borttagning av enkät",
+      "error_renaming_survey": "Fel vid namnbyte av enkät",
       "error_restoring_survey": "Kunde inte återställa undersökningen, försök igen",
       "error_updating_status": "Ett fel uppstod när undersökningens status uppdaterades",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Förhandsgranska enkät i en ny flik",
       "read_only_user_not_allowed_to_create_survey_warning": "Som skrivskyddad användare har du inte behörighet att skapa enkäter. Be en användare med skrivåtkomst att skapa en enkät eller en administratör att uppgradera din roll.",
       "relevance": "Relevans",
+      "rename_survey": "Byt namn på enkät",
+      "rename_survey_description": "Ge denna enkät ett nytt namn.",
+      "rename_survey_placeholder": "Enkätnamn",
       "responses": {
         "address_line_1": "Adressrad 1",
         "address_line_2": "Adressrad 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Undersökningen arkiverad",
       "survey_deleted_successfully": "Enkät borttagen!",
       "survey_duplicated_successfully": "Enkät duplicerad.",
+      "survey_name_required": "Vänligen ange ett enkätnamn.",
+      "survey_renamed_successfully": "Enkäten har bytt namn",
       "survey_restored_successfully": "Undersökningen återställd",
       "templates": {
         "all_channels": "Alla kanaler",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -445,6 +445,7 @@
     "refresh": "Yenile",
     "remove": "Kaldır",
     "remove_from_team": "Takımdan çıkar",
+    "rename": "Yeniden Adlandır",
     "reorder_and_hide_columns": "Sütunları yeniden sırala ve gizle",
     "replace": "Değiştir",
     "report_survey": "Anketi Raporla",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "Anket arşivlenemedi, tekrar dene",
       "error_deleting_survey": "Anket silinirken bir hata oluştu",
+      "error_renaming_survey": "Anket yeniden adlandırılırken hata oluştu",
       "error_restoring_survey": "Anket geri yüklenemedi, tekrar dene",
       "error_updating_status": "Anket durumu güncellenirken bir hata oluştu",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "Anketi yeni sekmede önizle",
       "read_only_user_not_allowed_to_create_survey_warning": "Salt Okunur kullanıcı olarak anket oluşturma yetkiniz bulunmamaktadır. Lütfen yazma yetkisi olan bir kullanıcıdan anket oluşturmasını isteyin veya yöneticinizden rolünüzü yükseltmesini talep edin.",
       "relevance": "İlgililik",
+      "rename_survey": "Anketi yeniden adlandır",
+      "rename_survey_description": "Bu ankete yeni bir ad ver.",
+      "rename_survey_placeholder": "Anket adı",
       "responses": {
         "address_line_1": "Adres Satırı 1",
         "address_line_2": "Adres Satırı 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "Anket arşivlendi",
       "survey_deleted_successfully": "Anket başarıyla silindi",
       "survey_duplicated_successfully": "Anket başarıyla kopyalandı",
+      "survey_name_required": "Lütfen bir anket adı gir.",
+      "survey_renamed_successfully": "Anket başarıyla yeniden adlandırıldı",
       "survey_restored_successfully": "Anket geri yüklendi",
       "templates": {
         "all_channels": "Tüm kanallar",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -445,6 +445,7 @@
     "refresh": "刷新",
     "remove": "移除",
     "remove_from_team": "从团队中移除",
+    "rename": "重命名",
     "reorder_and_hide_columns": "重新排序和隐藏列",
     "replace": "替换",
     "report_survey": "报告调查",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "无法归档问卷，请重试",
       "error_deleting_survey": "删除问卷时发生错误",
+      "error_renaming_survey": "重命名调查失败",
       "error_restoring_survey": "无法恢复问卷，请重试",
       "error_updating_status": "更新调查状态时出错",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "在 新 标签 中 预览 survey",
       "read_only_user_not_allowed_to_create_survey_warning": "作为 只读 用户，你 无法 创建 调查。请 询问 一位 具有 写 访问 权限 的 用户 创建 调查 或 请 一位 经理 升级 你的 角色。",
       "relevance": "相关性",
+      "rename_survey": "重命名调查",
+      "rename_survey_description": "为这个调查起一个新名称。",
+      "rename_survey_placeholder": "调查名称",
       "responses": {
         "address_line_1": "地址 第1行",
         "address_line_2": "地址 第2行",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "问卷已归档",
       "survey_deleted_successfully": "调查 删除 成功",
       "survey_duplicated_successfully": "调查成功复制。",
+      "survey_name_required": "请输入调查名称。",
+      "survey_renamed_successfully": "调查重命名成功",
       "survey_restored_successfully": "问卷已恢复",
       "templates": {
         "all_channels": "所有 渠道",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -445,6 +445,7 @@
     "refresh": "重新整理",
     "remove": "移除",
     "remove_from_team": "從團隊中移除",
+    "rename": "重新命名",
     "reorder_and_hide_columns": "重新排序和隱藏欄位",
     "replace": "取代",
     "report_survey": "報告問卷",
@@ -3661,6 +3662,7 @@
       },
       "error_archiving_survey": "無法封存問卷,請再試一次",
       "error_deleting_survey": "刪除問卷時發生錯誤",
+      "error_renaming_survey": "重新命名問卷時發生錯誤",
       "error_restoring_survey": "無法還原問卷,請再試一次",
       "error_updating_status": "更新問卷狀態時發生錯誤",
       "featured_templates": {
@@ -3685,6 +3687,9 @@
       "preview_survey_in_a_new_tab": "在新分頁中預覽問卷",
       "read_only_user_not_allowed_to_create_survey_warning": "身為唯讀使用者，您不得建立問卷。請要求具有寫入權限的使用者建立問卷或管理員升級您的角色。",
       "relevance": "相關性",
+      "rename_survey": "重新命名問卷",
+      "rename_survey_description": "為此問卷指定新名稱。",
+      "rename_survey_placeholder": "問卷名稱",
       "responses": {
         "address_line_1": "地址 1",
         "address_line_2": "地址 2",
@@ -3981,6 +3986,8 @@
       "survey_archived_successfully": "問卷已封存",
       "survey_deleted_successfully": "問卷已成功刪除！",
       "survey_duplicated_successfully": "問卷已成功複製。",
+      "survey_name_required": "請輸入問卷名稱。",
+      "survey_renamed_successfully": "問卷重新命名成功",
       "survey_restored_successfully": "問卷已還原",
       "templates": {
         "all_channels": "所有管道",

--- a/apps/web/modules/survey/list/components/rename-survey-modal.tsx
+++ b/apps/web/modules/survey/list/components/rename-survey-modal.tsx
@@ -89,7 +89,8 @@ export const RenameSurveyModal = ({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent>
-        <DialogHeader>
+        {/* DialogHeader pins its icon to the first line; center it on the title + description block. */}
+        <DialogHeader className="[&>svg]:top-1/2 [&>svg]:-translate-y-1/2">
           <PencilIcon />
           <DialogTitle>{t("workspace.surveys.rename_survey")}</DialogTitle>
           <DialogDescription>{t("workspace.surveys.rename_survey_description")}</DialogDescription>

--- a/apps/web/modules/survey/list/components/rename-survey-modal.tsx
+++ b/apps/web/modules/survey/list/components/rename-survey-modal.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { PencilIcon } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { useForm } from "react-hook-form";
+import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+import { getV3ApiErrorMessage } from "@/modules/api/lib/v3-client";
+import { Button } from "@/modules/ui/components/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/modules/ui/components/dialog";
+import {
+  FormControl,
+  FormError,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormProvider,
+} from "@/modules/ui/components/form";
+import { Input } from "@/modules/ui/components/input";
+
+interface RenameSurveyModalProps {
+  open: boolean;
+  setOpen: (value: boolean) => void;
+  surveyId: string;
+  surveyName: string;
+  renameSurvey: (surveyId: string, name: string) => Promise<void>;
+}
+
+// Mirrors ZV3SurveyName on the PATCH route: trimmed, at least one character.
+const ZRenameSurveyForm = z.object({
+  name: z.string().trim().min(1),
+});
+
+type TRenameSurveyForm = z.infer<typeof ZRenameSurveyForm>;
+
+export const RenameSurveyModal = ({
+  open,
+  setOpen,
+  surveyId,
+  surveyName,
+  renameSurvey,
+}: Readonly<RenameSurveyModalProps>) => {
+  const { t } = useTranslation();
+
+  const form = useForm<TRenameSurveyForm>({
+    resolver: zodResolver(ZRenameSurveyForm),
+    defaultValues: { name: surveyName },
+  });
+
+  const wasOpen = useRef(open);
+
+  // Re-seed on open only, so a cancelled edit does not linger. Deliberately not on every surveyName
+  // change: a failed rename rolls the list row back, and re-seeding then would wipe what the user
+  // typed just as they need it to retry.
+  useEffect(() => {
+    if (open && !wasOpen.current) {
+      form.reset({ name: surveyName });
+    }
+    wasOpen.current = open;
+  }, [open, surveyName, form]);
+
+  const onSubmit = async ({ name }: TRenameSurveyForm) => {
+    const nextName = name.trim();
+
+    if (nextName === surveyName) {
+      setOpen(false);
+      return;
+    }
+
+    try {
+      await renameSurvey(surveyId, nextName);
+      toast.success(t("workspace.surveys.survey_renamed_successfully"));
+      setOpen(false);
+    } catch (error) {
+      toast.error(getV3ApiErrorMessage(error, t("workspace.surveys.error_renaming_survey")));
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <PencilIcon />
+          <DialogTitle>{t("workspace.surveys.rename_survey")}</DialogTitle>
+          <DialogDescription>{t("workspace.surveys.rename_survey_description")}</DialogDescription>
+        </DialogHeader>
+
+        <FormProvider {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+            <DialogBody unconstrained className="p-1">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field, fieldState: { error } }) => (
+                  <FormItem>
+                    <FormLabel>{t("common.name")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        autoFocus
+                        data-testid="rename-survey-input"
+                        placeholder={t("workspace.surveys.rename_survey_placeholder")}
+                      />
+                    </FormControl>
+                    {error && <FormError>{t("workspace.surveys.survey_name_required")}</FormError>}
+                  </FormItem>
+                )}
+              />
+            </DialogBody>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setOpen(false)}
+                disabled={form.formState.isSubmitting}>
+                {t("common.cancel")}
+              </Button>
+              <Button type="submit" data-testid="rename-survey-save" loading={form.formState.isSubmitting}>
+                {t("common.save")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </FormProvider>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/web/modules/survey/list/components/rename-survey-modal.tsx
+++ b/apps/web/modules/survey/list/components/rename-survey-modal.tsx
@@ -86,8 +86,17 @@ export const RenameSurveyModal = ({
     }
   };
 
+  // Hold the dialog open until the rename settles. Cancel is already disabled, but the close button,
+  // Escape and an outside click all reach setOpen directly — and closing mid-flight is the only way to
+  // get two renames in flight on one query key, where the first failure's rollback would restore a
+  // snapshot taken before the second and silently undo it.
+  const handleOpenChange = (next: boolean) => {
+    if (form.formState.isSubmitting) return;
+    setOpen(next);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         {/* DialogHeader pins its icon to the first line; center it on the title + description block. */}
         <DialogHeader className="[&>svg]:top-1/2 [&>svg]:-translate-y-1/2">

--- a/apps/web/modules/survey/list/components/survey-card.tsx
+++ b/apps/web/modules/survey/list/components/survey-card.tsx
@@ -23,6 +23,7 @@ interface SurveyCardProps {
   updateSurveyStatus: (surveyId: string, status: TSurveyStatus) => Promise<void>;
   archiveSurvey: (surveyId: string) => Promise<void>;
   restoreSurvey: (surveyId: string) => Promise<void>;
+  renameSurvey: (surveyId: string, name: string) => Promise<void>;
   locale: TUserLocale;
 }
 export const SurveyCard = ({
@@ -33,6 +34,7 @@ export const SurveyCard = ({
   updateSurveyStatus,
   archiveSurvey,
   restoreSurvey,
+  renameSurvey,
   locale,
 }: Readonly<SurveyCardProps>) => {
   const { t } = useTranslation();
@@ -145,6 +147,7 @@ export const SurveyCard = ({
           updateSurveyStatus={updateSurveyStatus}
           archiveSurvey={archiveSurvey}
           restoreSurvey={restoreSurvey}
+          renameSurvey={renameSurvey}
         />
       </div>
     </div>

--- a/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
+++ b/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
@@ -10,6 +10,7 @@ import {
   EyeIcon,
   LinkIcon,
   MoreVertical,
+  PencilIcon,
   SquarePenIcon,
   TrashIcon,
 } from "lucide-react";
@@ -28,6 +29,7 @@ import { EditPublicSurveyAlertDialog } from "@/modules/survey/components/edit-pu
 import { copySurveyLink } from "@/modules/survey/lib/client-utils";
 import { copySurveyToOtherWorkspaceAction } from "@/modules/survey/list/actions";
 import { CopySurveyModal } from "@/modules/survey/list/components/copy-survey-modal";
+import { RenameSurveyModal } from "@/modules/survey/list/components/rename-survey-modal";
 import { surveyKeys } from "@/modules/survey/list/lib/query";
 import { TSurveyListItem } from "@/modules/survey/list/types/survey-overview";
 import { ConfirmationModal } from "@/modules/ui/components/confirmation-modal";
@@ -56,6 +58,7 @@ interface SurveyDropDownMenuProps {
   updateSurveyStatus: (surveyId: string, status: TSurveyStatus) => Promise<void>;
   archiveSurvey: (surveyId: string) => Promise<void>;
   restoreSurvey: (surveyId: string) => Promise<void>;
+  renameSurvey: (surveyId: string, name: string) => Promise<void>;
 }
 
 // Non-draft statuses that can be targeted by a status change from the list.
@@ -71,6 +74,7 @@ export const SurveyDropDownMenu = ({
   updateSurveyStatus,
   archiveSurvey,
   restoreSurvey,
+  renameSurvey,
 }: Readonly<SurveyDropDownMenuProps>) => {
   const { workspace } = useWorkspace();
 
@@ -83,6 +87,7 @@ export const SurveyDropDownMenu = ({
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
   const [isCautionDialogOpen, setIsCautionDialogOpen] = useState(false);
   const [isCopyModalOpen, setIsCopyModalOpen] = useState(false);
+  const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
   const router = useRouter();
   const queryClient = useQueryClient();
 
@@ -271,6 +276,18 @@ export const SurveyDropDownMenu = ({
               </DropdownMenuItem>
             )}
             {!isArchived && canManageSurvey && (
+              <DropdownMenuItem
+                data-testid="rename-survey"
+                icon={<PencilIcon className="size-4" />}
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setIsDropDownOpen(false);
+                  setIsRenameModalOpen(true);
+                }}>
+                {t("common.rename")}
+              </DropdownMenuItem>
+            )}
+            {!isArchived && canManageSurvey && (
               <DropdownMenuItem>
                 <button
                   type="button"
@@ -426,6 +443,16 @@ export const SurveyDropDownMenu = ({
           onConfirm={handleArchiveSurvey}
           hideCloseButton={isInProgress}
           closeOnOutsideClick={!isInProgress}
+        />
+      )}
+
+      {!isArchived && canManageSurvey && (
+        <RenameSurveyModal
+          open={isRenameModalOpen}
+          setOpen={setIsRenameModalOpen}
+          surveyId={survey.id}
+          surveyName={survey.name}
+          renameSurvey={renameSurvey}
         />
       )}
 

--- a/apps/web/modules/survey/list/components/survey-list.tsx
+++ b/apps/web/modules/survey/list/components/survey-list.tsx
@@ -17,6 +17,7 @@ import { CreateWithAIDialog } from "@/modules/survey/components/template-list/co
 import { useCreateSurveyFromTemplate } from "@/modules/survey/components/template-list/hooks/use-create-survey-from-template";
 import { useArchiveSurvey } from "@/modules/survey/list/hooks/use-archive-survey";
 import { useDeleteSurvey } from "@/modules/survey/list/hooks/use-delete-survey";
+import { useRenameSurvey } from "@/modules/survey/list/hooks/use-rename-survey";
 import { useRestoreSurvey } from "@/modules/survey/list/hooks/use-restore-survey";
 import { useSurveys } from "@/modules/survey/list/hooks/use-surveys";
 import { useUpdateSurveyStatus } from "@/modules/survey/list/hooks/use-update-survey-status";
@@ -207,6 +208,7 @@ export const SurveysList = ({
   const updateSurveyStatusMutation = useUpdateSurveyStatus({ queryKey });
   const archiveSurveyMutation = useArchiveSurvey({ queryKey });
   const restoreSurveyMutation = useRestoreSurvey({ queryKey });
+  const renameSurveyMutation = useRenameSurvey({ queryKey });
 
   const showInitialLoading = !isFilterInitialized || (isLoading && surveys.length === 0);
   // Only a workspace without a single survey gets the onboarding empty states. Every other empty
@@ -229,6 +231,10 @@ export const SurveysList = ({
 
   const handleRestoreSurvey = async (surveyId: string) => {
     await restoreSurveyMutation.mutateAsync({ surveyId });
+  };
+
+  const handleRenameSurvey = async (surveyId: string, name: string) => {
+    await renameSurveyMutation.mutateAsync({ surveyId, name });
   };
 
   const createSurveyButton = (
@@ -325,6 +331,7 @@ export const SurveysList = ({
               updateSurveyStatus={handleUpdateSurveyStatus}
               archiveSurvey={handleArchiveSurvey}
               restoreSurvey={handleRestoreSurvey}
+              renameSurvey={handleRenameSurvey}
               publicDomain={publicDomain}
               locale={locale}
             />

--- a/apps/web/modules/survey/list/hooks/use-rename-survey.test.ts
+++ b/apps/web/modules/survey/list/hooks/use-rename-survey.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { type ReactNode, createElement } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { surveyKeys } from "@/modules/survey/list/lib/query";
+import { TSurveyListPage } from "@/modules/survey/list/lib/v3-surveys-client";
+import { useRenameSurvey } from "./use-rename-survey";
+
+function createWrapper(queryClient: QueryClient) {
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+
+  Wrapper.displayName = "UseRenameSurveyTestWrapper";
+
+  return Wrapper;
+}
+
+function createQueryData(): { pages: TSurveyListPage[]; pageParams: (string | null)[] } {
+  return {
+    pages: [
+      {
+        data: [
+          {
+            id: "survey_1",
+            name: "Survey 1",
+            workspaceId: "env_1",
+            type: "link",
+            status: "inProgress",
+            createdAt: new Date("2026-04-15T10:00:00.000Z"),
+            updatedAt: new Date("2026-04-15T10:00:00.000Z"),
+            publishOn: null,
+            archivedAt: null,
+            responseCount: 5,
+            completedResponseCount: 5,
+            creator: { name: "Alice" },
+            singleUse: null,
+          },
+          {
+            id: "survey_2",
+            name: "Survey 2",
+            workspaceId: "env_1",
+            type: "link",
+            status: "completed",
+            createdAt: new Date("2026-04-16T10:00:00.000Z"),
+            updatedAt: new Date("2026-04-16T10:00:00.000Z"),
+            publishOn: null,
+            archivedAt: null,
+            responseCount: 0,
+            completedResponseCount: 0,
+            creator: { name: "Bob" },
+            singleUse: null,
+          },
+        ],
+        meta: {
+          limit: 20,
+          nextCursor: null,
+          totalCount: 2,
+          workspaceSurveyCount: 4,
+        },
+      },
+    ],
+    pageParams: [null],
+  };
+}
+
+const queryKeyInput = {
+  workspaceId: "env_1",
+  limit: 20,
+  filters: {
+    name: "",
+    status: [] as never[],
+    type: [] as never[],
+    sortBy: "relevance" as const,
+  },
+};
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+}
+
+describe("useRenameSurvey", () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("optimistically renames the survey in cache and resolves on success", async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+
+    vi.mocked(global.fetch).mockReturnValue(fetchPromise as Promise<Response>);
+
+    const queryClient = createQueryClient();
+    const queryKey = surveyKeys.list(queryKeyInput);
+    queryClient.setQueryData(queryKey, createQueryData());
+
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useRenameSurvey({ queryKey }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate({ surveyId: "survey_1", name: "Q3 feedback" });
+
+    // Optimistic update: the row shows the new name before the request resolves.
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<{ pages: TSurveyListPage[] }>(queryKey);
+      expect(cached?.pages[0]?.data.find((s) => s.id === "survey_1")?.name).toBe("Q3 feedback");
+    });
+
+    // Only the targeted survey is touched.
+    const cached = queryClient.getQueryData<{ pages: TSurveyListPage[] }>(queryKey);
+    expect(cached?.pages[0]?.data.find((s) => s.id === "survey_2")?.name).toBe("Survey 2");
+
+    resolveFetch?.(
+      new Response(JSON.stringify({ data: { id: "survey_1", name: "Q3 feedback" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: surveyKeys.lists() });
+  });
+
+  test("rolls back to the previous name when the mutation fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          title: "Forbidden",
+          status: 403,
+          detail: "You are not authorized to access this resource",
+          code: "forbidden",
+          requestId: "req_1",
+        }),
+        {
+          status: 403,
+          headers: { "Content-Type": "application/problem+json" },
+        }
+      )
+    );
+
+    const queryClient = createQueryClient();
+    const queryKey = surveyKeys.list(queryKeyInput);
+    queryClient.setQueryData(queryKey, createQueryData());
+
+    const { result } = renderHook(() => useRenameSurvey({ queryKey }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync({ surveyId: "survey_1", name: "Q3 feedback" });
+      })
+    ).rejects.toThrow("You are not authorized to access this resource");
+
+    const cached = queryClient.getQueryData<{ pages: TSurveyListPage[] }>(queryKey);
+    expect(cached?.pages[0]?.data.find((s) => s.id === "survey_1")?.name).toBe("Survey 1");
+  });
+
+  test("sends the surveyId and name to the PATCH endpoint", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ data: { id: "survey_2", name: "Renamed" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const queryClient = createQueryClient();
+    const queryKey = surveyKeys.list(queryKeyInput);
+    queryClient.setQueryData(queryKey, createQueryData());
+
+    const { result } = renderHook(() => useRenameSurvey({ queryKey }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ surveyId: "survey_2", name: "Renamed" });
+    });
+
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+      "/api/v3/surveys/survey_2",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ name: "Renamed" }),
+      })
+    );
+  });
+});

--- a/apps/web/modules/survey/list/hooks/use-rename-survey.ts
+++ b/apps/web/modules/survey/list/hooks/use-rename-survey.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { InfiniteData, useMutation, useQueryClient } from "@tanstack/react-query";
+import { surveyKeys, updateSurveyInInfiniteData } from "@/modules/survey/list/lib/query";
+import { TSurveyListPage, renameSurvey } from "@/modules/survey/list/lib/v3-surveys-client";
+
+export const useRenameSurvey = ({ queryKey }: { queryKey: ReturnType<typeof surveyKeys.list> }) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ surveyId, name }: { surveyId: string; name: string }) =>
+      renameSurvey(surveyId, name),
+    onMutate: async ({ surveyId, name }) => {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousData = queryClient.getQueryData<InfiniteData<TSurveyListPage>>(queryKey);
+
+      queryClient.setQueryData<InfiniteData<TSurveyListPage> | undefined>(queryKey, (currentData) =>
+        updateSurveyInInfiniteData(currentData, surveyId, { name })
+      );
+
+      return { previousData };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(queryKey, context.previousData);
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: surveyKeys.lists() });
+    },
+  });
+};

--- a/apps/web/modules/survey/list/lib/v3-surveys-client.test.ts
+++ b/apps/web/modules/survey/list/lib/v3-surveys-client.test.ts
@@ -6,6 +6,7 @@ import {
   createV3Survey,
   deleteSurvey,
   generateSurveyCreatePayload,
+  renameSurvey,
   validateSurveyCreatePayload,
 } from "./v3-surveys-client";
 
@@ -198,5 +199,49 @@ describe("deleteSurvey", () => {
       code: "forbidden",
     };
     await expect(deleteSurvey("survey_1")).rejects.toMatchObject(expectedError);
+  });
+});
+
+describe("renameSurvey", () => {
+  test("PATCHes only the name and returns the updated survey", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ data: { id: "survey_1", name: "Q3 feedback" } }, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(renameSurvey("survey_1", "Q3 feedback")).resolves.toEqual({
+      id: "survey_1",
+      name: "Q3 feedback",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/v3/surveys/survey_1", {
+      method: "PATCH",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Q3 feedback" }),
+    });
+  });
+
+  test("maps v3 problem responses to V3ApiError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        Response.json(
+          {
+            status: 422,
+            detail: "Survey name is required",
+            code: "unprocessable_entity",
+          },
+          { status: 422 }
+        )
+      )
+    );
+
+    const expectedError: Partial<V3ApiError> = {
+      status: 422,
+      detail: "Survey name is required",
+      code: "unprocessable_entity",
+    };
+    await expect(renameSurvey("survey_1", " ")).rejects.toMatchObject(expectedError);
   });
 });

--- a/apps/web/modules/survey/list/lib/v3-surveys-client.ts
+++ b/apps/web/modules/survey/list/lib/v3-surveys-client.ts
@@ -194,6 +194,31 @@ export async function updateSurveyStatus(
   return responseBody.data;
 }
 
+type TV3RenameSurveyResponse = {
+  data: {
+    id: string;
+    name: string;
+  };
+};
+
+export async function renameSurvey(surveyId: string, name: string): Promise<{ id: string; name: string }> {
+  const response = await fetch(`/api/v3/surveys/${surveyId}`, {
+    method: "PATCH",
+    cache: "no-store",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name }),
+  });
+
+  if (!response.ok) {
+    throw await parseV3ApiError(response);
+  }
+
+  const responseBody = (await response.json()) as TV3RenameSurveyResponse;
+  return responseBody.data;
+}
+
 export async function deleteSurvey(surveyId: string): Promise<void> {
   const response = await fetch(`/api/v3/surveys/${surveyId}`, {
     method: "DELETE",


### PR DESCRIPTION
Fixes ENG-2932

## What & why

**Was:** Renaming a survey meant opening the editor, and a survey with responses first had to get past the "editing a public survey" caution dialog — several navigations per rename.

**Now:** The survey list's "..." menu has a Rename item that opens a small modal, pre-filled with the current name; saving `PATCH`es `{ name }` and the row updates in place.

- Optimistic: the row shows the new name immediately and rolls back on a failed request.
- Gated behind the same `!isArchived && canManageSurvey` condition as Edit, so archived and read-only rows have no Rename.

## Where to look

- [survey-dropdown-menu.tsx:280](apps/web/modules/survey/list/components/survey-dropdown-menu.tsx:280) — menu item and its gate
- [rename-survey-modal.tsx:60](apps/web/modules/survey/list/components/rename-survey-modal.tsx:60) — re-seeds on open only, not on every name change
- [rename-survey-modal.tsx:89](apps/web/modules/survey/list/components/rename-survey-modal.tsx:89) — close gated while submitting, so two renames cannot overlap


https://github.com/user-attachments/assets/5e5fedd8-c2fc-40a6-b901-123bc0bbad17



## Breaking changes

- [ ] This PR contains breaking changes

None — the route, its schema and every API shape are untouched. The PATCH already accepted `name`; this only adds a client that calls it.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter=@formbricks/web exec vitest run modules/survey/list`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Rename absent for archived surveys | manual | Archived row's menu offers only Restore and Delete |
| Modal pre-fills, saves, row updates without navigating | manual | Row renamed in place; name survived a reload |
| Empty or whitespace-only name blocked client-side | manual | "Please enter a survey name." shown, no request sent |
| Failed PATCH reverts the row and keeps the typed name | manual | Injected 403: error toast, row reverted, input kept the edit |
| Rollback restores the previous name in the query cache | unit (mutation) | `use-rename-survey.test.ts`; mutate `use-rename-survey.ts:26` |
| `renameSurvey` PATCHes only `name`, maps problem+json | unit (mutation) | `v3-surveys-client.test.ts`; mutate `v3-surveys-client.ts:211` |

<details>
<summary>Also checked manually</summary>

- A survey with 17 responses renamed straight from the list — the "edit public survey" caution dialog never appeared.
- A draft renamed the same way.
- Enter in the input submits; renaming a row out of the active name filter drops it cleanly on refetch.
- Header icon centred on the title + description block: measured icon ink centre 415 vs block centre 415.
- Dialog held open while the rename is in flight: with the PATCH delayed 6s, Escape did not close it; it closed once settled.

</details>

**Open gaps**

- Read-only membership was not exercised with a second account; the item reads the same `canManageSurvey` boolean that already hides Edit, Duplicate and Delete.

**Risks**

- The rename modal is mounted per row alongside the existing dialogs; a stale `open` would show the wrong name, which is why the form re-seeds on the open transition.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `high`.


