### PR TITLE
docs(pr-template): stop folding screenshots into a collapsible

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 one idea each; the Coverage table is ≤6 rows. Short sentences, plain words, present tense, written
 for a colleague who has not read the ticket: user-visible effect first, mechanism second. Overflow
 folds rather than being dropped. Coverage, Open gaps and Breaking changes stay visible; only long
-media, command logs and Coverage rows past the sixth fold. -->
+command logs and Coverage rows past the sixth fold. -->
 
 <!-- NEVER WRITE — each of these reads as diligence and costs the reviewer a paragraph: blame
 archaeology (which commit introduced it, who touched what); a defence of a choice nobody questioned,
@@ -103,7 +103,7 @@ account, plan or flag state where it matters. `How` is one of `unit (red on main
 cheapest level that can fail. Every `unit` and `e2e` row names the test or spec it rests on, in the
 row or in a `Rerun:` line that names it. A `red on main` row names its own command where that
 differs from `Rerun:`; a `mutation` row names the mutated `file:line`. The table stays visible —
-fold long media and command logs, and rows past the sixth. -->
+fold long command logs, and rows past the sixth. -->
 
 | Behaviour | How | Outcome |
 | --- | --- | --- |


### PR DESCRIPTION
No ticket — small template tweak requested directly by Johannes.

## What & why

**Was:** The Coverage-table guidance told authors to fold long screenshots/media into a `<details>` collapsible, same as command logs.

**Now:** Only command logs fold; screenshots and other media stay visible in the PR body.

## Where to look

- [.github/pull_request_template.md](.github/pull_request_template.md) — the two comment lines that listed "media" as foldable

## Breaking changes

- [ ] This PR contains breaking changes

None — internal contributor-guidance comment, not reachable by any external consumer.

## Migrations & env

- none

## How this was tested

Rerun: `git diff main -- .github/pull_request_template.md`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Template comment text | manual | Read the rendered diff; only "media" was removed from both fold instructions, rest of file untouched |

**Open gaps**

- none

**Risks**

- none

---

> [!NOTE]
> **AI model used** — `claude-sonnet-5`, reasoning effort `unknown`.
