### PR TITLE
feat(surveys): import reference resolver — languages, action classes, entitlements, validation [ENG-2984]

### DIFF
--- a/apps/web/modules/survey/import/resolve/action-classes.ts
+++ b/apps/web/modules/survey/import/resolve/action-classes.ts
@@ -1,0 +1,161 @@
+import type { TActionClass, TActionClassInput } from "@formbricks/types/action-classes";
+import type { TSurveyExportActionClassReference } from "@/app/api/v3/surveys/export/schemas";
+import { importInfo, importWarning } from "../report";
+import type { TImportIssue } from "../types";
+import { isRecord } from "./paths";
+
+const IMPORTED_SUFFIX = " (imported)";
+
+export type TActionClassResolutionDeps = {
+  listActionClasses: (workspaceId: string) => Promise<TActionClass[]>;
+  createActionClass: (workspaceId: string, input: TActionClassInput) => Promise<{ id: string }>;
+};
+
+export type TActionClassResolutionParams = {
+  document: Record<string, unknown>;
+  references: readonly TSurveyExportActionClassReference[];
+  workspaceId: string;
+  dryRun: boolean;
+  deps: TActionClassResolutionDeps;
+};
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * Find the workspace action class an exported definition stands for: code actions by `key`, no-code
+ * actions by a deep-equal `noCodeConfig`, otherwise by name. Same heuristic as "Copy to".
+ */
+export function matchActionClass(
+  reference: TSurveyExportActionClassReference,
+  existing: readonly TActionClass[]
+): TActionClass | undefined {
+  if (reference.type === "code" && reference.key) {
+    const byKey = existing.find((candidate) => candidate.type === "code" && candidate.key === reference.key);
+    if (byKey) return byKey;
+  }
+
+  if (reference.type === "noCode" && reference.noCodeConfig) {
+    const wanted = stableStringify(reference.noCodeConfig);
+    const byConfig = existing.find(
+      (candidate) => candidate.type === "noCode" && stableStringify(candidate.noCodeConfig) === wanted
+    );
+    if (byConfig) return byConfig;
+  }
+
+  return existing.find((candidate) => candidate.name === reference.name && candidate.type === reference.type);
+}
+
+function uniqueName(name: string, takenNames: Set<string>): string {
+  if (!takenNames.has(name)) return name;
+  let candidate = `${name}${IMPORTED_SUFFIX}`;
+  let counter = 2;
+  while (takenNames.has(candidate)) {
+    candidate = `${name}${IMPORTED_SUFFIX.slice(0, -1)} ${counter})`;
+    counter += 1;
+  }
+  return candidate;
+}
+
+/**
+ * Rewrite `distribution.triggers[].actionClassId` for the target workspace. Ids that already exist in
+ * the workspace are kept as they are, which is what makes a second pass over a resolved document a
+ * no-op. Link surveys lose `distribution` entirely (v3 rejects it on them).
+ */
+export async function resolveImportActionClasses({
+  document,
+  references,
+  workspaceId,
+  dryRun,
+  deps,
+}: TActionClassResolutionParams): Promise<TImportIssue[]> {
+  const issues: TImportIssue[] = [];
+
+  if (document.type !== "app") {
+    if ("distribution" in document) {
+      delete document.distribution;
+      issues.push(
+        importInfo({ code: "unknown_field_stripped", path: "distribution", vars: { field: "distribution" } })
+      );
+    }
+    return issues;
+  }
+
+  const distribution = isRecord(document.distribution) ? document.distribution : null;
+  const triggers = distribution && Array.isArray(distribution.triggers) ? distribution.triggers : [];
+  if (!distribution || triggers.length === 0) {
+    return issues;
+  }
+
+  const existing = await deps.listActionClasses(workspaceId);
+  const existingById = new Map(existing.map((actionClass) => [actionClass.id, actionClass]));
+  const takenNames = new Set(existing.map((actionClass) => actionClass.name));
+  const resolvedBySourceId = new Map<string, string>();
+  const kept: { actionClassId: string }[] = [];
+
+  for (const [index, trigger] of triggers.entries()) {
+    const path = `distribution.triggers.${index}.actionClassId`;
+    const sourceId =
+      isRecord(trigger) && typeof trigger.actionClassId === "string" ? trigger.actionClassId : null;
+    if (!sourceId) {
+      issues.push(importWarning({ code: "trigger_dropped", path, vars: { id: "?" } }));
+      continue;
+    }
+
+    if (existingById.has(sourceId)) {
+      kept.push({ actionClassId: sourceId });
+      continue;
+    }
+
+    const alreadyResolved = resolvedBySourceId.get(sourceId);
+    if (alreadyResolved) {
+      kept.push({ actionClassId: alreadyResolved });
+      continue;
+    }
+
+    const reference = references.find((candidate) => candidate.id === sourceId);
+    if (!reference) {
+      issues.push(importWarning({ code: "trigger_dropped", path, vars: { id: sourceId } }));
+      continue;
+    }
+
+    const match = matchActionClass(reference, existing);
+    if (match) {
+      resolvedBySourceId.set(sourceId, match.id);
+      kept.push({ actionClassId: match.id });
+      issues.push(importInfo({ code: "trigger_mapped", path, vars: { name: reference.name } }));
+      continue;
+    }
+
+    const name = uniqueName(reference.name, takenNames);
+    if (dryRun) {
+      issues.push(importInfo({ code: "trigger_would_be_created", path, vars: { name } }));
+      kept.push({ actionClassId: sourceId });
+      continue;
+    }
+
+    const created = await deps.createActionClass(workspaceId, {
+      workspaceId,
+      name,
+      description: reference.description ?? undefined,
+      ...(reference.type === "code"
+        ? { type: "code" as const, key: reference.key }
+        : { type: "noCode" as const, noCodeConfig: reference.noCodeConfig }),
+    });
+    takenNames.add(name);
+    resolvedBySourceId.set(sourceId, created.id);
+    kept.push({ actionClassId: created.id });
+    issues.push(importInfo({ code: "trigger_created", path, vars: { name } }));
+  }
+
+  distribution.triggers = kept;
+  return issues;
+}

