### PR TITLE
feat(surveys): GET /api/v3/surveys/{surveyId}/export route + OpenAPI [ENG-2973]

### DIFF
--- a/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.test.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { DatabaseError } from "@formbricks/types/errors";
+import { problemForbidden } from "@/app/api/v3/lib/response";
+import type { TV3AuditLog } from "@/app/api/v3/lib/types";
+import { getAuthorizedV3Survey } from "@/app/api/v3/surveys/authorization";
+import { capturePostHogEvent } from "@/lib/posthog";
+import {
+  FIXTURE_APP_SURVEY,
+  FIXTURE_EMPTY_SURVEY,
+  FIXTURE_LINK_SURVEY,
+  FIXTURE_WORKSPACE_ID,
+} from "@/modules/survey/export/__fixtures__/surveys";
+import { exportV3Survey } from "./export-survey";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    withContext: vi.fn(() => ({
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock("@/app/api/v3/surveys/authorization", () => ({
+  getAuthorizedV3Survey: vi.fn(),
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  APP_VERSION: "6.2.0",
+  WEBAPP_URL: "https://app.formbricks.com",
+}));
+
+const requestId = "req_export_1";
+const instance = `/api/v3/surveys/${FIXTURE_LINK_SURVEY.id}/export`;
+const authResult = { workspaceId: FIXTURE_WORKSPACE_ID, organizationId: "org_1" };
+const apiKeyAuthentication = {
+  type: "apiKey",
+  apiKeyId: "api_key_1",
+  organizationId: "org_1",
+} as unknown as Parameters<typeof exportV3Survey>[0]["authentication"];
+const sessionAuthentication = {
+  user: { id: "user_1", email: "user@example.com", name: "User" },
+  expires: "2026-12-01",
+} as unknown as Parameters<typeof exportV3Survey>[0]["authentication"];
+
+describe("exportV3Survey", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getAuthorizedV3Survey).mockResolvedValue({
+      survey: FIXTURE_LINK_SURVEY,
+      authResult,
+      response: null,
+    } as unknown as Awaited<ReturnType<typeof getAuthorizedV3Survey>>);
+  });
+
+  test("returns the envelope under data with no-store caching for API-key callers", async () => {
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_LINK_SURVEY.id,
+      authentication: apiKeyAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(getAuthorizedV3Survey).toHaveBeenCalledWith({
+      surveyId: FIXTURE_LINK_SURVEY.id,
+      authentication: apiKeyAuthentication,
+      access: "read",
+      requestId,
+      instance,
+    });
+
+    const body = await response.json();
+    expect(Object.keys(body.data)).toEqual(["formbricks", "survey", "references"]);
+    expect(body.data.formbricks).toMatchObject({
+      exportFormat: 1,
+      appVersion: "6.2.0",
+      source: {
+        url: "https://app.formbricks.com",
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        surveyId: FIXTURE_LINK_SURVEY.id,
+      },
+    });
+    expect(body.data.survey.languages).toHaveLength(2);
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
+  });
+
+  test("fills the audit log and captures survey_exported for session users", async () => {
+    vi.mocked(getAuthorizedV3Survey).mockResolvedValue({
+      survey: FIXTURE_APP_SURVEY,
+      authResult,
+      response: null,
+    } as unknown as Awaited<ReturnType<typeof getAuthorizedV3Survey>>);
+    const auditLog = { action: "exported", targetType: "survey" } as unknown as TV3AuditLog;
+
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_APP_SURVEY.id,
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+      auditLog,
+    });
+
+    expect(response.status).toBe(200);
+    expect(auditLog).toMatchObject({
+      targetId: FIXTURE_APP_SURVEY.id,
+      organizationId: "org_1",
+      newObject: { exportFormat: 1, workspaceId: FIXTURE_WORKSPACE_ID },
+    });
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      "user_1",
+      "survey_exported",
+      {
+        survey_id: FIXTURE_APP_SURVEY.id,
+        survey_type: "app",
+        workspace_id: FIXTURE_WORKSPACE_ID,
+        organization_id: "org_1",
+        question_count: 17,
+        language_count: 2,
+      },
+      { organizationId: "org_1", workspaceId: FIXTURE_WORKSPACE_ID }
+    );
+  });
+
+  test("returns the authorization response when the caller cannot read the workspace", async () => {
+    vi.mocked(getAuthorizedV3Survey).mockResolvedValue({
+      survey: null,
+      authResult: null,
+      response: problemForbidden(requestId, "nope", instance),
+    } as unknown as Awaited<ReturnType<typeof getAuthorizedV3Survey>>);
+
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_LINK_SURVEY.id,
+      authentication: apiKeyAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(403);
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
+  });
+
+  test("answers 422 with invalid_params when the builder refuses the survey", async () => {
+    vi.mocked(getAuthorizedV3Survey).mockResolvedValue({
+      survey: FIXTURE_EMPTY_SURVEY,
+      authResult,
+      response: null,
+    } as unknown as Awaited<ReturnType<typeof getAuthorizedV3Survey>>);
+
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_EMPTY_SURVEY.id,
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.invalid_params).toEqual([
+      { name: "survey.blocks", reason: expect.stringContaining("Empty surveys cannot be exported") },
+    ]);
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
+  });
+
+  test("maps database errors to 500 without leaking details", async () => {
+    vi.mocked(getAuthorizedV3Survey).mockRejectedValue(new DatabaseError("boom"));
+
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_LINK_SURVEY.id,
+      authentication: apiKeyAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(500);
+    expect((await response.json()).detail).toBe("An unexpected error occurred.");
+  });
+});

