### PR TITLE
feat(surveys): export as JSON — envelope, API route and card menu (milestone 1) [ENG-2972, ENG-2973, ENG-2974]

### DIFF
--- a/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.test.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { DatabaseError } from "@formbricks/types/errors";
+import { problemForbidden } from "@/app/api/v3/lib/response";
+import type { TV3AuditLog } from "@/app/api/v3/lib/types";
+import { getAuthorizedV3Survey } from "@/app/api/v3/surveys/authorization";
+import { capturePostHogEvent } from "@/lib/posthog";
+import {
+  FIXTURE_APP_SURVEY,
+  FIXTURE_EMPTY_SURVEY,
+  FIXTURE_LINK_SURVEY,
+  FIXTURE_WORKSPACE_ID,
+} from "@/modules/survey/export/__fixtures__/surveys";
+import { exportV3Survey } from "./export-survey";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    withContext: vi.fn(() => ({
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock("@/app/api/v3/surveys/authorization", () => ({
+  getAuthorizedV3Survey: vi.fn(),
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  APP_VERSION: "6.2.0",
+  WEBAPP_URL: "https://app.formbricks.com",
+}));
+
+const requestId = "req_export_1";
+const instance = `/api/v3/surveys/${FIXTURE_LINK_SURVEY.id}/export`;
+const authResult = { workspaceId: FIXTURE_WORKSPACE_ID, organizationId: "org_1" };
+const apiKeyAuthentication = {
+  type: "apiKey",
+  apiKeyId: "api_key_1",
+  organizationId: "org_1",
+} as unknown as Parameters<typeof exportV3Survey>[0]["authentication"];
+const sessionAuthentication = {
+  user: { id: "user_1", email: "user@example.com", name: "User" },
+  expires: "2026-12-01",
+} as unknown as Parameters<typeof exportV3Survey>[0]["authentication"];
+
+describe("exportV3Survey", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getAuthorizedV3Survey).mockResolvedValue({
+      survey: FIXTURE_LINK_SURVEY,
+      authResult,
+      response: null,
+    } as unknown as Awaited<ReturnType<typeof getAuthorizedV3Survey>>);
+  });
+
+  test("returns the envelope under data with no-store caching for API-key callers", async () => {
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_LINK_SURVEY.id,
+      authentication: apiKeyAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(getAuthorizedV3Survey).toHaveBeenCalledWith({
+      surveyId: FIXTURE_LINK_SURVEY.id,
+      authentication: apiKeyAuthentication,
+      access: "read",
+      requestId,
+      instance,
+    });
+
+    const body = await response.json();
+    expect(Object.keys(body.data)).toEqual(["formbricks", "survey", "references"]);
+    expect(body.data.formbricks).toMatchObject({
+      exportFormat: 1,
+      appVersion: "6.2.0",
+      source: {
+        url: "https://app.formbricks.com",
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        surveyId: FIXTURE_LINK_SURVEY.id,
+      },
+    });
+    expect(body.data.survey.languages).toHaveLength(2);
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
+  });
+
+  test("fills the audit log and captures survey_exported for session users", async () => {
+    vi.mocked(getAuthorizedV3Survey).mockResolvedValue({
+      survey: FIXTURE_APP_SURVEY,
+      authResult,
+      response: null,
+    } as unknown as Awaited<ReturnType<typeof getAuthorizedV3Survey>>);
+    const auditLog = { action: "exported", targetType: "survey" } as unknown as TV3AuditLog;
+
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_APP_SURVEY.id,
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+      auditLog,
+    });
+
+    expect(response.status).toBe(200);
+    expect(auditLog).toMatchObject({
+      targetId: FIXTURE_APP_SURVEY.id,
+      organizationId: "org_1",
+      newObject: { exportFormat: 1, workspaceId: FIXTURE_WORKSPACE_ID },
+    });
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      "user_1",
+      "survey_exported",
+      {
+        survey_id: FIXTURE_APP_SURVEY.id,
+        survey_type: "app",
+        workspace_id: FIXTURE_WORKSPACE_ID,
+        organization_id: "org_1",
+        question_count: 17,
+        language_count: 2,
+      },
+      { organizationId: "org_1", workspaceId: FIXTURE_WORKSPACE_ID }
+    );
+  });
+
+  test("returns the authorization response when the caller cannot read the workspace", async () => {
+    vi.mocked(getAuthorizedV3Survey).mockResolvedValue({
+      survey: null,
+      authResult: null,
+      response: problemForbidden(requestId, "nope", instance),
+    } as unknown as Awaited<ReturnType<typeof getAuthorizedV3Survey>>);
+
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_LINK_SURVEY.id,
+      authentication: apiKeyAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(403);
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
+  });
+
+  test("answers 422 with invalid_params when the builder refuses the survey", async () => {
+    vi.mocked(getAuthorizedV3Survey).mockResolvedValue({
+      survey: FIXTURE_EMPTY_SURVEY,
+      authResult,
+      response: null,
+    } as unknown as Awaited<ReturnType<typeof getAuthorizedV3Survey>>);
+
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_EMPTY_SURVEY.id,
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.invalid_params).toEqual([
+      { name: "survey.blocks", reason: expect.stringContaining("Empty surveys cannot be exported") },
+    ]);
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
+  });
+
+  test("maps database errors to 500 without leaking details", async () => {
+    vi.mocked(getAuthorizedV3Survey).mockRejectedValue(new DatabaseError("boom"));
+
+    const response = await exportV3Survey({
+      surveyId: FIXTURE_LINK_SURVEY.id,
+      authentication: apiKeyAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(500);
+    expect((await response.json()).detail).toBe("An unexpected error occurred.");
+  });
+});