--- a/apps/web/modules/survey/import/resolve/document.ts
+++ b/apps/web/modules/survey/import/resolve/document.ts
@@ -1,0 +1,145 @@
+import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
+import { ZSurveyLogicConditionsOperator } from "@formbricks/types/surveys/logic";
+import {
+  V3_SURVEY_DOCUMENT_ROOT_KEYS,
+  getUnsupportedV3SurveyDocumentFields,
+} from "@/app/api/v3/surveys/schemas";
+import { importError, importInfo } from "../report";
+import type { TImportIssue } from "../types";
+import { deleteAtPath, isRecord } from "./paths";
+
+/** Fields no import may carry, whatever the source. Silently removed; they have no user-visible meaning. */
+const INSTANCE_BOUND_FIELDS = [
+  "id",
+  "workspaceId",
+  "createdAt",
+  "updatedAt",
+  "archivedAt",
+  "createdBy",
+  "customHeadScripts",
+  "customHeadScriptsMode",
+  "segmentId",
+] as const;
+
+const ELEMENT_TYPES = new Set<string>(Object.values(TSurveyElementTypeEnum));
+const LOGIC_OPERATORS = new Set<string>(ZSurveyLogicConditionsOperator.options);
+
+export type TDocumentHygieneResult = {
+  document: Record<string, unknown>;
+  issues: TImportIssue[];
+};
+
+function stripInstanceBoundFields(document: Record<string, unknown>, issues: TImportIssue[]): void {
+  for (const field of INSTANCE_BOUND_FIELDS) {
+    delete document[field];
+  }
+
+  if ("slug" in document) {
+    delete document.slug;
+    issues.push(importInfo({ code: "slug_not_imported", path: "slug" }));
+  }
+
+  if (document.publishOn != null || document.closeOn != null) {
+    issues.push(importInfo({ code: "schedule_cleared", path: "publishOn" }));
+  }
+  delete document.publishOn;
+  delete document.closeOn;
+
+  if (document.status !== undefined && document.status !== "draft") {
+    issues.push(
+      importInfo({ code: "status_reset", path: "status", vars: { status: String(document.status) } })
+    );
+  }
+  document.status = "draft";
+}
+
+/**
+ * Unknown element types and logic operators cannot be stripped into something meaningful: a file
+ * from a newer instance is fatal (edge case #68).
+ */
+function collectUnknownEnumIssues(document: Record<string, unknown>, issues: TImportIssue[]): void {
+  const blocks = Array.isArray(document.blocks) ? document.blocks : [];
+
+  blocks.forEach((block, blockIndex) => {
+    if (!isRecord(block)) return;
+
+    const elements = Array.isArray(block.elements) ? block.elements : [];
+    elements.forEach((element, elementIndex) => {
+      if (isRecord(element) && typeof element.type === "string" && !ELEMENT_TYPES.has(element.type)) {
+        issues.push(
+          importError({
+            code: "unknown_element",
+            path: `blocks.${blockIndex}.elements.${elementIndex}.type`,
+            vars: { type: element.type },
+          })
+        );
+      }
+    });
+
+    const logic = Array.isArray(block.logic) ? block.logic : [];
+    logic.forEach((rule, ruleIndex) => {
+      if (!isRecord(rule)) return;
+      collectUnknownOperators(rule.conditions, `blocks.${blockIndex}.logic.${ruleIndex}.conditions`, issues);
+    });
+  });
+}
+
+function collectUnknownOperators(group: unknown, path: string, issues: TImportIssue[]): void {
+  if (!isRecord(group) || !Array.isArray(group.conditions)) return;
+
+  group.conditions.forEach((condition, index) => {
+    if (!isRecord(condition)) return;
+    const conditionPath = `${path}.conditions.${index}`;
+
+    if (Array.isArray(condition.conditions)) {
+      collectUnknownOperators(condition, conditionPath, issues);
+      return;
+    }
+
+    if (typeof condition.operator === "string" && !LOGIC_OPERATORS.has(condition.operator)) {
+      issues.push(
+        importError({
+          code: "unknown_element",
+          path: `${conditionPath}.operator`,
+          vars: { type: condition.operator },
+        })
+      );
+    }
+  });
+}
+
+/**
+ * Strip and warn (D7). Every `unsupported_field` the create schema would reject is removed with its
+ * path; the create-side validation later reports what is genuinely wrong. Unknown element types and
+ * operators are fatal instead.
+ */
+export function applyDocumentHygiene(input: unknown): TDocumentHygieneResult {
+  const issues: TImportIssue[] = [];
+  const document: Record<string, unknown> = isRecord(input) ? structuredClone(input) : {};
+
+  stripInstanceBoundFields(document, issues);
+  collectUnknownEnumIssues(document, issues);
+
+  const unsupportedFields = getUnsupportedV3SurveyDocumentFields(
+    document,
+    new Set(V3_SURVEY_DOCUMENT_ROOT_KEYS),
+    typeof document.defaultLanguage === "string" ? document.defaultLanguage : undefined
+  ).filter((param) => param.code === "unsupported_field");
+
+  // Deepest paths first, so removing a parent never invalidates a child path we still hold.
+  unsupportedFields
+    .sort((left, right) => right.name.split(".").length - left.name.split(".").length)
+    .forEach((param) => {
+      if (deleteAtPath(document, param.name)) {
+        issues.push(
+          importInfo({
+            code: "unknown_field_stripped",
+            path: param.name,
+            vars: { field: param.name.split(".").at(-1) ?? param.name },
+          })
+        );
+      }
+    });
+
+  return { document, issues };
+}

