### PR TITLE
feat(surveys): import module skeleton, source detection and lossless lane [ENG-2983]

### DIFF
--- a/apps/web/modules/survey/import/detect.test.ts
+++ b/apps/web/modules/survey/import/detect.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "vitest";
+import {
+  detectImportSource,
+  detectJsonSourceKind,
+  getImportAcceptList,
+  getImportFileExtension,
+} from "./detect";
+
+const bytes = (text: string) => Buffer.from(text, "utf8");
+const zipWith = (entryName: string) =>
+  Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00]), Buffer.from(`......${entryName}......`)]);
+
+const exportEnvelope = { formbricks: { exportFormat: 1 }, survey: {}, references: {} };
+const qsf = { SurveyEntry: { SurveyName: "x" }, SurveyElements: [] };
+const v3Document = { name: "Survey", blocks: [] };
+
+describe("detectImportSource", () => {
+  test.each([
+    ["export.formbricks.json", exportEnvelope, "formbricks-export"],
+    ["renamed.json", qsf, "qsf"],
+    ["survey.qsf", qsf, "qsf"],
+    ["doc.json", v3Document, "v3-document"],
+    ["get-response.json", { data: v3Document }, "v3-document"],
+    ["wrapped-export.json", { data: exportEnvelope }, "formbricks-export"],
+  ])("recognizes %s by content as %s", (fileName, content, expected) => {
+    expect(detectImportSource({ fileName, bytes: bytes(JSON.stringify(content)) })).toEqual({
+      ok: true,
+      kind: expected,
+    });
+  });
+
+  test("content wins over a misleading extension", () => {
+    expect(
+      detectImportSource({ fileName: "notes.txt", bytes: bytes(JSON.stringify(exportEnvelope)) })
+    ).toEqual({ ok: true, kind: "formbricks-export" });
+    expect(detectImportSource({ fileName: "scan.docx", bytes: bytes("%PDF-1.7 ...") })).toEqual({
+      ok: true,
+      kind: "pdf",
+    });
+  });
+
+  test("tells docx from xlsx by the zip entry names", () => {
+    expect(detectImportSource({ fileName: "file.bin", bytes: zipWith("word/document.xml") })).toEqual({
+      ok: true,
+      kind: "docx",
+    });
+    expect(detectImportSource({ fileName: "file.bin", bytes: zipWith("xl/workbook.xml") })).toEqual({
+      ok: true,
+      kind: "xlsx",
+    });
+    expect(detectImportSource({ fileName: "archive.zip", bytes: zipWith("photos/a.png") })).toEqual({
+      ok: false,
+      code: "unsupported_source",
+      extension: "zip",
+    });
+  });
+
+  test.each([
+    ["survey.md", "markdown"],
+    ["survey.txt", "text"],
+    ["questions.csv", "csv"],
+  ])("falls back to the extension for %s", (fileName, expected) => {
+    expect(detectImportSource({ fileName, bytes: bytes("1. How are you?\n- Good\n- Bad") })).toEqual({
+      ok: true,
+      kind: expected,
+    });
+  });
+
+  test("falls back to the MIME type when the name has no usable extension", () => {
+    expect(detectImportSource({ fileName: "upload", mimeType: "text/csv", bytes: bytes("a;b") })).toEqual({
+      ok: true,
+      kind: "csv",
+    });
+    expect(detectImportSource({ fileName: null, mimeType: "application/pdf; charset=binary" })).toEqual({
+      ok: true,
+      kind: "pdf",
+    });
+  });
+
+  test("rejects legacy Office formats with their own code", () => {
+    expect(detectImportSource({ fileName: "survey.doc", bytes: bytes("\xd0\xcf\x11\xe0") })).toEqual({
+      ok: false,
+      code: "legacy_office_format",
+      extension: "doc",
+    });
+    expect(detectImportSource({ fileName: "survey.XLS" })).toEqual({
+      ok: false,
+      code: "legacy_office_format",
+      extension: "xls",
+    });
+  });
+
+  test("rejects empty files, unknown extensions, unrecognized JSON and broken JSON", () => {
+    expect(detectImportSource({ fileName: "empty.json", bytes: Buffer.alloc(0) })).toEqual({
+      ok: false,
+      code: "empty_file",
+      extension: "json",
+    });
+    expect(detectImportSource({ fileName: "image.png", bytes: bytes("\x89PNG") })).toEqual({
+      ok: false,
+      code: "unsupported_source",
+      extension: "png",
+    });
+    expect(detectImportSource({ fileName: "settings.json", bytes: bytes('{"theme":"dark"}') })).toEqual({
+      ok: false,
+      code: "unsupported_source",
+      extension: "json",
+    });
+    expect(detectImportSource({ fileName: "broken.json", bytes: bytes("{ not json") })).toEqual({
+      ok: false,
+      code: "invalid_json",
+      extension: "json",
+    });
+    expect(detectImportSource({})).toEqual({ ok: false, code: "unsupported_source", extension: null });
+  });
+
+  test("a BOM does not hide JSON", () => {
+    expect(
+      detectImportSource({ fileName: "x.json", bytes: bytes(`\uFEFF${JSON.stringify(v3Document)}`) })
+    ).toEqual({ ok: true, kind: "v3-document" });
+  });
+});
+
+describe("helpers", () => {
+  test("getImportFileExtension lower-cases and ignores paths without a dot", () => {
+    expect(getImportFileExtension("Survey.QSF")).toBe("qsf");
+    expect(getImportFileExtension("archive.tar.gz")).toBe("gz");
+    expect(getImportFileExtension("README")).toBeNull();
+    expect(getImportFileExtension(undefined)).toBeNull();
+  });
+
+  test("detectJsonSourceKind returns null for non-objects", () => {
+    expect(detectJsonSourceKind([])).toBeNull();
+    expect(detectJsonSourceKind("x")).toBeNull();
+    expect(detectJsonSourceKind({ data: 1 })).toBeNull();
+  });
+
+  test("getImportAcceptList carries every extension with a dot plus its MIME types", () => {
+    const accept = getImportAcceptList();
+
+    expect(accept).toContain(".qsf");
+    expect(accept).toContain(".formbricks.json".slice(11));
+    expect(accept).toContain("application/pdf");
+    expect(accept).not.toContain(".doc");
+  });
+});

