### PR TITLE
feat(surveys): export envelope builder and schema [ENG-2972]

### DIFF
--- a/apps/web/app/api/v3/surveys/export/schemas.test.ts
+++ b/apps/web/app/api/v3/surveys/export/schemas.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+import type { z } from "zod";
+import { ZSurveyExportEnvelope, getSurveyExportFormat } from "./schemas";
+
+/** Strict-object rejections carry the offending key in `keys`, not in `path`; flatten both. */
+function issueLocations(error: z.ZodError): string[] {
+  return error.issues.flatMap((issue) => {
+    const base = issue.path.join(".");
+    if (issue.code === "unrecognized_keys") {
+      return issue.keys.map((key) => (base ? `${base}.${key}` : key));
+    }
+    return [base];
+  });
+}
+
+const validEnvelope = {
+  formbricks: {
+    exportFormat: 1,
+    exportedAt: "2026-09-08T12:00:00.000Z",
+    appVersion: "6.2.0",
+    source: {
+      url: "https://app.formbricks.com",
+      workspaceId: "clxx1234567890123456789012",
+      surveyId: "clsv1234567890123456789012",
+    },
+  },
+  survey: {
+    name: "Product Feedback",
+    type: "link",
+    status: "inProgress",
+    defaultLanguage: "en-US",
+    languages: [{ code: "en-US", default: true, enabled: true }],
+    blocks: [
+      {
+        id: "clbk1234567890123456789012",
+        name: "Main",
+        elements: [
+          { id: "q1", type: "openText", headline: { "en-US": "What should we improve?" }, required: true },
+        ],
+      },
+    ],
+  },
+  references: { actionClasses: [] },
+};
+
+describe("ZSurveyExportEnvelope", () => {
+  test("parses a valid envelope into a typed v3 document", () => {
+    const parsed = ZSurveyExportEnvelope.safeParse(validEnvelope);
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.survey.type).toBe("link");
+      expect(parsed.data.survey.blocks[0].elements[0].headline).toEqual({
+        default: "What should we improve?",
+      });
+      expect(parsed.data.survey.endings).toEqual([]);
+    }
+  });
+
+  test("rejects an extensions block with its path", () => {
+    const parsed = ZSurveyExportEnvelope.safeParse({ ...validEnvelope, extensions: { styling: {} } });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(issueLocations(parsed.error)).toContain("extensions");
+    }
+  });
+
+  test("rejects instance-bound fields inside the survey with a nested path", () => {
+    const parsed = ZSurveyExportEnvelope.safeParse({
+      ...validEnvelope,
+      survey: { ...validEnvelope.survey, slug: "my-survey", workspaceId: "clxx1234567890123456789012" },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      const paths = issueLocations(parsed.error);
+      expect(paths).toContain("survey.slug");
+      expect(paths).toContain("survey.workspaceId");
+    }
+  });
+
+  test("rejects a newer export format and exposes it through the probe", () => {
+    const newer = { ...validEnvelope, formbricks: { ...validEnvelope.formbricks, exportFormat: 2 } };
+
+    expect(ZSurveyExportEnvelope.safeParse(newer).success).toBe(false);
+    expect(getSurveyExportFormat(newer)).toBe(2);
+    expect(getSurveyExportFormat({ survey: {} })).toBeNull();
+    expect(getSurveyExportFormat("nope")).toBeNull();
+  });
+
+  test("rejects unknown keys on action-class references and on the source", () => {
+    const parsed = ZSurveyExportEnvelope.safeParse({
+      ...validEnvelope,
+      formbricks: { ...validEnvelope.formbricks, source: { ...validEnvelope.formbricks.source, extra: 1 } },
+      references: {
+        actionClasses: [
+          {
+            id: "claa1234567890123456789012",
+            name: "Clicked",
+            key: null,
+            type: "noCode",
+            noCodeConfig: { type: "pageView", urlFilters: [] },
+            description: null,
+            workspaceId: "clxx1234567890123456789012",
+          },
+        ],
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      const paths = issueLocations(parsed.error);
+      expect(paths).toContain("formbricks.source.extra");
+      expect(paths).toContain("references.actionClasses.0.workspaceId");
+    }
+  });
+});

--- a/apps/web/app/api/v3/surveys/export/schemas.ts
+++ b/apps/web/app/api/v3/surveys/export/schemas.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { ZActionClass } from "@formbricks/types/action-classes";
+import { createZV3TypedSurveyDocumentSchema } from "../schemas";
+
+/**
+ * Portable survey export ("`.formbricks.json`"). Format 1 is the v3 survey document in a thin envelope:
+ * export metadata, the document itself (as `GET /api/v3/surveys/{id}` serializes it, minus the
+ * instance-bound fields), and the definitions of the action classes the document's triggers point at.
+ *
+ * Nothing the v3 document omits travels (D1): styling, follow-ups, quotas, survey settings, slug,
+ * custom scripts, targeting. Every level is `.strict()` so a hand-edited file with an `extensions`
+ * block is rejected with a path instead of being silently ignored.
+ */
+export const SURVEY_EXPORT_FORMAT = 1 as const;
+
+export const ZSurveyExportActionClassReference = ZActionClass.pick({
+  id: true,
+  name: true,
+  key: true,
+  type: true,
+  noCodeConfig: true,
+  description: true,
+}).strict();
+
+export type TSurveyExportActionClassReference = z.infer<typeof ZSurveyExportActionClassReference>;
+
+export const ZSurveyExportSource = z
+  .object({
+    url: z.url(),
+    workspaceId: z.cuid2(),
+    surveyId: z.cuid2(),
+  })
+  .strict();
+
+export const ZSurveyExportMetadata = z
+  .object({
+    exportFormat: z.literal(SURVEY_EXPORT_FORMAT),
+    exportedAt: z.iso.datetime(),
+    appVersion: z.string().trim().min(1),
+    source: ZSurveyExportSource,
+  })
+  .strict();
+
+export type TSurveyExportMetadata = z.infer<typeof ZSurveyExportMetadata>;
+
+export const ZSurveyExportReferences = z
+  .object({
+    actionClasses: z.array(ZSurveyExportActionClassReference),
+  })
+  .strict();
+
+export type TSurveyExportReferences = z.infer<typeof ZSurveyExportReferences>;
+
+/**
+ * The envelope as a file: three top-level keys, nothing else. `survey` is parsed with the same rules
+ * as a create body (public locale maps, strict unknown-field rejection, language declarations), so a
+ * parsed envelope's `survey` is a `TV3TypedSurveyDocument` — the importer only has to add `workspaceId`.
+ */
+export const ZSurveyExportEnvelope = z
+  .object({
+    formbricks: ZSurveyExportMetadata,
+    survey: createZV3TypedSurveyDocumentSchema(),
+    references: ZSurveyExportReferences,
+  })
+  .strict();
+
+export type TSurveyExportEnvelope = z.infer<typeof ZSurveyExportEnvelope>;
+
+/**
+ * A file that claims a newer format than this instance understands. Checked before the full parse so
+ * the message can say "newer instance" instead of "expected literal 1".
+ */
+export const ZSurveyExportFormatProbe = z.object({
+  formbricks: z.object({ exportFormat: z.number().int() }).loose(),
+});
+
+export function getSurveyExportFormat(value: unknown): number | null {
+  const probe = ZSurveyExportFormatProbe.safeParse(value);
+  return probe.success ? probe.data.formbricks.exportFormat : null;
+}

--- a/apps/web/app/api/v3/surveys/schemas.ts
+++ b/apps/web/app/api/v3/surveys/schemas.ts
@@ -394,6 +394,10 @@ const ROOT_KEYS = new Set([
   "distribution",
   "targeting",
 ]);
+// The create root keys minus `workspaceId`: the shape of a portable v3 survey document (export files,
+// raw documents pasted from the MCP `create_survey` tool) that names its own `type`.
+const TYPED_DOCUMENT_ROOT_KEYS = new Set([...ROOT_KEYS].filter((key) => key !== "workspaceId"));
+export const V3_SURVEY_DOCUMENT_ROOT_KEYS: ReadonlySet<string> = TYPED_DOCUMENT_ROOT_KEYS;
 const PATCH_ROOT_KEYS = new Set([
   "name",
   "status",
@@ -971,7 +975,7 @@ function validateTargeting(value: unknown, path: string, issues: InvalidParam[])
   addUnknownKeyIssues(value, TARGETING_KEYS, path, issues, "survey targeting");
 }
 
-function getUnsupportedV3SurveyDocumentFields(
+export function getUnsupportedV3SurveyDocumentFields(
   value: unknown,
   rootKeys: Set<string>,
   fallbackDefaultLanguage = DEFAULT_V3_SURVEY_LANGUAGE,
@@ -1242,6 +1246,47 @@ export const ZV3CreateSurveyBody = z
   })
   .pipe(ZV3CreateSurveyBodyBase);
 
+/**
+ * A v3 survey document that carries its own `type` but no `workspaceId` — the `survey` member of an
+ * export envelope, or a raw document produced by the MCP `create_survey` tool. Same normalizer,
+ * strictness and language rules as `ZV3CreateSurveyBody`; the importer adds the target workspace.
+ */
+export function createZV3TypedSurveyDocumentSchema(options?: TV3SurveyDocumentSchemaOptions) {
+  return z
+    .unknown()
+    .superRefine((value, ctx) => {
+      for (const issue of getUnsupportedV3SurveyDocumentFields(
+        value,
+        TYPED_DOCUMENT_ROOT_KEYS,
+        options?.fallbackDefaultLanguage,
+        options
+      )) {
+        addInvalidParamZodIssue(ctx, issue);
+      }
+    })
+    .pipe(
+      z.preprocess(
+        createV3SurveyDocumentNormalizer({
+          allowInternalDefaultTranslationKey: options?.allowInternalDefaultTranslationKey,
+          fallbackDefaultLanguage: options?.fallbackDefaultLanguage,
+          applyDefaultLanguage: true,
+          generateMissingCreateIds: true,
+          allowedLanguageCodes: options?.allowedLanguageCodes,
+        }),
+        z
+          .object({
+            type: ZSurveyType.prefault("link"),
+            ...createV3SurveyDocumentShape(options),
+          })
+          .strict()
+          .superRefine(addLanguageIssues)
+          .superRefine((body, ctx) => addAppDistributionIssues(body, body.type, ctx))
+      )
+    );
+}
+
+export const ZV3TypedSurveyDocument = createZV3TypedSurveyDocumentSchema();
+
 export const ZV3CreateSurveyQuery = z.object({
   createdFrom: z.enum(["blank", "template", "xm-template", "ai"]).optional(),
 });
@@ -1351,6 +1396,7 @@ export function formatV3ZodInvalidParams(error: z.ZodError, fallbackName: string
 }
 
 export type TV3SurveyDocument = z.infer<typeof ZV3SurveyDocumentBase>;
+export type TV3TypedSurveyDocument = z.infer<typeof ZV3TypedSurveyDocument>;
 export type TV3CreateSurveyBody = z.infer<typeof ZV3CreateSurveyBody>;
 export type TV3PatchSurveyBody = z.infer<typeof ZV3PatchSurveyBody>;
 export type TV3SurveyValidationRequestBody = z.infer<typeof ZV3SurveyValidationRequestBody>;

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -272,6 +272,18 @@ export const SENTRY_RELEASE = (() => {
     return undefined;
   }
 })();
+
+// The app version as built (package.json `version` is stamped by the release build; "0.0.0" in dev).
+// Read once, never thrown: an unreadable package.json must not take the process down.
+export const APP_VERSION: string = (() => {
+  try {
+    const pkg = require("../package.json") as { version?: string };
+    return typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+})();
+
 export const SENTRY_ENVIRONMENT = env.SENTRY_ENVIRONMENT;
 export const SENTRY_DSN = env.SENTRY_DSN;
 

--- a/apps/web/modules/survey/export/__fixtures__/surveys.ts
+++ b/apps/web/modules/survey/export/__fixtures__/surveys.ts
@@ -51,7 +51,7 @@ export const FIXTURE_LANGUAGES: TSurvey["languages"] = [
 ];
 
 /** One element of every type the v3 document supports, across three blocks. */
-export const FIXTURE_BLOCKS: TSurvey["blocks"] = [
+export const FIXTURE_BLOCKS = [
   {
     id: FIXTURE_BLOCK_1_ID,
     name: "Basics",
@@ -254,7 +254,7 @@ export const FIXTURE_BLOCKS: TSurvey["blocks"] = [
       },
     ],
   },
-];
+] as unknown as TSurvey["blocks"];
 
 export const FIXTURE_ENDINGS: TSurvey["endings"] = [
   {

--- a/apps/web/modules/survey/export/__fixtures__/surveys.ts
+++ b/apps/web/modules/survey/export/__fixtures__/surveys.ts
@@ -1,0 +1,442 @@
+import type { TActionClass } from "@formbricks/types/action-classes";
+import type { TSurvey } from "@formbricks/types/surveys/types";
+
+/**
+ * Stored-survey fixtures for the export/import round trip. Every shape is the internal one the survey
+ * service returns (`{ default, "de-DE" }` locale maps), not the public v3 shape.
+ */
+export const FIXTURE_WORKSPACE_ID = "clxx1234567890123456789012";
+export const FIXTURE_SURVEY_ID = "clsv1234567890123456789012";
+export const FIXTURE_BLOCK_1_ID = "clbk0000000000000000000001";
+export const FIXTURE_BLOCK_2_ID = "clbk0000000000000000000002";
+export const FIXTURE_BLOCK_3_ID = "clbk0000000000000000000003";
+export const FIXTURE_ENDING_ID = "clen0000000000000000000001";
+export const FIXTURE_VARIABLE_ID = "clva0000000000000000000001";
+
+const fixtureDate = new Date("2026-09-01T10:00:00.000Z");
+
+const i18n = (en: string, de: string) => ({ default: en, "de-DE": de });
+
+const toggleInput = (label: string) => ({
+  show: true,
+  required: false,
+  placeholder: i18n(label, `${label} (DE)`),
+});
+
+export const FIXTURE_LANGUAGES: TSurvey["languages"] = [
+  {
+    default: true,
+    enabled: true,
+    language: {
+      id: "cllangenus000000000000000",
+      code: "en-US",
+      alias: null,
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      createdAt: fixtureDate,
+      updatedAt: fixtureDate,
+    },
+  },
+  {
+    default: false,
+    enabled: true,
+    language: {
+      id: "cllangdede000000000000000",
+      code: "de-DE",
+      alias: "german",
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      createdAt: fixtureDate,
+      updatedAt: fixtureDate,
+    },
+  },
+];
+
+/** One element of every type the v3 document supports, across three blocks. */
+export const FIXTURE_BLOCKS: TSurvey["blocks"] = [
+  {
+    id: FIXTURE_BLOCK_1_ID,
+    name: "Basics",
+    buttonLabel: i18n("Next", "Weiter"),
+    elements: [
+      {
+        id: "q_open",
+        type: "openText",
+        headline: i18n("What should we improve?", "Was sollen wir verbessern?"),
+        subheader: i18n("Be specific", "Sei konkret"),
+        placeholder: i18n("Type here", "Hier tippen"),
+        required: true,
+        inputType: "text",
+        longAnswer: true,
+        charLimit: { enabled: false },
+      },
+      {
+        id: "q_nps",
+        type: "nps",
+        headline: i18n("How likely are you to recommend us?", "Wie wahrscheinlich empfehlen Sie uns?"),
+        lowerLabel: i18n("Not likely", "Unwahrscheinlich"),
+        upperLabel: i18n("Very likely", "Sehr wahrscheinlich"),
+        required: true,
+        isColorCodingEnabled: false,
+      },
+      {
+        id: "q_single",
+        type: "multipleChoiceSingle",
+        headline: i18n("Pick one", "Wähle eins"),
+        required: false,
+        choices: [
+          { id: "c_a", label: i18n("A", "A") },
+          { id: "c_b", label: i18n("B", "B") },
+          { id: "other", label: i18n("Other", "Andere") },
+        ],
+        otherOptionPlaceholder: i18n("Please specify", "Bitte angeben"),
+        shuffleOption: "none",
+      },
+      {
+        id: "q_multi",
+        type: "multipleChoiceMulti",
+        headline: i18n("Pick many", "Wähle mehrere"),
+        required: false,
+        choices: [
+          { id: "m_a", label: i18n("One", "Eins") },
+          { id: "m_b", label: i18n("Two", "Zwei") },
+        ],
+      },
+      {
+        id: "q_consent",
+        type: "consent",
+        headline: i18n("Terms", "Bedingungen"),
+        label: i18n("I agree", "Ich stimme zu"),
+        required: true,
+      },
+      {
+        id: "q_cta",
+        type: "cta",
+        headline: i18n("Read on", "Weiterlesen"),
+        required: false,
+        buttonExternal: false,
+        ctaButtonLabel: i18n("Next", "Weiter"),
+      },
+    ],
+    logic: [
+      {
+        id: "cllg0000000000000000000001",
+        conditions: {
+          id: "clcg0000000000000000000001",
+          connector: "and",
+          conditions: [
+            {
+              id: "clcd0000000000000000000001",
+              leftOperand: { type: "element", value: "q_nps" },
+              operator: "isGreaterThan",
+              rightOperand: { type: "static", value: 8 },
+            },
+          ],
+        },
+        actions: [
+          {
+            id: "clac0000000000000000000001",
+            objective: "jumpToBlock",
+            target: FIXTURE_ENDING_ID,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: FIXTURE_BLOCK_2_ID,
+    name: "Scales",
+    elements: [
+      {
+        id: "q_rating",
+        type: "rating",
+        headline: i18n("Rate us (you said: #recall:q_open/fallback:#)", "Bewerte uns"),
+        required: true,
+        scale: "number",
+        range: 5,
+        isColorCodingEnabled: false,
+      },
+      {
+        id: "q_csat",
+        type: "csat",
+        headline: i18n("Satisfied?", "Zufrieden?"),
+        required: true,
+        scale: "smiley",
+        range: 5,
+        isColorCodingEnabled: false,
+      },
+      {
+        id: "q_ces",
+        type: "ces",
+        headline: i18n("Effort?", "Aufwand?"),
+        required: true,
+        scale: "number",
+        range: 7,
+        isColorCodingEnabled: false,
+      },
+      {
+        id: "q_matrix",
+        type: "matrix",
+        headline: i18n("Grid", "Raster"),
+        required: false,
+        rows: [{ id: "r1", label: i18n("Row 1", "Zeile 1") }],
+        columns: [{ id: "c1", label: i18n("Col 1", "Spalte 1") }],
+        shuffleOption: "none",
+      },
+      {
+        id: "q_ranking",
+        type: "ranking",
+        headline: i18n("Rank", "Rangfolge"),
+        required: false,
+        choices: [
+          { id: "rk_a", label: i18n("First", "Erstes") },
+          { id: "rk_b", label: i18n("Second", "Zweites") },
+        ],
+      },
+      {
+        id: "q_pics",
+        type: "pictureSelection",
+        headline: i18n("Pick a picture", "Wähle ein Bild"),
+        required: false,
+        allowMulti: false,
+        choices: [
+          { id: "p_a", imageUrl: "https://example.com/a.png" },
+          { id: "p_b", imageUrl: "https://example.com/b.png" },
+        ],
+      },
+    ],
+  },
+  {
+    id: FIXTURE_BLOCK_3_ID,
+    name: "Details",
+    elements: [
+      {
+        id: "q_date",
+        type: "date",
+        headline: i18n("When?", "Wann?"),
+        required: false,
+        format: "M-d-y",
+      },
+      {
+        id: "q_file",
+        type: "fileUpload",
+        headline: i18n("Upload", "Hochladen"),
+        required: false,
+        allowMultipleFiles: false,
+      },
+      {
+        id: "q_cal",
+        type: "cal",
+        headline: i18n("Book a call", "Termin buchen"),
+        required: false,
+        calUserName: "formbricks",
+      },
+      {
+        id: "q_address",
+        type: "address",
+        headline: i18n("Address", "Adresse"),
+        required: false,
+        addressLine1: toggleInput("Street"),
+        addressLine2: toggleInput("Line 2"),
+        city: toggleInput("City"),
+        state: toggleInput("State"),
+        zip: toggleInput("ZIP"),
+        country: toggleInput("Country"),
+      },
+      {
+        id: "q_contact",
+        type: "contactInfo",
+        headline: i18n("Contact", "Kontakt"),
+        required: false,
+        firstName: toggleInput("First name"),
+        lastName: toggleInput("Last name"),
+        email: toggleInput("Email"),
+        phone: toggleInput("Phone"),
+        company: toggleInput("Company"),
+      },
+    ],
+  },
+];
+
+export const FIXTURE_ENDINGS: TSurvey["endings"] = [
+  {
+    id: FIXTURE_ENDING_ID,
+    type: "endScreen",
+    headline: i18n("Thanks, #recall:q_open/fallback:#!", "Danke, #recall:q_open/fallback:#!"),
+    subheader: i18n("We read every answer", "Wir lesen jede Antwort"),
+    buttonLabel: i18n("Back to site", "Zurück"),
+    buttonLink: "https://formbricks.com",
+  },
+];
+
+export const FIXTURE_CODE_ACTION_CLASS: TActionClass = {
+  id: "claa0000000000000000000001",
+  name: "Checkout Complete",
+  description: "Fired after checkout",
+  type: "code",
+  key: "checkout_complete",
+  noCodeConfig: null,
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  createdAt: fixtureDate,
+  updatedAt: fixtureDate,
+};
+
+export const FIXTURE_NOCODE_ACTION_CLASS: TActionClass = {
+  id: "claa0000000000000000000002",
+  name: "Clicked pricing",
+  description: null,
+  type: "noCode",
+  key: null,
+  noCodeConfig: {
+    type: "click",
+    urlFilters: [],
+    elementSelector: { cssSelector: "#pricing" },
+  },
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  createdAt: fixtureDate,
+  updatedAt: fixtureDate,
+};
+
+/**
+ * A fully featured stored link survey. Carries every field the export must NOT read (styling,
+ * follow-ups, single-use, PIN, slug, custom scripts, schedule) so tests can assert they never travel.
+ */
+export const FIXTURE_LINK_SURVEY = {
+  id: FIXTURE_SURVEY_ID,
+  createdAt: fixtureDate,
+  updatedAt: fixtureDate,
+  name: "Product Feedback",
+  type: "link",
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  createdBy: "cluser000000000000000000001",
+  status: "inProgress",
+  displayOption: "displayOnce",
+  autoClose: null,
+  triggers: [],
+  recontactDays: null,
+  displayLimit: null,
+  welcomeCard: {
+    enabled: true,
+    headline: i18n("Welcome", "Willkommen"),
+    subheader: i18n("Two minutes", "Zwei Minuten"),
+    buttonLabel: i18n("Start", "Los"),
+    timeToFinish: true,
+    showResponseCount: false,
+  },
+  questions: [],
+  blocks: FIXTURE_BLOCKS,
+  endings: FIXTURE_ENDINGS,
+  hiddenFields: { enabled: true, fieldIds: ["utm_source", "plan"] },
+  variables: [{ id: FIXTURE_VARIABLE_ID, name: "score", type: "number", value: 0 }],
+  followUps: [
+    {
+      id: "clfu0000000000000000000001",
+      surveyId: FIXTURE_SURVEY_ID,
+      name: "Notify team",
+      trigger: { type: "response", properties: null },
+      action: {
+        type: "send-email",
+        properties: {
+          to: "q_contact",
+          from: "team@example.com",
+          replyTo: ["team@example.com"],
+          subject: "New response",
+          body: "<p>Hi</p>",
+          attachResponseData: true,
+        },
+      },
+      createdAt: fixtureDate,
+      updatedAt: fixtureDate,
+    },
+  ],
+  delay: 0,
+  publishOn: new Date("2026-10-01T00:00:00.000Z"),
+  closeOn: new Date("2026-11-01T00:00:00.000Z"),
+  archivedAt: null,
+  autoComplete: null,
+  workspaceOverwrites: { brandColor: "#123456" },
+  styling: { brandColor: { light: "#00ff00" }, overwriteThemeStyling: true },
+  showLanguageSwitch: true,
+  surveyClosedMessage: { enabled: true, heading: "Closed", subheading: "Come back later" },
+  segment: null,
+  singleUse: { enabled: true, isEncrypted: true },
+  isVerifyEmailEnabled: false,
+  recaptcha: { enabled: true, threshold: 0.5 },
+  isBackButtonHidden: false,
+  isAutoProgressingEnabled: false,
+  isCaptureIpEnabled: false,
+  pin: "1234",
+  displayPercentage: null,
+  languages: FIXTURE_LANGUAGES,
+  metadata: {
+    title: i18n("Product Feedback", "Produktfeedback"),
+    description: i18n("Tell us what you think", "Sag uns deine Meinung"),
+  },
+  slug: "product-feedback",
+  customHeadScripts: "<script>alert(1)</script>",
+  customHeadScriptsMode: "add",
+} as unknown as TSurvey;
+
+/** App variant with two triggers and a segment with filters (targeting must not travel). */
+export const FIXTURE_APP_SURVEY = {
+  ...FIXTURE_LINK_SURVEY,
+  id: "clsvapp0000000000000000001",
+  name: "In-App Feedback",
+  type: "app",
+  displayOption: "respondMultiple",
+  recontactDays: 7,
+  delay: 5,
+  triggers: [{ actionClass: FIXTURE_CODE_ACTION_CLASS }, { actionClass: FIXTURE_NOCODE_ACTION_CLASS }],
+  segment: {
+    id: "clsg0000000000000000000001",
+    title: "clsvapp0000000000000000001",
+    description: null,
+    isPrivate: true,
+    filters: [
+      {
+        id: "clsf0000000000000000000001",
+        connector: null,
+        resource: {
+          id: "clsr0000000000000000000001",
+          root: { type: "attribute", contactAttributeKey: "plan" },
+          qualifier: { operator: "equals" },
+          value: "enterprise",
+        },
+      },
+    ],
+    workspaceId: FIXTURE_WORKSPACE_ID,
+    surveys: ["clsvapp0000000000000000001"],
+    createdAt: fixtureDate,
+    updatedAt: fixtureDate,
+  },
+} as unknown as TSurvey;
+
+/** Legacy question-based survey (no blocks): the export converts it. */
+export const FIXTURE_LEGACY_SURVEY = {
+  ...FIXTURE_LINK_SURVEY,
+  id: "clsvleg0000000000000000001",
+  name: "Legacy NPS",
+  blocks: [],
+  endings: [],
+  hiddenFields: { enabled: false },
+  variables: [],
+  questions: [
+    {
+      id: "legacy_open",
+      type: "openText",
+      headline: i18n("Anything else?", "Noch etwas?"),
+      required: false,
+      inputType: "text",
+      charLimit: { enabled: false },
+    },
+  ],
+} as unknown as TSurvey;
+
+export const FIXTURE_EMPTY_SURVEY = {
+  ...FIXTURE_LINK_SURVEY,
+  id: "clsvemp0000000000000000001",
+  name: "Empty",
+  blocks: [],
+  questions: [],
+  endings: [],
+  hiddenFields: { enabled: false },
+  variables: [],
+} as unknown as TSurvey;

--- a/apps/web/modules/survey/export/build-export-envelope.test.ts
+++ b/apps/web/modules/survey/export/build-export-envelope.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "vitest";
+import type { TSurvey } from "@formbricks/types/surveys/types";
+import { ZSurveyExportEnvelope } from "@/app/api/v3/surveys/export/schemas";
+import { ZV3CreateSurveyBody } from "@/app/api/v3/surveys/schemas";
+import {
+  FIXTURE_APP_SURVEY,
+  FIXTURE_BLOCK_1_ID,
+  FIXTURE_CODE_ACTION_CLASS,
+  FIXTURE_EMPTY_SURVEY,
+  FIXTURE_LEGACY_SURVEY,
+  FIXTURE_LINK_SURVEY,
+  FIXTURE_NOCODE_ACTION_CLASS,
+  FIXTURE_SURVEY_ID,
+  FIXTURE_WORKSPACE_ID,
+} from "./__fixtures__/surveys";
+import { buildSurveyExportEnvelope } from "./build-export-envelope";
+
+const ctx = {
+  appVersion: "6.2.0",
+  publicUrl: "https://app.formbricks.com",
+  exportedAt: new Date("2026-09-08T12:00:00.000Z"),
+};
+
+const ALL_ELEMENT_TYPES = [
+  "openText",
+  "nps",
+  "multipleChoiceSingle",
+  "multipleChoiceMulti",
+  "consent",
+  "cta",
+  "rating",
+  "csat",
+  "ces",
+  "matrix",
+  "ranking",
+  "pictureSelection",
+  "date",
+  "fileUpload",
+  "cal",
+  "address",
+  "contactInfo",
+];
+
+function expectOk<T, E>(result: { ok: true; data: T } | { ok: false; error: E }): T {
+  if (!result.ok) {
+    throw new Error(`Expected ok, got ${JSON.stringify(result.error, null, 2)}`);
+  }
+  return result.data;
+}
+
+describe("buildSurveyExportEnvelope", () => {
+  test("exports a fully featured link survey as a three-key envelope in export format 1", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+
+    expect(Object.keys(envelope)).toEqual(["formbricks", "survey", "references"]);
+    expect(envelope.formbricks).toEqual({
+      exportFormat: 1,
+      exportedAt: "2026-09-08T12:00:00.000Z",
+      appVersion: "6.2.0",
+      source: {
+        url: "https://app.formbricks.com",
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        surveyId: FIXTURE_SURVEY_ID,
+      },
+    });
+    expect(envelope.references.actionClasses).toEqual([]);
+
+    const { survey } = envelope;
+    expect(survey.type).toBe("link");
+    expect(survey.defaultLanguage).toBe("en-US");
+    expect(survey.languages).toEqual([
+      { code: "en-US", default: true, enabled: true },
+      { code: "de-DE", default: false, enabled: true },
+    ]);
+    expect(survey.blocks.flatMap((block) => block.elements.map((element) => element.type)).sort()).toEqual(
+      [...ALL_ELEMENT_TYPES].sort()
+    );
+    // Public locale maps, not the internal `default` key.
+    expect(survey.blocks[0].elements[0].headline).toEqual({
+      "en-US": "What should we improve?",
+      "de-DE": "Was sollen wir verbessern?",
+    });
+    expect(survey.endings[0]).toMatchObject({
+      type: "endScreen",
+      headline: { "en-US": "Thanks, #recall:q_open/fallback:#!" },
+    });
+    expect(survey.hiddenFields).toEqual({ enabled: true, fieldIds: ["utm_source", "plan"] });
+    expect(survey.variables).toHaveLength(1);
+  });
+
+  test("never reads styling, follow-ups, settings, slug, scripts, schedule or instance fields", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+    const serialized = JSON.stringify(envelope);
+
+    for (const forbidden of [
+      "styling",
+      "followUps",
+      "singleUse",
+      "pin",
+      "recaptcha",
+      "surveyClosedMessage",
+      "showLanguageSwitch",
+      "isVerifyEmailEnabled",
+      "isBackButtonHidden",
+      "slug",
+      "customHeadScripts",
+      "publishOn",
+      "closeOn",
+      "createdBy",
+      "createdAt",
+      "updatedAt",
+      "archivedAt",
+      "workspaceOverwrites",
+      "segment",
+      "targeting",
+      "alert(1)",
+      "product-feedback",
+    ]) {
+      expect(serialized, forbidden).not.toContain(`"${forbidden}"`);
+    }
+    expect(envelope.survey).not.toHaveProperty("id");
+    expect(envelope.survey).not.toHaveProperty("workspaceId");
+    expect(envelope.survey).not.toHaveProperty("distribution");
+  });
+
+  test("round-trips through the v3 create schema and the envelope schema", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+
+    const createBody = ZV3CreateSurveyBody.safeParse({
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      ...envelope.survey,
+    });
+    expect(createBody.success, JSON.stringify(createBody.error?.issues)).toBe(true);
+
+    const parsedEnvelope = ZSurveyExportEnvelope.safeParse(JSON.parse(JSON.stringify(envelope)));
+    expect(parsedEnvelope.success, JSON.stringify(parsedEnvelope.error?.issues)).toBe(true);
+  });
+
+  test("is deterministic apart from exportedAt", () => {
+    const first = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+    const second = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  test("carries triggers and action-class definitions for app surveys, but no targeting", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_APP_SURVEY, ctx));
+
+    expect(envelope.survey.type).toBe("app");
+    expect(envelope.survey.distribution).toMatchObject({
+      displayOption: "respondMultiple",
+      recontactDays: 7,
+      delay: 5,
+      triggers: [
+        { actionClassId: FIXTURE_CODE_ACTION_CLASS.id },
+        { actionClassId: FIXTURE_NOCODE_ACTION_CLASS.id },
+      ],
+    });
+    expect(envelope.survey).not.toHaveProperty("targeting");
+    expect(envelope.references.actionClasses).toEqual([
+      {
+        id: FIXTURE_CODE_ACTION_CLASS.id,
+        name: "Checkout Complete",
+        key: "checkout_complete",
+        type: "code",
+        noCodeConfig: null,
+        description: "Fired after checkout",
+      },
+      {
+        id: FIXTURE_NOCODE_ACTION_CLASS.id,
+        name: "Clicked pricing",
+        key: null,
+        type: "noCode",
+        noCodeConfig: FIXTURE_NOCODE_ACTION_CLASS.noCodeConfig,
+        description: null,
+      },
+    ]);
+    expect(JSON.stringify(envelope)).not.toContain("contactAttributeKey");
+
+    const createBody = ZV3CreateSurveyBody.safeParse({
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      ...envelope.survey,
+    });
+    expect(createBody.success, JSON.stringify(createBody.error?.issues)).toBe(true);
+  });
+
+  test("de-duplicates action classes referenced by more than one trigger", () => {
+    const survey = {
+      ...FIXTURE_APP_SURVEY,
+      triggers: [{ actionClass: FIXTURE_CODE_ACTION_CLASS }, { actionClass: FIXTURE_CODE_ACTION_CLASS }],
+    } as unknown as TSurvey;
+
+    const envelope = expectOk(buildSurveyExportEnvelope(survey, ctx));
+
+    expect(envelope.survey.distribution?.triggers).toHaveLength(2);
+    expect(envelope.references.actionClasses).toHaveLength(1);
+  });
+
+  test("converts legacy question-based surveys to blocks", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_LEGACY_SURVEY, ctx));
+
+    expect(envelope.survey.blocks).toHaveLength(1);
+    expect(envelope.survey.blocks[0].elements[0]).toMatchObject({ id: "legacy_open", type: "openText" });
+    expect(envelope.survey).not.toHaveProperty("questions");
+  });
+
+  test("refuses empty surveys", () => {
+    const result = buildSurveyExportEnvelope(FIXTURE_EMPTY_SURVEY, ctx);
+
+    expect(result).toEqual({
+      ok: false,
+      error: [{ name: "survey.blocks", reason: expect.stringContaining("Empty surveys cannot be exported") }],
+    });
+  });
+
+  test("refuses a survey with a dangling jumpToBlock target with the v3 path format", () => {
+    const survey = {
+      ...FIXTURE_LINK_SURVEY,
+      blocks: FIXTURE_LINK_SURVEY.blocks.map((block) =>
+        block.id === FIXTURE_BLOCK_1_ID
+          ? {
+              ...block,
+              logic: block.logic?.map((logic) => ({
+                ...logic,
+                actions: [{ ...logic.actions[0], target: "clbkmissing000000000000001" }],
+              })),
+            }
+          : block
+      ),
+    } as unknown as TSurvey;
+
+    const result = buildSurveyExportEnvelope(survey, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual([
+        expect.objectContaining({
+          name: "blocks.0.logic.0.actions.0.target",
+          code: "dangling_reference",
+          missingId: "clbkmissing000000000000001",
+        }),
+      ]);
+    }
+  });
+
+  test("fills a translation missing on a draft from the default language so the file re-imports", () => {
+    const survey = {
+      ...FIXTURE_LINK_SURVEY,
+      blocks: [
+        {
+          id: FIXTURE_BLOCK_1_ID,
+          name: "Only block",
+          elements: [
+            {
+              id: "q_incomplete",
+              type: "openText",
+              headline: { default: "English only" },
+              required: false,
+              inputType: "text",
+              charLimit: { enabled: false },
+            },
+          ],
+        },
+      ],
+      endings: [],
+      metadata: {},
+      welcomeCard: { enabled: false },
+      hiddenFields: { enabled: false },
+      variables: [],
+    } as unknown as TSurvey;
+
+    const envelope = expectOk(buildSurveyExportEnvelope(survey, ctx));
+
+    expect(envelope.survey.blocks[0].elements[0].headline).toEqual({
+      "en-US": "English only",
+      "de-DE": "English only",
+    });
+  });
+});