--- a/apps/web/modules/survey/import/resolve/entitlements.ts
+++ b/apps/web/modules/survey/import/resolve/entitlements.ts
@@ -1,0 +1,94 @@
+import { importWarning } from "../report";
+import type { TImportIssue } from "../types";
+import { isRecord } from "./paths";
+
+const ENDING_FALLBACK_HEADLINE = "Thank you!";
+
+/** Does the document use anything gated behind the external-URL entitlement? */
+export function hasImportExternalUrls(document: Record<string, unknown>): boolean {
+  const endings = Array.isArray(document.endings) ? document.endings : [];
+  const hasEndingUrl = endings.some(
+    (ending) =>
+      isRecord(ending) &&
+      ((ending.type === "endScreen" && Boolean(ending.buttonLink)) ||
+        (ending.type === "redirectToUrl" && Boolean(ending.url)))
+  );
+  if (hasEndingUrl) return true;
+
+  const blocks = Array.isArray(document.blocks) ? document.blocks : [];
+  return blocks.some(
+    (block) =>
+      isRecord(block) &&
+      Array.isArray(block.elements) &&
+      block.elements.some(
+        (element) =>
+          isRecord(element) &&
+          element.type === "cta" &&
+          (element.buttonExternal === true || element.buttonUrl)
+      )
+  );
+}
+
+/** Every language the document declares, default first — a new i18n field must carry all of them. */
+function getDocumentLanguageCodes(document: Record<string, unknown>): string[] {
+  const codes = new Set<string>();
+  codes.add(typeof document.defaultLanguage === "string" ? document.defaultLanguage : "en-US");
+  if (Array.isArray(document.languages)) {
+    for (const language of document.languages) {
+      if (isRecord(language) && typeof language.code === "string") codes.add(language.code);
+    }
+  }
+  return Array.from(codes);
+}
+
+/**
+ * Strip every external URL when the organization is not entitled to them: CTA buttons become plain
+ * "next" buttons, ending links go, redirect endings turn into an end screen. The survey still works.
+ */
+export function stripImportExternalUrls(document: Record<string, unknown>): TImportIssue[] {
+  const issues: TImportIssue[] = [];
+  const languageCodes = getDocumentLanguageCodes(document);
+
+  const blocks = Array.isArray(document.blocks) ? document.blocks : [];
+  blocks.forEach((block, blockIndex) => {
+    if (!isRecord(block) || !Array.isArray(block.elements)) return;
+    block.elements.forEach((element, elementIndex) => {
+      if (!isRecord(element) || element.type !== "cta") return;
+      if (element.buttonExternal !== true && !element.buttonUrl) return;
+
+      element.buttonExternal = false;
+      delete element.buttonUrl;
+      issues.push(
+        importWarning({
+          code: "external_url_removed",
+          path: `blocks.${blockIndex}.elements.${elementIndex}.buttonUrl`,
+        })
+      );
+    });
+  });
+
+  const endings = Array.isArray(document.endings) ? document.endings : [];
+  endings.forEach((ending, index) => {
+    if (!isRecord(ending)) return;
+
+    if (ending.type === "endScreen" && ending.buttonLink) {
+      delete ending.buttonLink;
+      delete ending.buttonLabel;
+      issues.push(importWarning({ code: "external_url_removed", path: `endings.${index}.buttonLink` }));
+      return;
+    }
+
+    if (ending.type === "redirectToUrl") {
+      const headline =
+        typeof ending.label === "string" && ending.label.trim() ? ending.label : ENDING_FALLBACK_HEADLINE;
+      endings[index] = {
+        id: ending.id,
+        type: "endScreen",
+        headline: Object.fromEntries(languageCodes.map((code) => [code, headline])),
+      };
+      issues.push(importWarning({ code: "external_url_removed", path: `endings.${index}.url` }));
+    }
+  });
+
+  return issues;
+}

