### PR TITLE
feat(ci): backport Apollo and Artemis branch deployments

### DIFF
--- a/.github/actions/build-and-push-docker/action.yml
+++ b/.github/actions/build-and-push-docker/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: "Tag image for staging deployment"
     required: false
     default: "false"
+  deployment_tag:
+    description: "Additional mutable environment tag (staging or staging-artemis)"
+    required: false
+    default: ""
   is_prerelease:
     description: "Whether this is a prerelease (auto-tags for staging/production)"
     required: false
@@ -92,6 +96,7 @@ runs:
         ECR_REGION: ${{ inputs.ecr_region }}
         AWS_ROLE_ARN: ${{ inputs.aws_role_arn }}
         GHCR_IMAGE_NAME: ${{ inputs.ghcr_image_name }}
+        DEPLOYMENT_TAG: ${{ inputs.deployment_tag }}
       run: |
         set -euo pipefail
 
@@ -112,6 +117,11 @@ runs:
             echo "ERROR: GHCR builds require ghcr_image_name"
             exit 1
           fi
+        fi
+
+        if [[ -n "$DEPLOYMENT_TAG" && "$DEPLOYMENT_TAG" != "staging" && "$DEPLOYMENT_TAG" != "staging-artemis" ]]; then
+          echo "ERROR: deployment_tag must be 'staging' or 'staging-artemis', got: $DEPLOYMENT_TAG"
+          exit 1
         fi
 
         echo "SUCCESS: Input validation passed for $REGISTRY_TYPE build"
@@ -157,6 +167,7 @@ runs:
         ECR_REPOSITORY: ${{ inputs.ecr_repository }}
         DEPLOY_PRODUCTION: ${{ inputs.deploy_production }}
         DEPLOY_STAGING: ${{ inputs.deploy_staging }}
+        DEPLOYMENT_TAG: ${{ inputs.deployment_tag }}
         IS_PRERELEASE: ${{ inputs.is_prerelease }}
         MAKE_LATEST: ${{ inputs.make_latest }}
       run: |
@@ -182,6 +193,10 @@ runs:
         if [[ "${DEPLOY_STAGING}" == "true" ]]; then
           TAGS="${TAGS}\n${ECR_REGISTRY}/${ECR_REPOSITORY}:staging"
           echo "Adding staging tag (manual override)"
+        fi
+        if [[ -n "${DEPLOYMENT_TAG}" ]]; then
+          TAGS="${TAGS}\n${ECR_REGISTRY}/${ECR_REPOSITORY}:${DEPLOYMENT_TAG}"
+          echo "Adding ${DEPLOYMENT_TAG} environment tag"
         fi
 
         echo "ECR tags generated:"
@@ -319,12 +334,16 @@ runs:
         REGISTRY_TYPE: ${{ inputs.registry_type }}
         IMAGE_TAG: ${{ steps.version.outputs.version }}
         VERSION_SOURCE: ${{ steps.version.outputs.source }}
+        DEPLOYMENT_TAG: ${{ inputs.deployment_tag }}
       run: |
         echo "SUCCESS: Built and pushed Docker image to $REGISTRY_TYPE"
         echo "Image Tag: $IMAGE_TAG (source: $VERSION_SOURCE)"
         if [[ "$REGISTRY_TYPE" == "ecr" ]]; then
           echo "ECR Registry: ${{ inputs.ecr_registry }}"
           echo "ECR Repository: ${{ inputs.ecr_repository }}"
+          if [[ -n "$DEPLOYMENT_TAG" ]]; then
+            echo "Environment Tag: $DEPLOYMENT_TAG"
+          fi
         else
           echo "GHCR Image: ghcr.io/${{ inputs.ghcr_image_name }}"
         fi

--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: boolean
         default: false
+      deployment_tag:
+        description: "Additional mutable environment tag for a manual environment deployment"
+        required: false
+        type: string
+        default: ""
     outputs:
       IMAGE_TAG:
         description: "Normalized image tag used for the build"