--- a/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts
@@ -1,0 +1,102 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { DatabaseError } from "@formbricks/types/errors";
+import {
+  problemInternalError,
+  problemUnprocessableContent,
+  successResponse,
+} from "@/app/api/v3/lib/response";
+import type { TV3AuditLog, TV3Authentication } from "@/app/api/v3/lib/types";
+import { getAuthorizedV3Survey } from "@/app/api/v3/surveys/authorization";
+import { getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
+import { APP_VERSION, WEBAPP_URL } from "@/lib/constants";
+import { capturePostHogEvent } from "@/lib/posthog";
+import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
+
+type TExportV3SurveyParams = {
+  surveyId: string;
+  authentication: TV3Authentication;
+  requestId: string;
+  instance: string;
+  auditLog?: TV3AuditLog;
+};
+
+/**
+ * `GET /api/v3/surveys/{surveyId}/export` — the portable export envelope for one survey.
+ *
+ * Read access is enough: the envelope contains nothing the survey page does not show. The body is the
+ * envelope under `data`; the client turns it into a file. A survey the builder refuses (empty, or one
+ * that would not re-import) answers 422 with the same `invalid_params` shape the create route uses.
+ */
+export async function exportV3Survey({
+  surveyId,
+  authentication,
+  requestId,
+  instance,
+  auditLog,
+}: TExportV3SurveyParams): Promise<Response> {
+  const log = logger.withContext({ requestId, surveyId });
+
+  try {
+    const { survey, authResult, response } = await getAuthorizedV3Survey({
+      surveyId,
+      authentication,
+      access: "read",
+      requestId,
+      instance,
+    });
+
+    if (response) {
+      log.warn({ statusCode: response.status }, "Survey not found or not accessible");
+      return response;
+    }
+
+    const result = buildSurveyExportEnvelope(survey, { appVersion: APP_VERSION, publicUrl: WEBAPP_URL });
+
+    if (!result.ok) {
+      log.warn({ statusCode: 422, invalidParams: result.error }, "Survey cannot be exported");
+      return problemUnprocessableContent(requestId, "Survey cannot be exported in its current state", {
+        invalid_params: result.error,
+        instance,
+      });
+    }
+
+    const envelope = result.data;
+
+    if (auditLog) {
+      auditLog.targetId = survey.id;
+      auditLog.organizationId = authResult.organizationId;
+      auditLog.newObject = {
+        exportFormat: envelope.formbricks.exportFormat,
+        workspaceId: survey.workspaceId,
+      };
+    }
+
+    const sessionUserId = getSessionUserId(authentication);
+    if (sessionUserId) {
+      capturePostHogEvent(
+        sessionUserId,
+        "survey_exported",
+        {
+          survey_id: survey.id,
+          survey_type: survey.type,
+          workspace_id: authResult.workspaceId,
+          organization_id: authResult.organizationId,
+          question_count: envelope.survey.blocks.reduce((count, block) => count + block.elements.length, 0),
+          language_count: envelope.survey.languages.length,
+        },
+        { organizationId: authResult.organizationId, workspaceId: authResult.workspaceId }
+      );
+    }
+
+    return successResponse(envelope, { requestId, cache: "private, no-store" });
+  } catch (error) {
+    if (error instanceof DatabaseError) {
+      log.error({ error, statusCode: 500 }, "Database error");
+      return problemInternalError(requestId, "An unexpected error occurred.", instance);
+    }
+
+    log.error({ error, statusCode: 500 }, "V3 survey export unexpected error");
+    return problemInternalError(requestId, "An unexpected error occurred.", instance);
+  }
+}

--- a/apps/web/app/api/v3/surveys/[surveyId]/export/route.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/route.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /api/v3/surveys/{surveyId}/export — portable export envelope (`.formbricks.json`) for one survey.
+ * Session cookie or x-api-key; read access on the survey's workspace. Audit-logged as `exported`.
+ */
+import { z } from "zod";
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { ZV3EmptyQuery } from "../../schemas";
+import { exportV3Survey } from "./lib/export-survey";
+
+const surveyParamsSchema = z.object({
+  surveyId: z.cuid2(),
+});
+
+export const GET = withV3ApiWrapper({
+  auth: "both",
+  action: "exported",
+  targetType: "survey",
+  schemas: {
+    params: surveyParamsSchema,
+    // Single-survey endpoints locate the survey by its globally-unique id; reject stray query params.
+    query: ZV3EmptyQuery,
+  },
+  handler: async ({ parsedInput, authentication, requestId, instance, auditLog }) => {
+    return await exportV3Survey({
+      surveyId: parsedInput.params.surveyId,
+      authentication,
+      requestId,
+      instance,
+      auditLog,
+    });
+  },
+});

--- a/apps/web/app/api/v3/surveys/export/schemas.test.ts
+++ b/apps/web/app/api/v3/surveys/export/schemas.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+import type { z } from "zod";
+import { ZSurveyExportEnvelope, getSurveyExportFormat } from "./schemas";
+
+/** Strict-object rejections carry the offending key in `keys`, not in `path`; flatten both. */
+function issueLocations(error: z.ZodError): string[] {
+  return error.issues.flatMap((issue) => {
+    const base = issue.path.join(".");
+    if (issue.code === "unrecognized_keys") {
+      return issue.keys.map((key) => (base ? `${base}.${key}` : key));
+    }
+    return [base];
+  });
+}
+
+const validEnvelope = {
+  formbricks: {
+    exportFormat: 1,
+    exportedAt: "2026-09-08T12:00:00.000Z",
+    appVersion: "6.2.0",
+    source: {
+      url: "https://app.formbricks.com",
+      workspaceId: "clxx1234567890123456789012",
+      surveyId: "clsv1234567890123456789012",
+    },
+  },
+  survey: {
+    name: "Product Feedback",
+    type: "link",
+    status: "inProgress",
+    defaultLanguage: "en-US",
+    languages: [{ code: "en-US", default: true, enabled: true }],
+    blocks: [
+      {
+        id: "clbk1234567890123456789012",
+        name: "Main",
+        elements: [
+          { id: "q1", type: "openText", headline: { "en-US": "What should we improve?" }, required: true },
+        ],
+      },
+    ],
+  },
+  references: { actionClasses: [] },
+};
+
+describe("ZSurveyExportEnvelope", () => {
+  test("parses a valid envelope into a typed v3 document", () => {
+    const parsed = ZSurveyExportEnvelope.safeParse(validEnvelope);
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.survey.type).toBe("link");
+      expect(parsed.data.survey.blocks[0].elements[0].headline).toEqual({
+        default: "What should we improve?",
+      });
+      expect(parsed.data.survey.endings).toEqual([]);
+    }
+  });
+
+  test("rejects an extensions block with its path", () => {
+    const parsed = ZSurveyExportEnvelope.safeParse({ ...validEnvelope, extensions: { styling: {} } });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(issueLocations(parsed.error)).toContain("extensions");
+    }
+  });
+
+  test("rejects instance-bound fields inside the survey with a nested path", () => {
+    const parsed = ZSurveyExportEnvelope.safeParse({
+      ...validEnvelope,
+      survey: { ...validEnvelope.survey, slug: "my-survey", workspaceId: "clxx1234567890123456789012" },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      const paths = issueLocations(parsed.error);
+      expect(paths).toContain("survey.slug");
+      expect(paths).toContain("survey.workspaceId");
+    }
+  });
+
+  test("rejects a newer export format and exposes it through the probe", () => {
+    const newer = { ...validEnvelope, formbricks: { ...validEnvelope.formbricks, exportFormat: 2 } };
+
+    expect(ZSurveyExportEnvelope.safeParse(newer).success).toBe(false);
+    expect(getSurveyExportFormat(newer)).toBe(2);
+    expect(getSurveyExportFormat({ survey: {} })).toBeNull();
+    expect(getSurveyExportFormat("nope")).toBeNull();
+  });
+
+  test("rejects unknown keys on action-class references and on the source", () => {
+    const parsed = ZSurveyExportEnvelope.safeParse({
+      ...validEnvelope,
+      formbricks: { ...validEnvelope.formbricks, source: { ...validEnvelope.formbricks.source, extra: 1 } },
+      references: {
+        actionClasses: [
+          {
+            id: "claa1234567890123456789012",
+            name: "Clicked",
+            key: null,
+            type: "noCode",
+            noCodeConfig: { type: "pageView", urlFilters: [] },
+            description: null,
+            workspaceId: "clxx1234567890123456789012",
+          },
+        ],
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      const paths = issueLocations(parsed.error);
+      expect(paths).toContain("formbricks.source.extra");
+      expect(paths).toContain("references.actionClasses.0.workspaceId");
+    }
+  });
+});

--- a/apps/web/app/api/v3/surveys/export/schemas.ts
+++ b/apps/web/app/api/v3/surveys/export/schemas.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { ZActionClass } from "@formbricks/types/action-classes";
+import { createZV3TypedSurveyDocumentSchema } from "../schemas";
+
+/**
+ * Portable survey export ("`.formbricks.json`"). Format 1 is the v3 survey document in a thin envelope:
+ * export metadata, the document itself (as `GET /api/v3/surveys/{id}` serializes it, minus the
+ * instance-bound fields), and the definitions of the action classes the document's triggers point at.
+ *
+ * Nothing the v3 document omits travels (D1): styling, follow-ups, quotas, survey settings, slug,
+ * custom scripts, targeting. Every level is `.strict()` so a hand-edited file with an `extensions`
+ * block is rejected with a path instead of being silently ignored.
+ */
+export const SURVEY_EXPORT_FORMAT = 1 as const;
+
+export const ZSurveyExportActionClassReference = ZActionClass.pick({
+  id: true,
+  name: true,
+  key: true,
+  type: true,
+  noCodeConfig: true,
+  description: true,
+}).strict();
+
+export type TSurveyExportActionClassReference = z.infer<typeof ZSurveyExportActionClassReference>;
+
+export const ZSurveyExportSource = z
+  .object({
+    url: z.url(),
+    workspaceId: z.cuid2(),
+    surveyId: z.cuid2(),
+  })
+  .strict();
+
+export const ZSurveyExportMetadata = z
+  .object({
+    exportFormat: z.literal(SURVEY_EXPORT_FORMAT),
+    exportedAt: z.iso.datetime(),
+    appVersion: z.string().trim().min(1),
+    source: ZSurveyExportSource,
+  })
+  .strict();
+
+export type TSurveyExportMetadata = z.infer<typeof ZSurveyExportMetadata>;
+
+export const ZSurveyExportReferences = z
+  .object({
+    actionClasses: z.array(ZSurveyExportActionClassReference),
+  })
+  .strict();
+
+export type TSurveyExportReferences = z.infer<typeof ZSurveyExportReferences>;
+
+/**
+ * The envelope as a file: three top-level keys, nothing else. `survey` is parsed with the same rules
+ * as a create body (public locale maps, strict unknown-field rejection, language declarations), so a
+ * parsed envelope's `survey` is a `TV3TypedSurveyDocument` — the importer only has to add `workspaceId`.
+ */
+export const ZSurveyExportEnvelope = z
+  .object({
+    formbricks: ZSurveyExportMetadata,
+    survey: createZV3TypedSurveyDocumentSchema(),
+    references: ZSurveyExportReferences,
+  })
+  .strict();
+
+export type TSurveyExportEnvelope = z.infer<typeof ZSurveyExportEnvelope>;
+
+/**
+ * A file that claims a newer format than this instance understands. Checked before the full parse so
+ * the message can say "newer instance" instead of "expected literal 1".
+ */
+export const ZSurveyExportFormatProbe = z.object({
+  formbricks: z.object({ exportFormat: z.number().int() }).loose(),
+});
+
+export function getSurveyExportFormat(value: unknown): number | null {
+  const probe = ZSurveyExportFormatProbe.safeParse(value);
+  return probe.success ? probe.data.formbricks.exportFormat : null;
+}

--- a/apps/web/app/api/v3/surveys/schemas.ts
+++ b/apps/web/app/api/v3/surveys/schemas.ts
@@ -394,6 +394,10 @@ const ROOT_KEYS = new Set([
   "distribution",
   "targeting",
 ]);
+// The create root keys minus `workspaceId`: the shape of a portable v3 survey document (export files,
+// raw documents pasted from the MCP `create_survey` tool) that names its own `type`.
+const TYPED_DOCUMENT_ROOT_KEYS = new Set([...ROOT_KEYS].filter((key) => key !== "workspaceId"));
+export const V3_SURVEY_DOCUMENT_ROOT_KEYS: ReadonlySet<string> = TYPED_DOCUMENT_ROOT_KEYS;
 const PATCH_ROOT_KEYS = new Set([
   "name",
   "status",
@@ -971,7 +975,7 @@ function validateTargeting(value: unknown, path: string, issues: InvalidParam[])
   addUnknownKeyIssues(value, TARGETING_KEYS, path, issues, "survey targeting");
 }
 
-function getUnsupportedV3SurveyDocumentFields(
+export function getUnsupportedV3SurveyDocumentFields(
   value: unknown,
   rootKeys: Set<string>,
   fallbackDefaultLanguage = DEFAULT_V3_SURVEY_LANGUAGE,
@@ -1242,6 +1246,47 @@ export const ZV3CreateSurveyBody = z
   })
   .pipe(ZV3CreateSurveyBodyBase);
 
+/**
+ * A v3 survey document that carries its own `type` but no `workspaceId` — the `survey` member of an
+ * export envelope, or a raw document produced by the MCP `create_survey` tool. Same normalizer,
+ * strictness and language rules as `ZV3CreateSurveyBody`; the importer adds the target workspace.
+ */
+export function createZV3TypedSurveyDocumentSchema(options?: TV3SurveyDocumentSchemaOptions) {
+  return z
+    .unknown()
+    .superRefine((value, ctx) => {
+      for (const issue of getUnsupportedV3SurveyDocumentFields(
+        value,
+        TYPED_DOCUMENT_ROOT_KEYS,
+        options?.fallbackDefaultLanguage,
+        options
+      )) {
+        addInvalidParamZodIssue(ctx, issue);
+      }
+    })
+    .pipe(
+      z.preprocess(
+        createV3SurveyDocumentNormalizer({
+          allowInternalDefaultTranslationKey: options?.allowInternalDefaultTranslationKey,
+          fallbackDefaultLanguage: options?.fallbackDefaultLanguage,
+          applyDefaultLanguage: true,
+          generateMissingCreateIds: true,
+          allowedLanguageCodes: options?.allowedLanguageCodes,
+        }),
+        z
+          .object({
+            type: ZSurveyType.prefault("link"),
+            ...createV3SurveyDocumentShape(options),
+          })
+          .strict()
+          .superRefine(addLanguageIssues)
+          .superRefine((body, ctx) => addAppDistributionIssues(body, body.type, ctx))
+      )
+    );
+}
+
+export const ZV3TypedSurveyDocument = createZV3TypedSurveyDocumentSchema();
+
 export const ZV3CreateSurveyQuery = z.object({
   createdFrom: z.enum(["blank", "template", "xm-template", "ai"]).optional(),
 });
@@ -1351,6 +1396,7 @@ export function formatV3ZodInvalidParams(error: z.ZodError, fallbackName: string
 }
 
 export type TV3SurveyDocument = z.infer<typeof ZV3SurveyDocumentBase>;
+export type TV3TypedSurveyDocument = z.infer<typeof ZV3TypedSurveyDocument>;
 export type TV3CreateSurveyBody = z.infer<typeof ZV3CreateSurveyBody>;
 export type TV3PatchSurveyBody = z.infer<typeof ZV3PatchSurveyBody>;
 export type TV3SurveyValidationRequestBody = z.infer<typeof ZV3SurveyValidationRequestBody>;

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -3595,6 +3595,10 @@ checksums:
     workspace/surveys/error_deleting_survey: 5a113f1cc0a430b54b21dd1fd4e65e00
     workspace/surveys/error_restoring_survey: a070c5b584187d4f1308943d6b378bea
     workspace/surveys/error_updating_status: f163ee51d64903a0c994d39008bf7fe4
+    workspace/surveys/export_as_json: d54da0037d7db2fd097b5ce903acbe7d
+    workspace/surveys/export_error: b906a9f38bf73c8ca27ea886a847c58f
+    workspace/surveys/export_success: ef5f85fc6b3908a0a98c8ca53fbc0a8f
+    workspace/surveys/exporting_survey: 5826127cc63ad867813becbf985c92e9
     workspace/surveys/featured_templates/churn_description: 095b315526140f3633b3da354b766ed4
     workspace/surveys/featured_templates/churn_title: 5ecbb56a7bc54e945fff08fed017a545
     workspace/surveys/featured_templates/csat_description: 0e64d5594f961e5070a95f715594549e

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -272,6 +272,18 @@ export const SENTRY_RELEASE = (() => {
     return undefined;
   }
 })();
+
+// The app version as built (package.json `version` is stamped by the release build; "0.0.0" in dev).
+// Read once, never thrown: an unreadable package.json must not take the process down.
+export const APP_VERSION: string = (() => {
+  try {
+    const pkg = require("../package.json") as { version?: string };
+    return typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+})();
+
 export const SENTRY_ENVIRONMENT = env.SENTRY_ENVIRONMENT;
 export const SENTRY_DSN = env.SENTRY_DSN;
 

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Beim Löschen der Umfrage ist ein Fehler aufgetreten",
       "error_restoring_survey": "Umfrage konnte nicht wiederhergestellt werden, versuch es noch mal",
       "error_updating_status": "Beim Aktualisieren des Umfragestatus ist ein Fehler aufgetreten",
+      "export_as_json": "Als JSON exportieren",
+      "export_error": "Umfrage konnte nicht exportiert werden",
+      "export_success": "Umfrage exportiert",
+      "exporting_survey": "Umfrage wird exportiert...",
       "featured_templates": {
         "churn_description": "Finde heraus, warum Leute ihre Abos kündigen.",
         "churn_title": "Churn-Umfrage",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "An error occurred while deleting survey",
       "error_restoring_survey": "Couldn't restore survey, try again",
       "error_updating_status": "An error occurred while updating survey status",
+      "export_as_json": "Export as JSON",
+      "export_error": "Failed to export survey",
+      "export_success": "Survey exported",
+      "exporting_survey": "Exporting survey...",
       "featured_templates": {
         "churn_description": "Find out why people cancel their subscriptions.",
         "churn_title": "Churn Survey",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Se produjo un error al eliminar la encuesta",
       "error_restoring_survey": "No se pudo restaurar la encuesta, inténtalo de nuevo",
       "error_updating_status": "Se produjo un error al actualizar el estado de la encuesta",
+      "export_as_json": "Exportar como JSON",
+      "export_error": "No se pudo exportar la encuesta",
+      "export_success": "Encuesta exportada",
+      "exporting_survey": "Exportando encuesta...",
       "featured_templates": {
         "churn_description": "Descubre por qué la gente cancela sus suscripciones.",
         "churn_title": "Encuesta de Cancelación",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Une erreur s'est produite lors de la suppression du sondage",
       "error_restoring_survey": "Impossible de restaurer le sondage, réessaye",
       "error_updating_status": "Une erreur s'est produite lors de la mise à jour du statut de l'enquête",
+      "export_as_json": "Exporter en JSON",
+      "export_error": "Échec de l'export du sondage",
+      "export_success": "Sondage exporté",
+      "exporting_survey": "Export du sondage en cours...",
       "featured_templates": {
         "churn_description": "Découvrez pourquoi les utilisateurs annulent leur abonnement.",
         "churn_title": "Enquête de désabonnement",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Hiba történt a kérdőív törlése során",
       "error_restoring_survey": "A felmérés visszaállítása sikertelen, kérjük, próbálja újra",
       "error_updating_status": "Hiba történt a felmérés állapotának frissítése során",
+      "export_as_json": "Exportálás JSON formátumban",
+      "export_error": "A felmérés exportálása sikertelen volt",
+      "export_success": "A felmérés exportálva",
+      "exporting_survey": "A felmérés exportálása folyamatban...",
       "featured_templates": {
         "churn_description": "Tudja meg, miért mondják le az emberek az előfizetésüket.",
         "churn_title": "Lemorzsolódási felmérés",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "アンケートの削除中にエラーが発生しました",
       "error_restoring_survey": "アンケートを復元できませんでした。もう一度お試しください",
       "error_updating_status": "アンケートのステータス更新中にエラーが発生しました",
+      "export_as_json": "JSONとしてエクスポート",
+      "export_error": "アンケートのエクスポートに失敗しました",
+      "export_success": "アンケートをエクスポートしました",
+      "exporting_survey": "アンケートをエクスポート中...",
       "featured_templates": {
         "churn_description": "サブスクリプションをキャンセルする理由を把握できます。",
         "churn_title": "解約調査",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Er is een fout opgetreden bij het verwijderen van de enquête",
       "error_restoring_survey": "Kan enquête niet herstellen, probeer het opnieuw",
       "error_updating_status": "Er is een fout opgetreden bij het bijwerken van de enquêtestatus",
+      "export_as_json": "Exporteren als JSON",
+      "export_error": "Enquête exporteren mislukt",
+      "export_success": "Enquête geëxporteerd",
+      "exporting_survey": "Enquête exporteren...",
       "featured_templates": {
         "churn_description": "Ontdek waarom mensen hun abonnementen opzeggen.",
         "churn_title": "Churn-enquête",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Ocorreu um erro ao excluir a pesquisa",
       "error_restoring_survey": "Não foi possível restaurar a pesquisa, tente novamente",
       "error_updating_status": "Ocorreu um erro ao atualizar o status da pesquisa",
+      "export_as_json": "Exportar como JSON",
+      "export_error": "Falha ao exportar pesquisa",
+      "export_success": "Pesquisa exportada",
+      "exporting_survey": "Exportando pesquisa...",
       "featured_templates": {
         "churn_description": "Descubra por que as pessoas cancelam suas assinaturas.",
         "churn_title": "Pesquisa de Churn",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Ocorreu um erro ao eliminar o inquérito",
       "error_restoring_survey": "Não foi possível restaurar o inquérito, tenta novamente",
       "error_updating_status": "Ocorreu um erro ao atualizar o estado do inquérito",
+      "export_as_json": "Exportar como JSON",
+      "export_error": "Falha ao exportar inquérito",
+      "export_success": "Inquérito exportado",
+      "exporting_survey": "A exportar inquérito...",
       "featured_templates": {
         "churn_description": "Descobre porque é que as pessoas cancelam as suas subscrições.",
         "churn_title": "Inquérito de Cancelamento",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "A apărut o eroare la ștergerea sondajului",
       "error_restoring_survey": "Nu s-a putut restaura sondajul, încearcă din nou",
       "error_updating_status": "A apărut o eroare la actualizarea statusului sondajului",
+      "export_as_json": "Exportă ca JSON",
+      "export_error": "Exportul sondajului a eșuat",
+      "export_success": "Sondaj exportat",
+      "exporting_survey": "Se exportă sondajul...",
       "featured_templates": {
         "churn_description": "Află de ce oamenii anulează abonamentele lor.",
         "churn_title": "Chestionar despre pierderea clienților",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Произошла ошибка при удалении опроса",
       "error_restoring_survey": "Не удалось восстановить опрос, попробуй ещё раз",
       "error_updating_status": "Произошла ошибка при обновлении статуса опроса",
+      "export_as_json": "Экспортировать как JSON",
+      "export_error": "Не удалось экспортировать опрос",
+      "export_success": "Опрос экспортирован",
+      "exporting_survey": "Экспортируем опрос...",
       "featured_templates": {
         "churn_description": "Узнайте, почему люди отменяют свои подписки.",
         "churn_title": "Опрос об оттоке",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Ett fel uppstod vid borttagning av enkät",
       "error_restoring_survey": "Kunde inte återställa undersökningen, försök igen",
       "error_updating_status": "Ett fel uppstod när undersökningens status uppdaterades",
+      "export_as_json": "Exportera som JSON",
+      "export_error": "Det gick inte att exportera undersökningen",
+      "export_success": "Undersökningen exporterad",
+      "exporting_survey": "Exporterar undersökning...",
       "featured_templates": {
         "churn_description": "Ta reda på varför människor avslutar sina prenumerationer.",
         "churn_title": "Churn-undersökning",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "Anket silinirken bir hata oluştu",
       "error_restoring_survey": "Anket geri yüklenemedi, tekrar dene",
       "error_updating_status": "Anket durumu güncellenirken bir hata oluştu",
+      "export_as_json": "JSON olarak dışa aktar",
+      "export_error": "Anket dışa aktarılamadı",
+      "export_success": "Anket dışa aktarıldı",
+      "exporting_survey": "Anket dışa aktarılıyor...",
       "featured_templates": {
         "churn_description": "İnsanların aboneliklerini neden iptal ettiğini öğren.",
         "churn_title": "Kayıp Anketi",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "删除问卷时发生错误",
       "error_restoring_survey": "无法恢复问卷，请重试",
       "error_updating_status": "更新调查状态时出错",
+      "export_as_json": "导出为 JSON",
+      "export_error": "导出调查失败",
+      "export_success": "调查已导出",
+      "exporting_survey": "正在导出调查...",
       "featured_templates": {
         "churn_description": "了解用户取消订阅的原因。",
         "churn_title": "流失调查",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -3721,6 +3721,10 @@
       "error_deleting_survey": "刪除問卷時發生錯誤",
       "error_restoring_survey": "無法還原問卷,請再試一次",
       "error_updating_status": "更新問卷狀態時發生錯誤",
+      "export_as_json": "匯出為 JSON",
+      "export_error": "問卷匯出失敗",
+      "export_success": "問卷已匯出",
+      "exporting_survey": "正在匯出問卷...",
       "featured_templates": {
         "churn_description": "了解用戶取消訂閱的原因。",
         "churn_title": "流失調查",

--- a/apps/web/modules/ee/audit-logs/types/audit-log.ts
+++ b/apps/web/modules/ee/audit-logs/types/audit-log.ts
@@ -45,6 +45,7 @@ export const ZAuditAction = z.enum([
   "verificationEmailSent",
   "createdFromCSV",
   "copiedToOtherWorkspace",
+  "exported",
   "addedToResponse",
   "removedFromResponse",
   "createdUpdated",

--- a/apps/web/modules/survey/export/__fixtures__/surveys.ts
+++ b/apps/web/modules/survey/export/__fixtures__/surveys.ts
@@ -51,7 +51,7 @@ export const FIXTURE_LANGUAGES: TSurvey["languages"] = [
 ];
 
 /** One element of every type the v3 document supports, across three blocks. */
-export const FIXTURE_BLOCKS: TSurvey["blocks"] = [
+export const FIXTURE_BLOCKS = [
   {
     id: FIXTURE_BLOCK_1_ID,
     name: "Basics",
@@ -254,7 +254,7 @@ export const FIXTURE_BLOCKS: TSurvey["blocks"] = [
       },
     ],
   },
-];
+] as unknown as TSurvey["blocks"];
 
 export const FIXTURE_ENDINGS: TSurvey["endings"] = [
   {

--- a/apps/web/modules/survey/export/__fixtures__/surveys.ts
+++ b/apps/web/modules/survey/export/__fixtures__/surveys.ts
@@ -1,0 +1,442 @@
+import type { TActionClass } from "@formbricks/types/action-classes";
+import type { TSurvey } from "@formbricks/types/surveys/types";
+
+/**
+ * Stored-survey fixtures for the export/import round trip. Every shape is the internal one the survey
+ * service returns (`{ default, "de-DE" }` locale maps), not the public v3 shape.
+ */
+export const FIXTURE_WORKSPACE_ID = "clxx1234567890123456789012";
+export const FIXTURE_SURVEY_ID = "clsv1234567890123456789012";
+export const FIXTURE_BLOCK_1_ID = "clbk0000000000000000000001";
+export const FIXTURE_BLOCK_2_ID = "clbk0000000000000000000002";
+export const FIXTURE_BLOCK_3_ID = "clbk0000000000000000000003";
+export const FIXTURE_ENDING_ID = "clen0000000000000000000001";
+export const FIXTURE_VARIABLE_ID = "clva0000000000000000000001";
+
+const fixtureDate = new Date("2026-09-01T10:00:00.000Z");
+
+const i18n = (en: string, de: string) => ({ default: en, "de-DE": de });
+
+const toggleInput = (label: string) => ({
+  show: true,
+  required: false,
+  placeholder: i18n(label, `${label} (DE)`),
+});
+
+export const FIXTURE_LANGUAGES: TSurvey["languages"] = [
+  {
+    default: true,
+    enabled: true,
+    language: {
+      id: "cllangenus000000000000000",
+      code: "en-US",
+      alias: null,
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      createdAt: fixtureDate,
+      updatedAt: fixtureDate,
+    },
+  },
+  {
+    default: false,
+    enabled: true,
+    language: {
+      id: "cllangdede000000000000000",
+      code: "de-DE",
+      alias: "german",
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      createdAt: fixtureDate,
+      updatedAt: fixtureDate,
+    },
+  },
+];
+
+/** One element of every type the v3 document supports, across three blocks. */
+export const FIXTURE_BLOCKS: TSurvey["blocks"] = [
+  {
+    id: FIXTURE_BLOCK_1_ID,
+    name: "Basics",
+    buttonLabel: i18n("Next", "Weiter"),
+    elements: [
+      {
+        id: "q_open",
+        type: "openText",
+        headline: i18n("What should we improve?", "Was sollen wir verbessern?"),
+        subheader: i18n("Be specific", "Sei konkret"),
+        placeholder: i18n("Type here", "Hier tippen"),
+        required: true,
+        inputType: "text",
+        longAnswer: true,
+        charLimit: { enabled: false },
+      },
+      {
+        id: "q_nps",
+        type: "nps",
+        headline: i18n("How likely are you to recommend us?", "Wie wahrscheinlich empfehlen Sie uns?"),
+        lowerLabel: i18n("Not likely", "Unwahrscheinlich"),
+        upperLabel: i18n("Very likely", "Sehr wahrscheinlich"),
+        required: true,
+        isColorCodingEnabled: false,
+      },
+      {
+        id: "q_single",
+        type: "multipleChoiceSingle",
+        headline: i18n("Pick one", "Wähle eins"),
+        required: false,
+        choices: [
+          { id: "c_a", label: i18n("A", "A") },
+          { id: "c_b", label: i18n("B", "B") },
+          { id: "other", label: i18n("Other", "Andere") },
+        ],
+        otherOptionPlaceholder: i18n("Please specify", "Bitte angeben"),
+        shuffleOption: "none",
+      },
+      {
+        id: "q_multi",
+        type: "multipleChoiceMulti",
+        headline: i18n("Pick many", "Wähle mehrere"),
+        required: false,
+        choices: [
+          { id: "m_a", label: i18n("One", "Eins") },
+          { id: "m_b", label: i18n("Two", "Zwei") },
+        ],
+      },
+      {
+        id: "q_consent",
+        type: "consent",
+        headline: i18n("Terms", "Bedingungen"),
+        label: i18n("I agree", "Ich stimme zu"),
+        required: true,
+      },
+      {
+        id: "q_cta",
+        type: "cta",
+        headline: i18n("Read on", "Weiterlesen"),
+        required: false,
+        buttonExternal: false,
+        ctaButtonLabel: i18n("Next", "Weiter"),
+      },
+    ],
+    logic: [
+      {
+        id: "cllg0000000000000000000001",
+        conditions: {
+          id: "clcg0000000000000000000001",
+          connector: "and",
+          conditions: [
+            {
+              id: "clcd0000000000000000000001",
+              leftOperand: { type: "element", value: "q_nps" },
+              operator: "isGreaterThan",
+              rightOperand: { type: "static", value: 8 },
+            },
+          ],
+        },
+        actions: [
+          {
+            id: "clac0000000000000000000001",
+            objective: "jumpToBlock",
+            target: FIXTURE_ENDING_ID,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: FIXTURE_BLOCK_2_ID,
+    name: "Scales",
+    elements: [
+      {
+        id: "q_rating",
+        type: "rating",
+        headline: i18n("Rate us (you said: #recall:q_open/fallback:#)", "Bewerte uns"),
+        required: true,
+        scale: "number",
+        range: 5,
+        isColorCodingEnabled: false,
+      },
+      {
+        id: "q_csat",
+        type: "csat",
+        headline: i18n("Satisfied?", "Zufrieden?"),
+        required: true,
+        scale: "smiley",
+        range: 5,
+        isColorCodingEnabled: false,
+      },
+      {
+        id: "q_ces",
+        type: "ces",
+        headline: i18n("Effort?", "Aufwand?"),
+        required: true,
+        scale: "number",
+        range: 7,
+        isColorCodingEnabled: false,
+      },
+      {
+        id: "q_matrix",
+        type: "matrix",
+        headline: i18n("Grid", "Raster"),
+        required: false,
+        rows: [{ id: "r1", label: i18n("Row 1", "Zeile 1") }],
+        columns: [{ id: "c1", label: i18n("Col 1", "Spalte 1") }],
+        shuffleOption: "none",
+      },
+      {
+        id: "q_ranking",
+        type: "ranking",
+        headline: i18n("Rank", "Rangfolge"),
+        required: false,
+        choices: [
+          { id: "rk_a", label: i18n("First", "Erstes") },
+          { id: "rk_b", label: i18n("Second", "Zweites") },
+        ],
+      },
+      {
+        id: "q_pics",
+        type: "pictureSelection",
+        headline: i18n("Pick a picture", "Wähle ein Bild"),
+        required: false,
+        allowMulti: false,
+        choices: [
+          { id: "p_a", imageUrl: "https://example.com/a.png" },
+          { id: "p_b", imageUrl: "https://example.com/b.png" },
+        ],
+      },
+    ],
+  },
+  {
+    id: FIXTURE_BLOCK_3_ID,
+    name: "Details",
+    elements: [
+      {
+        id: "q_date",
+        type: "date",
+        headline: i18n("When?", "Wann?"),
+        required: false,
+        format: "M-d-y",
+      },
+      {
+        id: "q_file",
+        type: "fileUpload",
+        headline: i18n("Upload", "Hochladen"),
+        required: false,
+        allowMultipleFiles: false,
+      },
+      {
+        id: "q_cal",
+        type: "cal",
+        headline: i18n("Book a call", "Termin buchen"),
+        required: false,
+        calUserName: "formbricks",
+      },
+      {
+        id: "q_address",
+        type: "address",
+        headline: i18n("Address", "Adresse"),
+        required: false,
+        addressLine1: toggleInput("Street"),
+        addressLine2: toggleInput("Line 2"),
+        city: toggleInput("City"),
+        state: toggleInput("State"),
+        zip: toggleInput("ZIP"),
+        country: toggleInput("Country"),
+      },
+      {
+        id: "q_contact",
+        type: "contactInfo",
+        headline: i18n("Contact", "Kontakt"),
+        required: false,
+        firstName: toggleInput("First name"),
+        lastName: toggleInput("Last name"),
+        email: toggleInput("Email"),
+        phone: toggleInput("Phone"),
+        company: toggleInput("Company"),
+      },
+    ],
+  },
+];
+
+export const FIXTURE_ENDINGS: TSurvey["endings"] = [
+  {
+    id: FIXTURE_ENDING_ID,
+    type: "endScreen",
+    headline: i18n("Thanks, #recall:q_open/fallback:#!", "Danke, #recall:q_open/fallback:#!"),
+    subheader: i18n("We read every answer", "Wir lesen jede Antwort"),
+    buttonLabel: i18n("Back to site", "Zurück"),
+    buttonLink: "https://formbricks.com",
+  },
+];
+
+export const FIXTURE_CODE_ACTION_CLASS: TActionClass = {
+  id: "claa0000000000000000000001",
+  name: "Checkout Complete",
+  description: "Fired after checkout",
+  type: "code",
+  key: "checkout_complete",
+  noCodeConfig: null,
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  createdAt: fixtureDate,
+  updatedAt: fixtureDate,
+};
+
+export const FIXTURE_NOCODE_ACTION_CLASS: TActionClass = {
+  id: "claa0000000000000000000002",
+  name: "Clicked pricing",
+  description: null,
+  type: "noCode",
+  key: null,
+  noCodeConfig: {
+    type: "click",
+    urlFilters: [],
+    elementSelector: { cssSelector: "#pricing" },
+  },
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  createdAt: fixtureDate,
+  updatedAt: fixtureDate,
+};
+
+/**
+ * A fully featured stored link survey. Carries every field the export must NOT read (styling,
+ * follow-ups, single-use, PIN, slug, custom scripts, schedule) so tests can assert they never travel.
+ */
+export const FIXTURE_LINK_SURVEY = {
+  id: FIXTURE_SURVEY_ID,
+  createdAt: fixtureDate,
+  updatedAt: fixtureDate,
+  name: "Product Feedback",
+  type: "link",
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  createdBy: "cluser000000000000000000001",
+  status: "inProgress",
+  displayOption: "displayOnce",
+  autoClose: null,
+  triggers: [],
+  recontactDays: null,
+  displayLimit: null,
+  welcomeCard: {
+    enabled: true,
+    headline: i18n("Welcome", "Willkommen"),
+    subheader: i18n("Two minutes", "Zwei Minuten"),
+    buttonLabel: i18n("Start", "Los"),
+    timeToFinish: true,
+    showResponseCount: false,
+  },
+  questions: [],
+  blocks: FIXTURE_BLOCKS,
+  endings: FIXTURE_ENDINGS,
+  hiddenFields: { enabled: true, fieldIds: ["utm_source", "plan"] },
+  variables: [{ id: FIXTURE_VARIABLE_ID, name: "score", type: "number", value: 0 }],
+  followUps: [
+    {
+      id: "clfu0000000000000000000001",
+      surveyId: FIXTURE_SURVEY_ID,
+      name: "Notify team",
+      trigger: { type: "response", properties: null },
+      action: {
+        type: "send-email",
+        properties: {
+          to: "q_contact",
+          from: "team@example.com",
+          replyTo: ["team@example.com"],
+          subject: "New response",
+          body: "<p>Hi</p>",
+          attachResponseData: true,
+        },
+      },
+      createdAt: fixtureDate,
+      updatedAt: fixtureDate,
+    },
+  ],
+  delay: 0,
+  publishOn: new Date("2026-10-01T00:00:00.000Z"),
+  closeOn: new Date("2026-11-01T00:00:00.000Z"),
+  archivedAt: null,
+  autoComplete: null,
+  workspaceOverwrites: { brandColor: "#123456" },
+  styling: { brandColor: { light: "#00ff00" }, overwriteThemeStyling: true },
+  showLanguageSwitch: true,
+  surveyClosedMessage: { enabled: true, heading: "Closed", subheading: "Come back later" },
+  segment: null,
+  singleUse: { enabled: true, isEncrypted: true },
+  isVerifyEmailEnabled: false,
+  recaptcha: { enabled: true, threshold: 0.5 },
+  isBackButtonHidden: false,
+  isAutoProgressingEnabled: false,
+  isCaptureIpEnabled: false,
+  pin: "1234",
+  displayPercentage: null,
+  languages: FIXTURE_LANGUAGES,
+  metadata: {
+    title: i18n("Product Feedback", "Produktfeedback"),
+    description: i18n("Tell us what you think", "Sag uns deine Meinung"),
+  },
+  slug: "product-feedback",
+  customHeadScripts: "<script>alert(1)</script>",
+  customHeadScriptsMode: "add",
+} as unknown as TSurvey;
+
+/** App variant with two triggers and a segment with filters (targeting must not travel). */
+export const FIXTURE_APP_SURVEY = {
+  ...FIXTURE_LINK_SURVEY,
+  id: "clsvapp0000000000000000001",
+  name: "In-App Feedback",
+  type: "app",
+  displayOption: "respondMultiple",
+  recontactDays: 7,
+  delay: 5,
+  triggers: [{ actionClass: FIXTURE_CODE_ACTION_CLASS }, { actionClass: FIXTURE_NOCODE_ACTION_CLASS }],
+  segment: {
+    id: "clsg0000000000000000000001",
+    title: "clsvapp0000000000000000001",
+    description: null,
+    isPrivate: true,
+    filters: [
+      {
+        id: "clsf0000000000000000000001",
+        connector: null,
+        resource: {
+          id: "clsr0000000000000000000001",
+          root: { type: "attribute", contactAttributeKey: "plan" },
+          qualifier: { operator: "equals" },
+          value: "enterprise",
+        },
+      },
+    ],
+    workspaceId: FIXTURE_WORKSPACE_ID,
+    surveys: ["clsvapp0000000000000000001"],
+    createdAt: fixtureDate,
+    updatedAt: fixtureDate,
+  },
+} as unknown as TSurvey;
+
+/** Legacy question-based survey (no blocks): the export converts it. */
+export const FIXTURE_LEGACY_SURVEY = {
+  ...FIXTURE_LINK_SURVEY,
+  id: "clsvleg0000000000000000001",
+  name: "Legacy NPS",
+  blocks: [],
+  endings: [],
+  hiddenFields: { enabled: false },
+  variables: [],
+  questions: [
+    {
+      id: "legacy_open",
+      type: "openText",
+      headline: i18n("Anything else?", "Noch etwas?"),
+      required: false,
+      inputType: "text",
+      charLimit: { enabled: false },
+    },
+  ],
+} as unknown as TSurvey;
+
+export const FIXTURE_EMPTY_SURVEY = {
+  ...FIXTURE_LINK_SURVEY,
+  id: "clsvemp0000000000000000001",
+  name: "Empty",
+  blocks: [],
+  questions: [],
+  endings: [],
+  hiddenFields: { enabled: false },
+  variables: [],
+} as unknown as TSurvey;

--- a/apps/web/modules/survey/export/build-export-envelope.test.ts
+++ b/apps/web/modules/survey/export/build-export-envelope.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "vitest";
+import type { TSurvey } from "@formbricks/types/surveys/types";
+import { ZSurveyExportEnvelope } from "@/app/api/v3/surveys/export/schemas";
+import { ZV3CreateSurveyBody } from "@/app/api/v3/surveys/schemas";
+import {
+  FIXTURE_APP_SURVEY,
+  FIXTURE_BLOCK_1_ID,
+  FIXTURE_CODE_ACTION_CLASS,
+  FIXTURE_EMPTY_SURVEY,
+  FIXTURE_LEGACY_SURVEY,
+  FIXTURE_LINK_SURVEY,
+  FIXTURE_NOCODE_ACTION_CLASS,
+  FIXTURE_SURVEY_ID,
+  FIXTURE_WORKSPACE_ID,
+} from "./__fixtures__/surveys";
+import { buildSurveyExportEnvelope } from "./build-export-envelope";
+
+const ctx = {
+  appVersion: "6.2.0",
+  publicUrl: "https://app.formbricks.com",
+  exportedAt: new Date("2026-09-08T12:00:00.000Z"),
+};
+
+const ALL_ELEMENT_TYPES = [
+  "openText",
+  "nps",
+  "multipleChoiceSingle",
+  "multipleChoiceMulti",
+  "consent",
+  "cta",
+  "rating",
+  "csat",
+  "ces",
+  "matrix",
+  "ranking",
+  "pictureSelection",
+  "date",
+  "fileUpload",
+  "cal",
+  "address",
+  "contactInfo",
+];
+
+function expectOk<T, E>(result: { ok: true; data: T } | { ok: false; error: E }): T {
+  if (!result.ok) {
+    throw new Error(`Expected ok, got ${JSON.stringify(result.error, null, 2)}`);
+  }
+  return result.data;
+}
+
+describe("buildSurveyExportEnvelope", () => {
+  test("exports a fully featured link survey as a three-key envelope in export format 1", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+
+    expect(Object.keys(envelope)).toEqual(["formbricks", "survey", "references"]);
+    expect(envelope.formbricks).toEqual({
+      exportFormat: 1,
+      exportedAt: "2026-09-08T12:00:00.000Z",
+      appVersion: "6.2.0",
+      source: {
+        url: "https://app.formbricks.com",
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        surveyId: FIXTURE_SURVEY_ID,
+      },
+    });
+    expect(envelope.references.actionClasses).toEqual([]);
+
+    const { survey } = envelope;
+    expect(survey.type).toBe("link");
+    expect(survey.defaultLanguage).toBe("en-US");
+    expect(survey.languages).toEqual([
+      { code: "en-US", default: true, enabled: true },
+      { code: "de-DE", default: false, enabled: true },
+    ]);
+    expect(survey.blocks.flatMap((block) => block.elements.map((element) => element.type)).sort()).toEqual(
+      [...ALL_ELEMENT_TYPES].sort()
+    );
+    // Public locale maps, not the internal `default` key.
+    expect(survey.blocks[0].elements[0].headline).toEqual({
+      "en-US": "What should we improve?",
+      "de-DE": "Was sollen wir verbessern?",
+    });
+    expect(survey.endings[0]).toMatchObject({
+      type: "endScreen",
+      headline: { "en-US": "Thanks, #recall:q_open/fallback:#!" },
+    });
+    expect(survey.hiddenFields).toEqual({ enabled: true, fieldIds: ["utm_source", "plan"] });
+    expect(survey.variables).toHaveLength(1);
+  });
+
+  test("never reads styling, follow-ups, settings, slug, scripts, schedule or instance fields", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+    const serialized = JSON.stringify(envelope);
+
+    for (const forbidden of [
+      "styling",
+      "followUps",
+      "singleUse",
+      "pin",
+      "recaptcha",
+      "surveyClosedMessage",
+      "showLanguageSwitch",
+      "isVerifyEmailEnabled",
+      "isBackButtonHidden",
+      "slug",
+      "customHeadScripts",
+      "publishOn",
+      "closeOn",
+      "createdBy",
+      "createdAt",
+      "updatedAt",
+      "archivedAt",
+      "workspaceOverwrites",
+      "segment",
+      "targeting",
+      "alert(1)",
+      "product-feedback",
+    ]) {
+      expect(serialized, forbidden).not.toContain(`"${forbidden}"`);
+    }
+    expect(envelope.survey).not.toHaveProperty("id");
+    expect(envelope.survey).not.toHaveProperty("workspaceId");
+    expect(envelope.survey).not.toHaveProperty("distribution");
+  });
+
+  test("round-trips through the v3 create schema and the envelope schema", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+
+    const createBody = ZV3CreateSurveyBody.safeParse({
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      ...envelope.survey,
+    });
+    expect(createBody.success, JSON.stringify(createBody.error?.issues)).toBe(true);
+
+    const parsedEnvelope = ZSurveyExportEnvelope.safeParse(JSON.parse(JSON.stringify(envelope)));
+    expect(parsedEnvelope.success, JSON.stringify(parsedEnvelope.error?.issues)).toBe(true);
+  });
+
+  test("is deterministic apart from exportedAt", () => {
+    const first = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+    const second = expectOk(buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, ctx));
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  test("carries triggers and action-class definitions for app surveys, but no targeting", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_APP_SURVEY, ctx));
+
+    expect(envelope.survey.type).toBe("app");
+    expect(envelope.survey.distribution).toMatchObject({
+      displayOption: "respondMultiple",
+      recontactDays: 7,
+      delay: 5,
+      triggers: [
+        { actionClassId: FIXTURE_CODE_ACTION_CLASS.id },
+        { actionClassId: FIXTURE_NOCODE_ACTION_CLASS.id },
+      ],
+    });
+    expect(envelope.survey).not.toHaveProperty("targeting");
+    expect(envelope.references.actionClasses).toEqual([
+      {
+        id: FIXTURE_CODE_ACTION_CLASS.id,
+        name: "Checkout Complete",
+        key: "checkout_complete",
+        type: "code",
+        noCodeConfig: null,
+        description: "Fired after checkout",
+      },
+      {
+        id: FIXTURE_NOCODE_ACTION_CLASS.id,
+        name: "Clicked pricing",
+        key: null,
+        type: "noCode",
+        noCodeConfig: FIXTURE_NOCODE_ACTION_CLASS.noCodeConfig,
+        description: null,
+      },
+    ]);
+    expect(JSON.stringify(envelope)).not.toContain("contactAttributeKey");
+
+    const createBody = ZV3CreateSurveyBody.safeParse({
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      ...envelope.survey,
+    });
+    expect(createBody.success, JSON.stringify(createBody.error?.issues)).toBe(true);
+  });
+
+  test("de-duplicates action classes referenced by more than one trigger", () => {
+    const survey = {
+      ...FIXTURE_APP_SURVEY,
+      triggers: [{ actionClass: FIXTURE_CODE_ACTION_CLASS }, { actionClass: FIXTURE_CODE_ACTION_CLASS }],
+    } as unknown as TSurvey;
+
+    const envelope = expectOk(buildSurveyExportEnvelope(survey, ctx));
+
+    expect(envelope.survey.distribution?.triggers).toHaveLength(2);
+    expect(envelope.references.actionClasses).toHaveLength(1);
+  });
+
+  test("converts legacy question-based surveys to blocks", () => {
+    const envelope = expectOk(buildSurveyExportEnvelope(FIXTURE_LEGACY_SURVEY, ctx));
+
+    expect(envelope.survey.blocks).toHaveLength(1);
+    expect(envelope.survey.blocks[0].elements[0]).toMatchObject({ id: "legacy_open", type: "openText" });
+    expect(envelope.survey).not.toHaveProperty("questions");
+  });
+
+  test("refuses empty surveys", () => {
+    const result = buildSurveyExportEnvelope(FIXTURE_EMPTY_SURVEY, ctx);
+
+    expect(result).toEqual({
+      ok: false,
+      error: [{ name: "survey.blocks", reason: expect.stringContaining("Empty surveys cannot be exported") }],
+    });
+  });
+
+  test("refuses a survey with a dangling jumpToBlock target with the v3 path format", () => {
+    const survey = {
+      ...FIXTURE_LINK_SURVEY,
+      blocks: FIXTURE_LINK_SURVEY.blocks.map((block) =>
+        block.id === FIXTURE_BLOCK_1_ID
+          ? {
+              ...block,
+              logic: block.logic?.map((logic) => ({
+                ...logic,
+                actions: [{ ...logic.actions[0], target: "clbkmissing000000000000001" }],
+              })),
+            }
+          : block
+      ),
+    } as unknown as TSurvey;
+
+    const result = buildSurveyExportEnvelope(survey, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual([
+        expect.objectContaining({
+          name: "blocks.0.logic.0.actions.0.target",
+          code: "dangling_reference",
+          missingId: "clbkmissing000000000000001",
+        }),
+      ]);
+    }
+  });
+
+  test("fills a translation missing on a draft from the default language so the file re-imports", () => {
+    const survey = {
+      ...FIXTURE_LINK_SURVEY,
+      blocks: [
+        {
+          id: FIXTURE_BLOCK_1_ID,
+          name: "Only block",
+          elements: [
+            {
+              id: "q_incomplete",
+              type: "openText",
+              headline: { default: "English only" },
+              required: false,
+              inputType: "text",
+              charLimit: { enabled: false },
+            },
+          ],
+        },
+      ],
+      endings: [],
+      metadata: {},
+      welcomeCard: { enabled: false },
+      hiddenFields: { enabled: false },
+      variables: [],
+    } as unknown as TSurvey;
+
+    const envelope = expectOk(buildSurveyExportEnvelope(survey, ctx));
+
+    expect(envelope.survey.blocks[0].elements[0].headline).toEqual({
+      "en-US": "English only",
+      "de-DE": "English only",
+    });
+  });
+});

--- a/apps/web/modules/survey/export/build-export-envelope.ts
+++ b/apps/web/modules/survey/export/build-export-envelope.ts
@@ -1,5 +1,10 @@
 import { type Result, err, ok } from "@formbricks/types/error-handlers";
-import type { TSurvey } from "@formbricks/types/surveys/types";
+import type {
+  TSurvey,
+  TSurveyHiddenFields,
+  TSurveyStatus,
+  TSurveyVariables,
+} from "@formbricks/types/surveys/types";
 import type { InvalidParam } from "@/app/api/v3/lib/response";
 import {
   SURVEY_EXPORT_FORMAT,
@@ -9,7 +14,11 @@ import {
 } from "@/app/api/v3/surveys/export/schemas";
 import { getV3SurveyLanguages } from "@/app/api/v3/surveys/language";
 import { prepareV3SurveyCreateInput } from "@/app/api/v3/surveys/prepare";
-import { DEFAULT_V3_SURVEY_LANGUAGE, formatV3ZodInvalidParams } from "@/app/api/v3/surveys/schemas";
+import {
+  DEFAULT_V3_SURVEY_LANGUAGE,
+  type TV3SurveyDistribution,
+  formatV3ZodInvalidParams,
+} from "@/app/api/v3/surveys/schemas";
 import { serializeV3SurveyResource } from "@/app/api/v3/surveys/serializers";
 import { transformQuestionsToBlocks } from "@/app/lib/api/survey-transformation";
 
@@ -20,17 +29,45 @@ export type TSurveyExportContext = {
   exportedAt?: Date;
 };
 
-type TSerializedSurveyResource = ReturnType<typeof serializeV3SurveyResource>;
+/** A translatable field in the file: a public locale-code map (`{ "en-US": "…", "de-DE": "…" }`). */
+export type TSurveyExportI18n = Record<string, string>;
+
+/** Public shapes of the document's parts. Loose on purpose: element and ending fields vary by type. */
+export type TSurveyExportElement = { id: string; type: string; headline?: TSurveyExportI18n } & Record<
+  string,
+  unknown
+>;
+export type TSurveyExportBlock = {
+  id: string;
+  name: string;
+  elements: TSurveyExportElement[];
+  logic?: unknown[];
+  logicFallback?: string;
+} & Record<string, unknown>;
+export type TSurveyExportEnding = { id: string; type: "endScreen" | "redirectToUrl" } & Record<
+  string,
+  unknown
+>;
 
 /**
  * The `survey` member of the envelope as written to the file: the v3 GET resource minus every
  * instance-bound field. Locale maps are public (`{ "en-US": … }`), so the file round-trips through
  * `POST /api/v3/surveys` unchanged apart from `workspaceId`.
  */
-export type TSurveyExportDocument = Omit<
-  TSerializedSurveyResource,
-  "id" | "workspaceId" | "createdAt" | "updatedAt" | "archivedAt" | "targeting" | "languages"
-> & { languages: { code: string; default: boolean; enabled: boolean }[] };
+export type TSurveyExportDocument = {
+  name: string;
+  type: TSurvey["type"];
+  status: TSurveyStatus;
+  metadata: Record<string, unknown>;
+  defaultLanguage: string;
+  languages: { code: string; default: boolean; enabled: boolean }[];
+  welcomeCard: Record<string, unknown>;
+  blocks: TSurveyExportBlock[];
+  endings: TSurveyExportEnding[];
+  hiddenFields: TSurveyHiddenFields;
+  variables: TSurveyVariables;
+  distribution?: TV3SurveyDistribution;
+};
 
 export type TSurveyExportEnvelopeFile = {
   formbricks: TSurveyExportMetadata;
@@ -128,14 +165,16 @@ export function buildSurveyExportEnvelope(
     ...rest
   } = resource;
   // Aliases are a workspace setting, not part of the survey document: the create schema rejects them.
-  const document: TSurveyExportDocument = {
+  // The serializer types translatable values loosely (`TSerializedValue`); the create-side validation
+  // below is what proves the shape, so the cast states the contract rather than inventing one.
+  const document = {
     ...rest,
     languages: languages.map(({ code, default: isDefault, enabled }) => ({
       code,
       default: isDefault,
       enabled,
     })),
-  };
+  } as unknown as TSurveyExportDocument;
 
   const preparation = prepareV3SurveyCreateInput({ workspaceId: survey.workspaceId, ...document });
   if (!preparation.ok) {

--- a/apps/web/modules/survey/export/build-export-envelope.ts
+++ b/apps/web/modules/survey/export/build-export-envelope.ts
@@ -1,0 +1,168 @@
+import { type Result, err, ok } from "@formbricks/types/error-handlers";
+import type { TSurvey } from "@formbricks/types/surveys/types";
+import type { InvalidParam } from "@/app/api/v3/lib/response";
+import {
+  SURVEY_EXPORT_FORMAT,
+  type TSurveyExportActionClassReference,
+  type TSurveyExportMetadata,
+  ZSurveyExportEnvelope,
+} from "@/app/api/v3/surveys/export/schemas";
+import { getV3SurveyLanguages } from "@/app/api/v3/surveys/language";
+import { prepareV3SurveyCreateInput } from "@/app/api/v3/surveys/prepare";
+import { DEFAULT_V3_SURVEY_LANGUAGE, formatV3ZodInvalidParams } from "@/app/api/v3/surveys/schemas";
+import { serializeV3SurveyResource } from "@/app/api/v3/surveys/serializers";
+import { transformQuestionsToBlocks } from "@/app/lib/api/survey-transformation";
+
+export type TSurveyExportContext = {
+  appVersion: string;
+  publicUrl: string;
+  /** Injectable for deterministic tests; defaults to now. */
+  exportedAt?: Date;
+};
+
+type TSerializedSurveyResource = ReturnType<typeof serializeV3SurveyResource>;
+
+/**
+ * The `survey` member of the envelope as written to the file: the v3 GET resource minus every
+ * instance-bound field. Locale maps are public (`{ "en-US": … }`), so the file round-trips through
+ * `POST /api/v3/surveys` unchanged apart from `workspaceId`.
+ */
+export type TSurveyExportDocument = Omit<
+  TSerializedSurveyResource,
+  "id" | "workspaceId" | "createdAt" | "updatedAt" | "archivedAt" | "targeting" | "languages"
+> & { languages: { code: string; default: boolean; enabled: boolean }[] };
+
+export type TSurveyExportEnvelopeFile = {
+  formbricks: TSurveyExportMetadata;
+  survey: TSurveyExportDocument;
+  references: { actionClasses: TSurveyExportActionClassReference[] };
+};
+
+/**
+ * Legacy question-based surveys are converted to blocks first — the v3 document has no `questions`.
+ * Returns the survey untouched when it already carries blocks.
+ */
+function withBlocks(survey: TSurvey): TSurvey {
+  if (Array.isArray(survey.questions) && survey.questions.length > 0 && survey.blocks.length === 0) {
+    return {
+      ...survey,
+      blocks: transformQuestionsToBlocks(survey.questions, survey.endings),
+      questions: [],
+    };
+  }
+
+  return survey;
+}
+
+function countElements(survey: TSurvey): number {
+  return survey.blocks.reduce((count, block) => count + block.elements.length, 0);
+}
+
+/**
+ * Action-class definitions the document's triggers point at, reduced to the six portable fields and
+ * de-duplicated by id. Link surveys have no triggers, so this is empty for them.
+ */
+function collectActionClassReferences(survey: TSurvey): TSurveyExportActionClassReference[] {
+  const seen = new Set<string>();
+  const references: TSurveyExportActionClassReference[] = [];
+
+  for (const trigger of survey.triggers ?? []) {
+    const actionClass = trigger.actionClass;
+    if (seen.has(actionClass.id)) {
+      continue;
+    }
+    seen.add(actionClass.id);
+    references.push({
+      id: actionClass.id,
+      name: actionClass.name,
+      key: actionClass.key,
+      type: actionClass.type,
+      noCodeConfig: actionClass.noCodeConfig,
+      description: actionClass.description,
+    });
+  }
+
+  return references;
+}
+
+/**
+ * Build the portable export envelope for a stored survey.
+ *
+ * The document is the `GET /api/v3/surveys/{id}` resource with the instance-bound fields removed
+ * (`id`, `workspaceId`, timestamps, `archivedAt`) and `targeting` dropped — segments are out of v1;
+ * triggers and languages travel. The serializer is asked for every configured language explicitly so
+ * a translation that is missing on a draft is filled from the default language instead of making the
+ * survey unexportable; the editor allows saving incomplete translations, the v3 create route does not.
+ *
+ * Before the envelope is returned it is run through the exact create-side validation
+ * (`prepareV3SurveyCreateInput`: strict schema, reference and recall checks, declared locales, media).
+ * A survey that would not re-import must not export silently (edge case #21).
+ */
+export function buildSurveyExportEnvelope(
+  survey: TSurvey,
+  ctx: TSurveyExportContext
+): Result<TSurveyExportEnvelopeFile, InvalidParam[]> {
+  const blockSurvey = withBlocks(survey);
+
+  if (countElements(blockSurvey) === 0) {
+    return err([
+      {
+        name: "survey.blocks",
+        reason: "Empty surveys cannot be exported. Add at least one question first.",
+      },
+    ]);
+  }
+
+  const languageCodes = getV3SurveyLanguages(blockSurvey, DEFAULT_V3_SURVEY_LANGUAGE).map(
+    (language) => language.code
+  );
+  const resource = serializeV3SurveyResource(blockSurvey, { lang: languageCodes });
+  const {
+    id: _id,
+    workspaceId: _workspaceId,
+    createdAt: _createdAt,
+    updatedAt: _updatedAt,
+    archivedAt: _archivedAt,
+    targeting: _targeting,
+    languages,
+    ...rest
+  } = resource;
+  // Aliases are a workspace setting, not part of the survey document: the create schema rejects them.
+  const document: TSurveyExportDocument = {
+    ...rest,
+    languages: languages.map(({ code, default: isDefault, enabled }) => ({
+      code,
+      default: isDefault,
+      enabled,
+    })),
+  };
+
+  const preparation = prepareV3SurveyCreateInput({ workspaceId: survey.workspaceId, ...document });
+  if (!preparation.ok) {
+    return err(preparation.validation.invalidParams);
+  }
+
+  const envelope: TSurveyExportEnvelopeFile = {
+    formbricks: {
+      exportFormat: SURVEY_EXPORT_FORMAT,
+      exportedAt: (ctx.exportedAt ?? new Date()).toISOString(),
+      appVersion: ctx.appVersion,
+      source: {
+        url: ctx.publicUrl,
+        workspaceId: survey.workspaceId,
+        surveyId: survey.id,
+      },
+    },
+    survey: document,
+    references: {
+      actionClasses: collectActionClassReferences(blockSurvey),
+    },
+  };
+
+  const parsed = ZSurveyExportEnvelope.safeParse(envelope);
+  if (!parsed.success) {
+    return err(formatV3ZodInvalidParams(parsed.error, "survey"));
+  }
+
+  return ok(envelope);
+}

--- a/apps/web/modules/survey/export/download.ts
+++ b/apps/web/modules/survey/export/download.ts
@@ -1,0 +1,29 @@
+import type { TSurveyExportEnvelopeFile } from "@/modules/survey/export/build-export-envelope";
+import { getSurveyExportFileName } from "@/modules/survey/export/file-name";
+import { exportSurvey } from "@/modules/survey/list/lib/v3-surveys-client";
+
+/**
+ * Fetch the export envelope for a survey and hand it to the browser as a `.formbricks.json` download.
+ * Throws the `V3ApiError` the client raises so the caller can show the API's message.
+ */
+export async function downloadSurveyExport(survey: { id: string; name: string }): Promise<void> {
+  const envelope = await exportSurvey(survey.id);
+  saveSurveyExportFile(envelope, getSurveyExportFileName(survey));
+}
+
+export function saveSurveyExportFile(envelope: TSurveyExportEnvelopeFile, fileName: string): void {
+  const blob = new Blob([`${JSON.stringify(envelope, null, 2)}\n`], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = fileName;
+    anchor.rel = "noopener";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/apps/web/modules/survey/export/file-name.test.ts
+++ b/apps/web/modules/survey/export/file-name.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { getSurveyExportFileName, toSurveyExportBaseName } from "./file-name";
+
+describe("toSurveyExportBaseName", () => {
+  test.each([
+    ["Product Feedback", "product-feedback"],
+    ["  NPS   Q3 / 2026  ", "nps-q3-2026"],
+    ["Café résumé — naïve", "cafe-resume-naive"],
+    ["../../etc/passwd", "etc-passwd"],
+    ['He said "hi" <script>', "he-said-hi-script"],
+    ["Umfrage: Zufriedenheit & Loyalität", "umfrage-zufriedenheit-loyalitat"],
+  ])("kebab-cases %j to %j", (input, expected) => {
+    expect(toSurveyExportBaseName(input)).toBe(expected);
+  });
+
+  test("falls back to 'survey' when nothing safe remains", () => {
+    expect(toSurveyExportBaseName("")).toBe("survey");
+    expect(toSurveyExportBaseName("   ")).toBe("survey");
+    expect(toSurveyExportBaseName("顧客満足度調査")).toBe("survey");
+    expect(toSurveyExportBaseName("🚀🚀🚀")).toBe("survey");
+  });
+
+  test("caps very long names without a trailing hyphen", () => {
+    const base = toSurveyExportBaseName(`${"word ".repeat(40)}end`);
+
+    expect(base.length).toBeLessThanOrEqual(80);
+    expect(base.endsWith("-")).toBe(false);
+  });
+});
+
+describe("getSurveyExportFileName", () => {
+  test("appends the .formbricks.json suffix", () => {
+    expect(getSurveyExportFileName({ name: "Product Feedback" })).toBe("product-feedback.formbricks.json");
+    expect(getSurveyExportFileName({ name: "" })).toBe("survey.formbricks.json");
+  });
+});

--- a/apps/web/modules/survey/export/file-name.ts
+++ b/apps/web/modules/survey/export/file-name.ts
@@ -1,0 +1,25 @@
+export const SURVEY_EXPORT_FILE_SUFFIX = ".formbricks.json";
+const FALLBACK_BASE_NAME = "survey";
+const MAX_BASE_NAME_LENGTH = 80;
+
+/**
+ * Kebab-case a survey name into a safe file base name: ASCII letters and digits only, hyphens between
+ * words, diacritics folded (`Café` → `cafe`), everything else (slashes, quotes, emoji, CJK) dropped.
+ * An empty result falls back to `survey`.
+ */
+export function toSurveyExportBaseName(name: string): string {
+  const folded = name
+    .normalize("NFKD")
+    .replaceAll(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "")
+    .slice(0, MAX_BASE_NAME_LENGTH)
+    .replaceAll(/-+$/g, "");
+
+  return folded.length > 0 ? folded : FALLBACK_BASE_NAME;
+}
+
+export function getSurveyExportFileName(survey: { name: string }): string {
+  return `${toSurveyExportBaseName(survey.name)}${SURVEY_EXPORT_FILE_SUFFIX}`;
+}

--- a/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
+++ b/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
@@ -7,6 +7,7 @@ import {
   ArchiveRestoreIcon,
   ArrowRightLeftIcon,
   CopyIcon,
+  DownloadIcon,
   EyeIcon,
   LinkIcon,
   MoreVertical,
@@ -25,6 +26,7 @@ import { cn } from "@/lib/cn";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { getV3ApiErrorMessage } from "@/modules/api/lib/v3-client";
 import { EditPublicSurveyAlertDialog } from "@/modules/survey/components/edit-public-survey-alert-dialog";
+import { downloadSurveyExport } from "@/modules/survey/export/download";
 import { copySurveyLink } from "@/modules/survey/lib/client-utils";
 import { copySurveyToOtherWorkspaceAction } from "@/modules/survey/list/actions";
 import { CopySurveyModal } from "@/modules/survey/list/components/copy-survey-modal";
@@ -182,6 +184,17 @@ export const SurveyDropDownMenu = ({
     }
   };
 
+  const handleExportSurvey = async () => {
+    setIsDropDownOpen(false);
+    const toastId = toast.loading(t("workspace.surveys.exporting_survey"));
+    try {
+      await downloadSurveyExport(survey);
+      toast.success(t("workspace.surveys.export_success"), { id: toastId });
+    } catch (error) {
+      toast.error(getV3ApiErrorMessage(error, t("workspace.surveys.export_error")), { id: toastId });
+    }
+  };
+
   const handleEditforActiveSurvey = (e: React.MouseEvent) => {
     e.preventDefault();
     setIsDropDownOpen(false);
@@ -327,6 +340,17 @@ export const SurveyDropDownMenu = ({
                 }}>
                 <ArrowRightLeftIcon className="size-4" />
                 {t("workspace.surveys.copy_to")}
+              </DropdownMenuItem>
+            )}
+            {!isArchived && (
+              <DropdownMenuItem
+                data-testid="export-survey"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  void handleExportSurvey();
+                }}>
+                <DownloadIcon className="size-4" />
+                {t("workspace.surveys.export_as_json")}
               </DropdownMenuItem>
             )}
             {canPreviewOrCopyLink && (

--- a/apps/web/modules/survey/list/lib/v3-surveys-client.ts
+++ b/apps/web/modules/survey/list/lib/v3-surveys-client.ts
@@ -2,6 +2,7 @@ import type { TSurveyStatus } from "@formbricks/types/surveys/types";
 import type { TV3SurveyGenerateBody } from "@/app/api/v3/surveys/generate/schemas";
 import type { TV3CreateSurveyBody, TV3SurveyValidationRequestBody } from "@/app/api/v3/surveys/schemas";
 import { parseV3ApiError } from "@/modules/api/lib/v3-client";
+import type { TSurveyExportEnvelopeFile } from "@/modules/survey/export/build-export-envelope";
 import { normalizeSurveyFilters } from "@/modules/survey/list/lib/utils";
 import { TSurveyListItem, TSurveyOverviewFilters } from "@/modules/survey/list/types/survey-overview";
 
@@ -311,5 +312,19 @@ export async function createV3Survey(
   }
 
   const responseBody = (await response.json()) as TV3CreateSurveyResponse;
+  return responseBody.data;
+}
+
+export async function exportSurvey(surveyId: string): Promise<TSurveyExportEnvelopeFile> {
+  const response = await fetch(`/api/v3/surveys/${encodeURIComponent(surveyId)}/export`, {
+    method: "GET",
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw await parseV3ApiError(response);
+  }
+
+  const responseBody = (await response.json()) as { data: TSurveyExportEnvelopeFile };
   return responseBody.data;
 }

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -5,7 +5,7 @@ openapi: 3.1.1
 info:
   title: Formbricks API v3
   description: |
-    **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, and **DELETE /api/v3/surveys/{surveyId}**.
+    **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, **DELETE /api/v3/surveys/{surveyId}**, and **GET /api/v3/surveys/{surveyId}/export**, which returns a portable `.formbricks.json` envelope that re-imports into any workspace or instance.
 
     **Workflows extension**: **GET /api/v3/workflows**, **POST /api/v3/workflows**, **GET /api/v3/workflows/{workflowId}**, **PATCH /api/v3/workflows/{workflowId}**, **DELETE /api/v3/workflows/{workflowId}**, **POST /api/v3/workflows/{workflowId}/duplicate**, **POST /api/v3/workflows/{workflowId}/enable**, **POST /api/v3/workflows/{workflowId}/disable**, **POST /api/v3/workflows/{workflowId}/archive**, **POST /api/v3/workflows/{workflowId}/unarchive**, **POST /api/v3/workflows/{workflowId}/test**, **GET /api/v3/workflows/runs**, and **GET /api/v3/workflows/runs/{runId}**.
 
@@ -1289,6 +1289,118 @@ paths:
           $ref: '#/components/responses/V3Unauthorized'
         '403':
           $ref: '#/components/responses/V3Forbidden'
+        '429':
+          $ref: '#/components/responses/V3TooManyRequests'
+        '500':
+          $ref: '#/components/responses/V3InternalServerError'
+      security:
+        - sessionAuth: []
+        - apiKeyAuth: []
+  /api/v3/surveys/{surveyId}/export:
+    get:
+      operationId: exportSurveyV3
+      summary: Export a survey
+      description: |
+        Returns the portable export envelope for one survey: export metadata, the v3 survey document and the action-class definitions its triggers reference. Save the `data` member as a `.formbricks.json` file; it imports into any workspace, organization or instance through `POST /api/v3/surveys/import`.
+
+        The document is the `GET /api/v3/surveys/{surveyId}` resource without the instance-bound fields. Styling, follow-ups, quotas, survey settings (single-use, PIN, reCAPTCHA, closed message, language switch), slug, custom scripts, the publish schedule, targeting and responses are not exported. Legacy question-based surveys are converted to blocks. A translation missing on a draft is filled from the default language so the file stays importable.
+
+        Read access is sufficient. Every export is written to the organization audit log as `exported`.
+      tags:
+        - V3 Surveys
+      parameters:
+        - in: path
+          name: surveyId
+          required: true
+          schema:
+            type: string
+            format: cuid2
+          description: Survey identifier.
+      responses:
+        '200':
+          description: Export envelope built successfully
+          headers:
+            X-Request-Id:
+              schema:
+                type: string
+              description: Request correlation ID
+            Cache-Control:
+              schema:
+                type: string
+              example: private, no-store
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SurveyExportEnvelope'
+              examples:
+                linkSurvey:
+                  summary: Exported link survey
+                  value:
+                    data:
+                      formbricks:
+                        exportFormat: 1
+                        exportedAt: '2026-09-08T12:00:00.000Z'
+                        appVersion: 6.2.0
+                        source:
+                          url: https://app.formbricks.com
+                          workspaceId: clxx1234567890123456789012
+                          surveyId: clsv1234567890123456789012
+                      survey:
+                        name: Product Feedback
+                        type: link
+                        status: inProgress
+                        metadata: {}
+                        defaultLanguage: en-US
+                        languages:
+                          - code: en-US
+                            default: true
+                            enabled: true
+                        welcomeCard:
+                          enabled: false
+                        blocks:
+                          - id: clbk1234567890123456789012
+                            name: Main Block
+                            elements:
+                              - id: satisfaction
+                                type: openText
+                                headline:
+                                  en-US: What should we improve?
+                                required: true
+                        endings: []
+                        hiddenFields:
+                          enabled: false
+                        variables: []
+                      references:
+                        actionClasses: []
+        '400':
+          $ref: '#/components/responses/V3BadRequest'
+        '401':
+          $ref: '#/components/responses/V3Unauthorized'
+        '403':
+          $ref: '#/components/responses/V3Forbidden'
+        '422':
+          description: 'Unprocessable Content — the survey cannot be exported in its current state: it has no questions, or its document would not re-import (a dangling logic target, an invalid media URL). `invalid_params` itemizes each issue with the v3 path format.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+              examples:
+                empty:
+                  summary: Empty survey
+                  value:
+                    title: Unprocessable Content
+                    status: 422
+                    detail: Survey cannot be exported in its current state
+                    code: unprocessable_content
+                    requestId: req_clsv1234567890123456789012
+                    invalid_params:
+                      - name: survey.blocks
+                        reason: Empty surveys cannot be exported. Add at least one question first.
         '429':
           $ref: '#/components/responses/V3TooManyRequests'
         '500':
@@ -4686,6 +4798,174 @@ components:
           description: Languages that a successful write would connect or create. Present only when `valid=true`.
           items:
             $ref: '#/components/schemas/SurveyValidationLanguage'
+      additionalProperties: false
+    SurveyExportMetadata:
+      type: object
+      description: Export metadata. `exportFormat` is bumped only for incompatible changes; an instance refuses files newer than it understands.
+      required:
+        - exportFormat
+        - exportedAt
+        - appVersion
+        - source
+      properties:
+        exportFormat:
+          type: integer
+          enum:
+            - 1
+          description: Envelope format version. Currently always `1`.
+        exportedAt:
+          type: string
+          format: date-time
+        appVersion:
+          type: string
+          description: Formbricks version that produced the file (`0.0.0` on development builds).
+        source:
+          type: object
+          required:
+            - url
+            - workspaceId
+            - surveyId
+          properties:
+            url:
+              type: string
+              format: uri
+              description: Public URL of the exporting instance.
+            workspaceId:
+              type: string
+              format: cuid2
+            surveyId:
+              type: string
+              format: cuid2
+          additionalProperties: false
+      additionalProperties: false
+    SurveyExportDocument:
+      type: object
+      description: |
+        The exported v3 survey document: the `GET /api/v3/surveys/{surveyId}` resource without the instance-bound fields (`id`, `workspaceId`, `createdAt`, `updatedAt`, `archivedAt`) and without `targeting`. Translatable fields are locale-code maps, so `{ workspaceId, ...survey }` is a valid `POST /api/v3/surveys` body. Styling, follow-ups, quotas, survey settings, slug, custom scripts and the publish schedule are not part of the document and do not travel.
+      required:
+        - name
+        - type
+        - status
+        - metadata
+        - defaultLanguage
+        - languages
+        - welcomeCard
+        - blocks
+        - endings
+        - hiddenFields
+        - variables
+      properties:
+        name:
+          type: string
+          minLength: 1
+        type:
+          type: string
+          enum:
+            - link
+            - app
+        status:
+          type: string
+          enum:
+            - draft
+            - inProgress
+            - paused
+            - completed
+          description: Status at export time. Import always creates a draft.
+        metadata:
+          $ref: '#/components/schemas/SurveyMetadata'
+        defaultLanguage:
+          $ref: '#/components/schemas/LocaleCode'
+        languages:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateSurveyLanguage'
+        welcomeCard:
+          $ref: '#/components/schemas/SurveyWelcomeCard'
+        blocks:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/SurveyBlock'
+        endings:
+          type: array
+          items:
+            $ref: '#/components/schemas/SurveyEnding'
+        hiddenFields:
+          $ref: '#/components/schemas/SurveyHiddenFields'
+        variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/SurveyVariable'
+        distribution:
+          allOf:
+            - $ref: '#/components/schemas/SurveyDistribution'
+          description: App-survey runtime settings and triggers. Present only for app surveys.
+      additionalProperties: false
+    SurveyExportActionClass:
+      type: object
+      description: |
+        Definition of an action class an exported app survey's trigger points at. On import the target workspace matches it by `key` (code actions), by `noCodeConfig` (no-code actions) or by `name`, and creates it when nothing matches.
+      required:
+        - id
+        - name
+        - key
+        - type
+        - noCodeConfig
+        - description
+      properties:
+        id:
+          type: string
+          format: cuid2
+          description: Id in the source workspace, referenced by `survey.distribution.triggers[].actionClassId`.
+        name:
+          type: string
+        key:
+          type:
+            - string
+            - 'null'
+          description: Code-action key; `null` for no-code actions.
+        type:
+          type: string
+          enum:
+            - code
+            - noCode
+        noCodeConfig:
+          type:
+            - object
+            - 'null'
+          description: No-code trigger configuration (click, pageView, exitIntent, fiftyPercentScroll, pageDwell); `null` for code actions.
+          additionalProperties: true
+        description:
+          type:
+            - string
+            - 'null'
+      additionalProperties: false
+    SurveyExportReferences:
+      type: object
+      description: Workspace-scoped definitions the document refers to by id. Empty for link surveys.
+      required:
+        - actionClasses
+      properties:
+        actionClasses:
+          type: array
+          items:
+            $ref: '#/components/schemas/SurveyExportActionClass'
+      additionalProperties: false
+    SurveyExportEnvelope:
+      type: object
+      description: |
+        Portable survey export (`.formbricks.json`). Three top-level keys, nothing else: import rejects unknown keys with their path. The same file imports into any workspace, organization or instance through `POST /api/v3/surveys/import`.
+      required:
+        - formbricks
+        - survey
+        - references
+      properties:
+        formbricks:
+          $ref: '#/components/schemas/SurveyExportMetadata'
+        survey:
+          $ref: '#/components/schemas/SurveyExportDocument'
+        references:
+          $ref: '#/components/schemas/SurveyExportReferences'
       additionalProperties: false
     WorkflowStatus:
       type: string

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportActionClass.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportActionClass.yml
@@ -1,0 +1,40 @@
+type: object
+description: >
+  Definition of an action class an exported app survey's trigger points at. On import the target
+  workspace matches it by `key` (code actions), by `noCodeConfig` (no-code actions) or by `name`, and
+  creates it when nothing matches.
+required:
+  - id
+  - name
+  - key
+  - type
+  - noCodeConfig
+  - description
+properties:
+  id:
+    type: string
+    format: cuid2
+    description: Id in the source workspace, referenced by `survey.distribution.triggers[].actionClassId`.
+  name:
+    type: string
+  key:
+    type:
+      - string
+      - "null"
+    description: Code-action key; `null` for no-code actions.
+  type:
+    type: string
+    enum:
+      - code
+      - noCode
+  noCodeConfig:
+    type:
+      - object
+      - "null"
+    description: No-code trigger configuration (click, pageView, exitIntent, fiftyPercentScroll, pageDwell); `null` for code actions.
+    additionalProperties: true
+  description:
+    type:
+      - string
+      - "null"
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportDocument.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportDocument.yml
@@ -1,0 +1,66 @@
+type: object
+description: >
+  The exported v3 survey document: the `GET /api/v3/surveys/{surveyId}` resource without the
+  instance-bound fields (`id`, `workspaceId`, `createdAt`, `updatedAt`, `archivedAt`) and without
+  `targeting`. Translatable fields are locale-code maps, so `{ workspaceId, ...survey }` is a valid
+  `POST /api/v3/surveys` body. Styling, follow-ups, quotas, survey settings, slug, custom scripts and
+  the publish schedule are not part of the document and do not travel.
+required:
+  - name
+  - type
+  - status
+  - metadata
+  - defaultLanguage
+  - languages
+  - welcomeCard
+  - blocks
+  - endings
+  - hiddenFields
+  - variables
+properties:
+  name:
+    type: string
+    minLength: 1
+  type:
+    type: string
+    enum:
+      - link
+      - app
+  status:
+    type: string
+    enum:
+      - draft
+      - inProgress
+      - paused
+      - completed
+    description: Status at export time. Import always creates a draft.
+  metadata:
+    $ref: ./SurveyMetadata.yml
+  defaultLanguage:
+    $ref: ./LocaleCode.yml
+  languages:
+    type: array
+    items:
+      $ref: ./CreateSurveyLanguage.yml
+  welcomeCard:
+    $ref: ./SurveyWelcomeCard.yml
+  blocks:
+    type: array
+    minItems: 1
+    items:
+      $ref: ./SurveyBlock.yml
+  endings:
+    type: array
+    items:
+      $ref: ./SurveyEnding.yml
+  hiddenFields:
+    $ref: ./SurveyHiddenFields.yml
+  variables:
+    type: array
+    items:
+      $ref: ./SurveyVariable.yml
+  distribution:
+    allOf:
+      - $ref: ./SurveyDistribution.yml
+    description: App-survey runtime settings and triggers. Present only for app surveys.
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportEnvelope.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportEnvelope.yml
@@ -1,0 +1,17 @@
+type: object
+description: >
+  Portable survey export (`.formbricks.json`). Three top-level keys, nothing else: import rejects
+  unknown keys with their path. The same file imports into any workspace, organization or instance
+  through `POST /api/v3/surveys/import`.
+required:
+  - formbricks
+  - survey
+  - references
+properties:
+  formbricks:
+    $ref: ./SurveyExportMetadata.yml
+  survey:
+    $ref: ./SurveyExportDocument.yml
+  references:
+    $ref: ./SurveyExportReferences.yml
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportMetadata.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportMetadata.yml
@@ -1,0 +1,38 @@
+type: object
+description: Export metadata. `exportFormat` is bumped only for incompatible changes; an instance refuses files newer than it understands.
+required:
+  - exportFormat
+  - exportedAt
+  - appVersion
+  - source
+properties:
+  exportFormat:
+    type: integer
+    enum:
+      - 1
+    description: Envelope format version. Currently always `1`.
+  exportedAt:
+    type: string
+    format: date-time
+  appVersion:
+    type: string
+    description: Formbricks version that produced the file (`0.0.0` on development builds).
+  source:
+    type: object
+    required:
+      - url
+      - workspaceId
+      - surveyId
+    properties:
+      url:
+        type: string
+        format: uri
+        description: Public URL of the exporting instance.
+      workspaceId:
+        type: string
+        format: cuid2
+      surveyId:
+        type: string
+        format: cuid2
+    additionalProperties: false
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyExportReferences.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyExportReferences.yml
@@ -1,0 +1,10 @@
+type: object
+description: Workspace-scoped definitions the document refers to by id. Empty for link surveys.
+required:
+  - actionClasses
+properties:
+  actionClasses:
+    type: array
+    items:
+      $ref: ./SurveyExportActionClass.yml
+additionalProperties: false

--- a/docs/api-v3-reference/src/openapi.yml
+++ b/docs/api-v3-reference/src/openapi.yml
@@ -8,8 +8,10 @@ info:
   description: >
     **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST
     /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET
-    /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, and
-    **DELETE /api/v3/surveys/{surveyId}**.
+    /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**,
+    **DELETE /api/v3/surveys/{surveyId}**, and **GET
+    /api/v3/surveys/{surveyId}/export**, which returns a portable
+    `.formbricks.json` envelope that re-imports into any workspace or instance.
 
 
     **Workflows extension**: **GET /api/v3/workflows**, **POST
@@ -179,6 +181,8 @@ paths:
     $ref: paths/api_v3_surveys_{surveyId}_archive.yml
   /api/v3/surveys/{surveyId}/restore:
     $ref: paths/api_v3_surveys_{surveyId}_restore.yml
+  /api/v3/surveys/{surveyId}/export:
+    $ref: paths/api_v3_surveys_{surveyId}_export.yml
   /api/v3/workflows:
     $ref: paths/api_v3_workflows.yml
   /api/v3/workflows/runs:

--- a/docs/api-v3-reference/src/paths/api_v3_surveys_{surveyId}_export.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_surveys_{surveyId}_export.yml
@@ -1,0 +1,123 @@
+get:
+  operationId: exportSurveyV3
+  summary: Export a survey
+  description: >
+    Returns the portable export envelope for one survey: export metadata, the v3 survey document and
+    the action-class definitions its triggers reference. Save the `data` member as a
+    `.formbricks.json` file; it imports into any workspace, organization or instance through
+    `POST /api/v3/surveys/import`.
+
+
+    The document is the `GET /api/v3/surveys/{surveyId}` resource without the instance-bound fields.
+    Styling, follow-ups, quotas, survey settings (single-use, PIN, reCAPTCHA, closed message, language
+    switch), slug, custom scripts, the publish schedule, targeting and responses are not exported.
+    Legacy question-based surveys are converted to blocks. A translation missing on a draft is filled
+    from the default language so the file stays importable.
+
+
+    Read access is sufficient. Every export is written to the organization audit log as `exported`.
+  tags:
+    - V3 Surveys
+  parameters:
+    - in: path
+      name: surveyId
+      required: true
+      schema:
+        type: string
+        format: cuid2
+      description: Survey identifier.
+  responses:
+    "200":
+      description: Export envelope built successfully
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
+          description: Request correlation ID
+        Cache-Control:
+          schema:
+            type: string
+          example: private, no-store
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../components/schemas/SurveyExportEnvelope.yml
+          examples:
+            linkSurvey:
+              summary: Exported link survey
+              value:
+                data:
+                  formbricks:
+                    exportFormat: 1
+                    exportedAt: "2026-09-08T12:00:00.000Z"
+                    appVersion: 6.2.0
+                    source:
+                      url: https://app.formbricks.com
+                      workspaceId: clxx1234567890123456789012
+                      surveyId: clsv1234567890123456789012
+                  survey:
+                    name: Product Feedback
+                    type: link
+                    status: inProgress
+                    metadata: {}
+                    defaultLanguage: en-US
+                    languages:
+                      - code: en-US
+                        default: true
+                        enabled: true
+                    welcomeCard:
+                      enabled: false
+                    blocks:
+                      - id: clbk1234567890123456789012
+                        name: Main Block
+                        elements:
+                          - id: satisfaction
+                            type: openText
+                            headline:
+                              en-US: What should we improve?
+                            required: true
+                    endings: []
+                    hiddenFields:
+                      enabled: false
+                    variables: []
+                  references:
+                    actionClasses: []
+    "400":
+      $ref: ../components/responses/V3BadRequest.yml
+    "401":
+      $ref: ../components/responses/V3Unauthorized.yml
+    "403":
+      $ref: ../components/responses/V3Forbidden.yml
+    "422":
+      description: >-
+        Unprocessable Content — the survey cannot be exported in its current state: it has no
+        questions, or its document would not re-import (a dangling logic target, an invalid media
+        URL). `invalid_params` itemizes each issue with the v3 path format.
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+          examples:
+            empty:
+              summary: Empty survey
+              value:
+                title: Unprocessable Content
+                status: 422
+                detail: Survey cannot be exported in its current state
+                code: unprocessable_content
+                requestId: req_clsv1234567890123456789012
+                invalid_params:
+                  - name: survey.blocks
+                    reason: Empty surveys cannot be exported. Add at least one question first.
+    "429":
+      $ref: ../components/responses/V3TooManyRequests.yml
+    "500":
+      $ref: ../components/responses/V3InternalServerError.yml
+  security:
+    - sessionAuth: []
+    - apiKeyAuth: []


### PR DESCRIPTION
Fixes ENG-2972
Fixes ENG-2973
Fixes ENG-2974

Milestone 1 of 5 of Survey Import & Export; per-ticket descriptions are in the fold at the bottom.

## What & why

**Was:** A survey had no portable form. "Copy to" works inside one organization only, and nothing could turn a stored survey into a file another instance can read.

**Now:** Every survey card menu has *Export as JSON*. It downloads `<survey-name>.formbricks.json` from `GET /api/v3/surveys/{surveyId}/export`: a versioned envelope with the v3 survey document and the action classes its triggers reference.

- Styling, follow-ups, survey settings, quotas, slug and schedule stay out of the file on purpose (decision D1); the importer refuses envelopes that carry them.
- The route is documented in OpenAPI, audit-logged as `exported` and tracked as `survey_exported` for session users; read access is enough.
- Archived surveys hide the menu item.

## Where to look

- [build-export-envelope.ts](apps/web/modules/survey/export/build-export-envelope.ts) — which fields leave the document and why
- [export-survey.ts](apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts) — authorization, audit, analytics
- [survey-card menu](apps/web/modules/survey/list/components/survey-dropdown-menu.tsx) — the download flow and toasts

## Breaking changes

- [ ] This PR contains breaking changes

None — one new endpoint and one new menu item; nothing existing changes shape.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/export app/api/v3/surveys/export 'app/api/v3/surveys/[surveyId]/export' && pnpm api:v3:check`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Full link survey (17 element types, 2 languages, logic, recall) exports and round-trips through `ZV3CreateSurveyBody` | unit (mutation) | `build-export-envelope.test.ts` |
| Styling, follow-ups, settings, slug, scripts and schedule never appear in the file; envelope rejects `extensions` and a newer `exportFormat` | unit (mutation) | `build-export-envelope.test.ts`, `export/schemas.test.ts` |
| Route: 200 envelope with `Cache-Control: private, no-store`; 403 passthrough; 422 for an empty survey; audit and `survey_exported` for session users only | unit (mutation) | `export-survey.test.ts` |
| OpenAPI source lints and the bundle is in sync; contract test hits the seeded survey | unit (guard) + e2e | `pnpm api:v3:check`; Schemathesis job on this PR |
| File name: kebab-case, diacritics folded, unicode-only names → `survey`, `.formbricks.json` suffix | unit (mutation) | `file-name.test.ts` |
| Export used from the product: the round-trip E2E in milestone 2 exports through this route with the page's session | e2e | `survey-import-export.spec.ts`, passes locally on the full stack (8 s) |

**Open gaps**

- No screenshot of the menu item and toasts yet; the download was exercised through the API, not by clicking, in the live runs.
- Schemathesis on this PR is the first contract-test drive of the route.

**Risks**

- The envelope is a public file format from now on: a change to the `GET /api/v3/surveys/{id}` shape changes every export. `exportFormat` exists for that.

<details>
<summary>Per-ticket notes (ENG-2972, ENG-2973, ENG-2974) — the original per-ticket PR descriptions, kept for the evidence</summary>


### ENG-2972 — feat(surveys): export envelope builder and schema

#### What & why

**Was:** A survey had no portable representation. "Copy to" only works inside one organization, and nothing could turn a stored survey into a file another instance can read.

**Now:** `buildSurveyExportEnvelope` turns a stored survey into a `.formbricks.json` envelope: export metadata, the v3 survey document (the `GET /api/v3/surveys/{id}` shape minus instance-bound fields), and the action-class definitions its triggers point at. `ZSurveyExportEnvelope` is the strict schema the export route and the importer validate against.

- Styling, follow-ups, quotas, survey settings, slug, scripts, schedule and targeting are never read (D1).
- Legacy question surveys are converted to blocks; empty surveys and surveys that would not re-import are refused with v3 `invalid_params`.
- A translation missing on a draft is filled from the default language so the file stays importable.

Stack: first PR of the Survey Import & Export project, based on `main`. Pure library code, no route or UI yet.

#### Where to look

- [build-export-envelope.ts](apps/web/modules/survey/export/build-export-envelope.ts) — serializer → strip → create-side validation
- [schemas.ts (typed document)](apps/web/app/api/v3/surveys/schemas.ts) — new `createZV3TypedSurveyDocumentSchema`, shares the create normalizer
- [export/schemas.ts](apps/web/app/api/v3/surveys/export/schemas.ts) — the envelope, `.strict()` at every level

#### Breaking changes

- [ ] This PR contains breaking changes

None — additive library code, no public surface yet.

#### Migrations & env

- none

#### How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/export app/api/v3/surveys/export app/api/v3/surveys/schemas.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Full link survey (17 element types, 2 languages, logic, recall) exports and round-trips through `ZV3CreateSurveyBody` | unit (mutation) | `build-export-envelope.test.ts`; passes |
| Styling/follow-ups/settings/slug/scripts/schedule never appear in the file | unit (mutation) | asserted on the serialized envelope |
| App survey carries triggers + de-duplicated action-class references, no targeting | unit (mutation) | passes |
| Legacy questions → blocks; empty survey refused; dangling `jumpToBlock` refused with v3 path | unit (mutation) | passes |
| Envelope rejects `extensions`, nested `slug`/`workspaceId`, newer `exportFormat` | unit (mutation) | `export/schemas.test.ts`; passes |

**Open gaps**

- Not run against a live instance yet; the route PR (ENG-2973) exercises it end to end.

**Risks**

- `schemas.ts` gained an exported helper and a new schema; existing create/patch schemas are untouched (their tests pass unchanged).

---


### ENG-2973 — feat(surveys): GET /api/v3/surveys/{surveyId}/export route + OpenAPI

#### What & why

**Was:** The export envelope existed only as a library function; nothing served it.

**Now:** `GET /api/v3/surveys/{surveyId}/export` returns the envelope under `data` for session and API-key callers with read access, documented in OpenAPI, audit-logged as `exported`, and tracked as `survey_exported` for session users.

- 422 with v3 `invalid_params` when the survey cannot be exported (empty, or would not re-import); 403 from the shared authorizer; never 5xx on caller input.
- New audit action `exported` on the survey target.


#### Where to look

- [export-survey.ts](apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts) — authorize read → build → 200/422, audit + PostHog
- [api_v3_surveys_{surveyId}_export.yml](docs/api-v3-reference/src/paths/api_v3_surveys_{surveyId}_export.yml) — the contract Schemathesis drives
- [SurveyExportDocument.yml](docs/api-v3-reference/src/components/schemas/SurveyExportDocument.yml) — must stay in step with the create request schema

#### Breaking changes

- [ ] This PR contains breaking changes

None — a new endpoint and a new audit action value; nothing existing changes shape.

#### Migrations & env

- none

#### How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run 'app/api/v3/surveys/[surveyId]/export' && pnpm api:v3:check`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| 200 envelope, `Cache-Control: private, no-store`, read access requested | unit (mutation) | `export-survey.test.ts`; passes |
| Audit log filled and `survey_exported` captured for session users, not for API keys | unit (mutation) | passes |
| 403 passthrough from the authorizer; 422 with `invalid_params` for an empty survey; 500 on `DatabaseError` | unit (mutation) | passes |
| OpenAPI source lints, bundle committed in sync | unit (guard) | `pnpm api:v3:lint` + `api:v3:check` green locally |
| Contract test hits a seeded survey (`read.surveyId` already maps to the read fixture) | e2e | runs in the Schemathesis job on this PR |

**Open gaps**

- Not exercised against a live instance in this PR; the download button PR (ENG-2974) does that manually.

**Risks**

- `ZAuditAction` gained a value; anything that maps audit actions to labels exhaustively would need the new one (none found).

---


### ENG-2974 — feat(surveys): "Export as JSON" in the survey card menu

#### What & why

**Was:** The export endpoint existed but nothing in the product called it.

**Now:** Every survey card menu has *Export as JSON* (right after *Copy to…*). It downloads `<survey-name>.formbricks.json` via `GET /api/v3/surveys/{id}/export`, with a loading → success/error toast. Read permission is enough; archived surveys hide it.


#### Where to look

- [survey-dropdown-menu.tsx](apps/web/modules/survey/list/components/survey-dropdown-menu.tsx) — the menu item and toast flow
- [download.ts](apps/web/modules/survey/export/download.ts) — Blob → object URL → click → revoke
- [file-name.ts](apps/web/modules/survey/export/file-name.ts) — kebab-cased, ASCII-only base name with a `survey` fallback

#### Breaking changes

- [ ] This PR contains breaking changes

None — new UI entry point only.

#### Migrations & env

- none

#### How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/export/file-name.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| File name: kebab-case, diacritics folded, unsafe chars dropped, unicode-only names → `survey`, `.formbricks.json` suffix | unit (mutation) | `file-name.test.ts`; 5 tests pass |
| Menu item placement, downloaded file is valid JSON, toast copy | manual | pending — screenshots to be added once the stack runs on a local instance |

**Open gaps**

- Manual QA screenshots not yet attached (draft stack, no live instance run yet).

**Risks**

- `downloadSurveyExport` relies on `<a download>`; browsers that block programmatic downloads show the error toast only if the fetch fails, not if the save is suppressed.

---


</details>

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