--- a/apps/web/modules/survey/import/resolve/index.test.ts
+++ b/apps/web/modules/survey/import/resolve/index.test.ts
@@ -1,0 +1,407 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TActionClass } from "@formbricks/types/action-classes";
+import {
+  FIXTURE_APP_SURVEY,
+  FIXTURE_CODE_ACTION_CLASS,
+  FIXTURE_LINK_SURVEY,
+  FIXTURE_NOCODE_ACTION_CLASS,
+  FIXTURE_WORKSPACE_ID,
+} from "@/modules/survey/export/__fixtures__/surveys";
+import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
+import { formbricksLane } from "../lanes/formbricks";
+import type { TImportCandidate, TImportContext } from "../types";
+import { type TResolveImportDeps, resolveImportCandidate } from "./index";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: { language: { findMany: vi.fn() } },
+}));
+
+vi.mock("@/lib/actionClass/service", () => ({ getActionClasses: vi.fn() }));
+vi.mock("@/modules/survey/editor/lib/action-class", () => ({ createActionClass: vi.fn() }));
+vi.mock("@/modules/survey/lib/permission", () => ({ getExternalUrlsPermission: vi.fn() }));
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  WEBAPP_URL: "https://app.formbricks.com",
+}));
+
+const laneCtx: TImportContext = {
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  organizationId: "org_1",
+  userId: "user_1",
+  requestId: "req_1",
+  importRunId: "run_1",
+};
+
+const resolveCtx = {
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  organizationId: "org_1",
+  userId: "user_1",
+  requestId: "req_1",
+  dryRun: false,
+};
+
+const existingCodeAction: TActionClass = {
+  ...FIXTURE_CODE_ACTION_CLASS,
+  id: "claaexisting00000000000001",
+  name: "Purchase done",
+};
+
+const deps = {
+  listActionClasses: vi.fn<TResolveImportDeps["listActionClasses"]>(),
+  createActionClass: vi.fn<TResolveImportDeps["createActionClass"]>(),
+  listWorkspaceLanguageCodes: vi.fn<TResolveImportDeps["listWorkspaceLanguageCodes"]>(),
+  isExternalUrlAllowed: vi.fn<TResolveImportDeps["isExternalUrlAllowed"]>(),
+  instanceUrl: "https://app.formbricks.com",
+};
+
+async function candidateFor(survey: typeof FIXTURE_LINK_SURVEY): Promise<TImportCandidate> {
+  const result = buildSurveyExportEnvelope(survey, {
+    appVersion: "6.2.0",
+    publicUrl: "https://source.example",
+  });
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return formbricksLane(
+    {
+      kind: "formbricks-export",
+      fileName: "x.formbricks.json",
+      content: { type: "json", value: result.data },
+    },
+    laneCtx
+  );
+}
+
+function codes(issues: { code: string }[]): string[] {
+  return issues.map((issue) => issue.code);
+}
+
+describe("resolveImportCandidate", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    deps.listActionClasses.mockResolvedValue([existingCodeAction]);
+    deps.createActionClass.mockImplementation(async (_workspaceId, input) => ({
+      id: input.type === "code" ? "claacreatedcode0000000001" : "claacreatednocode00000001",
+    }));
+    deps.listWorkspaceLanguageCodes.mockResolvedValue(["en-US"]);
+    deps.isExternalUrlAllowed.mockResolvedValue(true);
+  });
+
+  test("resolves a link export: valid create body, languages reported, settings note, no errors", async () => {
+    const result = await resolveImportCandidate(await candidateFor(FIXTURE_LINK_SURVEY), resolveCtx, deps);
+
+    expect(result.validation).toEqual({ valid: true, invalid_params: [] });
+    expect(result.createBody).toMatchObject({
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      status: "draft",
+      type: "link",
+    });
+    expect(result.document).toMatchObject({ status: "draft" });
+    expect(result.document).not.toHaveProperty("workspaceId");
+    // The picture-selection fixture hosts its images on example.com, hence the external-asset note.
+    expect(codes(result.report.issues)).toEqual([
+      "status_reset",
+      "language_created",
+      "asset_url_external",
+      "settings_not_exported",
+    ]);
+    expect(result.report.issues[1]).toMatchObject({ vars: { code: "de-DE" } });
+    expect(result.report.summary).toMatchObject({
+      blocks: 3,
+      elements: 17,
+      endings: 1,
+      languages: ["en-US", "de-DE"],
+      logicRules: 1,
+      hiddenFields: 2,
+    });
+    expect(deps.createActionClass).not.toHaveBeenCalled();
+  });
+
+  test("app export: matches one trigger by key, creates the other with an (imported) suffix on a name clash", async () => {
+    deps.listActionClasses.mockResolvedValue([
+      { ...FIXTURE_CODE_ACTION_CLASS, id: "claaexisting00000000000001" },
+      // Same name as the exported no-code action but a different type: not a match, but a name clash.
+      {
+        ...FIXTURE_CODE_ACTION_CLASS,
+        id: "claaother0000000000000001",
+        name: "Clicked pricing",
+        key: "pricing_clicked",
+      },
+    ]);
+
+    const result = await resolveImportCandidate(await candidateFor(FIXTURE_APP_SURVEY), resolveCtx, deps);
+
+    expect(result.validation.valid).toBe(true);
+    expect(result.createBody?.distribution?.triggers).toEqual([
+      { actionClassId: "claaexisting00000000000001" },
+      { actionClassId: "claacreatednocode00000001" },
+    ]);
+    expect(deps.createActionClass).toHaveBeenCalledWith(FIXTURE_WORKSPACE_ID, {
+      workspaceId: FIXTURE_WORKSPACE_ID,
+      name: "Clicked pricing (imported)",
+      description: undefined,
+      type: "noCode",
+      noCodeConfig: FIXTURE_NOCODE_ACTION_CLASS.noCodeConfig,
+    });
+    expect(codes(result.report.issues)).toContain("trigger_mapped");
+    expect(codes(result.report.issues)).toContain("trigger_created");
+    expect(result.document).not.toHaveProperty("targeting");
+  });
+
+  test("dryRun reports what would be created and writes nothing", async () => {
+    const result = await resolveImportCandidate(
+      await candidateFor(FIXTURE_APP_SURVEY),
+      { ...resolveCtx, dryRun: true },
+      deps
+    );
+
+    expect(deps.createActionClass).not.toHaveBeenCalled();
+    expect(codes(result.report.issues)).toContain("trigger_would_be_created");
+    expect(result.report.issues.find((issue) => issue.code === "trigger_would_be_created")).toMatchObject({
+      vars: { name: "Clicked pricing" },
+    });
+    expect(result.validation.valid).toBe(true);
+  });
+
+  test("keeps triggers whose action class already exists in the workspace, without references (idempotent)", async () => {
+    const first = await resolveImportCandidate(await candidateFor(FIXTURE_APP_SURVEY), resolveCtx, deps);
+    deps.listActionClasses.mockResolvedValue([
+      existingCodeAction,
+      { ...FIXTURE_CODE_ACTION_CLASS, id: "claacreatedcode0000000001" },
+      { ...FIXTURE_NOCODE_ACTION_CLASS, id: "claacreatednocode00000001" },
+    ]);
+    deps.listWorkspaceLanguageCodes.mockResolvedValue(["en-US", "de-DE"]);
+
+    const second = await resolveImportCandidate(
+      { document: first.document, issues: [], source: { lane: "lossless", kind: "v3-document" } },
+      resolveCtx,
+      deps
+    );
+
+    expect(second.validation.valid).toBe(true);
+    // The external-asset note is a fact about the file, so it is the one line a second pass repeats.
+    expect(codes(second.report.issues).filter((code) => code !== "asset_url_external")).toEqual([]);
+    expect(second.createBody?.distribution?.triggers).toEqual(first.createBody?.distribution?.triggers);
+    expect(deps.createActionClass).toHaveBeenCalledTimes(1);
+  });
+
+  test("drops a trigger with no definition, removes distribution from a link survey", async () => {
+    const appCandidate = await candidateFor(FIXTURE_APP_SURVEY);
+    const noReferences = { ...appCandidate, references: { actionClasses: [] } };
+    deps.listActionClasses.mockResolvedValue([]);
+
+    const dropped = await resolveImportCandidate(noReferences, resolveCtx, deps);
+    expect(codes(dropped.report.issues).filter((code) => code === "trigger_dropped")).toHaveLength(2);
+    expect(dropped.createBody?.distribution?.triggers).toEqual([]);
+
+    const linkWithDistribution = await candidateFor(FIXTURE_LINK_SURVEY);
+    (linkWithDistribution.document as Record<string, unknown>).distribution = {
+      displayOption: "displayOnce",
+      triggers: [],
+    };
+    const link = await resolveImportCandidate(linkWithDistribution, resolveCtx, deps);
+    expect(link.validation.valid).toBe(true);
+    expect(link.report.issues).toContainEqual(
+      expect.objectContaining({ code: "unknown_field_stripped", path: "distribution" })
+    );
+  });
+
+  test("deletes hand-crafted targeting with a note only when it has filters", async () => {
+    const candidate = await candidateFor(FIXTURE_APP_SURVEY);
+    const document = candidate.document as Record<string, unknown>;
+    document.targeting = { filters: [{ id: "f1" }] };
+
+    const result = await resolveImportCandidate(candidate, resolveCtx, deps);
+    expect(result.validation.valid).toBe(true);
+    expect(codes(result.report.issues)).toContain("targeting_not_imported");
+
+    document.targeting = { filters: [] };
+    const silent = await resolveImportCandidate(candidate, resolveCtx, deps);
+    expect(codes(silent.report.issues)).not.toContain("targeting_not_imported");
+    expect(silent.document).not.toHaveProperty("targeting");
+  });
+
+  test("strips external URLs when the organization lacks the entitlement", async () => {
+    deps.isExternalUrlAllowed.mockResolvedValue(false);
+    const candidate = await candidateFor(FIXTURE_LINK_SURVEY);
+    const document = candidate.document as Record<string, unknown>;
+    const blocks = document.blocks as { elements: Record<string, unknown>[] }[];
+    const cta = blocks[0].elements.find((element) => element.type === "cta")!;
+    cta.buttonExternal = true;
+    cta.buttonUrl = "https://example.com";
+    (document.endings as Record<string, unknown>[]).push({
+      id: "clen0000000000000000000002",
+      type: "redirectToUrl",
+      url: "https://example.com/next",
+      label: "Go on",
+    });
+
+    const result = await resolveImportCandidate(candidate, resolveCtx, deps);
+
+    expect(result.validation.valid, JSON.stringify(result.validation)).toBe(true);
+    expect(codes(result.report.issues).filter((code) => code === "external_url_removed")).toHaveLength(3);
+    const resolvedCta = (
+      result.document?.blocks as { elements: Record<string, unknown>[] }[]
+    )[0].elements.find((element) => element.type === "cta");
+    expect(resolvedCta).toMatchObject({ buttonExternal: false });
+    expect(resolvedCta).not.toHaveProperty("buttonUrl");
+    const endings = result.document?.endings as Record<string, unknown>[];
+    expect(endings[0]).not.toHaveProperty("buttonLink");
+    expect(endings[1]).toEqual({
+      id: "clen0000000000000000000002",
+      type: "endScreen",
+      headline: { "en-US": "Go on", "de-DE": "Go on" },
+    });
+  });
+
+  test("removes invalid media with a warning and notes foreign-hosted images", async () => {
+    const candidate = await candidateFor(FIXTURE_LINK_SURVEY);
+    const document = candidate.document as Record<string, unknown>;
+    const blocks = document.blocks as { elements: Record<string, unknown>[] }[];
+    blocks[0].elements[0].imageUrl = "https://evil.example/pic.svg";
+    blocks[0].elements[1].videoUrl = "https://example.com/video.mp4";
+    blocks[0].elements[2].imageUrl = "https://other-instance.example/storage/ws/public/a.png";
+
+    const result = await resolveImportCandidate(candidate, resolveCtx, deps);
+
+    expect(result.validation.valid).toBe(true);
+    expect(result.report.issues).toContainEqual(
+      expect.objectContaining({ code: "media_invalid", path: "blocks.0.elements.0.imageUrl" })
+    );
+    expect(result.report.issues).toContainEqual(
+      expect.objectContaining({ code: "media_invalid", path: "blocks.0.elements.1.videoUrl" })
+    );
+    expect(result.report.issues).toContainEqual(
+      expect.objectContaining({ code: "asset_url_external", path: "blocks.0.elements.2.imageUrl" })
+    );
+    const resolvedBlocks = result.document?.blocks as { elements: Record<string, unknown>[] }[];
+    expect(resolvedBlocks[0].elements[0]).not.toHaveProperty("imageUrl");
+    expect(resolvedBlocks[0].elements[2].imageUrl).toBe(
+      "https://other-instance.example/storage/ws/public/a.png"
+    );
+  });
+
+  test("strips pre-D1 fields with their path and keeps the rest", async () => {
+    const candidate = await candidateFor(FIXTURE_LINK_SURVEY);
+    const document = candidate.document as Record<string, unknown>;
+    document.styling = { brandColor: "#000" };
+    document.followUps = [];
+    (document.blocks as Record<string, unknown>[])[0].customFlag = true;
+    document.slug = "hand-edited";
+
+    const result = await resolveImportCandidate(candidate, resolveCtx, deps);
+
+    expect(result.validation.valid, JSON.stringify(result.validation)).toBe(true);
+    expect(result.report.issues).toContainEqual(
+      expect.objectContaining({ code: "unknown_field_stripped", path: "styling" })
+    );
+    expect(result.report.issues).toContainEqual(
+      expect.objectContaining({ code: "unknown_field_stripped", path: "followUps" })
+    );
+    expect(result.report.issues).toContainEqual(
+      expect.objectContaining({ code: "unknown_field_stripped", path: "blocks.0.customFlag" })
+    );
+    expect(result.report.issues).toContainEqual(expect.objectContaining({ code: "slug_not_imported" }));
+    expect(result.document).not.toHaveProperty("styling");
+  });
+
+  test("an unknown element type is fatal", async () => {
+    const candidate = await candidateFor(FIXTURE_LINK_SURVEY);
+    const blocks = (candidate.document as Record<string, unknown>).blocks as {
+      elements: Record<string, unknown>[];
+    }[];
+    blocks[0].elements[0].type = "hologram";
+
+    const result = await resolveImportCandidate(candidate, resolveCtx, deps);
+
+    expect(result.document).toBeNull();
+    expect(result.createBody).toBeNull();
+    expect(result.report.issues).toContainEqual(
+      expect.objectContaining({
+        severity: "error",
+        code: "unknown_element",
+        path: "blocks.0.elements.0.type",
+      })
+    );
+    expect(deps.listWorkspaceLanguageCodes).not.toHaveBeenCalled();
+  });
+
+  test("a dangling jumpToBlock fails v3 validation and lands in the report and validation", async () => {
+    const candidate = await candidateFor(FIXTURE_LINK_SURVEY);
+    const blocks = (candidate.document as Record<string, unknown>).blocks as Record<string, unknown>[];
+    (blocks[0].logic as { actions: { target: string }[] }[])[0].actions[0].target =
+      "clbkmissing000000000000001";
+
+    const result = await resolveImportCandidate(candidate, resolveCtx, deps);
+
+    expect(result.document).toBeNull();
+    expect(result.validation.valid).toBe(false);
+    expect(result.validation.invalid_params[0]).toMatchObject({
+      name: "blocks.0.logic.0.actions.0.target",
+      code: "dangling_reference",
+    });
+    expect(result.report.issues).toContainEqual(
+      expect.objectContaining({
+        severity: "error",
+        code: "invalid_document",
+        path: "blocks.0.logic.0.actions.0.target",
+      })
+    );
+  });
+
+  test("normalizes language codes, rewrites translation keys, and fails on an unknown code", async () => {
+    const candidate = await candidateFor(FIXTURE_LINK_SURVEY);
+    const document = candidate.document as Record<string, unknown>;
+    (document.languages as { code: string }[])[1].code = "de_de";
+    const headline = (document.blocks as { elements: Record<string, unknown>[] }[])[0].elements[0]
+      .headline as Record<string, string>;
+    headline.de_de = headline["de-DE"];
+    delete headline["de-DE"];
+
+    const result = await resolveImportCandidate(candidate, resolveCtx, deps);
+    expect(result.validation.valid, JSON.stringify(result.validation)).toBe(true);
+    expect((result.document?.languages as { code: string }[])[1].code).toBe("de-DE");
+
+    document.defaultLanguage = "klingon";
+    const unknown = await resolveImportCandidate(candidate, resolveCtx, deps);
+    expect(unknown.document).toBeNull();
+    expect(unknown.report.issues).toContainEqual(
+      expect.objectContaining({ severity: "error", code: "language_unknown" })
+    );
+  });
+
+  test("applies the review name override and passes fatal lane issues through untouched", async () => {
+    const candidate = await candidateFor(FIXTURE_LINK_SURVEY);
+    const renamed = await resolveImportCandidate(
+      candidate,
+      { ...resolveCtx, name: "  Renamed (imported) " },
+      deps
+    );
+    expect(renamed.createBody?.name).toBe("Renamed (imported)");
+
+    const fatal = await resolveImportCandidate(
+      {
+        document: null,
+        issues: [{ severity: "error", code: "legacy_questions_unsupported", message: "legacy" }],
+        source: { lane: "lossless", kind: "v3-document" },
+      },
+      resolveCtx,
+      deps
+    );
+    expect(fatal.document).toBeNull();
+    expect(fatal.report.issues).toHaveLength(1);
+    // Only the rename run above reached the language step; the fatal candidate never did.
+    expect(deps.listWorkspaceLanguageCodes).toHaveBeenCalledTimes(1);
+  });
+
+  test("the QSF source kind does not get the settings note", async () => {
+    const candidate = await candidateFor(FIXTURE_LINK_SURVEY);
+    const result = await resolveImportCandidate(
+      { ...candidate, references: undefined, source: { lane: "structured", kind: "qsf" } },
+      resolveCtx,
+      deps
+    );
+
+    expect(codes(result.report.issues)).not.toContain("settings_not_exported");
+  });
+});