@@ -84,6 +89,7 @@ jobs:
           version: ${{ inputs.version_override || inputs.image_tag }}
           deploy_production: ${{ inputs.deploy_production }}
           deploy_staging: ${{ inputs.deploy_staging }}
+          deployment_tag: ${{ inputs.deployment_tag }}
           is_prerelease: ${{ inputs.IS_PRERELEASE }}
           make_latest: ${{ inputs.MAKE_LATEST }}
         env:

--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -42,6 +42,29 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      AWS_ECR_PUSH_ROLE_ARN:
+        required: true
+      DEPOT_PROJECT_TOKEN:
+        required: true
+      DUMMY_DATABASE_URL:
+        required: false
+      DUMMY_ENCRYPTION_KEY:
+        required: false
+      DUMMY_REDIS_URL:
+        required: false
+      DUMMY_HUB_API_URL:
+        required: false
+      DUMMY_HUB_API_KEY:
+        required: false
+      DUMMY_CUBEJS_API_URL:
+        required: false
+      DUMMY_CUBEJS_API_SECRET:
+        required: false
+      SENTRY_AUTH_TOKEN:
+        required: false
+      POSTHOG_KEY:
+        required: false
     outputs:
       IMAGE_TAG:
         description: "Normalized image tag used for the build"
@@ -53,6 +76,11 @@ on:
 permissions:
   contents: read
   id-token: write
+
+# Serialize writers of each mutable environment tag across releases and manual deployments.
+concurrency:
+  group: ecr-${{ inputs.deployment_tag || (inputs.IS_PRERELEASE && 'staging') || (inputs.deploy_staging && 'staging') || (inputs.deploy_production && 'production') || (inputs.MAKE_LATEST && 'production') || github.run_id }}
+  cancel-in-progress: false
 
 env:
   ECR_REGION: ${{ vars.ECR_REGION }}