--- a/apps/web/modules/survey/import/detect.ts
+++ b/apps/web/modules/survey/import/detect.ts
@@ -1,0 +1,187 @@
+import {
+  IMPORT_ALLOWED_EXTENSIONS,
+  IMPORT_LEGACY_OFFICE_EXTENSIONS,
+  type TImportAllowedExtension,
+  type TImportSourceKind,
+} from "./types";
+
+export type TImportDetectionFailureCode =
+  | "empty_file"
+  | "legacy_office_format"
+  | "unsupported_source"
+  | "invalid_json";
+
+export type TImportDetection =
+  | { ok: true; kind: TImportSourceKind }
+  | { ok: false; code: TImportDetectionFailureCode; extension: string | null };
+
+type TDetectInput = {
+  fileName?: string | null;
+  mimeType?: string | null;
+  bytes?: Buffer | Uint8Array | null;
+};
+
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+const PDF_MAGIC = Buffer.from("%PDF");
+/** How far into a zip we look for the entry names that tell DOCX from XLSX. */
+const ZIP_SNIFF_BYTES = 64 * 1024;
+const JSON_SNIFF_BYTES = 16 * 1024 * 1024;
+
+export function getImportFileExtension(fileName: string | null | undefined): string | null {
+  if (!fileName) return null;
+  const match = /\.([a-z0-9]+)$/i.exec(fileName.trim());
+  return match ? match[1].toLowerCase() : null;
+}
+
+function isAllowedExtension(extension: string): extension is TImportAllowedExtension {
+  return Object.hasOwn(IMPORT_ALLOWED_EXTENSIONS, extension);
+}
+
+const MIME_TO_EXTENSION: Record<string, TImportAllowedExtension> = {
+  "application/pdf": "pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+  "text/csv": "csv",
+  "application/csv": "csv",
+  "text/markdown": "md",
+  "text/x-markdown": "md",
+  "application/json": "json",
+  "text/json": "json",
+};
+
+const EXTENSION_TO_KIND: Record<TImportAllowedExtension, TImportSourceKind> = {
+  json: "v3-document",
+  qsf: "qsf",
+  docx: "docx",
+  pdf: "pdf",
+  md: "markdown",
+  txt: "text",
+  csv: "csv",
+  xlsx: "xlsx",
+};
+
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function looksLikeExportEnvelope(value: Record<string, unknown>): boolean {
+  return isRecord(value.formbricks) && "exportFormat" in value.formbricks;
+}
+
+function looksLikeQsf(value: Record<string, unknown>): boolean {
+  return "SurveyEntry" in value && "SurveyElements" in value;
+}
+
+function looksLikeV3Document(value: Record<string, unknown>): boolean {
+  return typeof value.name === "string" && Array.isArray(value.blocks);
+}
+
+/** Classify parsed JSON: an export envelope, a QSF, a v3 document (optionally wrapped in `{ data }`), or none. */
+export function detectJsonSourceKind(value: unknown): TImportSourceKind | null {
+  if (!isRecord(value)) return null;
+  if (looksLikeExportEnvelope(value)) return "formbricks-export";
+  if (looksLikeQsf(value)) return "qsf";
+  if (looksLikeV3Document(value)) return "v3-document";
+  if (isRecord(value.data)) {
+    if (looksLikeExportEnvelope(value.data)) return "formbricks-export";
+    if (looksLikeV3Document(value.data)) return "v3-document";
+  }
+  return null;
+}
+
+function detectZipKind(bytes: Buffer): TImportSourceKind | null {
+  const head = bytes.subarray(0, ZIP_SNIFF_BYTES).toString("latin1");
+  if (head.includes("word/document.xml") || head.includes("word/_rels/")) return "docx";
+  if (head.includes("xl/workbook.xml") || head.includes("xl/_rels/")) return "xlsx";
+  return null;
+}
+
+type TTextDetection = { kind: TImportSourceKind } | { kind: null; invalidJson: boolean };
+
+function detectTextKind(bytes: Buffer, extension: string | null): TTextDetection {
+  const text = stripBom(bytes.subarray(0, JSON_SNIFF_BYTES).toString("utf8")).trimStart();
+  const firstChar = text.charAt(0);
+  if (firstChar !== "{" && firstChar !== "[") {
+    return { kind: null, invalidJson: false };
+  }
+
+  if (bytes.byteLength > JSON_SNIFF_BYTES) {
+    return { kind: null, invalidJson: false };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return { kind: detectJsonSourceKind(parsed), invalidJson: false };
+  } catch {
+    return { kind: null, invalidJson: extension === "json" || extension === "qsf" };
+  }
+}
+
+/**
+ * Decide which lane a source belongs to. Content wins over the extension, and the extension wins over
+ * the MIME type (browsers send `application/octet-stream` for anything they do not know).
+ */
+export function detectImportSource(input: TDetectInput): TImportDetection {
+  const extension = getImportFileExtension(input.fileName);
+  const bytes = input.bytes ? Buffer.from(input.bytes) : null;
+
+  if (extension && (IMPORT_LEGACY_OFFICE_EXTENSIONS as readonly string[]).includes(extension)) {
+    return { ok: false, code: "legacy_office_format", extension };
+  }
+
+  if (bytes && bytes.byteLength === 0) {
+    return { ok: false, code: "empty_file", extension };
+  }
+
+  if (bytes) {
+    if (bytes.subarray(0, 4).equals(PDF_MAGIC)) {
+      return { ok: true, kind: "pdf" };
+    }
+
+    if (bytes.subarray(0, 4).equals(ZIP_MAGIC)) {
+      const zipKind = detectZipKind(bytes);
+      return zipKind ? { ok: true, kind: zipKind } : { ok: false, code: "unsupported_source", extension };
+    }
+
+    const textDetection = detectTextKind(bytes, extension);
+    if (textDetection.kind) {
+      return { ok: true, kind: textDetection.kind };
+    }
+    if (textDetection.kind === null && textDetection.invalidJson) {
+      return { ok: false, code: "invalid_json", extension };
+    }
+    if (extension === "json") {
+      // Parsed fine but is none of the shapes we know.
+      return { ok: false, code: "unsupported_source", extension };
+    }
+  }
+
+  const resolvedExtension =
+    extension && isAllowedExtension(extension)
+      ? extension
+      : input.mimeType
+        ? MIME_TO_EXTENSION[input.mimeType.split(";")[0].trim().toLowerCase()]
+        : undefined;
+
+  if (!resolvedExtension) {
+    return { ok: false, code: "unsupported_source", extension };
+  }
+
+  if (resolvedExtension === "json" && !bytes) {
+    return { ok: true, kind: "v3-document" };
+  }
+
+  return { ok: true, kind: EXTENSION_TO_KIND[resolvedExtension] };
+}
+
+/** The `accept` attribute for the drop zone: extensions plus their MIME types. */
+export function getImportAcceptList(): string[] {
+  return Object.entries(IMPORT_ALLOWED_EXTENSIONS).flatMap(([extension, mimeTypes]) => [
+    `.${extension}`,
+    ...mimeTypes,
+  ]);
+}