--- a/apps/web/modules/survey/import/resolve/index.ts
+++ b/apps/web/modules/survey/import/resolve/index.ts
@@ -1,0 +1,151 @@
+import "server-only";
+import { prisma } from "@formbricks/database";
+import type { InvalidParam } from "@/app/api/v3/lib/response";
+import { prepareV3SurveyCreateInput } from "@/app/api/v3/surveys/prepare";
+import type { TV3CreateSurveyBody } from "@/app/api/v3/surveys/schemas";
+import { getActionClasses } from "@/lib/actionClass/service";
+import { WEBAPP_URL } from "@/lib/constants";
+import { createActionClass } from "@/modules/survey/editor/lib/action-class";
+import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
+import { createImportReport, hasFatalIssues, importError, importInfo, summarizeDocument } from "../report";
+import type { TImportCandidate, TImportIssue, TImportReport } from "../types";
+import type { TActionClassResolutionDeps } from "./action-classes";
+import { resolveImportActionClasses } from "./action-classes";
+import { applyDocumentHygiene } from "./document";
+import { hasImportExternalUrls, stripImportExternalUrls } from "./entitlements";
+import { resolveImportLanguages } from "./languages";
+import { resolveImportMedia } from "./media";
+import { resolveImportTargeting } from "./targeting";
+
+export type TResolveImportContext = {
+  workspaceId: string;
+  organizationId: string;
+  userId: string | null;
+  requestId: string;
+  /** Report what would be created instead of creating it; nothing is written. */
+  dryRun: boolean;
+  /** Overrides `document.name` when the user renamed the survey in the review step. */
+  name?: string;
+};
+
+/** Injectable I/O so the pipeline is unit-testable without a database. */
+export type TResolveImportDeps = TActionClassResolutionDeps & {
+  listWorkspaceLanguageCodes: (workspaceId: string) => Promise<string[]>;
+  isExternalUrlAllowed: (organizationId: string) => Promise<boolean>;
+  instanceUrl?: string;
+};
+
+export type TResolveImportResult = {
+  /** The resolved document in its public shape (locale-code maps), ready to be sent back to the API. */
+  document: Record<string, unknown> | null;
+  /** The parsed create body the import route persists; null when the report has errors. */
+  createBody: TV3CreateSurveyBody | null;
+  report: TImportReport;
+  validation: { valid: boolean; invalid_params: InvalidParam[] };
+};
+
+const defaultDeps: TResolveImportDeps = {
+  listActionClasses: getActionClasses,
+  createActionClass: (workspaceId, input) => createActionClass(workspaceId, input),
+  listWorkspaceLanguageCodes: async (workspaceId) => {
+    const languages = await prisma.language.findMany({ where: { workspaceId }, select: { code: true } });
+    return languages.map((language) => language.code);
+  },
+  isExternalUrlAllowed: getExternalUrlsPermission,
+  instanceUrl: WEBAPP_URL,
+};
+
+function invalidParamToIssue(param: InvalidParam): TImportIssue {
+  return importError({
+    code: "invalid_document",
+    path: param.name,
+    message: param.reason,
+    vars: { detail: param.reason, ...(param.code ? { v3Code: param.code } : {}) },
+  });
+}
+
+/**
+ * Turn a lane's candidate into a document the target workspace can hold, and say what changed.
+ *
+ * Steps run in a fixed order — hygiene, languages, action classes, targeting, external URLs, media,
+ * validation — and each one only appends to the issue list. Resolving an already-resolved document
+ * adds no issues: ids that exist are kept, nothing left to strip, nothing left to warn about.
+ */
+export async function resolveImportCandidate(
+  candidate: TImportCandidate,
+  ctx: TResolveImportContext,
+  deps: TResolveImportDeps = defaultDeps
+): Promise<TResolveImportResult> {
+  const report = createImportReport(candidate.source, candidate.issues);
+
+  if (candidate.document === null || candidate.document === undefined || hasFatalIssues(candidate.issues)) {
+    return {
+      document: null,
+      createBody: null,
+      report,
+      validation: { valid: false, invalid_params: [] },
+    };
+  }
+
+  const hygiene = applyDocumentHygiene(candidate.document);
+  const document = hygiene.document;
+  report.issues.push(...hygiene.issues);
+
+  if (ctx.name !== undefined && ctx.name.trim().length > 0) {
+    document.name = ctx.name.trim();
+  }
+
+  if (hasFatalIssues(hygiene.issues)) {
+    report.summary = summarizeDocument(document);
+    return { document: null, createBody: null, report, validation: { valid: false, invalid_params: [] } };
+  }
+
+  const languages = resolveImportLanguages(document, await deps.listWorkspaceLanguageCodes(ctx.workspaceId));
+  report.issues.push(...languages.issues);
+
+  report.issues.push(
+    ...(await resolveImportActionClasses({
+      document,
+      references: candidate.references?.actionClasses ?? [],
+      workspaceId: ctx.workspaceId,
+      dryRun: ctx.dryRun,
+      deps,
+    }))
+  );
+
+  report.issues.push(...resolveImportTargeting(document));
+
+  if (hasImportExternalUrls(document) && !(await deps.isExternalUrlAllowed(ctx.organizationId))) {
+    report.issues.push(...stripImportExternalUrls(document));
+  }
+
+  report.issues.push(...resolveImportMedia(document, deps.instanceUrl));
+
+  if (candidate.source.kind === "formbricks-export") {
+    report.issues.push(importInfo({ code: "settings_not_exported" }));
+  }
+
+  const preparation = prepareV3SurveyCreateInput({ ...document, workspaceId: ctx.workspaceId });
+  report.summary = summarizeDocument(document);
+
+  if (!preparation.ok) {
+    report.issues.push(...preparation.validation.invalidParams.map(invalidParamToIssue));
+    return {
+      document: null,
+      createBody: null,
+      report,
+      validation: { valid: false, invalid_params: preparation.validation.invalidParams },
+    };
+  }
+
+  if (hasFatalIssues(report.issues)) {
+    return { document: null, createBody: null, report, validation: { valid: false, invalid_params: [] } };
+  }
+
+  return {
+    document,
+    createBody: preparation.document,
+    report,
+    validation: { valid: true, invalid_params: [] },
+  };
+}