--- a/.github/workflows/deploy-apollo.yml
+++ b/.github/workflows/deploy-apollo.yml
@@ -20,7 +20,18 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    secrets: inherit
+    secrets:
+      AWS_ECR_PUSH_ROLE_ARN: ${{ secrets.AWS_ECR_PUSH_ROLE_ARN }}
+      DEPOT_PROJECT_TOKEN: ${{ secrets.DEPOT_PROJECT_TOKEN }}
+      DUMMY_DATABASE_URL: ${{ secrets.DUMMY_DATABASE_URL }}
+      DUMMY_ENCRYPTION_KEY: ${{ secrets.DUMMY_ENCRYPTION_KEY }}
+      DUMMY_REDIS_URL: ${{ secrets.DUMMY_REDIS_URL }}
+      DUMMY_HUB_API_URL: ${{ secrets.DUMMY_HUB_API_URL }}
+      DUMMY_HUB_API_KEY: ${{ secrets.DUMMY_HUB_API_KEY }}
+      DUMMY_CUBEJS_API_URL: ${{ secrets.DUMMY_CUBEJS_API_URL }}
+      DUMMY_CUBEJS_API_SECRET: ${{ secrets.DUMMY_CUBEJS_API_SECRET }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
     with:
       image_tag: 0.0.0-apollo-${{ github.sha }}
       deployment_tag: staging

--- a/.github/workflows/deploy-apollo.yml
+++ b/.github/workflows/deploy-apollo.yml
@@ -1,0 +1,26 @@
+name: Deploy Selected Branch to Apollo
+run-name: Deploy ${{ github.ref_name }} to Apollo
+
+on:
+  # Select the source branch from the Run workflow branch dropdown.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-apollo
+  cancel-in-progress: false
+
+jobs:
+  build-and-promote:
+    name: Build and promote to Apollo
+    uses: ./.github/workflows/build-and-push-ecr.yml
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      image_tag: 0.0.0-apollo-${{ github.sha }}
+      deployment_tag: staging

--- a/.github/workflows/deploy-artemis.yml
+++ b/.github/workflows/deploy-artemis.yml
@@ -20,7 +20,18 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    secrets: inherit
+    secrets:
+      AWS_ECR_PUSH_ROLE_ARN: ${{ secrets.AWS_ECR_PUSH_ROLE_ARN }}
+      DEPOT_PROJECT_TOKEN: ${{ secrets.DEPOT_PROJECT_TOKEN }}
+      DUMMY_DATABASE_URL: ${{ secrets.DUMMY_DATABASE_URL }}
+      DUMMY_ENCRYPTION_KEY: ${{ secrets.DUMMY_ENCRYPTION_KEY }}
+      DUMMY_REDIS_URL: ${{ secrets.DUMMY_REDIS_URL }}
+      DUMMY_HUB_API_URL: ${{ secrets.DUMMY_HUB_API_URL }}
+      DUMMY_HUB_API_KEY: ${{ secrets.DUMMY_HUB_API_KEY }}
+      DUMMY_CUBEJS_API_URL: ${{ secrets.DUMMY_CUBEJS_API_URL }}
+      DUMMY_CUBEJS_API_SECRET: ${{ secrets.DUMMY_CUBEJS_API_SECRET }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
     with:
       image_tag: 0.0.0-artemis-${{ github.sha }}
       deployment_tag: staging-artemis

--- a/.github/workflows/deploy-artemis.yml
+++ b/.github/workflows/deploy-artemis.yml
@@ -1,0 +1,26 @@
+name: Deploy Selected Branch to Artemis
+run-name: Deploy ${{ github.ref_name }} to Artemis
+
+on:
+  # Select the source branch from the Run workflow branch dropdown.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-artemis
+  cancel-in-progress: false
+
+jobs:
+  build-and-promote:
+    name: Build and promote to Artemis
+    uses: ./.github/workflows/build-and-push-ecr.yml
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      image_tag: 0.0.0-artemis-${{ github.sha }}
+      deployment_tag: staging-artemis


### PR DESCRIPTION
No ticket; this backport makes the deployment workflows runnable from `release/5.4`.

## What & why

**Was:** GitHub could not dispatch the new environment workflows from `release/5.4` because workflow definitions are resolved from the selected ref.

**Now:** The release branch contains the same manual Apollo and Artemis workflows and environment-tag support as main.

- Apollo promotes `staging`.
- Artemis promotes isolated `staging-artemis`.
- Each build also receives an immutable commit-SHA tag.

## Where to look

- [Apollo workflow](https://github.com/formbricks/formbricks/blob/c657481e4/.github/workflows/deploy-apollo.yml#L16-L26) — Apollo promotion
- [Artemis workflow](https://github.com/formbricks/formbricks/blob/c657481e4/.github/workflows/deploy-artemis.yml#L16-L26) — Artemis promotion
- [Build action](https://github.com/formbricks/formbricks/blob/c657481e4/.github/actions/build-and-push-docker/action.yml#L188-L200) — environment tag handling

## Breaking changes

- [ ] This PR contains breaking changes

None. Existing release and manual build inputs retain their behavior.

## Migrations & env

- none

## How this was tested

Rerun: `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/deploy-apollo.yml .github/workflows/deploy-artemis.yml .github/workflows/build-and-push-ecr.yml && git diff --check origin/release/5.4...HEAD`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Release branch workflows | manual | Actionlint accepts all three workflow files |
| Apollo tag wiring | manual | Dispatch promotes `staging` |
| Artemis tag wiring | manual | Dispatch promotes only `staging-artemis` |

**Open gaps**

- Live dispatch requires this backport to merge.
- ECR push and Argo rollout are verified after merge.

**Risks**

- Selected branches supply their own workflow and local action; dispatch only trusted refs.

---

> [!NOTE]
> **AI model used** — `unknown`, reasoning effort `unknown`.