--- a/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts
@@ -1,0 +1,102 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { DatabaseError } from "@formbricks/types/errors";
+import {
+  problemInternalError,
+  problemUnprocessableContent,
+  successResponse,
+} from "@/app/api/v3/lib/response";
+import type { TV3AuditLog, TV3Authentication } from "@/app/api/v3/lib/types";
+import { getAuthorizedV3Survey } from "@/app/api/v3/surveys/authorization";
+import { getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
+import { APP_VERSION, WEBAPP_URL } from "@/lib/constants";
+import { capturePostHogEvent } from "@/lib/posthog";
+import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
+
+type TExportV3SurveyParams = {
+  surveyId: string;
+  authentication: TV3Authentication;
+  requestId: string;
+  instance: string;
+  auditLog?: TV3AuditLog;
+};
+
+/**
+ * `GET /api/v3/surveys/{surveyId}/export` — the portable export envelope for one survey.
+ *
+ * Read access is enough: the envelope contains nothing the survey page does not show. The body is the
+ * envelope under `data`; the client turns it into a file. A survey the builder refuses (empty, or one
+ * that would not re-import) answers 422 with the same `invalid_params` shape the create route uses.
+ */
+export async function exportV3Survey({
+  surveyId,
+  authentication,
+  requestId,
+  instance,
+  auditLog,
+}: TExportV3SurveyParams): Promise<Response> {
+  const log = logger.withContext({ requestId, surveyId });
+
+  try {
+    const { survey, authResult, response } = await getAuthorizedV3Survey({
+      surveyId,
+      authentication,
+      access: "read",
+      requestId,
+      instance,
+    });
+
+    if (response) {
+      log.warn({ statusCode: response.status }, "Survey not found or not accessible");
+      return response;
+    }
+
+    const result = buildSurveyExportEnvelope(survey, { appVersion: APP_VERSION, publicUrl: WEBAPP_URL });
+
+    if (!result.ok) {
+      log.warn({ statusCode: 422, invalidParams: result.error }, "Survey cannot be exported");
+      return problemUnprocessableContent(requestId, "Survey cannot be exported in its current state", {
+        invalid_params: result.error,
+        instance,
+      });
+    }
+
+    const envelope = result.data;
+
+    if (auditLog) {
+      auditLog.targetId = survey.id;
+      auditLog.organizationId = authResult.organizationId;
+      auditLog.newObject = {
+        exportFormat: envelope.formbricks.exportFormat,
+        workspaceId: survey.workspaceId,
+      };
+    }
+
+    const sessionUserId = getSessionUserId(authentication);
+    if (sessionUserId) {
+      capturePostHogEvent(
+        sessionUserId,
+        "survey_exported",
+        {
+          survey_id: survey.id,
+          survey_type: survey.type,
+          workspace_id: authResult.workspaceId,
+          organization_id: authResult.organizationId,
+          question_count: envelope.survey.blocks.reduce((count, block) => count + block.elements.length, 0),
+          language_count: envelope.survey.languages.length,
+        },
+        { organizationId: authResult.organizationId, workspaceId: authResult.workspaceId }
+      );
+    }
+
+    return successResponse(envelope, { requestId, cache: "private, no-store" });
+  } catch (error) {
+    if (error instanceof DatabaseError) {
+      log.error({ error, statusCode: 500 }, "Database error");
+      return problemInternalError(requestId, "An unexpected error occurred.", instance);
+    }
+
+    log.error({ error, statusCode: 500 }, "V3 survey export unexpected error");
+    return problemInternalError(requestId, "An unexpected error occurred.", instance);
+  }
+}

--- a/apps/web/app/api/v3/surveys/[surveyId]/export/route.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/route.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /api/v3/surveys/{surveyId}/export — portable export envelope (`.formbricks.json`) for one survey.
+ * Session cookie or x-api-key; read access on the survey's workspace. Audit-logged as `exported`.
+ */
+import { z } from "zod";
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { ZV3EmptyQuery } from "../../schemas";
+import { exportV3Survey } from "./lib/export-survey";
+
+const surveyParamsSchema = z.object({
+  surveyId: z.cuid2(),
+});
+
+export const GET = withV3ApiWrapper({
+  auth: "both",
+  action: "exported",
+  targetType: "survey",
+  schemas: {
+    params: surveyParamsSchema,
+    // Single-survey endpoints locate the survey by its globally-unique id; reject stray query params.
+    query: ZV3EmptyQuery,
+  },
+  handler: async ({ parsedInput, authentication, requestId, instance, auditLog }) => {
+    return await exportV3Survey({
+      surveyId: parsedInput.params.surveyId,
+      authentication,
+      requestId,
+      instance,
+      auditLog,
+    });
+  },
+});

--- a/apps/web/modules/ee/audit-logs/types/audit-log.ts
+++ b/apps/web/modules/ee/audit-logs/types/audit-log.ts
@@ -45,6 +45,7 @@ export const ZAuditAction = z.enum([
   "verificationEmailSent",
   "createdFromCSV",
   "copiedToOtherWorkspace",
+  "exported",
   "addedToResponse",
   "removedFromResponse",
   "createdUpdated",

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -5,7 +5,7 @@ openapi: 3.1.1
 info:
   title: Formbricks API v3
   description: |
-    **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, and **DELETE /api/v3/surveys/{surveyId}**.
+    **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, **DELETE /api/v3/surveys/{surveyId}**, and **GET /api/v3/surveys/{surveyId}/export**, which returns a portable `.formbricks.json` envelope that re-imports into any workspace or instance.
 
     **Workflows extension**: **GET /api/v3/workflows**, **POST /api/v3/workflows**, **GET /api/v3/workflows/{workflowId}**, **PATCH /api/v3/workflows/{workflowId}**, **DELETE /api/v3/workflows/{workflowId}**, **POST /api/v3/workflows/{workflowId}/duplicate**, **POST /api/v3/workflows/{workflowId}/enable**, **POST /api/v3/workflows/{workflowId}/disable**, **POST /api/v3/workflows/{workflowId}/archive**, **POST /api/v3/workflows/{workflowId}/unarchive**, **POST /api/v3/workflows/{workflowId}/test**, **GET /api/v3/workflows/runs**, and **GET /api/v3/workflows/runs/{runId}**.
 
@@ -1289,6 +1289,118 @@ paths:
           $ref: '#/components/responses/V3Unauthorized'
         '403':
           $ref: '#/components/responses/V3Forbidden'
+        '429':
+          $ref: '#/components/responses/V3TooManyRequests'
+        '500':
+          $ref: '#/components/responses/V3InternalServerError'
+      security:
+        - sessionAuth: []
+        - apiKeyAuth: []
+  /api/v3/surveys/{surveyId}/export:
+    get:
+      operationId: exportSurveyV3
+      summary: Export a survey
+      description: |
+        Returns the portable export envelope for one survey: export metadata, the v3 survey document and the action-class definitions its triggers reference. Save the `data` member as a `.formbricks.json` file; it imports into any workspace, organization or instance through `POST /api/v3/surveys/import`.
+
+        The document is the `GET /api/v3/surveys/{surveyId}` resource without the instance-bound fields. Styling, follow-ups, quotas, survey settings (single-use, PIN, reCAPTCHA, closed message, language switch), slug, custom scripts, the publish schedule, targeting and responses are not exported. Legacy question-based surveys are converted to blocks. A translation missing on a draft is filled from the default language so the file stays importable.
+
+        Read access is sufficient. Every export is written to the organization audit log as `exported`.
+      tags:
+        - V3 Surveys
+      parameters:
+        - in: path
+          name: surveyId
+          required: true
+          schema:
+            type: string
+            format: cuid2
+          description: Survey identifier.
+      responses:
+        '200':
+          description: Export envelope built successfully
+          headers:
+            X-Request-Id:
+              schema:
+                type: string
+              description: Request correlation ID
+            Cache-Control:
+              schema:
+                type: string
+              example: private, no-store
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SurveyExportEnvelope'
+              examples:
+                linkSurvey:
+                  summary: Exported link survey
+                  value:
+                    data:
+                      formbricks:
+                        exportFormat: 1
+                        exportedAt: '2026-09-08T12:00:00.000Z'
+                        appVersion: 6.2.0
+                        source:
+                          url: https://app.formbricks.com
+                          workspaceId: clxx1234567890123456789012
+                          surveyId: clsv1234567890123456789012
+                      survey:
+                        name: Product Feedback
+                        type: link
+                        status: inProgress
+                        metadata: {}
+                        defaultLanguage: en-US
+                        languages:
+                          - code: en-US
+                            default: true
+                            enabled: true
+                        welcomeCard:
+                          enabled: false
+                        blocks:
+                          - id: clbk1234567890123456789012
+                            name: Main Block
+                            elements:
+                              - id: satisfaction
+                                type: openText
+                                headline:
+                                  en-US: What should we improve?
+                                required: true
+                        endings: []
+                        hiddenFields:
+                          enabled: false
+                        variables: []
+                      references:
+                        actionClasses: []
+        '400':
+          $ref: '#/components/responses/V3BadRequest'
+        '401':
+          $ref: '#/components/responses/V3Unauthorized'
+        '403':
+          $ref: '#/components/responses/V3Forbidden'
+        '422':
+          description: 'Unprocessable Content — the survey cannot be exported in its current state: it has no questions, or its document would not re-import (a dangling logic target, an invalid media URL). `invalid_params` itemizes each issue with the v3 path format.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+              examples:
+                empty:
+                  summary: Empty survey
+                  value:
+                    title: Unprocessable Content
+                    status: 422
+                    detail: Survey cannot be exported in its current state
+                    code: unprocessable_content
+                    requestId: req_clsv1234567890123456789012
+                    invalid_params:
+                      - name: survey.blocks
+                        reason: Empty surveys cannot be exported. Add at least one question first.
         '429':
           $ref: '#/components/responses/V3TooManyRequests'
         '500':
@@ -4686,6 +4798,174 @@ components:
           description: Languages that a successful write would connect or create. Present only when `valid=true`.
           items:
             $ref: '#/components/schemas/SurveyValidationLanguage'
+      additionalProperties: false
+    SurveyExportMetadata:
+      type: object
+      description: Export metadata. `exportFormat` is bumped only for incompatible changes; an instance refuses files newer than it understands.
+      required:
+        - exportFormat
+        - exportedAt
+        - appVersion
+        - source
+      properties:
+        exportFormat:
+          type: integer
+          enum:
+            - 1
+          description: Envelope format version. Currently always `1`.
+        exportedAt:
+          type: string
+          format: date-time
+        appVersion:
+          type: string
+          description: Formbricks version that produced the file (`0.0.0` on development builds).
+        source:
+          type: object
+          required:
+            - url
+            - workspaceId
+            - surveyId
+          properties:
+            url:
+              type: string
+              format: uri
+              description: Public URL of the exporting instance.
+            workspaceId:
+              type: string
+              format: cuid2
+            surveyId:
+              type: string
+              format: cuid2
+          additionalProperties: false
+      additionalProperties: false
+    SurveyExportDocument:
+      type: object
+      description: |
+        The exported v3 survey document: the `GET /api/v3/surveys/{surveyId}` resource without the instance-bound fields (`id`, `workspaceId`, `createdAt`, `updatedAt`, `archivedAt`) and without `targeting`. Translatable fields are locale-code maps, so `{ workspaceId, ...survey }` is a valid `POST /api/v3/surveys` body. Styling, follow-ups, quotas, survey settings, slug, custom scripts and the publish schedule are not part of the document and do not travel.
+      required:
+        - name
+        - type
+        - status
+        - metadata
+        - defaultLanguage
+        - languages
+        - welcomeCard
+        - blocks
+        - endings
+        - hiddenFields
+        - variables
+      properties:
+        name:
+          type: string
+          minLength: 1
+        type:
+          type: string
+          enum:
+            - link
+            - app
+        status:
+          type: string
+          enum:
+            - draft
+            - inProgress
+            - paused
+            - completed
+          description: Status at export time. Import always creates a draft.
+        metadata:
+          $ref: '#/components/schemas/SurveyMetadata'
+        defaultLanguage:
+          $ref: '#/components/schemas/LocaleCode'
+        languages:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateSurveyLanguage'
+        welcomeCard:
+          $ref: '#/components/schemas/SurveyWelcomeCard'
+        blocks:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/SurveyBlock'
+        endings:
+          type: array
+          items:
+            $ref: '#/components/schemas/SurveyEnding'
+        hiddenFields:
+          $ref: '#/components/schemas/SurveyHiddenFields'
+        variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/SurveyVariable'
+        distribution:
+          allOf:
+            - $ref: '#/components/schemas/SurveyDistribution'
+          description: App-survey runtime settings and triggers. Present only for app surveys.
+      additionalProperties: false
+    SurveyExportActionClass:
+      type: object
+      description: |
+        Definition of an action class an exported app survey's trigger points at. On import the target workspace matches it by `key` (code actions), by `noCodeConfig` (no-code actions) or by `name`, and creates it when nothing matches.
+      required:
+        - id
+        - name
+        - key
+        - type
+        - noCodeConfig
+        - description
+      properties:
+        id:
+          type: string
+          format: cuid2
+          description: Id in the source workspace, referenced by `survey.distribution.triggers[].actionClassId`.
+        name:
+          type: string
+        key:
+          type:
+            - string
+            - 'null'
+          description: Code-action key; `null` for no-code actions.
+        type:
+          type: string
+          enum:
+            - code
+            - noCode
+        noCodeConfig:
+          type:
+            - object
+            - 'null'
+          description: No-code trigger configuration (click, pageView, exitIntent, fiftyPercentScroll, pageDwell); `null` for code actions.
+          additionalProperties: true
+        description:
+          type:
+            - string
+            - 'null'
+      additionalProperties: false
+    SurveyExportReferences:
+      type: object
+      description: Workspace-scoped definitions the document refers to by id. Empty for link surveys.
+      required:
+        - actionClasses
+      properties:
+        actionClasses:
+          type: array
+          items:
+            $ref: '#/components/schemas/SurveyExportActionClass'
+      additionalProperties: false
+    SurveyExportEnvelope:
+      type: object
+      description: |
+        Portable survey export (`.formbricks.json`). Three top-level keys, nothing else: import rejects unknown keys with their path. The same file imports into any workspace, organization or instance through `POST /api/v3/surveys/import`.
+      required:
+        - formbricks
+        - survey
+        - references
+      properties:
+        formbricks:
+          $ref: '#/components/schemas/SurveyExportMetadata'
+        survey:
+          $ref: '#/components/schemas/SurveyExportDocument'
+        references:
+          $ref: '#/components/schemas/SurveyExportReferences'
       additionalProperties: false
     WorkflowStatus:
       type: string

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportActionClass.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportActionClass.yml
@@ -1,0 +1,40 @@
+type: object
+description: >
+  Definition of an action class an exported app survey's trigger points at. On import the target
+  workspace matches it by `key` (code actions), by `noCodeConfig` (no-code actions) or by `name`, and
+  creates it when nothing matches.
+required:
+  - id
+  - name
+  - key
+  - type
+  - noCodeConfig
+  - description
+properties:
+  id:
+    type: string
+    format: cuid2
+    description: Id in the source workspace, referenced by `survey.distribution.triggers[].actionClassId`.
+  name:
+    type: string
+  key:
+    type:
+      - string
+      - "null"
+    description: Code-action key; `null` for no-code actions.
+  type:
+    type: string
+    enum:
+      - code
+      - noCode
+  noCodeConfig:
+    type:
+      - object
+      - "null"
+    description: No-code trigger configuration (click, pageView, exitIntent, fiftyPercentScroll, pageDwell); `null` for code actions.
+    additionalProperties: true
+  description:
+    type:
+      - string
+      - "null"
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportDocument.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportDocument.yml
@@ -1,0 +1,66 @@
+type: object
+description: >
+  The exported v3 survey document: the `GET /api/v3/surveys/{surveyId}` resource without the
+  instance-bound fields (`id`, `workspaceId`, `createdAt`, `updatedAt`, `archivedAt`) and without
+  `targeting`. Translatable fields are locale-code maps, so `{ workspaceId, ...survey }` is a valid
+  `POST /api/v3/surveys` body. Styling, follow-ups, quotas, survey settings, slug, custom scripts and
+  the publish schedule are not part of the document and do not travel.
+required:
+  - name
+  - type
+  - status
+  - metadata
+  - defaultLanguage
+  - languages
+  - welcomeCard
+  - blocks
+  - endings
+  - hiddenFields
+  - variables
+properties:
+  name:
+    type: string
+    minLength: 1
+  type:
+    type: string
+    enum:
+      - link
+      - app
+  status:
+    type: string
+    enum:
+      - draft
+      - inProgress
+      - paused
+      - completed
+    description: Status at export time. Import always creates a draft.
+  metadata:
+    $ref: ./SurveyMetadata.yml
+  defaultLanguage:
+    $ref: ./LocaleCode.yml
+  languages:
+    type: array
+    items:
+      $ref: ./CreateSurveyLanguage.yml
+  welcomeCard:
+    $ref: ./SurveyWelcomeCard.yml
+  blocks:
+    type: array
+    minItems: 1
+    items:
+      $ref: ./SurveyBlock.yml
+  endings:
+    type: array
+    items:
+      $ref: ./SurveyEnding.yml
+  hiddenFields:
+    $ref: ./SurveyHiddenFields.yml
+  variables:
+    type: array
+    items:
+      $ref: ./SurveyVariable.yml
+  distribution:
+    allOf:
+      - $ref: ./SurveyDistribution.yml
+    description: App-survey runtime settings and triggers. Present only for app surveys.
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportEnvelope.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportEnvelope.yml
@@ -1,0 +1,17 @@
+type: object
+description: >
+  Portable survey export (`.formbricks.json`). Three top-level keys, nothing else: import rejects
+  unknown keys with their path. The same file imports into any workspace, organization or instance
+  through `POST /api/v3/surveys/import`.
+required:
+  - formbricks
+  - survey
+  - references
+properties:
+  formbricks:
+    $ref: ./SurveyExportMetadata.yml
+  survey:
+    $ref: ./SurveyExportDocument.yml
+  references:
+    $ref: ./SurveyExportReferences.yml
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportMetadata.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportMetadata.yml
@@ -1,0 +1,38 @@
+type: object
+description: Export metadata. `exportFormat` is bumped only for incompatible changes; an instance refuses files newer than it understands.
+required:
+  - exportFormat
+  - exportedAt
+  - appVersion
+  - source
+properties:
+  exportFormat:
+    type: integer
+    enum:
+      - 1
+    description: Envelope format version. Currently always `1`.
+  exportedAt:
+    type: string
+    format: date-time
+  appVersion:
+    type: string
+    description: Formbricks version that produced the file (`0.0.0` on development builds).
+  source:
+    type: object
+    required:
+      - url
+      - workspaceId
+      - surveyId
+    properties:
+      url:
+        type: string
+        format: uri
+        description: Public URL of the exporting instance.
+      workspaceId:
+        type: string
+        format: cuid2
+      surveyId:
+        type: string
+        format: cuid2
+    additionalProperties: false
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportReferences.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportReferences.yml
@@ -1,0 +1,10 @@
+type: object
+description: Workspace-scoped definitions the document refers to by id. Empty for link surveys.
+required:
+  - actionClasses
+properties:
+  actionClasses:
+    type: array
+    items:
+      $ref: ./SurveyExportActionClass.yml
+additionalProperties: false

--- a/docs/api-v3-reference/src/openapi.yml
+++ b/docs/api-v3-reference/src/openapi.yml
@@ -8,8 +8,10 @@ info:
   description: >
     **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST
     /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET
-    /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, and
-    **DELETE /api/v3/surveys/{surveyId}**.
+    /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**,
+    **DELETE /api/v3/surveys/{surveyId}**, and **GET
+    /api/v3/surveys/{surveyId}/export**, which returns a portable
+    `.formbricks.json` envelope that re-imports into any workspace or instance.
 
 
     **Workflows extension**: **GET /api/v3/workflows**, **POST
@@ -179,6 +181,8 @@ paths:
     $ref: paths/api_v3_surveys_{surveyId}_archive.yml
   /api/v3/surveys/{surveyId}/restore:
     $ref: paths/api_v3_surveys_{surveyId}_restore.yml
+  /api/v3/surveys/{surveyId}/export:
+    $ref: paths/api_v3_surveys_{surveyId}_export.yml
   /api/v3/workflows:
     $ref: paths/api_v3_workflows.yml
   /api/v3/workflows/runs:

--- a/docs/api-v3-reference/src/paths/api_v3_surveys_{surveyId}_export.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_surveys_{surveyId}_export.yml
@@ -1,0 +1,123 @@
+get:
+  operationId: exportSurveyV3
+  summary: Export a survey
+  description: >
+    Returns the portable export envelope for one survey: export metadata, the v3 survey document and
+    the action-class definitions its triggers reference. Save the `data` member as a
+    `.formbricks.json` file; it imports into any workspace, organization or instance through
+    `POST /api/v3/surveys/import`.
+
+
+    The document is the `GET /api/v3/surveys/{surveyId}` resource without the instance-bound fields.
+    Styling, follow-ups, quotas, survey settings (single-use, PIN, reCAPTCHA, closed message, language
+    switch), slug, custom scripts, the publish schedule, targeting and responses are not exported.
+    Legacy question-based surveys are converted to blocks. A translation missing on a draft is filled
+    from the default language so the file stays importable.
+
+
+    Read access is sufficient. Every export is written to the organization audit log as `exported`.
+  tags:
+    - V3 Surveys
+  parameters:
+    - in: path
+      name: surveyId
+      required: true
+      schema:
+        type: string
+        format: cuid2
+      description: Survey identifier.
+  responses:
+    "200":
+      description: Export envelope built successfully
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
+          description: Request correlation ID
+        Cache-Control:
+          schema:
+            type: string
+          example: private, no-store
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../components/schemas/SurveyExportEnvelope.yml
+          examples:
+            linkSurvey:
+              summary: Exported link survey
+              value:
+                data:
+                  formbricks:
+                    exportFormat: 1
+                    exportedAt: "2026-09-08T12:00:00.000Z"
+                    appVersion: 6.2.0
+                    source:
+                      url: https://app.formbricks.com
+                      workspaceId: clxx1234567890123456789012
+                      surveyId: clsv1234567890123456789012
+                  survey:
+                    name: Product Feedback
+                    type: link
+                    status: inProgress
+                    metadata: {}
+                    defaultLanguage: en-US
+                    languages:
+                      - code: en-US
+                        default: true
+                        enabled: true
+                    welcomeCard:
+                      enabled: false
+                    blocks:
+                      - id: clbk1234567890123456789012
+                        name: Main Block
+                        elements:
+                          - id: satisfaction
+                            type: openText
+                            headline:
+                              en-US: What should we improve?
+                            required: true
+                    endings: []
+                    hiddenFields:
+                      enabled: false
+                    variables: []
+                  references:
+                    actionClasses: []
+    "400":
+      $ref: ../components/responses/V3BadRequest.yml
+    "401":
+      $ref: ../components/responses/V3Unauthorized.yml
+    "403":
+      $ref: ../components/responses/V3Forbidden.yml
+    "422":
+      description: >-
+        Unprocessable Content — the survey cannot be exported in its current state: it has no
+        questions, or its document would not re-import (a dangling logic target, an invalid media
+        URL). `invalid_params` itemizes each issue with the v3 path format.
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+          examples:
+            empty:
+              summary: Empty survey
+              value:
+                title: Unprocessable Content
+                status: 422
+                detail: Survey cannot be exported in its current state
+                code: unprocessable_content
+                requestId: req_clsv1234567890123456789012
+                invalid_params:
+                  - name: survey.blocks
+                    reason: Empty surveys cannot be exported. Add at least one question first.
+    "429":
+      $ref: ../components/responses/V3TooManyRequests.yml
+    "500":
+      $ref: ../components/responses/V3InternalServerError.yml
+  security:
+    - sessionAuth: []
+    - apiKeyAuth: []


### PR DESCRIPTION
Fixes ENG-2973

## What & why

**Was:** The export envelope existed only as a library function; nothing served it.

**Now:** `GET /api/v3/surveys/{surveyId}/export` returns the envelope under `data` for session and API-key callers with read access, documented in OpenAPI, audit-logged as `exported`, and tracked as `survey_exported` for session users.

- 422 with v3 `invalid_params` when the survey cannot be exported (empty, or would not re-import); 403 from the shared authorizer; never 5xx on caller input.
- New audit action `exported` on the survey target.

Stacked on #9188 (ENG-2972); merge that first.

## Where to look

- [export-survey.ts](apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts) — authorize read → build → 200/422, audit + PostHog
- [api_v3_surveys_{surveyId}_export.yml](docs/api-v3-reference/src/paths/api_v3_surveys_{surveyId}_export.yml) — the contract Schemathesis drives
- [SurveyExportDocument.yml](docs/api-v3-reference/src/components/schemas/SurveyExportDocument.yml) — must stay in step with the create request schema

## Breaking changes

- [ ] This PR contains breaking changes

None — a new endpoint and a new audit action value; nothing existing changes shape.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run 'app/api/v3/surveys/[surveyId]/export' && pnpm api:v3:check`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| 200 envelope, `Cache-Control: private, no-store`, read access requested | unit (mutation) | `export-survey.test.ts`; passes |
| Audit log filled and `survey_exported` captured for session users, not for API keys | unit (mutation) | passes |
| 403 passthrough from the authorizer; 422 with `invalid_params` for an empty survey; 500 on `DatabaseError` | unit (mutation) | passes |
| OpenAPI source lints, bundle committed in sync | unit (guard) | `pnpm api:v3:lint` + `api:v3:check` green locally |
| Contract test hits a seeded survey (`read.surveyId` already maps to the read fixture) | e2e | runs in the Schemathesis job on this PR |

**Open gaps**

- Not exercised against a live instance in this PR; the download button PR (ENG-2974) does that manually.

**Risks**

- `ZAuditAction` gained a value; anything that maps audit actions to labels exhaustively would need the new one (none found).

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