--- a/apps/web/modules/survey/import/resolve/languages.ts
+++ b/apps/web/modules/survey/import/resolve/languages.ts
@@ -1,0 +1,92 @@
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/canonical";
+import { normalizeV3SurveyLanguageTag } from "@/app/api/v3/surveys/language";
+import { DEFAULT_V3_SURVEY_LANGUAGE } from "@/app/api/v3/surveys/schemas";
+import { importError, importInfo } from "../report";
+import type { TImportIssue } from "../types";
+import { isI18nMap, isRecord } from "./paths";
+
+export type TLanguageResolutionResult = {
+  document: Record<string, unknown>;
+  issues: TImportIssue[];
+  /** Every language code the document uses after normalization, default first. */
+  codes: string[];
+};
+
+/** A code as the file wrote it → the canonical BCP-47 tag v3 stores, or null when nothing recognizes it. */
+export function canonicalizeImportLanguageCode(code: string): string | null {
+  return normalizeV3SurveyLanguageTag(code) ?? normalizeLanguageCode(code) ?? null;
+}
+
+/** Rewrite one locale key everywhere a translatable map uses it. */
+function rewriteLanguageKey(value: unknown, from: string, to: string): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => rewriteLanguageKey(entry, from, to));
+    return;
+  }
+  if (!isRecord(value)) return;
+
+  if (isI18nMap(value)) {
+    if (Object.hasOwn(value, from) && from !== to) {
+      value[to] = value[from];
+      delete value[from];
+    }
+    return;
+  }
+
+  Object.values(value).forEach((entry) => rewriteLanguageKey(entry, from, to));
+}
+
+/**
+ * Normalize every language code the document declares and say which ones the workspace does not
+ * have yet. Creation itself happens in the v3 create route (`ensureV3WorkspaceLanguages`).
+ */
+export function resolveImportLanguages(
+  input: Record<string, unknown>,
+  workspaceLanguageCodes: readonly string[]
+): TLanguageResolutionResult {
+  const document = input;
+  const issues: TImportIssue[] = [];
+  const knownCodes = new Set(workspaceLanguageCodes.map((code) => code.toLowerCase()));
+  const canonicalByRaw = new Map<string, string>();
+
+  const canonicalize = (raw: string, path: string): string | null => {
+    const canonical = canonicalizeImportLanguageCode(raw);
+    if (!canonical) {
+      issues.push(importError({ code: "language_unknown", path, vars: { code: raw } }));
+      return null;
+    }
+    if (canonical !== raw) {
+      canonicalByRaw.set(raw, canonical);
+    }
+    return canonical;
+  };
+
+  const rawDefault = typeof document.defaultLanguage === "string" ? document.defaultLanguage : undefined;
+  const defaultCode = rawDefault ? canonicalize(rawDefault, "defaultLanguage") : DEFAULT_V3_SURVEY_LANGUAGE;
+  if (defaultCode) {
+    document.defaultLanguage = defaultCode;
+  }
+
+  const codes: string[] = defaultCode ? [defaultCode] : [];
+  if (Array.isArray(document.languages)) {
+    document.languages.forEach((language, index) => {
+      if (!isRecord(language) || typeof language.code !== "string") return;
+      const canonical = canonicalize(language.code, `languages.${index}.code`);
+      if (!canonical) return;
+      language.code = canonical;
+      if (!codes.includes(canonical)) codes.push(canonical);
+    });
+  }
+
+  for (const [raw, canonical] of canonicalByRaw) {
+    rewriteLanguageKey(document, raw, canonical);
+  }
+
+  for (const code of codes) {
+    if (!knownCodes.has(code.toLowerCase())) {
+      issues.push(importInfo({ code: "language_created", vars: { code } }));
+    }
+  }
+
+  return { document, issues, codes };
+}