--- a/apps/web/modules/survey/export/build-export-envelope.ts
+++ b/apps/web/modules/survey/export/build-export-envelope.ts
@@ -1,5 +1,10 @@
 import { type Result, err, ok } from "@formbricks/types/error-handlers";
-import type { TSurvey } from "@formbricks/types/surveys/types";
+import type {
+  TSurvey,
+  TSurveyHiddenFields,
+  TSurveyStatus,
+  TSurveyVariables,
+} from "@formbricks/types/surveys/types";
 import type { InvalidParam } from "@/app/api/v3/lib/response";
 import {
   SURVEY_EXPORT_FORMAT,
@@ -9,7 +14,11 @@ import {
 } from "@/app/api/v3/surveys/export/schemas";
 import { getV3SurveyLanguages } from "@/app/api/v3/surveys/language";
 import { prepareV3SurveyCreateInput } from "@/app/api/v3/surveys/prepare";
-import { DEFAULT_V3_SURVEY_LANGUAGE, formatV3ZodInvalidParams } from "@/app/api/v3/surveys/schemas";
+import {
+  DEFAULT_V3_SURVEY_LANGUAGE,
+  type TV3SurveyDistribution,
+  formatV3ZodInvalidParams,
+} from "@/app/api/v3/surveys/schemas";
 import { serializeV3SurveyResource } from "@/app/api/v3/surveys/serializers";
 import { transformQuestionsToBlocks } from "@/app/lib/api/survey-transformation";
 
@@ -20,17 +29,45 @@ export type TSurveyExportContext = {
   exportedAt?: Date;
 };
 
-type TSerializedSurveyResource = ReturnType<typeof serializeV3SurveyResource>;
+/** A translatable field in the file: a public locale-code map (`{ "en-US": "…", "de-DE": "…" }`). */
+export type TSurveyExportI18n = Record<string, string>;
+
+/** Public shapes of the document's parts. Loose on purpose: element and ending fields vary by type. */
+export type TSurveyExportElement = { id: string; type: string; headline?: TSurveyExportI18n } & Record<
+  string,
+  unknown
+>;
+export type TSurveyExportBlock = {
+  id: string;
+  name: string;
+  elements: TSurveyExportElement[];
+  logic?: unknown[];
+  logicFallback?: string;
+} & Record<string, unknown>;
+export type TSurveyExportEnding = { id: string; type: "endScreen" | "redirectToUrl" } & Record<
+  string,
+  unknown
+>;
 
 /**
  * The `survey` member of the envelope as written to the file: the v3 GET resource minus every
  * instance-bound field. Locale maps are public (`{ "en-US": … }`), so the file round-trips through
  * `POST /api/v3/surveys` unchanged apart from `workspaceId`.
  */
-export type TSurveyExportDocument = Omit<
-  TSerializedSurveyResource,
-  "id" | "workspaceId" | "createdAt" | "updatedAt" | "archivedAt" | "targeting" | "languages"
-> & { languages: { code: string; default: boolean; enabled: boolean }[] };
+export type TSurveyExportDocument = {
+  name: string;
+  type: TSurvey["type"];
+  status: TSurveyStatus;
+  metadata: Record<string, unknown>;
+  defaultLanguage: string;
+  languages: { code: string; default: boolean; enabled: boolean }[];
+  welcomeCard: Record<string, unknown>;
+  blocks: TSurveyExportBlock[];
+  endings: TSurveyExportEnding[];
+  hiddenFields: TSurveyHiddenFields;
+  variables: TSurveyVariables;
+  distribution?: TV3SurveyDistribution;
+};
 
 export type TSurveyExportEnvelopeFile = {
   formbricks: TSurveyExportMetadata;
@@ -128,14 +165,16 @@ export function buildSurveyExportEnvelope(
     ...rest
   } = resource;
   // Aliases are a workspace setting, not part of the survey document: the create schema rejects them.
-  const document: TSurveyExportDocument = {
+  // The serializer types translatable values loosely (`TSerializedValue`); the create-side validation
+  // below is what proves the shape, so the cast states the contract rather than inventing one.
+  const document = {
     ...rest,
     languages: languages.map(({ code, default: isDefault, enabled }) => ({
       code,
       default: isDefault,
       enabled,
     })),
-  };
+  } as unknown as TSurveyExportDocument;
 
   const preparation = prepareV3SurveyCreateInput({ workspaceId: survey.workspaceId, ...document });
   if (!preparation.ok) {

--- a/apps/web/modules/survey/export/build-export-envelope.ts
+++ b/apps/web/modules/survey/export/build-export-envelope.ts
@@ -1,0 +1,168 @@
+import { type Result, err, ok } from "@formbricks/types/error-handlers";
+import type { TSurvey } from "@formbricks/types/surveys/types";
+import type { InvalidParam } from "@/app/api/v3/lib/response";
+import {
+  SURVEY_EXPORT_FORMAT,
+  type TSurveyExportActionClassReference,
+  type TSurveyExportMetadata,
+  ZSurveyExportEnvelope,
+} from "@/app/api/v3/surveys/export/schemas";
+import { getV3SurveyLanguages } from "@/app/api/v3/surveys/language";
+import { prepareV3SurveyCreateInput } from "@/app/api/v3/surveys/prepare";
+import { DEFAULT_V3_SURVEY_LANGUAGE, formatV3ZodInvalidParams } from "@/app/api/v3/surveys/schemas";
+import { serializeV3SurveyResource } from "@/app/api/v3/surveys/serializers";
+import { transformQuestionsToBlocks } from "@/app/lib/api/survey-transformation";
+
+export type TSurveyExportContext = {
+  appVersion: string;
+  publicUrl: string;
+  /** Injectable for deterministic tests; defaults to now. */
+  exportedAt?: Date;
+};
+
+type TSerializedSurveyResource = ReturnType<typeof serializeV3SurveyResource>;
+
+/**
+ * The `survey` member of the envelope as written to the file: the v3 GET resource minus every
+ * instance-bound field. Locale maps are public (`{ "en-US": … }`), so the file round-trips through
+ * `POST /api/v3/surveys` unchanged apart from `workspaceId`.
+ */
+export type TSurveyExportDocument = Omit<
+  TSerializedSurveyResource,
+  "id" | "workspaceId" | "createdAt" | "updatedAt" | "archivedAt" | "targeting" | "languages"
+> & { languages: { code: string; default: boolean; enabled: boolean }[] };
+
+export type TSurveyExportEnvelopeFile = {
+  formbricks: TSurveyExportMetadata;
+  survey: TSurveyExportDocument;
+  references: { actionClasses: TSurveyExportActionClassReference[] };
+};
+
+/**
+ * Legacy question-based surveys are converted to blocks first — the v3 document has no `questions`.
+ * Returns the survey untouched when it already carries blocks.
+ */
+function withBlocks(survey: TSurvey): TSurvey {
+  if (Array.isArray(survey.questions) && survey.questions.length > 0 && survey.blocks.length === 0) {
+    return {
+      ...survey,
+      blocks: transformQuestionsToBlocks(survey.questions, survey.endings),
+      questions: [],
+    };
+  }
+
+  return survey;
+}
+
+function countElements(survey: TSurvey): number {
+  return survey.blocks.reduce((count, block) => count + block.elements.length, 0);
+}
+
+/**
+ * Action-class definitions the document's triggers point at, reduced to the six portable fields and
+ * de-duplicated by id. Link surveys have no triggers, so this is empty for them.
+ */
+function collectActionClassReferences(survey: TSurvey): TSurveyExportActionClassReference[] {
+  const seen = new Set<string>();
+  const references: TSurveyExportActionClassReference[] = [];
+
+  for (const trigger of survey.triggers ?? []) {
+    const actionClass = trigger.actionClass;
+    if (seen.has(actionClass.id)) {
+      continue;
+    }
+    seen.add(actionClass.id);
+    references.push({
+      id: actionClass.id,
+      name: actionClass.name,
+      key: actionClass.key,
+      type: actionClass.type,
+      noCodeConfig: actionClass.noCodeConfig,
+      description: actionClass.description,
+    });
+  }
+
+  return references;
+}
+
+/**
+ * Build the portable export envelope for a stored survey.
+ *
+ * The document is the `GET /api/v3/surveys/{id}` resource with the instance-bound fields removed
+ * (`id`, `workspaceId`, timestamps, `archivedAt`) and `targeting` dropped — segments are out of v1;
+ * triggers and languages travel. The serializer is asked for every configured language explicitly so
+ * a translation that is missing on a draft is filled from the default language instead of making the
+ * survey unexportable; the editor allows saving incomplete translations, the v3 create route does not.
+ *
+ * Before the envelope is returned it is run through the exact create-side validation
+ * (`prepareV3SurveyCreateInput`: strict schema, reference and recall checks, declared locales, media).
+ * A survey that would not re-import must not export silently (edge case #21).
+ */
+export function buildSurveyExportEnvelope(
+  survey: TSurvey,
+  ctx: TSurveyExportContext
+): Result<TSurveyExportEnvelopeFile, InvalidParam[]> {
+  const blockSurvey = withBlocks(survey);
+
+  if (countElements(blockSurvey) === 0) {
+    return err([
+      {
+        name: "survey.blocks",
+        reason: "Empty surveys cannot be exported. Add at least one question first.",
+      },
+    ]);
+  }
+
+  const languageCodes = getV3SurveyLanguages(blockSurvey, DEFAULT_V3_SURVEY_LANGUAGE).map(
+    (language) => language.code
+  );
+  const resource = serializeV3SurveyResource(blockSurvey, { lang: languageCodes });
+  const {
+    id: _id,
+    workspaceId: _workspaceId,
+    createdAt: _createdAt,
+    updatedAt: _updatedAt,
+    archivedAt: _archivedAt,
+    targeting: _targeting,
+    languages,
+    ...rest
+  } = resource;
+  // Aliases are a workspace setting, not part of the survey document: the create schema rejects them.
+  const document: TSurveyExportDocument = {
+    ...rest,
+    languages: languages.map(({ code, default: isDefault, enabled }) => ({
+      code,
+      default: isDefault,
+      enabled,
+    })),
+  };
+
+  const preparation = prepareV3SurveyCreateInput({ workspaceId: survey.workspaceId, ...document });
+  if (!preparation.ok) {
+    return err(preparation.validation.invalidParams);
+  }
+
+  const envelope: TSurveyExportEnvelopeFile = {
+    formbricks: {
+      exportFormat: SURVEY_EXPORT_FORMAT,
+      exportedAt: (ctx.exportedAt ?? new Date()).toISOString(),
+      appVersion: ctx.appVersion,
+      source: {
+        url: ctx.publicUrl,
+        workspaceId: survey.workspaceId,
+        surveyId: survey.id,
+      },
+    },
+    survey: document,
+    references: {
+      actionClasses: collectActionClassReferences(blockSurvey),
+    },
+  };
+
+  const parsed = ZSurveyExportEnvelope.safeParse(envelope);
+  if (!parsed.success) {
+    return err(formatV3ZodInvalidParams(parsed.error, "survey"));
+  }
+
+  return ok(envelope);
+}


### PR DESCRIPTION
Fixes ENG-2972

## What & why

**Was:** A survey had no portable representation. "Copy to" only works inside one organization, and nothing could turn a stored survey into a file another instance can read.

**Now:** `buildSurveyExportEnvelope` turns a stored survey into a `.formbricks.json` envelope: export metadata, the v3 survey document (the `GET /api/v3/surveys/{id}` shape minus instance-bound fields), and the action-class definitions its triggers point at. `ZSurveyExportEnvelope` is the strict schema the export route and the importer validate against.

- Styling, follow-ups, quotas, survey settings, slug, scripts, schedule and targeting are never read (D1).
- Legacy question surveys are converted to blocks; empty surveys and surveys that would not re-import are refused with v3 `invalid_params`.
- A translation missing on a draft is filled from the default language so the file stays importable.

Stack: first PR of the Survey Import & Export project, based on `main`. Pure library code, no route or UI yet.

## Where to look

- [build-export-envelope.ts](apps/web/modules/survey/export/build-export-envelope.ts) — serializer → strip → create-side validation
- [schemas.ts (typed document)](apps/web/app/api/v3/surveys/schemas.ts) — new `createZV3TypedSurveyDocumentSchema`, shares the create normalizer
- [export/schemas.ts](apps/web/app/api/v3/surveys/export/schemas.ts) — the envelope, `.strict()` at every level

## Breaking changes

- [ ] This PR contains breaking changes

None — additive library code, no public surface yet.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/export app/api/v3/surveys/export app/api/v3/surveys/schemas.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Full link survey (17 element types, 2 languages, logic, recall) exports and round-trips through `ZV3CreateSurveyBody` | unit (mutation) | `build-export-envelope.test.ts`; passes |
| Styling/follow-ups/settings/slug/scripts/schedule never appear in the file | unit (mutation) | asserted on the serialized envelope |
| App survey carries triggers + de-duplicated action-class references, no targeting | unit (mutation) | passes |
| Legacy questions → blocks; empty survey refused; dangling `jumpToBlock` refused with v3 path | unit (mutation) | passes |
| Envelope rejects `extensions`, nested `slug`/`workspaceId`, newer `exportFormat` | unit (mutation) | `export/schemas.test.ts`; passes |

**Open gaps**

- Not run against a live instance yet; the route PR (ENG-2973) exercises it end to end.

**Risks**

- `schemas.ts` gained an exported helper and a new schema; existing create/patch schemas are untouched (their tests pass unchanged).

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