--- a/apps/web/modules/survey/import/lanes/formbricks/index.test.ts
+++ b/apps/web/modules/survey/import/lanes/formbricks/index.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "vitest";
+import {
+  FIXTURE_APP_SURVEY,
+  FIXTURE_LINK_SURVEY,
+  FIXTURE_WORKSPACE_ID,
+} from "@/modules/survey/export/__fixtures__/surveys";
+import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
+import type { TImportContext, TImportLaneInput } from "../../types";
+import { formbricksLane } from "./index";
+
+const ctx: TImportContext = {
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  organizationId: "org_1",
+  userId: "user_1",
+  requestId: "req_1",
+  importRunId: "run_1",
+};
+
+function envelopeOf(survey: typeof FIXTURE_LINK_SURVEY) {
+  const result = buildSurveyExportEnvelope(survey, {
+    appVersion: "6.2.0",
+    publicUrl: "https://app.formbricks.com",
+    exportedAt: new Date("2026-09-08T12:00:00.000Z"),
+  });
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.data;
+}
+
+const asBytes = (value: unknown, fileName = "survey.formbricks.json"): TImportLaneInput => ({
+  kind: "formbricks-export",
+  fileName,
+  content: { type: "bytes", bytes: Buffer.from(JSON.stringify(value)) },
+});
+
+/** A hand-written raw v3 document, as the MCP `create_survey` tool documents it. */
+const mcpDocument = {
+  name: "Onboarding feedback",
+  type: "link",
+  defaultLanguage: "en-US",
+  blocks: [
+    {
+      name: "Main",
+      elements: [{ id: "why", type: "openText", headline: { "en-US": "Why did you stop?" }, required: true }],
+    },
+  ],
+};
+
+describe("formbricksLane", () => {
+  test("reads an export envelope: document, references, source kind, no instance fields", async () => {
+    const envelope = envelopeOf(FIXTURE_APP_SURVEY);
+
+    const candidate = await formbricksLane(asBytes(envelope, "in-app.formbricks.json"), ctx);
+
+    expect(candidate.source).toEqual({
+      lane: "lossless",
+      kind: "formbricks-export",
+      fileName: "in-app.formbricks.json",
+    });
+    expect(candidate.issues).toEqual([]);
+    expect(candidate.references?.actionClasses).toHaveLength(2);
+    expect(candidate.document).toEqual(envelope.survey);
+    expect(candidate.document).not.toHaveProperty("workspaceId");
+  });
+
+  test("accepts a raw v3 document from a GET response body, stripping id, workspaceId and timestamps", async () => {
+    const envelope = envelopeOf(FIXTURE_LINK_SURVEY);
+    const getResponse = {
+      data: {
+        id: "clsv1234567890123456789012",
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        createdAt: "2026-09-01T10:00:00.000Z",
+        updatedAt: "2026-09-01T10:00:00.000Z",
+        archivedAt: null,
+        ...envelope.survey,
+      },
+    };
+
+    const candidate = await formbricksLane(
+      { kind: "v3-document", fileName: "response.json", content: { type: "json", value: getResponse } },
+      ctx
+    );
+
+    expect(candidate.source.kind).toBe("v3-document");
+    expect(candidate.references).toBeUndefined();
+    expect(candidate.document).toEqual(envelope.survey);
+    expect(candidate.issues).toEqual([]);
+  });
+
+  test("accepts a hand-written document from the MCP tool docs, as text with a BOM", async () => {
+    const candidate = await formbricksLane(
+      { kind: "v3-document", content: { type: "text", text: `\uFEFF${JSON.stringify(mcpDocument)}` } },
+      ctx
+    );
+
+    expect(candidate.document).toEqual(mcpDocument);
+    expect(candidate.source).toEqual({ lane: "lossless", kind: "v3-document" });
+  });
+
+  test("reports slug and schedule from a hand-edited file and removes them", async () => {
+    const candidate = await formbricksLane(
+      {
+        kind: "v3-document",
+        content: {
+          type: "json",
+          value: { ...mcpDocument, slug: "my-link", publishOn: "2026-10-01T00:00:00.000Z", createdBy: "u1" },
+        },
+      },
+      ctx
+    );
+
+    expect(candidate.document).toEqual(mcpDocument);
+    expect(candidate.issues.map((issue) => issue.code)).toEqual(["slug_not_imported", "schedule_cleared"]);
+    expect(candidate.issues.every((issue) => issue.severity === "info")).toBe(true);
+  });
+
+  test("leaves an extensions block for the report and passes references through", async () => {
+    const envelope = envelopeOf(FIXTURE_LINK_SURVEY);
+
+    const candidate = await formbricksLane(
+      asBytes({ ...envelope, extensions: { styling: { brandColor: "#000" } } }),
+      ctx
+    );
+
+    expect(candidate.document).toEqual(envelope.survey);
+    expect(candidate.issues).toEqual([
+      expect.objectContaining({ severity: "info", code: "unknown_field_stripped", path: "extensions" }),
+    ]);
+  });
+
+  test("refuses a newer export format", async () => {
+    const envelope = envelopeOf(FIXTURE_LINK_SURVEY);
+
+    const candidate = await formbricksLane(
+      asBytes({ ...envelope, formbricks: { ...envelope.formbricks, exportFormat: 2 } }),
+      ctx
+    );
+
+    expect(candidate.document).toBeNull();
+    expect(candidate.issues).toEqual([
+      expect.objectContaining({
+        severity: "error",
+        code: "export_format_unsupported",
+        path: "formbricks.exportFormat",
+        message: expect.stringContaining("export format 2"),
+      }),
+    ]);
+  });
+
+  test("refuses legacy question-based documents", async () => {
+    const candidate = await formbricksLane(
+      {
+        kind: "v3-document",
+        content: {
+          type: "json",
+          value: { name: "Old", blocks: [], questions: [{ id: "q1", type: "openText" }] },
+        },
+      },
+      ctx
+    );
+
+    expect(candidate.document).toBeNull();
+    expect(candidate.issues).toEqual([
+      expect.objectContaining({ severity: "error", code: "legacy_questions_unsupported", path: "questions" }),
+    ]);
+  });
+
+  test("refuses broken JSON, non-objects and envelopes with invalid metadata or references", async () => {
+    const broken = await formbricksLane(
+      { kind: "formbricks-export", content: { type: "text", text: "{ nope" } },
+      ctx
+    );
+    expect(broken.document).toBeNull();
+    expect(broken.issues[0]).toMatchObject({ severity: "error", code: "invalid_document" });
+
+    const array = await formbricksLane(
+      { kind: "v3-document", content: { type: "json", value: [1, 2, 3] } },
+      ctx
+    );
+    expect(array.issues[0]).toMatchObject({ code: "invalid_document" });
+
+    const envelope = envelopeOf(FIXTURE_LINK_SURVEY);
+    const badMetadata = await formbricksLane(
+      asBytes({ ...envelope, formbricks: { exportFormat: 1, exportedAt: "yesterday" } }),
+      ctx
+    );
+    expect(badMetadata.document).toBeNull();
+    expect(badMetadata.issues.every((issue) => issue.code === "invalid_document")).toBe(true);
+    expect(badMetadata.issues[0].path?.startsWith("formbricks")).toBe(true);
+
+    const badReferences = await formbricksLane(
+      asBytes({ ...envelope, references: { actionClasses: [{ id: "x" }] } }),
+      ctx
+    );
+    expect(badReferences.document).toBeNull();
+    expect(badReferences.issues[0].path?.startsWith("references")).toBe(true);
+
+    const noSurvey = await formbricksLane(
+      asBytes({ formbricks: envelope.formbricks, references: { actionClasses: [] } }),
+      ctx
+    );
+    expect(noSurvey.issues[0]).toMatchObject({ code: "invalid_document", path: "survey" });
+  });
+});