--- a/apps/web/modules/survey/import/resolve/media.ts
+++ b/apps/web/modules/survey/import/resolve/media.ts
@@ -1,0 +1,110 @@
+import { isValidVideoUrl } from "@/lib/utils/video-upload";
+import { isValidImageFile } from "@/modules/storage/utils";
+import { importInfo, importWarning } from "../report";
+import type { TImportIssue } from "../types";
+import { isRecord } from "./paths";
+
+type TMediaKind = "image" | "video";
+
+type TMediaSlot = { container: Record<string, unknown>; key: string; path: string; kind: TMediaKind };
+
+function collectElementMedia(document: Record<string, unknown>, slots: TMediaSlot[]): void {
+  const blocks = Array.isArray(document.blocks) ? document.blocks : [];
+  blocks.forEach((block, blockIndex) => {
+    if (!isRecord(block) || !Array.isArray(block.elements)) return;
+    block.elements.forEach((element, elementIndex) => {
+      if (!isRecord(element)) return;
+      const base = `blocks.${blockIndex}.elements.${elementIndex}`;
+      slots.push({ container: element, key: "imageUrl", path: `${base}.imageUrl`, kind: "image" });
+      slots.push({ container: element, key: "videoUrl", path: `${base}.videoUrl`, kind: "video" });
+      if (element.type === "pictureSelection" && Array.isArray(element.choices)) {
+        element.choices.forEach((choice, choiceIndex) => {
+          if (isRecord(choice)) {
+            slots.push({
+              container: choice,
+              key: "imageUrl",
+              path: `${base}.choices.${choiceIndex}.imageUrl`,
+              kind: "image",
+            });
+          }
+        });
+      }
+    });
+  });
+}
+
+function collectMediaSlots(document: Record<string, unknown>): TMediaSlot[] {
+  const slots: TMediaSlot[] = [];
+  collectElementMedia(document, slots);
+
+  if (isRecord(document.welcomeCard)) {
+    slots.push({
+      container: document.welcomeCard,
+      key: "fileUrl",
+      path: "welcomeCard.fileUrl",
+      kind: "image",
+    });
+    slots.push({
+      container: document.welcomeCard,
+      key: "videoUrl",
+      path: "welcomeCard.videoUrl",
+      kind: "video",
+    });
+  }
+
+  const endings = Array.isArray(document.endings) ? document.endings : [];
+  endings.forEach((ending, index) => {
+    if (!isRecord(ending)) return;
+    slots.push({ container: ending, key: "imageUrl", path: `endings.${index}.imageUrl`, kind: "image" });
+    slots.push({ container: ending, key: "videoUrl", path: `endings.${index}.videoUrl`, kind: "video" });
+  });
+
+  if (isRecord(document.metadata)) {
+    slots.push({ container: document.metadata, key: "ogImage", path: "metadata.ogImage", kind: "image" });
+  }
+
+  return slots;
+}
+
+function isForeignAsset(url: string, instanceUrl: string | undefined): boolean {
+  if (url.startsWith("/")) return false;
+  try {
+    const parsed = new URL(url);
+    if (!instanceUrl) return true;
+    return parsed.origin !== new URL(instanceUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Media is validated the way the write path validates it (image extension allowlist, YouTube/Vimeo/
+ * Loom only); anything invalid is removed with a warning so the create call cannot fail on it.
+ * Picture-selection choices are the exception: their image is the choice, so an invalid one stays
+ * and the create-side validation reports it. Images hosted by another instance keep working only as
+ * long as that instance serves them, hence the info line.
+ */
+export function resolveImportMedia(document: Record<string, unknown>, instanceUrl?: string): TImportIssue[] {
+  const issues: TImportIssue[] = [];
+  let reportedForeign = false;
+
+  for (const slot of collectMediaSlots(document)) {
+    const url = slot.container[slot.key];
+    if (typeof url !== "string" || url.length === 0) continue;
+
+    const valid = slot.kind === "image" ? isValidImageFile(url) : isValidVideoUrl(url);
+    if (!valid) {
+      if (slot.path.includes(".choices.")) continue;
+      delete slot.container[slot.key];
+      issues.push(importWarning({ code: "media_invalid", path: slot.path, vars: { url } }));
+      continue;
+    }
+
+    if (slot.kind === "image" && !reportedForeign && isForeignAsset(url, instanceUrl)) {
+      reportedForeign = true;
+      issues.push(importInfo({ code: "asset_url_external", path: slot.path }));
+    }
+  }
+
+  return issues;
+}

--- a/apps/web/modules/survey/import/resolve/paths.ts
+++ b/apps/web/modules/survey/import/resolve/paths.ts
@@ -1,0 +1,49 @@
+/** Small helpers for the dotted v3 paths (`blocks.0.elements.1.buttonUrl`) the resolver reports and edits. */
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getContainer(root: unknown, segments: string[]): unknown {
+  let current: unknown = root;
+  for (const segment of segments) {
+    if (Array.isArray(current)) {
+      current = current[Number(segment)];
+    } else if (isRecord(current)) {
+      current = current[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+/** Delete the value at a dotted path. Returns whether something was there. */
+export function deleteAtPath(root: unknown, path: string): boolean {
+  const segments = path.split(".");
+  const last = segments.pop();
+  if (last === undefined) return false;
+
+  const container = getContainer(root, segments);
+  if (isRecord(container) && Object.hasOwn(container, last)) {
+    delete container[last];
+    return true;
+  }
+  return false;
+}
+
+export function getAtPath(root: unknown, path: string): unknown {
+  return getContainer(root, path.split("."));
+}
+
+/**
+ * A translatable map: a plain object whose values are all strings. Public shape (`{ "en-US": … }`),
+ * so the keys are locale codes.
+ */
+export function isI18nMap(value: unknown): value is Record<string, string> {
+  return (
+    isRecord(value) &&
+    Object.keys(value).length > 0 &&
+    Object.values(value).every((entry) => typeof entry === "string")
+  );
+}

--- a/apps/web/modules/survey/import/resolve/targeting.ts
+++ b/apps/web/modules/survey/import/resolve/targeting.ts
@@ -1,0 +1,18 @@
+import { importInfo } from "../report";
+import type { TImportIssue } from "../types";
+import { isRecord } from "./paths";
+
+/**
+ * Targeting (segment filters) is out of v1: the export never carries it, and a hand-crafted document
+ * loses it here. An empty filter list means "everyone", which is also the default, so only a
+ * non-empty one is worth a line in the report.
+ */
+export function resolveImportTargeting(document: Record<string, unknown>): TImportIssue[] {
+  if (!("targeting" in document)) return [];
+
+  const targeting = document.targeting;
+  const hadFilters = isRecord(targeting) && Array.isArray(targeting.filters) && targeting.filters.length > 0;
+  delete document.targeting;
+
+  return hadFilters ? [importInfo({ code: "targeting_not_imported", path: "targeting" })] : [];
+}


### PR DESCRIPTION
Fixes ENG-2984

## What & why

**Was:** A lane could read a file into a candidate document, but nothing made it fit the target workspace.

**Now:** `resolveImportCandidate` turns a candidate into a create body the workspace can hold and a report of everything that changed: strip-and-warn hygiene (D7), language normalization with `language_created` notes, action-class matching/creation for app triggers (`(imported)` suffix on a name clash, `trigger_would_be_created` in dry run), targeting dropped, external URLs stripped without the entitlement, invalid media removed, then the exact v3 create validation.

- Ids that already exist in the workspace are kept as they are, so a resolved document resolves again with no new issues.
- Unknown element types or logic operators are fatal (`unknown_element`); everything else is a warning or info.
- I/O is injected (`TResolveImportDeps`), so the whole pipeline is unit-tested without a database.

Stacked on #9191 (ENG-2983).

## Where to look

- [resolve/index.ts](apps/web/modules/survey/import/resolve/index.ts) — step order and the two documents it returns (public shape + parsed create body)
- [resolve/action-classes.ts](apps/web/modules/survey/import/resolve/action-classes.ts) — match by key → config → name, create with suffix, dry-run branch
- [resolve/document.ts](apps/web/modules/survey/import/resolve/document.ts) — which fields are stripped silently, which are reported, which are fatal

## Breaking changes

- [ ] This PR contains breaking changes

None — internal module, not yet reachable from a route.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/import/resolve`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Link export → valid create body, `language_created`, `settings_not_exported`; app export → one trigger mapped by key, one created with `(imported)`; dry run creates nothing | unit (mutation) | `resolve/index.test.ts`; passes |
| Second pass over a resolved document adds no issues and keeps existing action-class ids | unit (mutation) | passes |
| Targeting deleted (note only with filters); stray `distribution` on a link survey removed; triggers without a definition dropped | unit (mutation) | passes |
| No external-URL entitlement: CTA blanked, ending link removed, redirect ending → end screen in every language | unit (mutation) | passes |
| Invalid `.svg`/`.mp4` media removed with a warning, foreign-hosted image noted; pre-D1 `styling`/`followUps`/unknown block key stripped with paths | unit (mutation) | passes |
| Unknown element type fatal; dangling `jumpToBlock` reported via v3 validation; `de_de` normalized to `de-DE` with translation keys rewritten; unknown language fatal | unit (mutation) | passes |

**Open gaps**

- Only exercised through the lossless lane's candidates; QSF/AI candidates arrive in later PRs.

**Risks**

- The name-match fallback for action classes can bind a trigger to an existing action of the same name and type; that is the same heuristic "Copy to" uses.

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
