### PR TITLE
feat(surveys): POST /api/v3/surveys/import (JSON, dryRun) + createdFrom=import + OpenAPI [ENG-2986]

### DIFF
--- a/apps/web/app/api/v3/lib/response.ts
+++ b/apps/web/app/api/v3/lib/response.ts
@@ -160,12 +160,18 @@ export function problemAIUnavailable(
 export function problemUnprocessableContent(
   requestId: string,
   detail: string,
-  options?: { invalid_params?: InvalidParam[]; instance?: string; code?: string }
+  options?: {
+    invalid_params?: InvalidParam[];
+    instance?: string;
+    code?: string;
+    details?: Record<string, unknown>;
+  }
 ): Response {
   return problemResponse(422, "Unprocessable Content", detail, requestId, {
     code: options?.code ?? "unprocessable_content",
     instance: options?.instance,
     invalid_params: options?.invalid_params,
+    details: options?.details,
   });
 }
 

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
+import { problemForbidden } from "@/app/api/v3/lib/response";
+import { createV3SurveyResponse } from "@/app/api/v3/surveys/lib/operations";
+import { getActionClasses } from "@/lib/actionClass/service";
+import { createActionClass } from "@/modules/survey/editor/lib/action-class";
+import {
+  FIXTURE_APP_SURVEY,
+  FIXTURE_LINK_SURVEY,
+  FIXTURE_WORKSPACE_ID,
+} from "@/modules/survey/export/__fixtures__/surveys";
+import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
+import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
+import { ZV3SurveyImportBody } from "../schemas";
+import { importV3Survey } from "./import-survey";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { withContext: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() })) },
+}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: { language: { findMany: vi.fn() }, survey: { create: vi.fn() } },
+}));
+
+vi.mock("@/app/api/v3/lib/auth", () => ({ requireV3WorkspaceAccess: vi.fn() }));
+vi.mock("@/app/api/v3/lib/audit", () => ({
+  buildV3AuditLog: vi.fn(() => ({ action: "created", targetType: "survey" })),
+  queueV3AuditLog: vi.fn(),
+}));
+vi.mock("@/app/api/v3/surveys/lib/operations", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/app/api/v3/surveys/lib/operations")>()),
+  createV3SurveyResponse: vi.fn(),
+}));
+vi.mock("@/lib/actionClass/service", () => ({ getActionClasses: vi.fn() }));
+vi.mock("@/modules/survey/editor/lib/action-class", () => ({ createActionClass: vi.fn() }));
+vi.mock("@/modules/survey/lib/permission", () => ({ getExternalUrlsPermission: vi.fn() }));
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  WEBAPP_URL: "https://app.formbricks.com",
+}));
+
+const requestId = "req_import_1";
+const instance = "/api/v3/surveys/import";
+const authResult = { workspaceId: FIXTURE_WORKSPACE_ID, organizationId: "org_1" };
+const sessionAuthentication = {
+  user: { id: "user_1", email: "user@example.com", name: "User" },
+  expires: "2026-12-01",
+} as unknown as Parameters<typeof importV3Survey>[0]["authentication"];
+const req = new Request("https://app.formbricks.com/api/v3/surveys/import", { method: "POST" });
+
+function envelopeOf(survey: typeof FIXTURE_LINK_SURVEY) {
+  const result = buildSurveyExportEnvelope(survey, {
+    appVersion: "6.2.0",
+    publicUrl: "https://source.example",
+  });
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return JSON.parse(JSON.stringify(result.data)) as Record<string, unknown>;
+}
+
+function parseBody(body: unknown) {
+  return ZV3SurveyImportBody.parse(body);
+}
+
+describe("importV3Survey", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(authResult);
+    vi.mocked(prisma.language.findMany).mockResolvedValue([{ code: "en-US" }] as never);
+    vi.mocked(getActionClasses).mockResolvedValue([]);
+    vi.mocked(createActionClass).mockResolvedValue({ id: "claacreated000000000000001" } as never);
+    vi.mocked(getExternalUrlsPermission).mockResolvedValue(true);
+    vi.mocked(createV3SurveyResponse).mockResolvedValue(
+      Response.json(
+        { data: { id: "clsvnew0000000000000000001", name: "Imported" } },
+        { status: 201, headers: { Location: "/api/v3/surveys/clsvnew0000000000000000001" } }
+      )
+    );
+  });
+
+  test("dryRun returns document, report and validation and writes nothing", async () => {
+    const response = await importV3Survey({
+      req,
+      body: parseBody({
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        export: envelopeOf(FIXTURE_APP_SURVEY),
+        options: { dryRun: true },
+      }),
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.validation).toEqual({ valid: true, invalid_params: [] });
+    expect(body.data.document).toMatchObject({ type: "app", status: "draft" });
+    expect(body.data.document).not.toHaveProperty("workspaceId");
+    expect(body.data.report.source).toEqual({ lane: "lossless", kind: "formbricks-export" });
+    expect(body.data.report.issues.map((issue: { code: string }) => issue.code)).toContain(
+      "trigger_would_be_created"
+    );
+    expect(createActionClass).not.toHaveBeenCalled();
+    expect(createV3SurveyResponse).not.toHaveBeenCalled();
+    expect(prisma.survey.create).not.toHaveBeenCalled();
+  });
+
+  test("creates through the shared v3 create path with createdFrom import and returns survey + report", async () => {
+    const response = await importV3Survey({
+      req,
+      body: parseBody({
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        export: envelopeOf(FIXTURE_LINK_SURVEY),
+        options: { name: "Renamed" },
+      }),
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get("Location")).toBe("/api/v3/surveys/clsvnew0000000000000000001");
+    const body = await response.json();
+    expect(body.data.survey).toEqual({ id: "clsvnew0000000000000000001", name: "Imported" });
+    expect(body.data.report.issues.map((issue: { code: string }) => issue.code)).toContain(
+      "settings_not_exported"
+    );
+
+    expect(createV3SurveyResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authResult,
+        createdFrom: "import",
+        createOptions: { skipExternalUrlPermissionCheck: true },
+        body: expect.objectContaining({
+          workspaceId: FIXTURE_WORKSPACE_ID,
+          name: "Renamed",
+          status: "draft",
+        }),
+        analyticsProperties: expect.objectContaining({
+          import_source: "formbricks-export",
+          import_lane: "lossless",
+          import_ai_used: false,
+          import_chunk_count: 0,
+        }),
+        auditLog: expect.objectContaining({ action: "created" }),
+      })
+    );
+  });
+
+  test("accepts a raw document with references, creating the referenced action class", async () => {
+    const envelope = envelopeOf(FIXTURE_APP_SURVEY);
+
+    const response = await importV3Survey({
+      req,
+      body: parseBody({
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        document: envelope.survey,
+        references: envelope.references,
+      }),
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(201);
+    expect(createActionClass).toHaveBeenCalledTimes(2);
+    const createBody = vi.mocked(createV3SurveyResponse).mock.calls[0][0].body;
+    expect(createBody.distribution?.triggers).toEqual([
+      { actionClassId: "claacreated000000000000001" },
+      { actionClassId: "claacreated000000000000001" },
+    ]);
+  });
+
+  test("answers 422 with invalid_params and the report when the document cannot be imported", async () => {
+    const envelope = envelopeOf(FIXTURE_LINK_SURVEY);
+    const survey = envelope.survey as Record<string, unknown>;
+    const blocks = survey.blocks as { elements: Record<string, unknown>[] }[];
+    blocks[0].elements[0].type = "hologram";
+
+    const response = await importV3Survey({
+      req,
+      body: parseBody({ workspaceId: FIXTURE_WORKSPACE_ID, export: envelope }),
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.invalid_params).toEqual([
+      { name: "blocks.0.elements.0.type", reason: expect.stringContaining("hologram") },
+    ]);
+    expect(body.details.report.issues).toContainEqual(
+      expect.objectContaining({ severity: "error", code: "unknown_element" })
+    );
+    expect(createV3SurveyResponse).not.toHaveBeenCalled();
+  });
+
+  test("strips an extensions block and still creates, with a warning in the report", async () => {
+    const envelope = { ...envelopeOf(FIXTURE_LINK_SURVEY), extensions: { styling: {} } };
+
+    const response = await importV3Survey({
+      req,
+      body: parseBody({ workspaceId: FIXTURE_WORKSPACE_ID, export: envelope }),
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.data.report.issues).toContainEqual(
+      expect.objectContaining({ code: "unknown_field_stripped", path: "extensions" })
+    );
+  });
+
+  test("returns the authorization response for a workspace the caller cannot write", async () => {
+    vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(problemForbidden(requestId, "nope", instance));
+
+    const response = await importV3Survey({
+      req,
+      body: parseBody({ workspaceId: FIXTURE_WORKSPACE_ID, document: { name: "x", blocks: [] } }),
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(403);
+    expect(prisma.language.findMany).not.toHaveBeenCalled();
+  });
+
+  test("passes a non-201 create response through unchanged", async () => {
+    vi.mocked(createV3SurveyResponse).mockResolvedValue(
+      Response.json({ title: "Forbidden" }, { status: 403 })
+    );
+
+    const response = await importV3Survey({
+      req,
+      body: parseBody({ workspaceId: FIXTURE_WORKSPACE_ID, export: envelopeOf(FIXTURE_LINK_SURVEY) }),
+      authentication: sessionAuthentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(403);
+  });
+});
+
+describe("ZV3SurveyImportBody", () => {
+  test("requires exactly one of export or document", () => {
+    expect(ZV3SurveyImportBody.safeParse({ workspaceId: FIXTURE_WORKSPACE_ID }).success).toBe(false);
+    expect(
+      ZV3SurveyImportBody.safeParse({ workspaceId: FIXTURE_WORKSPACE_ID, export: {}, document: {} }).success
+    ).toBe(false);
+    expect(ZV3SurveyImportBody.safeParse({ workspaceId: FIXTURE_WORKSPACE_ID, document: {} }).success).toBe(
+      true
+    );
+    expect(
+      ZV3SurveyImportBody.safeParse({
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        document: {},
+        options: { dryRun: "yes" },
+      }).success
+    ).toBe(false);
+  });
+});

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
@@ -1,0 +1,187 @@
+import "server-only";
+import { createId } from "@paralleldrive/cuid2";
+import { logger } from "@formbricks/logger";
+import { DatabaseError } from "@formbricks/types/errors";
+import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
+import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
+import {
+  type InvalidParam,
+  createdResponse,
+  problemInternalError,
+  problemUnprocessableContent,
+  successResponse,
+} from "@/app/api/v3/lib/response";
+import type { TV3Authentication } from "@/app/api/v3/lib/types";
+import { createV3SurveyResponse, getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
+import { formbricksLane } from "@/modules/survey/import/lanes/formbricks";
+import { countIssues } from "@/modules/survey/import/report";
+import { type TResolveImportResult, resolveImportCandidate } from "@/modules/survey/import/resolve";
+import type { TImportCandidate, TImportReport } from "@/modules/survey/import/types";
+import type { TV3SurveyImportBody } from "../schemas";
+
+type TImportV3SurveyParams = {
+  req: Request;
+  body: TV3SurveyImportBody;
+  authentication: TV3Authentication;
+  requestId: string;
+  instance: string;
+};
+
+/** Report errors as v3 `invalid_params`, so agents repair a file the same way they repair a create body. */
+export function reportErrorsToInvalidParams(report: TImportReport): InvalidParam[] {
+  return report.issues
+    .filter((issue) => issue.severity === "error")
+    .map((issue) => ({ name: issue.path ?? "document", reason: issue.message }));
+}
+
+/** The `survey_created` properties product reads import adoption from. */
+export function buildImportAnalyticsProperties(report: TImportReport) {
+  const counts = countIssues(report.issues);
+  return {
+    import_source: report.source.kind,
+    import_lane: report.source.lane,
+    import_ai_used: report.source.lane === "ai",
+    import_warning_count: counts.warning,
+    import_chunk_count: report.source.chunks ?? 0,
+  };
+}
+
+async function runLosslessImport(
+  body: TV3SurveyImportBody,
+  ctx: {
+    workspaceId: string;
+    organizationId: string;
+    userId: string | null;
+    requestId: string;
+    importRunId: string;
+  }
+): Promise<TResolveImportResult> {
+  const candidate: TImportCandidate = await formbricksLane(
+    {
+      kind: body.export !== undefined ? "formbricks-export" : "v3-document",
+      content: { type: "json", value: body.export ?? body.document },
+    },
+    ctx
+  );
+
+  // A resolved draft sent back by the dialog carries its references next to the document.
+  if (!candidate.references && body.references) {
+    candidate.references = body.references;
+  }
+
+  return resolveImportCandidate(candidate, {
+    workspaceId: ctx.workspaceId,
+    organizationId: ctx.organizationId,
+    userId: ctx.userId,
+    requestId: ctx.requestId,
+    dryRun: body.options?.dryRun === true,
+    name: body.options?.name,
+  });
+}
+
+/**
+ * `POST /api/v3/surveys/import` — the lossless lane on the public API, and the one door every lane
+ * creates through: the dialog sends the reviewed document here after a convert.
+ *
+ * `options.dryRun` answers 200 with the resolved document, the report and the validation, and writes
+ * nothing. Otherwise a report with errors answers 422 (the report rides in `details`), and a valid
+ * document is created through the shared v3 create path with `createdFrom: "import"`.
+ */
+export async function importV3Survey({
+  req,
+  body,
+  authentication,
+  requestId,
+  instance,
+}: TImportV3SurveyParams): Promise<Response> {
+  const importRunId = createId();
+  const log = logger.withContext({ requestId, importRunId, workspaceId: body.workspaceId });
+
+  try {
+    const authResult = await requireV3WorkspaceAccess(
+      authentication,
+      body.workspaceId,
+      "readWrite",
+      requestId,
+      instance
+    );
+    if (authResult instanceof Response) {
+      return authResult;
+    }
+
+    const resolved = await runLosslessImport(body, {
+      workspaceId: authResult.workspaceId,
+      organizationId: authResult.organizationId,
+      userId: getSessionUserId(authentication),
+      requestId,
+      importRunId,
+    });
+
+    if (body.options?.dryRun === true) {
+      return successResponse(
+        {
+          document: resolved.document,
+          references: body.references ?? null,
+          report: resolved.report,
+          validation: resolved.validation,
+        },
+        { requestId, cache: "private, no-store" }
+      );
+    }
+
+    if (!resolved.createBody) {
+      const invalidParams =
+        resolved.validation.invalid_params.length > 0
+          ? resolved.validation.invalid_params
+          : reportErrorsToInvalidParams(resolved.report);
+      log.warn(
+        { statusCode: 422, sourceKind: resolved.report.source.kind, invalidParamCount: invalidParams.length },
+        "Survey import refused"
+      );
+      return problemUnprocessableContent(requestId, "The survey could not be imported", {
+        instance,
+        invalid_params: invalidParams,
+        details: { report: resolved.report },
+      });
+    }
+
+    // Audited by hand rather than through the wrapper: a dry run must not leave a `created` row.
+    const auditLog = buildV3AuditLog(authentication, "created", "survey", req.url);
+
+    const createResponse = await createV3SurveyResponse({
+      body: resolved.createBody,
+      authentication,
+      requestId,
+      instance,
+      auditLog,
+      authResult,
+      createdFrom: "import",
+      createOptions: { skipExternalUrlPermissionCheck: true },
+      analyticsProperties: buildImportAnalyticsProperties(resolved.report),
+    });
+
+    if (auditLog) {
+      auditLog.status = createResponse.ok ? "success" : "failure";
+      if (!createResponse.ok) auditLog.eventId = requestId;
+      await queueV3AuditLog(auditLog, requestId, log);
+    }
+
+    if (createResponse.status !== 201) {
+      return createResponse;
+    }
+
+    const created = (await createResponse.json()) as { data: { id: string } };
+    return createdResponse(
+      { survey: created.data, report: resolved.report },
+      { requestId, location: createResponse.headers.get("Location") ?? `/api/v3/surveys/${created.data.id}` }
+    );
+  } catch (error) {
+    if (error instanceof DatabaseError) {
+      log.error({ error, statusCode: 500 }, "Database error");
+      return problemInternalError(requestId, "An unexpected error occurred.", instance);
+    }
+
+    log.error({ error, statusCode: 500 }, "V3 survey import unexpected error");
+    return problemInternalError(requestId, "An unexpected error occurred.", instance);
+  }
+}

--- a/apps/web/app/api/v3/surveys/import/route.ts
+++ b/apps/web/app/api/v3/surveys/import/route.ts
@@ -1,0 +1,28 @@
+/**
+ * POST /api/v3/surveys/import — import a `.formbricks.json` export or a raw v3 survey document into a
+ * workspace. `options.dryRun` returns the resolved document and report without writing.
+ * Session cookie or x-api-key; readWrite access on the target workspace.
+ */
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { ZV3EmptyQuery } from "../schemas";
+import { importV3Survey } from "./lib/import-survey";
+import { ZV3SurveyImportBody } from "./schemas";
+
+export const POST = withV3ApiWrapper({
+  auth: "both",
+  schemas: {
+    body: ZV3SurveyImportBody,
+    query: ZV3EmptyQuery,
+  },
+  // No wrapper-level audit: a dry run writes nothing, so the `created` row is queued by the
+  // handler only when a survey was actually created.
+  handler: async ({ req, authentication, parsedInput, requestId, instance }) => {
+    return await importV3Survey({
+      req,
+      body: parsedInput.body,
+      authentication,
+      requestId,
+      instance,
+    });
+  },
+});

--- a/apps/web/app/api/v3/surveys/import/schemas.ts
+++ b/apps/web/app/api/v3/surveys/import/schemas.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { ZSurveyExportReferences } from "../export/schemas";
+
+const ZImportObject = z.record(z.string(), z.unknown());
+
+export const ZV3SurveyImportOptions = z
+  .object({
+    /** Overrides the survey name (the review step's "Survey name" input). */
+    name: z.string().trim().min(1).max(200).optional(),
+    /** Resolve and validate only. Nothing is written, no action classes or languages are created. */
+    dryRun: z.boolean().optional(),
+  })
+  .strict();
+
+/**
+ * Exactly one of `export` (a `.formbricks.json` envelope) or `document` (a raw v3 survey document).
+ * Both are parsed by the lossless lane, not here, so a file with a stray `extensions` block or a
+ * hand-edited `slug` is reported instead of rejected at the door. `references` travels with a
+ * `document` when the dialog sends back a resolved draft whose triggers still point at the source
+ * workspace's action classes.
+ */
+export const ZV3SurveyImportBody = z
+  .object({
+    workspaceId: z.cuid2(),
+    export: ZImportObject.optional(),
+    document: ZImportObject.optional(),
+    references: ZSurveyExportReferences.optional(),
+    options: ZV3SurveyImportOptions.optional(),
+  })
+  .strict()
+  .superRefine((body, ctx) => {
+    const provided = [body.export !== undefined, body.document !== undefined].filter(Boolean).length;
+    if (provided !== 1) {
+      ctx.addIssue({
+        code: "custom",
+        path: provided === 0 ? ["document"] : ["export"],
+        message: "Provide exactly one of 'export' or 'document'",
+      });
+    }
+  });
+
+export type TV3SurveyImportBody = z.infer<typeof ZV3SurveyImportBody>;

--- a/apps/web/app/api/v3/surveys/lib/operations.ts
+++ b/apps/web/app/api/v3/surveys/lib/operations.ts
@@ -63,10 +63,14 @@ type TCreateV3SurveyParams = {
   requestId: string;
   instance: string;
   auditLog?: TV3AuditLog;
-  createdFrom?: "blank" | "template" | "xm-template" | "ai";
+  createdFrom?: TV3SurveyCreatedFrom;
   createOptions?: TV3SurveyCreateOptions;
   authResult?: V3WorkspaceContext;
+  /** Extra `survey_created` properties the import route passes through from its report. */
+  analyticsProperties?: Record<string, string | number | boolean | null | undefined>;
 };
+
+export type TV3SurveyCreatedFrom = "blank" | "template" | "xm-template" | "ai" | "import";
 
 type TRawCreateV3SurveyParams = Omit<TCreateV3SurveyParams, "body"> & {
   body: unknown;
@@ -295,6 +299,7 @@ export async function createV3SurveyResponse({
   createdFrom,
   createOptions,
   authResult: providedAuthResult,
+  analyticsProperties,
 }: TCreateV3SurveyParams): Promise<Response> {
   const log = logger.withContext({ requestId, workspaceId: body.workspaceId });
 
@@ -345,6 +350,7 @@ export async function createV3SurveyResponse({
           workspace_id: authResult.workspaceId,
           question_count: survey.questions?.length ?? 0,
           created_from: createdFrom,
+          ...analyticsProperties,
         },
         { organizationId: authResult.organizationId, workspaceId: authResult.workspaceId }
       );

--- a/apps/web/app/api/v3/surveys/schemas.ts
+++ b/apps/web/app/api/v3/surveys/schemas.ts
@@ -1288,7 +1288,7 @@ export function createZV3TypedSurveyDocumentSchema(options?: TV3SurveyDocumentSc
 export const ZV3TypedSurveyDocument = createZV3TypedSurveyDocumentSchema();
 
 export const ZV3CreateSurveyQuery = z.object({
-  createdFrom: z.enum(["blank", "template", "xm-template", "ai"]).optional(),
+  createdFrom: z.enum(["blank", "template", "xm-template", "ai", "import"]).optional(),
 });
 
 export type TV3CreateSurveyQuery = z.infer<typeof ZV3CreateSurveyQuery>;

--- a/apps/web/modules/survey/import/resolve/index.test.ts
+++ b/apps/web/modules/survey/import/resolve/index.test.ts
@@ -394,6 +394,40 @@ describe("resolveImportCandidate", () => {
     expect(deps.listWorkspaceLanguageCodes).toHaveBeenCalledTimes(1);
   });
 
+  test("a minimal raw document comes back complete, with the create defaults filled in", async () => {
+    const result = await resolveImportCandidate(
+      {
+        document: {
+          name: "Minimal",
+          blocks: [
+            {
+              name: "Main",
+              elements: [{ id: "why", type: "openText", headline: { "en-US": "Why?" }, required: true }],
+            },
+          ],
+        },
+        issues: [],
+        source: { lane: "lossless", kind: "v3-document" },
+      },
+      resolveCtx,
+      deps
+    );
+
+    expect(result.validation.valid).toBe(true);
+    expect(result.document).toMatchObject({
+      type: "link",
+      status: "draft",
+      metadata: {},
+      defaultLanguage: "en-US",
+      languages: [],
+      welcomeCard: { enabled: false },
+      endings: [],
+      hiddenFields: { enabled: false },
+      variables: [],
+    });
+    expect(JSON.stringify(result.document)).not.toContain('"default"');
+  });
+
   test("the QSF source kind does not get the settings note", async () => {
     const candidate = await candidateFor(FIXTURE_LINK_SURVEY);
     const result = await resolveImportCandidate(

--- a/apps/web/modules/survey/import/resolve/index.ts
+++ b/apps/web/modules/survey/import/resolve/index.ts
@@ -143,9 +143,39 @@ export async function resolveImportCandidate(
   }
 
   return {
-    document,
+    document: withCreateDefaults(document, preparation.document),
     createBody: preparation.document,
     report,
     validation: { valid: true, invalid_params: [] },
   };
+}
+
+/**
+ * Fields the create schema defaults when a raw document omits them. Copied back so the public
+ * document the dialog receives is complete; none of these carry translatable text in their default
+ * form, so the internal `default` key never leaks into the public shape.
+ */
+const DEFAULTED_DOCUMENT_FIELDS = [
+  "type",
+  "status",
+  "metadata",
+  "defaultLanguage",
+  "languages",
+  "welcomeCard",
+  "endings",
+  "hiddenFields",
+  "variables",
+] as const;
+
+function withCreateDefaults(
+  document: Record<string, unknown>,
+  createBody: TV3CreateSurveyBody
+): Record<string, unknown> {
+  const complete = { ...document };
+  for (const field of DEFAULTED_DOCUMENT_FIELDS) {
+    if (complete[field] === undefined) {
+      complete[field] = createBody[field];
+    }
+  }
+  return complete;
 }

--- a/apps/web/modules/survey/list/lib/v3-surveys-client.ts
+++ b/apps/web/modules/survey/list/lib/v3-surveys-client.ts
@@ -293,7 +293,7 @@ export async function validateSurveyCreatePayload(
 
 export async function createV3Survey(
   payload: TV3CreateSurveyBody,
-  createdFrom?: "blank" | "template" | "xm-template" | "ai"
+  createdFrom?: "blank" | "template" | "xm-template" | "ai" | "import"
 ): Promise<TV3CreateSurveyResponse["data"]> {
   const url = createdFrom
     ? `/api/v3/surveys?createdFrom=${encodeURIComponent(createdFrom)}`

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -5,7 +5,7 @@ openapi: 3.1.1
 info:
   title: Formbricks API v3
   description: |
-    **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, **DELETE /api/v3/surveys/{surveyId}**, and **GET /api/v3/surveys/{surveyId}/export**, which returns a portable `.formbricks.json` envelope that re-imports into any workspace or instance.
+    **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, **DELETE /api/v3/surveys/{surveyId}**, **GET /api/v3/surveys/{surveyId}/export**, which returns a portable `.formbricks.json` envelope, and **POST /api/v3/surveys/import**, which creates a survey from such an envelope or a raw v3 document in any workspace or instance (with a dry-run mode).
 
     **Workflows extension**: **GET /api/v3/workflows**, **POST /api/v3/workflows**, **GET /api/v3/workflows/{workflowId}**, **PATCH /api/v3/workflows/{workflowId}**, **DELETE /api/v3/workflows/{workflowId}**, **POST /api/v3/workflows/{workflowId}/duplicate**, **POST /api/v3/workflows/{workflowId}/enable**, **POST /api/v3/workflows/{workflowId}/disable**, **POST /api/v3/workflows/{workflowId}/archive**, **POST /api/v3/workflows/{workflowId}/unarchive**, **POST /api/v3/workflows/{workflowId}/test**, **GET /api/v3/workflows/runs**, and **GET /api/v3/workflows/runs/{runId}**.
 
@@ -1401,6 +1401,102 @@ paths:
                     invalid_params:
                       - name: survey.blocks
                         reason: Empty surveys cannot be exported. Add at least one question first.
+        '429':
+          $ref: '#/components/responses/V3TooManyRequests'
+        '500':
+          $ref: '#/components/responses/V3InternalServerError'
+      security:
+        - sessionAuth: []
+        - apiKeyAuth: []
+  /api/v3/surveys/import:
+    post:
+      operationId: importSurveyV3
+      summary: Import a survey
+      description: |
+        Imports a `.formbricks.json` export or a raw v3 survey document into a workspace. The document is made to fit the target workspace before it is created: the survey becomes a draft; the link slug, schedule and instance-bound fields are dropped; unknown fields are stripped with a report line; languages the workspace lacks are created; app-survey triggers are matched to existing action classes by key, configuration or name and created otherwise; targeting is not imported; external links are removed when the organization is not entitled to them; invalid media is removed. Every change is one line in `report.issues`.
+
+        With `options.dryRun: true` the endpoint answers **200** with the resolved document, the report and the validation and writes nothing. Otherwise a document that cannot be imported answers **422** (the report rides in `details.report`), and a valid one is created through the same path as `POST /api/v3/surveys` and answers **201** with the survey and the report.
+      tags:
+        - V3 Surveys
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SurveyImportRequest'
+            examples:
+              dryRun:
+                summary: Check a raw document without creating it
+                value:
+                  workspaceId: clxx1234567890123456789012
+                  document:
+                    name: Onboarding feedback
+                    type: link
+                    defaultLanguage: en-US
+                    blocks:
+                      - id: clbk1234567890123456789012
+                        name: Main
+                        elements:
+                          - id: why
+                            type: openText
+                            headline:
+                              en-US: Why did you stop?
+                            required: true
+                  options:
+                    dryRun: true
+      responses:
+        '200':
+          description: Dry run completed. The document may still be invalid; nothing was written.
+          headers:
+            X-Request-Id:
+              schema:
+                type: string
+              description: Request correlation ID
+            Cache-Control:
+              schema:
+                type: string
+              example: private, no-store
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SurveyImportDryRunResult'
+        '201':
+          description: Survey imported. `Location` points at the new survey.
+          headers:
+            X-Request-Id:
+              schema:
+                type: string
+              description: Request correlation ID
+            Location:
+              schema:
+                type: string
+              description: URL of the created survey
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SurveyImportResult'
+        '400':
+          $ref: '#/components/responses/V3BadRequest'
+        '401':
+          $ref: '#/components/responses/V3Unauthorized'
+        '403':
+          $ref: '#/components/responses/V3Forbidden'
+        '422':
+          description: 'Unprocessable Content — the document cannot be imported: an unknown element type or logic operator (a file from a newer instance), a newer export format, the legacy question format, or a v3 validation failure such as a dangling logic target. `invalid_params` itemizes each issue; `details.report` carries the full import report.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         '429':
           $ref: '#/components/responses/V3TooManyRequests'
         '500':
@@ -4966,6 +5062,210 @@ components:
           $ref: '#/components/schemas/SurveyExportDocument'
         references:
           $ref: '#/components/schemas/SurveyExportReferences'
+      additionalProperties: false
+    SurveyImportRequest:
+      type: object
+      description: |
+        Import request. Provide exactly one of `export` (a `.formbricks.json` envelope as returned by `GET /api/v3/surveys/{surveyId}/export`) or `document` (a raw v3 survey document). `references` carries action-class definitions for a `document` whose triggers point at another workspace's action classes — the dialog sends a resolved draft back this way.
+      required:
+        - workspaceId
+      properties:
+        workspaceId:
+          type: string
+          format: cuid2
+          description: Target workspace. Requires read/write access.
+        export:
+          type: object
+          description: 'An export envelope (see `SurveyExportEnvelope`). Deliberately loose here: unknown keys, a hand-edited `slug` or a pre-release `extensions` block are reported in the import report instead of being rejected at the door.'
+          additionalProperties: true
+        document:
+          type: object
+          description: A raw v3 survey document (see `SurveyExportDocument`). Same leniency as `export`; omitted fields take the create defaults.
+          additionalProperties: true
+        references:
+          $ref: '#/components/schemas/SurveyExportReferences'
+        options:
+          type: object
+          properties:
+            name:
+              type: string
+              minLength: 1
+              maxLength: 200
+              description: Overrides the survey name.
+            dryRun:
+              type: boolean
+              description: Resolve and validate only; nothing is written and no action classes or languages are created.
+          additionalProperties: false
+      additionalProperties: false
+    SurveyImportSource:
+      type: object
+      description: What was imported and through which lane.
+      required:
+        - lane
+        - kind
+      properties:
+        lane:
+          type: string
+          enum:
+            - lossless
+            - structured
+            - ai
+        kind:
+          type: string
+          enum:
+            - formbricks-export
+            - v3-document
+            - qsf
+            - docx
+            - pdf
+            - markdown
+            - text
+            - csv
+            - xlsx
+        fileName:
+          type: string
+        detectedLanguages:
+          type: array
+          items:
+            type: object
+            required:
+              - code
+              - confidence
+            properties:
+              code:
+                type: string
+              confidence:
+                type: number
+            additionalProperties: false
+        chunks:
+          type: integer
+          description: Number of model calls the AI lane made for this file.
+      additionalProperties: false
+    SurveyImportIssue:
+      type: object
+      description: One line of the import report. `code` is stable and machine-readable; `message` is English prose.
+      required:
+        - severity
+        - code
+        - message
+      properties:
+        severity:
+          type: string
+          enum:
+            - error
+            - warning
+            - info
+          description: '`error` stops the import; `warning` changed the document; `info` is worth knowing.'
+        code:
+          type: string
+          description: Stable issue code, e.g. `unknown_field_stripped`, `trigger_created`, `language_created`, `external_url_removed`, `settings_not_exported`, `unknown_element`, `export_format_unsupported`.
+        path:
+          type: string
+          description: v3 document path the issue points at (`blocks.2.elements.0.headline`).
+        message:
+          type: string
+        sourceRef:
+          type: string
+          description: Where in the source file the issue comes from (a Qualtrics `QID`, a document heading).
+        vars:
+          type: object
+          description: Interpolation values for a translated rendering of `code`.
+          additionalProperties: true
+      additionalProperties: false
+    SurveyImportReport:
+      type: object
+      description: |
+        Everything the import changed or could not carry over. Nothing is dropped silently: every strip, match or creation is one issue.
+      required:
+        - source
+        - summary
+        - issues
+      properties:
+        source:
+          $ref: '#/components/schemas/SurveyImportSource'
+        summary:
+          type: object
+          required:
+            - blocks
+            - elements
+            - endings
+            - languages
+            - logicRules
+            - logicRulesReported
+            - hiddenFields
+          properties:
+            blocks:
+              type: integer
+            elements:
+              type: integer
+            endings:
+              type: integer
+            languages:
+              type: array
+              items:
+                type: string
+            logicRules:
+              type: integer
+              description: Logic rules in the imported document.
+            logicRulesReported:
+              type: integer
+              description: Source logic rules that were described in the report instead of imported (QSF).
+            hiddenFields:
+              type: integer
+          additionalProperties: false
+        issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/SurveyImportIssue'
+      additionalProperties: false
+    SurveyImportValidation:
+      type: object
+      description: Outcome of the v3 create validation on the resolved document.
+      required:
+        - valid
+        - invalid_params
+      properties:
+        valid:
+          type: boolean
+        invalid_params:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvalidParam'
+      additionalProperties: false
+    SurveyImportDryRunResult:
+      type: object
+      description: |
+        Result of a dry run: the resolved document in its public shape (send it back as `document` together with `references` to create it), the report and the validation. `document` is `null` when the report contains errors.
+      required:
+        - document
+        - references
+        - report
+        - validation
+      properties:
+        document:
+          oneOf:
+            - $ref: '#/components/schemas/SurveyExportDocument'
+            - type: 'null'
+        references:
+          oneOf:
+            - $ref: '#/components/schemas/SurveyExportReferences'
+            - type: 'null'
+        report:
+          $ref: '#/components/schemas/SurveyImportReport'
+        validation:
+          $ref: '#/components/schemas/SurveyImportValidation'
+      additionalProperties: false
+    SurveyImportResult:
+      type: object
+      description: The created survey and the report of what changed on the way in.
+      required:
+        - survey
+        - report
+      properties:
+        survey:
+          $ref: '#/components/schemas/SurveyResource'
+        report:
+          $ref: '#/components/schemas/SurveyImportReport'
       additionalProperties: false
     WorkflowStatus:
       type: string

--- a/docs/api-v3-reference/src/components/schemas/SurveyImportDryRunResult.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyImportDryRunResult.yml
@@ -1,0 +1,24 @@
+type: object
+description: >
+  Result of a dry run: the resolved document in its public shape (send it back as `document`
+  together with `references` to create it), the report and the validation. `document` is `null`
+  when the report contains errors.
+required:
+  - document
+  - references
+  - report
+  - validation
+properties:
+  document:
+    oneOf:
+      - $ref: ./SurveyExportDocument.yml
+      - type: "null"
+  references:
+    oneOf:
+      - $ref: ./SurveyExportReferences.yml
+      - type: "null"
+  report:
+    $ref: ./SurveyImportReport.yml
+  validation:
+    $ref: ./SurveyImportValidation.yml
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyImportIssue.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyImportIssue.yml
@@ -1,0 +1,32 @@
+type: object
+description: One line of the import report. `code` is stable and machine-readable; `message` is English prose.
+required:
+  - severity
+  - code
+  - message
+properties:
+  severity:
+    type: string
+    enum:
+      - error
+      - warning
+      - info
+    description: "`error` stops the import; `warning` changed the document; `info` is worth knowing."
+  code:
+    type: string
+    description: >-
+      Stable issue code, e.g. `unknown_field_stripped`, `trigger_created`, `language_created`,
+      `external_url_removed`, `settings_not_exported`, `unknown_element`, `export_format_unsupported`.
+  path:
+    type: string
+    description: v3 document path the issue points at (`blocks.2.elements.0.headline`).
+  message:
+    type: string
+  sourceRef:
+    type: string
+    description: Where in the source file the issue comes from (a Qualtrics `QID`, a document heading).
+  vars:
+    type: object
+    description: Interpolation values for a translated rendering of `code`.
+    additionalProperties: true
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyImportReport.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyImportReport.yml
@@ -1,0 +1,46 @@
+type: object
+description: >
+  Everything the import changed or could not carry over. Nothing is dropped silently: every strip,
+  match or creation is one issue.
+required:
+  - source
+  - summary
+  - issues
+properties:
+  source:
+    $ref: ./SurveyImportSource.yml
+  summary:
+    type: object
+    required:
+      - blocks
+      - elements
+      - endings
+      - languages
+      - logicRules
+      - logicRulesReported
+      - hiddenFields
+    properties:
+      blocks:
+        type: integer
+      elements:
+        type: integer
+      endings:
+        type: integer
+      languages:
+        type: array
+        items:
+          type: string
+      logicRules:
+        type: integer
+        description: Logic rules in the imported document.
+      logicRulesReported:
+        type: integer
+        description: Source logic rules that were described in the report instead of imported (QSF).
+      hiddenFields:
+        type: integer
+    additionalProperties: false
+  issues:
+    type: array
+    items:
+      $ref: ./SurveyImportIssue.yml
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyImportRequest.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyImportRequest.yml
@@ -1,0 +1,41 @@
+type: object
+description: >
+  Import request. Provide exactly one of `export` (a `.formbricks.json` envelope as returned by
+  `GET /api/v3/surveys/{surveyId}/export`) or `document` (a raw v3 survey document). `references`
+  carries action-class definitions for a `document` whose triggers point at another workspace's
+  action classes — the dialog sends a resolved draft back this way.
+required:
+  - workspaceId
+properties:
+  workspaceId:
+    type: string
+    format: cuid2
+    description: Target workspace. Requires read/write access.
+  export:
+    type: object
+    description: >-
+      An export envelope (see `SurveyExportEnvelope`). Deliberately loose here: unknown keys, a
+      hand-edited `slug` or a pre-release `extensions` block are reported in the import report
+      instead of being rejected at the door.
+    additionalProperties: true
+  document:
+    type: object
+    description: >-
+      A raw v3 survey document (see `SurveyExportDocument`). Same leniency as `export`; omitted
+      fields take the create defaults.
+    additionalProperties: true
+  references:
+    $ref: ./SurveyExportReferences.yml
+  options:
+    type: object
+    properties:
+      name:
+        type: string
+        minLength: 1
+        maxLength: 200
+        description: Overrides the survey name.
+      dryRun:
+        type: boolean
+        description: Resolve and validate only; nothing is written and no action classes or languages are created.
+    additionalProperties: false
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyImportResult.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyImportResult.yml
@@ -1,0 +1,11 @@
+type: object
+description: The created survey and the report of what changed on the way in.
+required:
+  - survey
+  - report
+properties:
+  survey:
+    $ref: ./SurveyResource.yml
+  report:
+    $ref: ./SurveyImportReport.yml
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyImportSource.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyImportSource.yml
@@ -1,0 +1,43 @@
+type: object
+description: What was imported and through which lane.
+required:
+  - lane
+  - kind
+properties:
+  lane:
+    type: string
+    enum:
+      - lossless
+      - structured
+      - ai
+  kind:
+    type: string
+    enum:
+      - formbricks-export
+      - v3-document
+      - qsf
+      - docx
+      - pdf
+      - markdown
+      - text
+      - csv
+      - xlsx
+  fileName:
+    type: string
+  detectedLanguages:
+    type: array
+    items:
+      type: object
+      required:
+        - code
+        - confidence
+      properties:
+        code:
+          type: string
+        confidence:
+          type: number
+      additionalProperties: false
+  chunks:
+    type: integer
+    description: Number of model calls the AI lane made for this file.
+additionalProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyImportValidation.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyImportValidation.yml
@@ -1,0 +1,13 @@
+type: object
+description: Outcome of the v3 create validation on the resolved document.
+required:
+  - valid
+  - invalid_params
+properties:
+  valid:
+    type: boolean
+  invalid_params:
+    type: array
+    items:
+      $ref: ./InvalidParam.yml
+additionalProperties: false

--- a/docs/api-v3-reference/src/openapi.yml
+++ b/docs/api-v3-reference/src/openapi.yml
@@ -9,9 +9,11 @@ info:
     **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST
     /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET
     /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**,
-    **DELETE /api/v3/surveys/{surveyId}**, and **GET
+    **DELETE /api/v3/surveys/{surveyId}**, **GET
     /api/v3/surveys/{surveyId}/export**, which returns a portable
-    `.formbricks.json` envelope that re-imports into any workspace or instance.
+    `.formbricks.json` envelope, and **POST /api/v3/surveys/import**, which
+    creates a survey from such an envelope or a raw v3 document in any
+    workspace or instance (with a dry-run mode).
 
 
     **Workflows extension**: **GET /api/v3/workflows**, **POST
@@ -183,6 +185,8 @@ paths:
     $ref: paths/api_v3_surveys_{surveyId}_restore.yml
   /api/v3/surveys/{surveyId}/export:
     $ref: paths/api_v3_surveys_{surveyId}_export.yml
+  /api/v3/surveys/import:
+    $ref: paths/api_v3_surveys_import.yml
   /api/v3/workflows:
     $ref: paths/api_v3_workflows.yml
   /api/v3/workflows/runs:

--- a/docs/api-v3-reference/src/paths/api_v3_surveys_import.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_surveys_import.yml
@@ -1,0 +1,109 @@
+post:
+  operationId: importSurveyV3
+  summary: Import a survey
+  description: >
+    Imports a `.formbricks.json` export or a raw v3 survey document into a workspace. The document
+    is made to fit the target workspace before it is created: the survey becomes a draft; the link
+    slug, schedule and instance-bound fields are dropped; unknown fields are stripped with a report
+    line; languages the workspace lacks are created; app-survey triggers are matched to existing
+    action classes by key, configuration or name and created otherwise; targeting is not imported;
+    external links are removed when the organization is not entitled to them; invalid media is
+    removed. Every change is one line in `report.issues`.
+
+
+    With `options.dryRun: true` the endpoint answers **200** with the resolved document, the report
+    and the validation and writes nothing. Otherwise a document that cannot be imported answers
+    **422** (the report rides in `details.report`), and a valid one is created through the same path
+    as `POST /api/v3/surveys` and answers **201** with the survey and the report.
+  tags:
+    - V3 Surveys
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/SurveyImportRequest.yml
+        examples:
+          dryRun:
+            summary: Check a raw document without creating it
+            value:
+              workspaceId: clxx1234567890123456789012
+              document:
+                name: Onboarding feedback
+                type: link
+                defaultLanguage: en-US
+                blocks:
+                  - id: clbk1234567890123456789012
+                    name: Main
+                    elements:
+                      - id: why
+                        type: openText
+                        headline:
+                          en-US: Why did you stop?
+                        required: true
+              options:
+                dryRun: true
+  responses:
+    "200":
+      description: Dry run completed. The document may still be invalid; nothing was written.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
+          description: Request correlation ID
+        Cache-Control:
+          schema:
+            type: string
+          example: private, no-store
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../components/schemas/SurveyImportDryRunResult.yml
+    "201":
+      description: Survey imported. `Location` points at the new survey.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
+          description: Request correlation ID
+        Location:
+          schema:
+            type: string
+          description: URL of the created survey
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../components/schemas/SurveyImportResult.yml
+    "400":
+      $ref: ../components/responses/V3BadRequest.yml
+    "401":
+      $ref: ../components/responses/V3Unauthorized.yml
+    "403":
+      $ref: ../components/responses/V3Forbidden.yml
+    "422":
+      description: >-
+        Unprocessable Content — the document cannot be imported: an unknown element type or logic
+        operator (a file from a newer instance), a newer export format, the legacy question format,
+        or a v3 validation failure such as a dangling logic target. `invalid_params` itemizes each
+        issue; `details.report` carries the full import report.
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+    "429":
+      $ref: ../components/responses/V3TooManyRequests.yml
+    "500":
+      $ref: ../components/responses/V3InternalServerError.yml
+  security:
+    - sessionAuth: []
+    - apiKeyAuth: []


### PR DESCRIPTION
Fixes ENG-2986

## What & why

**Was:** Import existed only as library code.

**Now:** `POST /api/v3/surveys/import` takes an export envelope or a raw v3 document, resolves it for the target workspace and either dry-runs (200 with document, report, validation; nothing written) or creates the survey through the shared v3 create path with `createdFrom: "import"` (201 with survey and report). A document that cannot be imported answers 422 with `invalid_params` and the report in `details`.

- `references` may accompany a `document`, so the dialog can send a resolved draft back without losing app triggers.
- `survey_created` gains `import_source`, `import_lane`, `import_ai_used`, `import_warning_count`, `import_chunk_count`.
- The `created` audit row is queued by the handler, not the wrapper, so a dry run leaves no audit trace.

Stacked on #9192 (ENG-2984).

## Where to look

- [import-survey.ts](apps/web/app/api/v3/surveys/import/lib/import-survey.ts) — dry run vs create, 422 shape, manual audit
- [schemas.ts](apps/web/app/api/v3/surveys/import/schemas.ts) — exactly one of `export`/`document`; both stay loose so the report can explain
- [api_v3_surveys_import.yml](docs/api-v3-reference/src/paths/api_v3_surveys_import.yml) — the contract Schemathesis drives

## Breaking changes

- [ ] This PR contains breaking changes

None — new endpoint; `createdFrom` gains a value; `problemUnprocessableContent` gains an optional `details` argument.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run app/api/v3/surveys/import modules/survey/import/resolve && pnpm api:v3:check`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| dryRun: 200 with document/report/validation, no action class or survey written | unit (mutation) | `import-survey.test.ts`; passes |
| Create: shared path called with `createdFrom: "import"`, `skipExternalUrlPermissionCheck`, analytics props, audit; 201 wraps survey + report | unit (mutation) | passes |
| Raw document + references creates the referenced action classes; `extensions` block stripped with a warning and still 201 | unit (mutation) | passes |
| Unknown element → 422 with paths and report in details; 403 passthrough; non-201 create response passed through | unit (mutation) | passes |
| Minimal raw document comes back complete (create defaults filled) so the dry-run response matches its schema | unit (mutation) | `resolve/index.test.ts`; passes |
| OpenAPI lints and bundle in sync | unit (guard) | `api:v3:lint` + `api:v3:check` green locally |

**Open gaps**

- Not exercised against a live database; the E2E round trip (ENG-2990) covers that.

**Risks**

- Schemathesis will synthesize `document` bodies; every rejection path answers 200/422, never 5xx, but that is verified only by unit tests here.

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