--- a/apps/web/modules/survey/import/lanes/formbricks/index.ts
+++ b/apps/web/modules/survey/import/lanes/formbricks/index.ts
@@ -1,0 +1,230 @@
+import {
+  SURVEY_EXPORT_FORMAT,
+  type TSurveyExportReferences,
+  ZSurveyExportMetadata,
+  ZSurveyExportReferences,
+  getSurveyExportFormat,
+} from "@/app/api/v3/surveys/export/schemas";
+import { formatV3ZodInvalidParams } from "@/app/api/v3/surveys/schemas";
+import { detectJsonSourceKind } from "../../detect";
+import { importError, importInfo } from "../../report";
+import type {
+  TImportCandidate,
+  TImportIssue,
+  TImportLaneHandler,
+  TImportLaneInput,
+  TImportReportSource,
+} from "../../types";
+
+/**
+ * Instance-bound fields a hand-edited file may carry. They are removed here, before the resolver's
+ * strict unknown-field pass, so the user reads "slug not imported" rather than "unsupported field".
+ * `status`, `publishOn` and `closeOn` are reported because they change behaviour; the rest is noise.
+ */
+const SILENTLY_STRIPPED_ROOT_FIELDS = [
+  "id",
+  "workspaceId",
+  "createdAt",
+  "updatedAt",
+  "archivedAt",
+  "createdBy",
+] as const;
+
+const ENVELOPE_ROOT_KEYS = new Set(["formbricks", "survey", "references"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+function parseContent(input: TImportLaneInput): { value: unknown } | { error: TImportIssue } {
+  const { content } = input;
+  if (content.type === "json") {
+    return { value: content.value };
+  }
+
+  const text = content.type === "text" ? content.text : content.bytes.toString("utf8");
+
+  try {
+    return { value: JSON.parse(stripBom(text)) };
+  } catch {
+    return {
+      error: importError({
+        code: "invalid_document",
+        vars: { detail: "The file is not valid JSON." },
+      }),
+    };
+  }
+}
+
+/** Accept a `GET /api/v3/surveys/{id}` response body as well as the bare document. */
+function unwrapDataEnvelope(value: Record<string, unknown>): Record<string, unknown> {
+  if (isRecord(value.data) && detectJsonSourceKind(value.data) !== null && !("blocks" in value)) {
+    return value.data;
+  }
+  return value;
+}
+
+function stripInstanceFields(
+  document: Record<string, unknown>,
+  issues: TImportIssue[]
+): Record<string, unknown> {
+  const stripped = { ...document };
+
+  for (const field of SILENTLY_STRIPPED_ROOT_FIELDS) {
+    delete stripped[field];
+  }
+
+  if ("slug" in stripped) {
+    delete stripped.slug;
+    issues.push(importInfo({ code: "slug_not_imported", path: "slug" }));
+  }
+
+  if (stripped.publishOn != null || stripped.closeOn != null) {
+    issues.push(importInfo({ code: "schedule_cleared", path: "publishOn" }));
+  }
+  delete stripped.publishOn;
+  delete stripped.closeOn;
+
+  return stripped;
+}
+
+function hasLegacyQuestions(document: Record<string, unknown>): boolean {
+  return Array.isArray(document.questions) && document.questions.length > 0;
+}
+
+type TEnvelopeParts =
+  | { ok: true; survey: Record<string, unknown>; references: TSurveyExportReferences; issues: TImportIssue[] }
+  | { ok: false; issues: TImportIssue[] };
+
+function readEnvelope(value: Record<string, unknown>): TEnvelopeParts {
+  const issues: TImportIssue[] = [];
+  const format = getSurveyExportFormat(value);
+
+  if (format !== null && format > SURVEY_EXPORT_FORMAT) {
+    return {
+      ok: false,
+      issues: [
+        importError({ code: "export_format_unsupported", path: "formbricks.exportFormat", vars: { format } }),
+      ],
+    };
+  }
+
+  const metadata = ZSurveyExportMetadata.safeParse(value.formbricks);
+  if (!metadata.success) {
+    return {
+      ok: false,
+      issues: formatV3ZodInvalidParams(metadata.error, "formbricks").map((param) =>
+        importError({
+          code: "invalid_document",
+          path: param.name.startsWith("formbricks") ? param.name : `formbricks.${param.name}`,
+          vars: { detail: `Export metadata is invalid: ${param.reason}` },
+        })
+      ),
+    };
+  }
+
+  const references = ZSurveyExportReferences.safeParse(value.references ?? { actionClasses: [] });
+  if (!references.success) {
+    return {
+      ok: false,
+      issues: formatV3ZodInvalidParams(references.error, "references").map((param) =>
+        importError({
+          code: "invalid_document",
+          path: param.name.startsWith("references") ? param.name : `references.${param.name}`,
+          vars: { detail: `Action-class references are invalid: ${param.reason}` },
+        })
+      ),
+    };
+  }
+
+  if (!isRecord(value.survey)) {
+    return {
+      ok: false,
+      issues: [
+        importError({
+          code: "invalid_document",
+          path: "survey",
+          vars: { detail: "The export has no survey document." },
+        }),
+      ],
+    };
+  }
+
+  // A pre-D1 draft file with an `extensions` block, or any other stray root key, is reported here
+  // because the resolver only ever sees `survey`.
+  for (const key of Object.keys(value)) {
+    if (!ENVELOPE_ROOT_KEYS.has(key)) {
+      issues.push(importInfo({ code: "unknown_field_stripped", path: key, vars: { field: key } }));
+    }
+  }
+
+  return { ok: true, survey: value.survey, references: references.data, issues };
+}
+
+function fatal(source: TImportReportSource, issues: TImportIssue[]): TImportCandidate {
+  return { document: null, issues, source };
+}
+
+/**
+ * Lossless lane: a Formbricks export envelope or a raw v3 survey document (what the MCP
+ * `create_survey` tool and a `GET /api/v3/surveys/{id}` response carry). No mapping happens here;
+ * the document goes to the resolver as it is, minus the instance-bound fields.
+ */
+export const formbricksLane: TImportLaneHandler = async (input) => {
+  const source: TImportReportSource = {
+    lane: "lossless",
+    kind: input.kind,
+    ...(input.fileName ? { fileName: input.fileName } : {}),
+  };
+
+  const parsed = parseContent(input);
+  if ("error" in parsed) {
+    return fatal(source, [parsed.error]);
+  }
+
+  if (!isRecord(parsed.value)) {
+    return fatal(source, [
+      importError({
+        code: "invalid_document",
+        vars: { detail: "The file does not contain a survey object." },
+      }),
+    ]);
+  }
+
+  const value = unwrapDataEnvelope(parsed.value);
+  const issues: TImportIssue[] = [];
+  let survey: Record<string, unknown>;
+  let references: TSurveyExportReferences | undefined;
+
+  if (detectJsonSourceKind(value) === "formbricks-export") {
+    const envelope = readEnvelope(value);
+    if (!envelope.ok) {
+      return fatal({ ...source, kind: "formbricks-export" }, envelope.issues);
+    }
+    source.kind = "formbricks-export";
+    survey = envelope.survey;
+    references = envelope.references;
+    issues.push(...envelope.issues);
+  } else {
+    source.kind = "v3-document";
+    survey = value;
+  }
+
+  if (hasLegacyQuestions(survey)) {
+    return fatal(source, [importError({ code: "legacy_questions_unsupported", path: "questions" })]);
+  }
+
+  const document = stripInstanceFields(survey, issues);
+  delete document.questions;
+
+  return {
+    document,
+    ...(references ? { references } : {}),
+    issues,
+    source,
+  };
+};

--- a/apps/web/modules/survey/import/messages.ts
+++ b/apps/web/modules/survey/import/messages.ts
@@ -1,0 +1,79 @@
+import type { TImportIssueCode } from "./types";
+
+type TVars = Record<string, string | number>;
+
+const str = (vars: TVars | undefined, key: string, fallback = ""): string => {
+  const value = vars?.[key];
+  return value === undefined ? fallback : String(value);
+};
+
+/**
+ * English message per issue code. The API returns these; the dialog translates by `code` with the
+ * same `vars` and falls back to this text.
+ */
+const MESSAGES: Record<TImportIssueCode, (vars?: TVars) => string> = {
+  unsupported_question_type: (v) =>
+    `${str(v, "sourceRef", "A question")} uses the type '${str(v, "type")}', which Formbricks does not support. It was not imported.`,
+  type_approximated: (v) =>
+    `${str(v, "sourceRef", "A question")} was imported as '${str(v, "to")}' because '${str(v, "from")}' has no exact equivalent.`,
+  unknown_element: (v) =>
+    `Unknown element type '${str(v, "type")}'. This file was made by a newer Formbricks version.`,
+  unknown_field_stripped: (v) =>
+    `The field '${str(v, "field")}' is not part of a survey document and was removed.`,
+  invalid_document: (v) => str(v, "detail", "The file is not a survey document Formbricks can read."),
+  export_format_unsupported: (v) =>
+    `This file uses export format ${str(v, "format")}, which this Formbricks version cannot read. Export it again from a current instance or upgrade.`,
+  legacy_questions_unsupported: () =>
+    "This file uses the legacy question format. Export the survey again from a current Formbricks instance.",
+  text_truncated: (v) => `Text was shortened to ${str(v, "max")} characters.`,
+  choices_truncated: (v) => `Only the first ${str(v, "max")} options were kept.`,
+  logic_dropped: (v) => str(v, "detail", "A logic rule was not imported. Rebuild it in the editor."),
+  pipe_stripped: (v) => `The piped text '${str(v, "token")}' has no equivalent and was removed.`,
+  randomizer_flattened: () => "Randomized blocks were imported in file order. Randomization is not imported.",
+  block_not_in_flow: (v) =>
+    `Block '${str(v, "block")}' is not part of the survey flow and was appended at the end.`,
+  welcome_card_from_descriptive_text: () => "The first text page became the welcome card.",
+  language_created: (v) =>
+    `Language '${str(v, "code")}' does not exist in this workspace yet and will be created.`,
+  language_ambiguous: (v) =>
+    `The document language is ambiguous (${str(v, "reasons")}). Only '${str(v, "code")}' was imported.`,
+  language_unknown: (v) =>
+    `Language code '${str(v, "code")}' is not recognized. Its texts were kept under the default language.`,
+  translation_filled: (v) =>
+    `Missing '${str(v, "code")}' translation was filled with the default-language text.`,
+  translation_missing: (v) => `Missing '${str(v, "code")}' translation.`,
+  trigger_mapped: (v) => `Trigger '${str(v, "name")}' was matched to an existing action in this workspace.`,
+  trigger_created: (v) => `Trigger '${str(v, "name")}' was created in this workspace.`,
+  trigger_dropped: (v) =>
+    `Trigger '${str(v, "name", str(v, "id"))}' has no definition in the file and was removed.`,
+  trigger_would_be_created: (v) => `Trigger '${str(v, "name")}' will be created in this workspace on import.`,
+  targeting_not_imported: () => "Targeting (segment filters) is not imported. Set it up in the editor.",
+  quota_dropped: () => "Quotas are not imported.",
+  settings_not_exported: () =>
+    "Styling, follow-ups and survey settings are not part of the export. Set them up in the editor.",
+  setting_not_imported: (v) => `The setting '${str(v, "setting")}' is not imported. Set it up in the editor.`,
+  slug_not_imported: () => "The survey link slug is unique per instance and was not imported.",
+  schedule_cleared: () => "The publish and close schedule was cleared. The survey is created as a draft.",
+  status_reset: () => "The survey is created as a draft regardless of its status in the file.",
+  external_url_removed: () =>
+    "External links are not available on this plan. The link was removed; the survey still works.",
+  asset_url_external: () =>
+    "An image or video points at another Formbricks instance. It keeps working as long as that instance serves it.",
+  media_invalid: (v) => `The media URL '${str(v, "url")}' is not supported and was removed.`,
+  embedded_data_name_refused: (v) =>
+    `The hidden field '${str(v, "name")}' uses a reserved name and was renamed to '${str(v, "renamed")}'.`,
+  field_renamed: (v) =>
+    `The field '${str(v, "from")}' was renamed to '${str(v, "to")}' to follow the naming rules.`,
+  no_text_extracted: () => "We couldn't find any text in this file. Scanned PDFs need OCR first.",
+  archive_rejected: () => "This file could not be opened safely and was rejected.",
+  document_encrypted: () => "This PDF is password-protected. Remove the password and try again.",
+  nothing_extracted: () => "No questions were found in this document.",
+  chunked: (v) => `The document was read in ${str(v, "count")} parts.`,
+  chunk_failed: (v) =>
+    `Part ${str(v, "index")} of ${str(v, "total")} could not be read. The rest was imported.`,
+  model_note: (v) => str(v, "detail"),
+};
+
+export function formatImportIssueMessage(code: TImportIssueCode, vars?: TVars): string {
+  return MESSAGES[code](vars);
+}

--- a/apps/web/modules/survey/import/report.test.ts
+++ b/apps/web/modules/survey/import/report.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import { formatImportIssueMessage } from "./messages";
+import {
+  addIssue,
+  countIssues,
+  createImportReport,
+  hasFatalIssues,
+  importError,
+  importInfo,
+  importWarning,
+  summarizeDocument,
+} from "./report";
+import { IMPORT_ISSUE_CODES } from "./types";
+
+describe("issue factories", () => {
+  test("build a message from the code and vars, and keep sourceRef in vars", () => {
+    const issue = importInfo({
+      code: "unsupported_question_type",
+      sourceRef: "QID4",
+      vars: { type: "Timing" },
+    });
+
+    expect(issue).toEqual({
+      severity: "info",
+      code: "unsupported_question_type",
+      message: "QID4 uses the type 'Timing', which Formbricks does not support. It was not imported.",
+      sourceRef: "QID4",
+      vars: { sourceRef: "QID4", type: "Timing" },
+    });
+  });
+
+  test("a provided message wins over the template", () => {
+    expect(importError({ code: "invalid_document", message: "custom" }).message).toBe("custom");
+  });
+
+  test("every issue code has a message template", () => {
+    for (const code of IMPORT_ISSUE_CODES) {
+      expect(formatImportIssueMessage(code, { detail: "d" }).length, code).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("report helpers", () => {
+  test("createImportReport starts with an empty summary and copies issues", () => {
+    const issues = [importWarning({ code: "slug_not_imported" })];
+    const report = createImportReport({ lane: "lossless", kind: "formbricks-export" }, issues);
+
+    expect(report.summary.blocks).toBe(0);
+    expect(report.issues).toEqual(issues);
+    expect(report.issues).not.toBe(issues);
+
+    addIssue(report, importInfo({ code: "schedule_cleared" }));
+    expect(report.issues).toHaveLength(2);
+  });
+
+  test("hasFatalIssues and countIssues read severities", () => {
+    const issues = [
+      importInfo({ code: "schedule_cleared" }),
+      importWarning({ code: "external_url_removed" }),
+      importError({ code: "unknown_element", vars: { type: "x" } }),
+    ];
+
+    expect(hasFatalIssues(issues)).toBe(true);
+    expect(hasFatalIssues(issues.slice(0, 2))).toBe(false);
+    expect(countIssues(issues)).toEqual({ error: 1, warning: 1, info: 1 });
+  });
+});
+
+describe("summarizeDocument", () => {
+  test("counts blocks, elements, endings, logic rules, languages and hidden fields", () => {
+    expect(
+      summarizeDocument({
+        defaultLanguage: "en-US",
+        languages: [{ code: "en-US" }, { code: "de-DE" }, { bogus: true }],
+        blocks: [{ elements: [{}, {}], logic: [{}] }, { elements: [{}] }, "not a block"],
+        endings: [{}, {}],
+        hiddenFields: { enabled: true, fieldIds: ["a", "b", "c"] },
+      })
+    ).toEqual({
+      blocks: 3,
+      elements: 3,
+      endings: 2,
+      languages: ["en-US", "de-DE"],
+      logicRules: 1,
+      logicRulesReported: 0,
+      hiddenFields: 3,
+    });
+  });
+
+  test("tolerates anything that is not a document", () => {
+    expect(summarizeDocument(null).blocks).toBe(0);
+    expect(summarizeDocument("x").languages).toEqual([]);
+    expect(summarizeDocument({ blocks: "nope" }).elements).toBe(0);
+  });
+});

--- a/apps/web/modules/survey/import/report.ts
+++ b/apps/web/modules/survey/import/report.ts
@@ -1,0 +1,118 @@
+import { formatImportIssueMessage } from "./messages";
+import type {
+  TImportIssue,
+  TImportIssueCode,
+  TImportIssueSeverity,
+  TImportReport,
+  TImportReportSource,
+  TImportReportSummary,
+} from "./types";
+
+type TIssueInput = {
+  code: TImportIssueCode;
+  path?: string;
+  sourceRef?: string;
+  vars?: Record<string, string | number>;
+  /** Overrides the message template; the resolver passes v3 `invalid_params` reasons through. */
+  message?: string;
+};
+
+export function createImportIssue(severity: TImportIssueSeverity, input: TIssueInput): TImportIssue {
+  const vars = { ...(input.sourceRef ? { sourceRef: input.sourceRef } : {}), ...input.vars };
+  return {
+    severity,
+    code: input.code,
+    message: input.message ?? formatImportIssueMessage(input.code, vars),
+    ...(input.path ? { path: input.path } : {}),
+    ...(input.sourceRef ? { sourceRef: input.sourceRef } : {}),
+    ...(Object.keys(vars).length > 0 ? { vars } : {}),
+  };
+}
+
+export const importError = (input: TIssueInput): TImportIssue => createImportIssue("error", input);
+export const importWarning = (input: TIssueInput): TImportIssue => createImportIssue("warning", input);
+export const importInfo = (input: TIssueInput): TImportIssue => createImportIssue("info", input);
+
+export const EMPTY_IMPORT_SUMMARY: TImportReportSummary = {
+  blocks: 0,
+  elements: 0,
+  endings: 0,
+  languages: [],
+  logicRules: 0,
+  logicRulesReported: 0,
+  hiddenFields: 0,
+};
+
+export function createImportReport(source: TImportReportSource, issues: TImportIssue[] = []): TImportReport {
+  return { source, summary: { ...EMPTY_IMPORT_SUMMARY }, issues: [...issues] };
+}
+
+export function addIssue(report: TImportReport, issue: TImportIssue): TImportReport {
+  report.issues.push(issue);
+  return report;
+}
+
+export function hasFatalIssues(issues: readonly TImportIssue[]): boolean {
+  return issues.some((issue) => issue.severity === "error");
+}
+
+export function countIssues(issues: readonly TImportIssue[]): Record<TImportIssueSeverity, number> {
+  return issues.reduce(
+    (counts, issue) => {
+      counts[issue.severity] += 1;
+      return counts;
+    },
+    { error: 0, warning: 0, info: 0 }
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Counts for the facts row. Tolerant by design: it runs on a candidate before validation, so every
+ * field may be missing or malformed and simply counts as zero.
+ */
+export function summarizeDocument(document: unknown): TImportReportSummary {
+  if (!isRecord(document)) {
+    return { ...EMPTY_IMPORT_SUMMARY };
+  }
+
+  const blocks = Array.isArray(document.blocks) ? document.blocks : [];
+  const elements = blocks.reduce<number>(
+    (count, block) => count + (isRecord(block) && Array.isArray(block.elements) ? block.elements.length : 0),
+    0
+  );
+  const logicRules = blocks.reduce<number>(
+    (count, block) => count + (isRecord(block) && Array.isArray(block.logic) ? block.logic.length : 0),
+    0
+  );
+  const endings = Array.isArray(document.endings) ? document.endings.length : 0;
+  const hiddenFields =
+    isRecord(document.hiddenFields) && Array.isArray(document.hiddenFields.fieldIds)
+      ? document.hiddenFields.fieldIds.length
+      : 0;
+
+  const languages = new Set<string>();
+  if (typeof document.defaultLanguage === "string") {
+    languages.add(document.defaultLanguage);
+  }
+  if (Array.isArray(document.languages)) {
+    for (const language of document.languages) {
+      if (isRecord(language) && typeof language.code === "string") {
+        languages.add(language.code);
+      }
+    }
+  }
+
+  return {
+    blocks: blocks.length,
+    elements,
+    endings,
+    languages: Array.from(languages),
+    logicRules,
+    logicRulesReported: 0,
+    hiddenFields,
+  };
+}

--- a/apps/web/modules/survey/import/types.ts
+++ b/apps/web/modules/survey/import/types.ts
@@ -1,0 +1,205 @@
+import type { TSurveyExportReferences } from "@/app/api/v3/surveys/export/schemas";
+
+/**
+ * Shared vocabulary of the survey import pipeline. Every lane (lossless JSON, structured QSF, AI
+ * documents) produces a `TImportCandidate`; the resolver turns it into a create document and a report.
+ */
+
+export const IMPORT_SOURCE_KINDS = [
+  "formbricks-export",
+  "v3-document",
+  "qsf",
+  "docx",
+  "pdf",
+  "markdown",
+  "text",
+  "csv",
+  "xlsx",
+] as const;
+
+export type TImportSourceKind = (typeof IMPORT_SOURCE_KINDS)[number];
+
+export type TImportLane = "lossless" | "structured" | "ai";
+
+export const IMPORT_LANE_BY_KIND: Record<TImportSourceKind, TImportLane> = {
+  "formbricks-export": "lossless",
+  "v3-document": "lossless",
+  qsf: "structured",
+  docx: "ai",
+  pdf: "ai",
+  markdown: "ai",
+  text: "ai",
+  csv: "ai",
+  xlsx: "ai",
+};
+
+export const AI_IMPORT_SOURCE_KINDS: readonly TImportSourceKind[] = IMPORT_SOURCE_KINDS.filter(
+  (kind) => IMPORT_LANE_BY_KIND[kind] === "ai"
+);
+
+/** 15 MB per file (D3). The transport adds 1 MB of multipart slack on top. */
+export const IMPORT_MAX_FILE_BYTES = 15 * 1024 * 1024;
+
+/**
+ * Import owns its own allowlist. `ZAllowedFileExtension` (packages/types/storage.ts) is the upload
+ * allowlist for survey media and deliberately lacks `.qsf` and `.md` (edge case #36).
+ */
+export const IMPORT_ALLOWED_EXTENSIONS = {
+  json: ["application/json", "text/json"],
+  qsf: ["application/json", "application/octet-stream"],
+  docx: ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+  pdf: ["application/pdf"],
+  md: ["text/markdown", "text/x-markdown", "text/plain"],
+  txt: ["text/plain"],
+  csv: ["text/csv", "application/csv", "text/plain"],
+  xlsx: ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
+} as const satisfies Record<string, readonly string[]>;
+
+export type TImportAllowedExtension = keyof typeof IMPORT_ALLOWED_EXTENSIONS;
+
+/** Legacy Office formats are refused with a "save as" hint instead of a generic rejection. */
+export const IMPORT_LEGACY_OFFICE_EXTENSIONS = ["doc", "xls", "rtf", "odt", "ods"] as const;
+
+export const IMPORT_ISSUE_CODES = [
+  // Structure and types
+  "unsupported_question_type",
+  "type_approximated",
+  "unknown_element",
+  "unknown_field_stripped",
+  "invalid_document",
+  "export_format_unsupported",
+  "legacy_questions_unsupported",
+  "text_truncated",
+  "choices_truncated",
+  // Logic and pipes
+  "logic_dropped",
+  "pipe_stripped",
+  "randomizer_flattened",
+  "block_not_in_flow",
+  "welcome_card_from_descriptive_text",
+  // Languages
+  "language_created",
+  "language_ambiguous",
+  "language_unknown",
+  "translation_filled",
+  "translation_missing",
+  // Workspace references
+  "trigger_mapped",
+  "trigger_created",
+  "trigger_dropped",
+  "trigger_would_be_created",
+  "targeting_not_imported",
+  "quota_dropped",
+  // Settings and hygiene
+  "settings_not_exported",
+  "setting_not_imported",
+  "slug_not_imported",
+  "schedule_cleared",
+  "status_reset",
+  "external_url_removed",
+  "asset_url_external",
+  "media_invalid",
+  // Hidden fields / embedded data
+  "embedded_data_name_refused",
+  "field_renamed",
+  // Documents (AI lane)
+  "no_text_extracted",
+  "archive_rejected",
+  "document_encrypted",
+  "nothing_extracted",
+  "chunked",
+  "chunk_failed",
+  "model_note",
+] as const;
+
+export type TImportIssueCode = (typeof IMPORT_ISSUE_CODES)[number];
+
+export type TImportIssueSeverity = "error" | "warning" | "info";
+
+export type TImportIssue = {
+  severity: TImportIssueSeverity;
+  code: TImportIssueCode;
+  /** v3 document path (`blocks.2.elements.0.headline`) when the issue points at one place. */
+  path?: string;
+  /** English fallback; the UI translates by `code` and `vars`. */
+  message: string;
+  /** Where in the source the issue comes from (a QSF `QID`, a document heading). */
+  sourceRef?: string;
+  /** Interpolation values for the translated message. */
+  vars?: Record<string, string | number>;
+};
+
+export type TImportDetectedLanguage = { code: string; confidence: number };
+
+export type TImportReportSource = {
+  lane: TImportLane;
+  kind: TImportSourceKind;
+  fileName?: string;
+  detectedLanguages?: TImportDetectedLanguage[];
+  /** Number of model calls the AI lane made for this file. */
+  chunks?: number;
+};
+
+export type TImportReportSummary = {
+  blocks: number;
+  elements: number;
+  endings: number;
+  languages: string[];
+  logicRules: number;
+  logicRulesReported: number;
+  hiddenFields: number;
+};
+
+export type TImportReport = {
+  source: TImportReportSource;
+  summary: TImportReportSummary;
+  issues: TImportIssue[];
+};
+
+/**
+ * What a lane hands to the resolver. `document` stays `unknown` until the resolver has stripped and
+ * validated it; `references` carries the action-class definitions an export travelled with.
+ */
+export type TImportCandidate = {
+  document: unknown;
+  references?: TSurveyExportReferences;
+  issues: TImportIssue[];
+  source: TImportReportSource;
+};
+
+export type TImportSourceContent =
+  | { type: "bytes"; bytes: Buffer }
+  | { type: "text"; text: string }
+  | { type: "json"; value: unknown };
+
+/** Server-side lane input: raw bytes, text or an already-parsed JSON body — never a `File`. */
+export type TImportLaneInput = {
+  kind: TImportSourceKind;
+  fileName?: string;
+  content: TImportSourceContent;
+};
+
+export type TImportProgressStage = "reading" | "detecting_languages" | "extracting" | "validating";
+
+export type TImportProgress = {
+  stage: TImportProgressStage;
+  chunk?: { index: number; total: number };
+  detail?: string;
+};
+
+export type TImportContext = {
+  workspaceId: string;
+  organizationId: string;
+  userId: string | null;
+  requestId: string;
+  /** Cuid shared by every log line of one import run. */
+  importRunId: string;
+  /** Hint from the dialog (the workspace default) that breaks language-detection ties. */
+  languageHint?: string;
+  signal?: AbortSignal;
+  onProgress?: (progress: TImportProgress) => void;
+  /** Streams partial drafts to the dialog; `blockOffset` counts blocks already finalized by earlier chunks. */
+  onPartial?: (draft: unknown, blockOffset: number) => void;
+};
+
+export type TImportLaneHandler = (input: TImportLaneInput, ctx: TImportContext) => Promise<TImportCandidate>;


### PR DESCRIPTION
Fixes ENG-2983

## What & why

**Was:** Nothing could read an exported survey back in.

**Now:** `modules/survey/import` holds the skeleton every lane plugs into: source detection (content over extension), the lane contract, the import report type with its issue codes and English messages, and the first lane. The lossless lane reads an export envelope or a raw v3 document (a `GET` response body or an MCP-written document), strips instance-bound fields, and hands the document to the resolver untouched.

- Detection tells DOCX from XLSX by zip entry names, QSF from a renamed `.json`, and rejects `.doc`/`.xls` with a "save as" code.
- Newer `exportFormat` and legacy `questions` are fatal with a clear message; `slug` and schedule are removed with an info line.
- Pure `.ts`, no HTTP, no UI. Import owns its own extension allowlist (`.qsf`, `.md` are not in the storage allowlist).

Stacked on #9190 (ENG-2974).

## Where to look

- [detect.ts](apps/web/modules/survey/import/detect.ts) — the sniffing order and the failure codes the UI keys on
- [lanes/formbricks/index.ts](apps/web/modules/survey/import/lanes/formbricks/index.ts) — envelope vs raw document, what is stripped here vs left for the resolver
- [types.ts](apps/web/modules/survey/import/types.ts) — the issue-code union every later lane extends

## Breaking changes

- [ ] This PR contains breaking changes

None — new internal module, nothing wired to a route yet.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/import`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Detection matrix: every kind, content-over-extension, zip sniffing, MIME fallback, `.doc` rejection, empty/broken/unknown JSON, BOM | unit (mutation) | `detect.test.ts`; 12 tests pass |
| Lossless lane on the M1 export fixture (app survey → references), a GET response body, an MCP document | unit (mutation) | `lanes/formbricks/index.test.ts`; passes |
| Fatal cases (newer format, legacy questions, broken JSON, bad metadata/references) produce `error` issues and `document: null` | unit (mutation) | passes |
| Every issue code has a message template; report helpers and `summarizeDocument` tolerate malformed input | unit (guard) | `report.test.ts`; passes |

**Open gaps**

- The lane is not reachable from a route yet (ENG-2986 / ENG-2987).

**Risks**

- none beyond the module itself

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
