### PR TITLE
feat(surveys): multipart support in the v3 wrapper + POST /api/v3/surveys/import/convert [ENG-2987]

### DIFF
--- a/apps/web/app/api/v3/lib/api-wrapper.test.ts
+++ b/apps/web/app/api/v3/lib/api-wrapper.test.ts
@@ -482,6 +482,173 @@ describe("withV3ApiWrapper", () => {
     );
   });
 
+  describe("multipart bodies", () => {
+    const multipartHandlerSchema = z.object({
+      fields: z.object({ workspaceId: z.string() }),
+      files: z.array(
+        z.object({
+          name: z.string(),
+          fileName: z.string(),
+          mimeType: z.string(),
+          bytes: z.instanceof(Buffer),
+        })
+      ),
+    });
+
+    function multipartRequest(formData: FormData, headers: Record<string, string> = {}): NextRequest {
+      // Let the platform serialize the boundary; NextRequest copies the body and content-type over.
+      const base = new Request("http://localhost/api/v3/surveys/import/convert", {
+        method: "POST",
+        body: formData,
+      });
+      return new NextRequest(base.url, {
+        method: "POST",
+        body: base.body,
+        headers: { "content-type": base.headers.get("content-type") ?? "", ...headers },
+        // @ts-expect-error duplex is required by undici for streamed bodies and not in the DOM typings
+        duplex: "half",
+      });
+    }
+
+    test("hands fields and files to the handler", async () => {
+      const handler = vi.fn(async ({ parsedInput }) => Response.json({ received: parsedInput.body }));
+      const wrapped = withV3ApiWrapper({
+        auth: "none",
+        body: "multipart",
+        schemas: { body: multipartHandlerSchema },
+        handler,
+      });
+
+      const formData = new FormData();
+      formData.set("workspaceId", "clxx1234567890123456789012");
+      formData.set("file", new File(["hello"], "survey.formbricks.json", { type: "application/json" }));
+
+      const response = await wrapped(
+        multipartRequest(formData, { "x-request-id": "req-multipart" }),
+        {} as never
+      );
+
+      expect(response.status).toBe(200);
+      const parsed = handler.mock.calls[0][0].parsedInput.body;
+      expect(parsed.fields).toEqual({ workspaceId: "clxx1234567890123456789012" });
+      expect(parsed.files).toHaveLength(1);
+      expect(parsed.files[0]).toMatchObject({
+        name: "file",
+        fileName: "survey.formbricks.json",
+        mimeType: "application/json",
+      });
+      expect(parsed.files[0].bytes.toString("utf8")).toBe("hello");
+    });
+
+    test("returns 415 for a non-multipart request on a multipart route", async () => {
+      const handler = vi.fn(async () => Response.json({ ok: true }));
+      const wrapped = withV3ApiWrapper({
+        auth: "none",
+        body: "multipart",
+        schemas: { body: multipartHandlerSchema },
+        handler,
+      });
+
+      const response = await wrapped(
+        new NextRequest("http://localhost/api/v3/surveys/import/convert", {
+          method: "POST",
+          body: "plain text",
+          headers: { "Content-Type": "text/plain", "x-request-id": "req-415" },
+        }),
+        {} as never
+      );
+
+      expect(response.status).toBe(415);
+      expect(handler).not.toHaveBeenCalled();
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({ code: "unsupported_media_type", status: 415, requestId: "req-415" })
+      );
+    });
+
+    test("returns 413 from the declared content-length and from the counted bytes", async () => {
+      const handler = vi.fn(async () => Response.json({ ok: true }));
+      const wrapped = withV3ApiWrapper({
+        auth: "none",
+        body: "multipart",
+        bodyLimitBytes: 64,
+        schemas: { body: multipartHandlerSchema },
+        handler,
+      });
+
+      const small = new FormData();
+      small.set("workspaceId", "x");
+      const declared = await wrapped(multipartRequest(small, { "content-length": "9999" }), {} as never);
+      expect(declared.status).toBe(413);
+
+      // A body larger than the cap, with no content-length header to pre-check against.
+      const big = new FormData();
+      big.set("file", new File(["x".repeat(512)], "big.txt", { type: "text/plain" }));
+      const counted = await wrapped(multipartRequest(big), {} as never);
+      expect(counted.status).toBe(413);
+      await expect(counted.json()).resolves.toEqual(expect.objectContaining({ code: "payload_too_large" }));
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    test("returns 400 for malformed multipart data and for a body the schema rejects", async () => {
+      const handler = vi.fn(async () => Response.json({ ok: true }));
+      const wrapped = withV3ApiWrapper({
+        auth: "none",
+        body: "multipart",
+        schemas: {
+          body: multipartHandlerSchema.extend({ files: z.array(z.unknown()).min(1, "A file is required") }),
+        },
+        handler,
+      });
+
+      const malformed = await wrapped(
+        new NextRequest("http://localhost/api/v3/surveys/import/convert", {
+          method: "POST",
+          body: "--nope\r\nthis is not multipart\r\n",
+          headers: { "Content-Type": "multipart/form-data; boundary=other", "x-request-id": "req-malformed" },
+        }),
+        {} as never
+      );
+      expect(malformed.status).toBe(400);
+      await expect(malformed.json()).resolves.toEqual(
+        expect.objectContaining({
+          invalid_params: [
+            { name: "body", reason: "Malformed multipart form data, please check your request body" },
+          ],
+        })
+      );
+
+      const noFile = new FormData();
+      noFile.set("workspaceId", "clxx1234567890123456789012");
+      const rejected = await wrapped(multipartRequest(noFile), {} as never);
+      expect(rejected.status).toBe(400);
+      await expect(rejected.json()).resolves.toEqual(
+        expect.objectContaining({ invalid_params: [{ name: "files", reason: "A file is required" }] })
+      );
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    test("JSON routes are unaffected by the body mode option", async () => {
+      const handler = vi.fn(async ({ parsedInput }) => Response.json(parsedInput.body));
+      const wrapped = withV3ApiWrapper({
+        auth: "none",
+        schemas: { body: z.object({ name: z.string() }) },
+        handler,
+      });
+
+      const response = await wrapped(
+        new NextRequest("http://localhost/api/v3/surveys", {
+          method: "POST",
+          body: JSON.stringify({ name: "Survey" }),
+          headers: { "Content-Type": "application/json" },
+        }),
+        {} as never
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ name: "Survey" });
+    });
+  });
+
   test("returns 400 problem response for invalid route params", async () => {
     const handler = vi.fn(async () => Response.json({ ok: true }));
     const wrapped = withV3ApiWrapper({

--- a/apps/web/app/api/v3/lib/api-wrapper.test.ts
+++ b/apps/web/app/api/v3/lib/api-wrapper.test.ts
@@ -505,7 +505,7 @@ describe("withV3ApiWrapper", () => {
         method: "POST",
         body: base.body,
         headers: { "content-type": base.headers.get("content-type") ?? "", ...headers },
-        // @ts-expect-error duplex is required by undici for streamed bodies and not in the DOM typings
+        // Required by undici for streamed bodies.
         duplex: "half",
       });
     }

--- a/apps/web/app/api/v3/lib/api-wrapper.ts
+++ b/apps/web/app/api/v3/lib/api-wrapper.ts
@@ -224,7 +224,8 @@ async function readMultipartBody(req: NextRequest, limitBytes: number): Promise<
   const formData = await new Request(req.url, {
     method: "POST",
     headers: { "content-type": req.headers.get("content-type") ?? "" },
-    body: bytes,
+    // A fresh copy: `BodyInit` wants a view over a plain ArrayBuffer, which the reader's chunks need not be.
+    body: new Uint8Array(bytes),
   }).formData();
 
   const fields: Record<string, string> = {};

--- a/apps/web/app/api/v3/lib/api-wrapper.ts
+++ b/apps/web/app/api/v3/lib/api-wrapper.ts
@@ -3,7 +3,12 @@ import { z } from "zod";
 import { logger } from "@formbricks/logger";
 import { TooManyRequestsError } from "@formbricks/types/errors";
 import { authenticateRequest } from "@/app/api/v1/auth";
-import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
+import {
+  DEFAULT_REQUEST_BODY_LIMIT_BYTES,
+  RequestBodyTooLargeError,
+  parseJsonBodyWithLimit,
+  readRequestBodyBytesWithLimit,
+} from "@/app/lib/api/request-body";
 import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { getApiKeyFromHeaders } from "@/modules/api/lib/api-key-auth";
 import { getSession } from "@/modules/auth/lib/session";
@@ -20,6 +25,7 @@ import {
   problemPayloadTooLarge,
   problemTooManyRequests,
   problemUnauthorized,
+  problemUnsupportedMediaType,
 } from "./response";
 import type { TV3AuditLog, TV3Authentication } from "./types";
 
@@ -27,6 +33,23 @@ type TV3Schema = z.ZodTypeAny;
 type MaybePromise<T> = T | Promise<T>;
 
 export type TV3AuthMode = "none" | "session" | "apiKey" | "both";
+
+/** How the request body is read before `schemas.body` sees it. */
+export type TV3BodyMode = "json" | "multipart";
+
+export type TV3MultipartFile = {
+  /** The form field name the file was sent under. */
+  name: string;
+  fileName: string;
+  mimeType: string;
+  bytes: Buffer;
+};
+
+/** What a `body: "multipart"` route's body schema receives. */
+export type TV3MultipartBody = {
+  fields: Record<string, string>;
+  files: TV3MultipartFile[];
+};
 
 export type TV3Schemas = {
   body?: TV3Schema;
@@ -53,6 +76,10 @@ export type TV3HandlerParams<TParsedInput = Record<string, never>, TProps = unkn
 export type TWithV3ApiWrapperParams<S extends TV3Schemas | undefined, TProps = unknown> = {
   auth?: TV3AuthMode;
   schemas?: S;
+  /** `json` (default) parses a JSON body; `multipart` reads `multipart/form-data` into fields + files. */
+  body?: TV3BodyMode;
+  /** Byte cap for the request body. Defaults to the 2 MB JSON limit. */
+  bodyLimitBytes?: number;
   rateLimit?: boolean;
   customRateLimitConfig?: TRateLimitConfig;
   action?: TAuditAction;
@@ -170,43 +197,121 @@ async function authenticateV3Request(req: NextRequest, authMode: TV3AuthMode): P
   return null;
 }
 
+function bodyParseFailure(requestId: string, instance: string, reason: string): TV3InputParseFailure {
+  const invalidParams = [{ name: "body", reason }];
+  return {
+    ok: false,
+    detail: "Invalid request body",
+    invalidParams,
+    response: problemBadRequest(requestId, "Invalid request body", {
+      instance,
+      invalid_params: invalidParams,
+    }),
+  };
+}
+
+function isMultipartRequest(req: NextRequest): boolean {
+  return (req.headers.get("content-type") ?? "").toLowerCase().startsWith("multipart/form-data");
+}
+
+/**
+ * Read a multipart body into plain fields and files. The bytes are counted while reading (the
+ * `Content-Length` header can be absent or wrong), then handed to the platform parser as a fresh
+ * request so the boundary handling stays the runtime's job.
+ */
+async function readMultipartBody(req: NextRequest, limitBytes: number): Promise<TV3MultipartBody> {
+  const bytes = await readRequestBodyBytesWithLimit(req, limitBytes);
+  const formData = await new Request(req.url, {
+    method: "POST",
+    headers: { "content-type": req.headers.get("content-type") ?? "" },
+    body: bytes,
+  }).formData();
+
+  const fields: Record<string, string> = {};
+  const files: TV3MultipartFile[] = [];
+
+  for (const [name, value] of formData.entries()) {
+    if (typeof value === "string") {
+      fields[name] = value;
+      continue;
+    }
+
+    files.push({
+      name,
+      fileName: value.name,
+      mimeType: value.type,
+      bytes: Buffer.from(await value.arrayBuffer()),
+    });
+  }
+
+  return { fields, files };
+}
+
+async function readV3Body(
+  req: NextRequest,
+  mode: TV3BodyMode,
+  limitBytes: number,
+  requestId: string,
+  instance: string
+): Promise<{ ok: true; data: unknown } | TV3InputParseFailure> {
+  if (mode === "multipart" && !isMultipartRequest(req)) {
+    return {
+      ok: false,
+      detail: "Unsupported media type",
+      invalidParams: [],
+      response: problemUnsupportedMediaType(
+        requestId,
+        "This endpoint accepts multipart/form-data request bodies only",
+        instance
+      ),
+    };
+  }
+
+  try {
+    const data =
+      mode === "multipart"
+        ? await readMultipartBody(req, limitBytes)
+        : await parseJsonBodyWithLimit(req, limitBytes);
+    return { ok: true, data };
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return {
+        ok: false,
+        detail: error.message,
+        invalidParams: [],
+        response: problemPayloadTooLarge(requestId, error.message, instance),
+      };
+    }
+
+    return bodyParseFailure(
+      requestId,
+      instance,
+      mode === "multipart"
+        ? "Malformed multipart form data, please check your request body"
+        : "Malformed JSON input, please check your request body"
+    );
+  }
+}
+
 async function parseV3Input<S extends TV3Schemas | undefined, TProps>(
   req: NextRequest,
   props: TProps,
   schemas: S | undefined,
   requestId: string,
-  instance: string
+  instance: string,
+  bodyOptions: { mode: TV3BodyMode; limitBytes: number } = {
+    mode: "json",
+    limitBytes: DEFAULT_REQUEST_BODY_LIMIT_BYTES,
+  }
 ): Promise<{ ok: true; parsedInput: TV3ParsedInput<S> } | TV3InputParseFailure> {
   const parsedInput = {} as TV3ParsedInput<S>;
 
   if (schemas?.body) {
-    let bodyData: unknown;
-
-    try {
-      bodyData = await parseJsonBodyWithLimit(req);
-    } catch (error) {
-      if (error instanceof RequestBodyTooLargeError) {
-        return {
-          ok: false,
-          detail: error.message,
-          invalidParams: [],
-          response: problemPayloadTooLarge(requestId, error.message, instance),
-        };
-      }
-
-      const invalidParams = [
-        { name: "body", reason: "Malformed JSON input, please check your request body" },
-      ];
-      return {
-        ok: false,
-        detail: "Invalid request body",
-        invalidParams,
-        response: problemBadRequest(requestId, "Invalid request body", {
-          instance,
-          invalid_params: invalidParams,
-        }),
-      };
+    const bodyRead = await readV3Body(req, bodyOptions.mode, bodyOptions.limitBytes, requestId, instance);
+    if (!bodyRead.ok) {
+      return bodyRead;
     }
+    const bodyData: unknown = bodyRead.data;
 
     const bodyResult = schemas.body.safeParse(bodyData);
     if (!bodyResult.success) {
@@ -339,6 +444,8 @@ export const withV3ApiWrapper = <S extends TV3Schemas | undefined, TProps = unkn
   const {
     auth = "both",
     schemas,
+    body: bodyMode = "json",
+    bodyLimitBytes = DEFAULT_REQUEST_BODY_LIMIT_BYTES,
     rateLimit = true,
     customRateLimitConfig,
     handler,
@@ -377,7 +484,10 @@ export const withV3ApiWrapper = <S extends TV3Schemas | undefined, TProps = unkn
         return rateLimitResponse;
       }
 
-      const parsedInputResult = await parseV3Input(req, props, schemas, requestId, instance);
+      const parsedInputResult = await parseV3Input(req, props, schemas, requestId, instance, {
+        mode: bodyMode,
+        limitBytes: bodyLimitBytes,
+      });
       if (!parsedInputResult.ok) {
         log.warn(
           {

--- a/apps/web/app/api/v3/lib/response.ts
+++ b/apps/web/app/api/v3/lib/response.ts
@@ -101,12 +101,24 @@ function problemResponse(
 export function problemBadRequest(
   requestId: string,
   detail: string,
-  options?: { invalid_params?: InvalidParam[]; instance?: string }
+  options?: { invalid_params?: InvalidParam[]; instance?: string; code?: string }
 ): Response {
   return problemResponse(400, "Bad Request", detail, requestId, {
-    code: "bad_request",
+    code: options?.code ?? "bad_request",
     instance: options?.instance,
     invalid_params: options?.invalid_params,
+  });
+}
+
+/** 415 for a request whose `Content-Type` the endpoint does not accept (e.g. JSON on a multipart-only route). */
+export function problemUnsupportedMediaType(
+  requestId: string,
+  detail: string = "Unsupported Media Type",
+  instance?: string
+): Response {
+  return problemResponse(415, "Unsupported Media Type", detail, requestId, {
+    code: "unsupported_media_type",
+    instance,
   });
 }
 

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
+import { problemForbidden } from "@/app/api/v3/lib/response";
+import { getActionClasses } from "@/lib/actionClass/service";
+import { createActionClass } from "@/modules/survey/editor/lib/action-class";
+import {
+  FIXTURE_APP_SURVEY,
+  FIXTURE_LINK_SURVEY,
+  FIXTURE_WORKSPACE_ID,
+} from "@/modules/survey/export/__fixtures__/surveys";
+import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
+import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
+import { ZV3SurveyImportConvertBody } from "../schemas";
+import { convertImportFile } from "./convert-import";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@formbricks/logger", () => ({
+  logger: { withContext: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() })) },
+}));
+vi.mock("@formbricks/database", () => ({ prisma: { language: { findMany: vi.fn() } } }));
+vi.mock("@/app/api/v3/lib/auth", () => ({ requireV3WorkspaceAccess: vi.fn() }));
+vi.mock("@/lib/actionClass/service", () => ({ getActionClasses: vi.fn() }));
+vi.mock("@/modules/survey/editor/lib/action-class", () => ({ createActionClass: vi.fn() }));
+vi.mock("@/modules/survey/lib/permission", () => ({ getExternalUrlsPermission: vi.fn() }));
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  WEBAPP_URL: "https://app.formbricks.com",
+}));
+
+const requestId = "req_convert_1";
+const instance = "/api/v3/surveys/import/convert";
+const authResult = { workspaceId: FIXTURE_WORKSPACE_ID, organizationId: "org_1" };
+const authentication = {
+  user: { id: "user_1", email: "user@example.com", name: "User" },
+  expires: "2026-12-01",
+} as unknown as Parameters<typeof convertImportFile>[0]["authentication"];
+
+function envelopeBytes(survey: typeof FIXTURE_LINK_SURVEY): Buffer {
+  const result = buildSurveyExportEnvelope(survey, {
+    appVersion: "6.2.0",
+    publicUrl: "https://source.example",
+  });
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return Buffer.from(JSON.stringify(result.data));
+}
+
+function body(fileName: string, bytes: Buffer, mimeType = "application/octet-stream") {
+  return ZV3SurveyImportConvertBody.parse({
+    fields: { workspaceId: FIXTURE_WORKSPACE_ID },
+    files: [{ name: "file", fileName, mimeType, bytes }],
+  });
+}
+
+describe("convertImportFile", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(authResult);
+    vi.mocked(prisma.language.findMany).mockResolvedValue([] as never);
+    vi.mocked(getActionClasses).mockResolvedValue([]);
+    vi.mocked(getExternalUrlsPermission).mockResolvedValue(true);
+  });
+
+  test("converts a .formbricks.json upload through the lossless lane without persisting", async () => {
+    const response = await convertImportFile({
+      body: body("in-app.formbricks.json", envelopeBytes(FIXTURE_APP_SURVEY), "application/json"),
+      authentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.data.source).toEqual({
+      lane: "lossless",
+      kind: "formbricks-export",
+      fileName: "in-app.formbricks.json",
+    });
+    expect(json.data.validation.valid).toBe(true);
+    expect(json.data.document).toMatchObject({ type: "app", status: "draft" });
+    expect(json.data.references.actionClasses).toHaveLength(2);
+    expect(json.data.report.issues.map((issue: { code: string }) => issue.code)).toContain(
+      "trigger_would_be_created"
+    );
+    expect(createActionClass).not.toHaveBeenCalled();
+  });
+
+  test("a raw v3 document renamed to .txt is still detected by content", async () => {
+    const response = await convertImportFile({
+      body: body(
+        "notes.txt",
+        Buffer.from(
+          JSON.stringify({
+            name: "Doc",
+            blocks: [
+              {
+                name: "B",
+                elements: [{ id: "q", type: "openText", headline: { "en-US": "Q?" }, required: false }],
+              },
+            ],
+          })
+        )
+      ),
+      authentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.data.source.kind).toBe("v3-document");
+    expect(json.data.references).toBeNull();
+  });
+
+  test("a file the lane cannot read answers 200 with document null and the reasons in the report", async () => {
+    const response = await convertImportFile({
+      body: body(
+        "old.json",
+        Buffer.from(JSON.stringify({ name: "Old", blocks: [], questions: [{ id: "q1" }] }))
+      ),
+      authentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.data.document).toBeNull();
+    expect(json.data.report.issues[0]).toMatchObject({
+      severity: "error",
+      code: "legacy_questions_unsupported",
+    });
+  });
+
+  test.each([
+    ["survey.doc", Buffer.from("\xd0\xcf\x11\xe0 legacy"), "legacy_office_format", "Save the file as .docx"],
+    ["photo.png", Buffer.from("\x89PNG..."), "unsupported_source", "not supported"],
+    ["empty.json", Buffer.alloc(0), "unsupported_source", "empty"],
+    ["broken.json", Buffer.from("{ nope"), "unsupported_source", "not valid JSON"],
+  ])("rejects %s with 422 and code %s", async (fileName, bytes, code, detail) => {
+    const response = await convertImportFile({
+      body: body(fileName, bytes),
+      authentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(422);
+    const json = await response.json();
+    expect(json.code).toBe(code);
+    expect(json.detail).toContain(detail);
+    expect(json.invalid_params[0].name).toBe("file");
+  });
+
+  test("answers 400 lane_not_available for a kind whose lane has not shipped", async () => {
+    const response = await convertImportFile({
+      body: body("questions.csv", Buffer.from("Question;Type\nHow?;openText"), "text/csv"),
+      authentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.code).toBe("lane_not_available");
+    expect(json.invalid_params[0]).toMatchObject({ name: "file", reason: expect.stringContaining("csv") });
+  });
+
+  test("returns the authorization response before touching the file", async () => {
+    vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(problemForbidden(requestId, "nope", instance));
+
+    const response = await convertImportFile({
+      body: body("x.json", envelopeBytes(FIXTURE_LINK_SURVEY)),
+      authentication,
+      requestId,
+      instance,
+    });
+
+    expect(response.status).toBe(403);
+    expect(prisma.language.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("ZV3SurveyImportConvertBody", () => {
+  test("requires exactly one part named file and a cuid2 workspaceId", () => {
+    const file = { name: "file", fileName: "a.json", mimeType: "application/json", bytes: Buffer.from("{}") };
+    expect(
+      ZV3SurveyImportConvertBody.safeParse({ fields: { workspaceId: FIXTURE_WORKSPACE_ID }, files: [file] })
+        .success
+    ).toBe(true);
+    expect(
+      ZV3SurveyImportConvertBody.safeParse({ fields: { workspaceId: FIXTURE_WORKSPACE_ID }, files: [] })
+        .success
+    ).toBe(false);
+    expect(
+      ZV3SurveyImportConvertBody.safeParse({
+        fields: { workspaceId: FIXTURE_WORKSPACE_ID },
+        files: [file, file],
+      }).success
+    ).toBe(false);
+    expect(
+      ZV3SurveyImportConvertBody.safeParse({
+        fields: { workspaceId: FIXTURE_WORKSPACE_ID },
+        files: [{ ...file, name: "upload" }],
+      }).success
+    ).toBe(false);
+    expect(
+      ZV3SurveyImportConvertBody.safeParse({ fields: { workspaceId: "nope" }, files: [file] }).success
+    ).toBe(false);
+    expect(
+      ZV3SurveyImportConvertBody.safeParse({
+        fields: { workspaceId: FIXTURE_WORKSPACE_ID, extra: "x" },
+        files: [file],
+      }).success
+    ).toBe(false);
+  });
+});

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
@@ -205,7 +205,7 @@ describe("ZV3SurveyImportConvertBody", () => {
       }).success
     ).toBe(false);
     expect(
-      ZV3SurveyImportConvertBody.safeParse({ fields: { workspaceId: "nope" }, files: [file] }).success
+      ZV3SurveyImportConvertBody.safeParse({ fields: { workspaceId: "NOT-A-CUID!" }, files: [file] }).success
     ).toBe(false);
     expect(
       ZV3SurveyImportConvertBody.safeParse({

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
@@ -1,0 +1,149 @@
+import "server-only";
+import { createId } from "@paralleldrive/cuid2";
+import { logger } from "@formbricks/logger";
+import { DatabaseError } from "@formbricks/types/errors";
+import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
+import {
+  problemBadRequest,
+  problemInternalError,
+  problemUnprocessableContent,
+  successResponse,
+} from "@/app/api/v3/lib/response";
+import type { TV3Authentication } from "@/app/api/v3/lib/types";
+import { getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
+import { type TImportDetectionFailureCode, detectImportSource } from "@/modules/survey/import/detect";
+import { getImportLaneHandler } from "@/modules/survey/import/lanes";
+import { resolveImportCandidate } from "@/modules/survey/import/resolve";
+import type { TImportContext } from "@/modules/survey/import/types";
+import type { TV3SurveyImportConvertBody } from "../schemas";
+
+type TConvertImportParams = {
+  body: TV3SurveyImportConvertBody;
+  authentication: TV3Authentication;
+  requestId: string;
+  instance: string;
+};
+
+const DETECTION_FAILURE_REASONS: Record<TImportDetectionFailureCode, string> = {
+  empty_file: "The file is empty.",
+  legacy_office_format:
+    "Legacy Office formats are not supported. Save the file as .docx or .xlsx and try again.",
+  unsupported_source:
+    "This file type is not supported. Use a Formbricks export (.json), a Qualtrics .qsf, or a .docx, .pdf, .md, .txt, .csv or .xlsx document.",
+  invalid_json: "The file is not valid JSON.",
+};
+
+/**
+ * `POST /api/v3/surveys/import/convert` — turn a file into a reviewed survey document without
+ * persisting anything. Detect → lane → resolve (always dry run: creating is the import route's job).
+ *
+ * A file the allowlist rejects is a 422 (the request was well-formed; the file is not something we
+ * take), a non-multipart request is a 415 (wrapper), a lane that has not shipped is a 400
+ * `lane_not_available`. A file the lane cannot read still answers 200 with `document: null` and
+ * the reasons in `report` — the dialog shows them; the 422 belongs to the persisting endpoint.
+ */
+export async function convertImportFile({
+  body,
+  authentication,
+  requestId,
+  instance,
+}: TConvertImportParams): Promise<Response> {
+  const importRunId = createId();
+  const file = body.files[0];
+  const extension = file.fileName.split(".").pop()?.toLowerCase() ?? null;
+  const log = logger.withContext({
+    requestId,
+    importRunId,
+    workspaceId: body.fields.workspaceId,
+    fileExtension: extension,
+    fileBytes: file.bytes.byteLength,
+  });
+
+  try {
+    const authResult = await requireV3WorkspaceAccess(
+      authentication,
+      body.fields.workspaceId,
+      "readWrite",
+      requestId,
+      instance
+    );
+    if (authResult instanceof Response) {
+      return authResult;
+    }
+
+    const detection = detectImportSource({
+      fileName: file.fileName,
+      mimeType: file.mimeType,
+      bytes: file.bytes,
+    });
+    if (!detection.ok) {
+      log.warn({ statusCode: 422, detectionCode: detection.code }, "Import file rejected");
+      return problemUnprocessableContent(requestId, DETECTION_FAILURE_REASONS[detection.code], {
+        instance,
+        code: detection.code === "legacy_office_format" ? "legacy_office_format" : "unsupported_source",
+        invalid_params: [{ name: "file", reason: DETECTION_FAILURE_REASONS[detection.code] }],
+      });
+    }
+
+    const lane = getImportLaneHandler(detection.kind);
+    if (!lane) {
+      log.warn({ statusCode: 400, sourceKind: detection.kind }, "Import lane not available");
+      return problemBadRequest(requestId, `Importing ${detection.kind} files is not available yet`, {
+        instance,
+        code: "lane_not_available",
+        invalid_params: [{ name: "file", reason: `No import lane handles '${detection.kind}' files yet` }],
+      });
+    }
+
+    const ctx: TImportContext = {
+      workspaceId: authResult.workspaceId,
+      organizationId: authResult.organizationId,
+      userId: getSessionUserId(authentication),
+      requestId,
+      importRunId,
+      languageHint: body.fields.language,
+    };
+
+    const candidate = await lane(
+      { kind: detection.kind, fileName: file.fileName, content: { type: "bytes", bytes: file.bytes } },
+      ctx
+    );
+
+    const resolved = await resolveImportCandidate(candidate, {
+      workspaceId: authResult.workspaceId,
+      organizationId: authResult.organizationId,
+      userId: ctx.userId,
+      requestId,
+      dryRun: true,
+    });
+
+    log.info(
+      {
+        sourceKind: resolved.report.source.kind,
+        lane: resolved.report.source.lane,
+        valid: resolved.validation.valid,
+        issueCount: resolved.report.issues.length,
+      },
+      "Import file converted"
+    );
+
+    return successResponse(
+      {
+        document: resolved.document,
+        references: candidate.references ?? null,
+        report: resolved.report,
+        validation: resolved.validation,
+        source: resolved.report.source,
+      },
+      { requestId, cache: "private, no-store" }
+    );
+  } catch (error) {
+    if (error instanceof DatabaseError) {
+      log.error({ error, statusCode: 500 }, "Database error");
+      return problemInternalError(requestId, "An unexpected error occurred.", instance);
+    }
+
+    log.error({ error, statusCode: 500 }, "V3 survey import convert unexpected error");
+    return problemInternalError(requestId, "An unexpected error occurred.", instance);
+  }
+}

--- a/apps/web/app/api/v3/surveys/import/convert/route.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/route.ts
@@ -1,0 +1,33 @@
+/**
+ * POST /api/v3/surveys/import/convert — convert a survey file (Formbricks JSON today; QSF and
+ * documents as their lanes ship) into a reviewed v3 document plus import report. Multipart only,
+ * 15 MB per file, never persists. Session cookie or x-api-key; readWrite access on the workspace.
+ */
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import { ZV3EmptyQuery } from "../../schemas";
+import { convertImportFile } from "./lib/convert-import";
+import { IMPORT_CONVERT_BODY_LIMIT_BYTES, ZV3SurveyImportConvertBody } from "./schemas";
+
+// File parsing needs Node buffers; nothing here is edge-compatible.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const POST = withV3ApiWrapper({
+  auth: "both",
+  body: "multipart",
+  bodyLimitBytes: IMPORT_CONVERT_BODY_LIMIT_BYTES,
+  customRateLimitConfig: rateLimitConfigs.api.v3SurveyImportConvert,
+  schemas: {
+    body: ZV3SurveyImportConvertBody,
+    query: ZV3EmptyQuery,
+  },
+  handler: async ({ authentication, parsedInput, requestId, instance }) => {
+    return await convertImportFile({
+      body: parsedInput.body,
+      authentication,
+      requestId,
+      instance,
+    });
+  },
+});

--- a/apps/web/app/api/v3/surveys/import/convert/schemas.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/schemas.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import type { TV3MultipartBody } from "@/app/api/v3/lib/api-wrapper";
+import { IMPORT_MAX_FILE_BYTES } from "@/modules/survey/import/types";
+
+/** 15 MB file plus 1 MB of multipart framing slack (D3). */
+export const IMPORT_CONVERT_BODY_LIMIT_BYTES = IMPORT_MAX_FILE_BYTES + 1024 * 1024;
+
+const ZMultipartFile = z.object({
+  name: z.string(),
+  fileName: z.string(),
+  mimeType: z.string(),
+  bytes: z.instanceof(Buffer),
+});
+
+/**
+ * The multipart body as the wrapper hands it over: `workspaceId` (+ optional `type`, `language`) as
+ * fields and exactly one `file` part. Anything else is a 400 at the door.
+ */
+export const ZV3SurveyImportConvertBody = z
+  .object({
+    fields: z
+      .object({
+        workspaceId: z.cuid2(),
+        type: z.enum(["link", "app"]).optional(),
+        language: z.string().trim().min(2).max(35).optional(),
+      })
+      .strict(),
+    files: z
+      .array(ZMultipartFile)
+      .min(1, "A 'file' part is required")
+      .max(1, "Send exactly one file")
+      .refine((files) => files.every((file) => file.name === "file"), {
+        message: "The file part must be named 'file'",
+      }),
+  })
+  .strict() satisfies z.ZodType<unknown, TV3MultipartBody>;
+
+export type TV3SurveyImportConvertBody = z.infer<typeof ZV3SurveyImportConvertBody>;

--- a/apps/web/app/lib/api/request-body.ts
+++ b/apps/web/app/lib/api/request-body.ts
@@ -34,17 +34,21 @@ const assertBodySize = (actualBytes: number, limitBytes: number): void => {
   }
 };
 
-export const readRequestBodyWithLimit = async (
+/**
+ * Read a request body as bytes, counting while reading. `Content-Length` is checked first when
+ * present, but the byte count is what enforces the limit: the header can be absent or lie.
+ */
+export const readRequestBodyBytesWithLimit = async (
   request: Request,
   limitBytes: number = DEFAULT_REQUEST_BODY_LIMIT_BYTES
-): Promise<string> => {
+): Promise<Uint8Array> => {
   const contentLength = getContentLength(request.headers);
   if (contentLength !== null) {
     assertBodySize(contentLength, limitBytes);
   }
 
   if (!request.body) {
-    return "";
+    return new Uint8Array(0);
   }
 
   const reader = request.body.getReader();
@@ -66,12 +70,8 @@ export const readRequestBodyWithLimit = async (
     chunks.push(value);
   }
 
-  if (chunks.length === 0) {
-    return "";
-  }
-
   if (chunks.length === 1) {
-    return textDecoder.decode(chunks[0]);
+    return chunks[0];
   }
 
   const body = new Uint8Array(receivedBytes);
@@ -81,7 +81,15 @@ export const readRequestBodyWithLimit = async (
     offset += chunk.byteLength;
   }
 
-  return textDecoder.decode(body);
+  return body;
+};
+
+export const readRequestBodyWithLimit = async (
+  request: Request,
+  limitBytes: number = DEFAULT_REQUEST_BODY_LIMIT_BYTES
+): Promise<string> => {
+  const body = await readRequestBodyBytesWithLimit(request, limitBytes);
+  return body.byteLength === 0 ? "" : textDecoder.decode(body);
 };
 
 export const parseJsonBodyWithLimit = async <TJson = unknown>(

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
@@ -94,6 +94,7 @@ describe("rateLimitConfigs", () => {
         "v3",
         "mcpAuth",
         "v3SurveyGenerate",
+        "v3SurveyImportConvert",
         "internalDatasetPurge",
         "client",
         "clientEnvironment",

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.ts
@@ -21,6 +21,11 @@ export const rateLimitConfigs = {
       allowedPerInterval: 10,
       namespace: "api:v3:surveys:generate",
     }, // 10 per minute (AI survey generation)
+    v3SurveyImportConvert: {
+      interval: 60,
+      allowedPerInterval: 30,
+      namespace: "api:v3:surveys:import:convert",
+    }, // 30 per minute per user or key — deterministic file conversions; the AI lane additionally spends from v3SurveyGenerate
     internalDatasetPurge: {
       interval: 3600,
       allowedPerInterval: 5,

--- a/apps/web/modules/survey/import/lanes/index.ts
+++ b/apps/web/modules/survey/import/lanes/index.ts
@@ -1,0 +1,24 @@
+import {
+  IMPORT_LANE_BY_KIND,
+  type TImportLane,
+  type TImportLaneHandler,
+  type TImportSourceKind,
+} from "../types";
+import { formbricksLane } from "./formbricks";
+
+/**
+ * Lane registry. A kind without a handler is a lane that has not shipped yet; the convert route
+ * answers `lane_not_available` for it instead of guessing.
+ */
+const LANE_HANDLERS: Partial<Record<TImportLane, TImportLaneHandler>> = {
+  lossless: formbricksLane,
+};
+
+export function getImportLaneHandler(kind: TImportSourceKind): TImportLaneHandler | null {
+  return LANE_HANDLERS[IMPORT_LANE_BY_KIND[kind]] ?? null;
+}
+
+/** Test seam and future registration point for the structured and AI lanes. */
+export function registerImportLane(lane: TImportLane, handler: TImportLaneHandler): void {
+  LANE_HANDLERS[lane] = handler;
+}

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -5,7 +5,7 @@ openapi: 3.1.1
 info:
   title: Formbricks API v3
   description: |
-    **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, **DELETE /api/v3/surveys/{surveyId}**, **GET /api/v3/surveys/{surveyId}/export**, which returns a portable `.formbricks.json` envelope, and **POST /api/v3/surveys/import**, which creates a survey from such an envelope or a raw v3 document in any workspace or instance (with a dry-run mode).
+    **Surveys**: **GET /api/v3/surveys**, **POST /api/v3/surveys**, **POST /api/v3/surveys/generate**, **POST /api/v3/surveys/validate**, **GET /api/v3/surveys/{surveyId}**, **PATCH /api/v3/surveys/{surveyId}**, **DELETE /api/v3/surveys/{surveyId}**, **GET /api/v3/surveys/{surveyId}/export**, which returns a portable `.formbricks.json` envelope, and **POST /api/v3/surveys/import**, which creates a survey from such an envelope or a raw v3 document in any workspace or instance (with a dry-run mode). **POST /api/v3/surveys/import/convert** turns an uploaded survey file into a reviewed document plus import report without persisting anything.
 
     **Workflows extension**: **GET /api/v3/workflows**, **POST /api/v3/workflows**, **GET /api/v3/workflows/{workflowId}**, **PATCH /api/v3/workflows/{workflowId}**, **DELETE /api/v3/workflows/{workflowId}**, **POST /api/v3/workflows/{workflowId}/duplicate**, **POST /api/v3/workflows/{workflowId}/enable**, **POST /api/v3/workflows/{workflowId}/disable**, **POST /api/v3/workflows/{workflowId}/archive**, **POST /api/v3/workflows/{workflowId}/unarchive**, **POST /api/v3/workflows/{workflowId}/test**, **GET /api/v3/workflows/runs**, and **GET /api/v3/workflows/runs/{runId}**.
 
@@ -1504,6 +1504,102 @@ paths:
       security:
         - sessionAuth: []
         - apiKeyAuth: []
+  /api/v3/surveys/import/convert:
+    post:
+      operationId: convertSurveyImportFileV3
+      summary: Convert a survey file for import
+      description: |
+        Turns an uploaded survey file into a reviewed v3 survey document and an import report, without persisting anything. The file is detected by content first, then by extension: a Formbricks export (`.formbricks.json`) or raw v3 document today; Qualtrics `.qsf` and DOCX, PDF, Markdown, TXT, CSV and XLSX documents as their lanes ship (until then those answer `400 lane_not_available`). The document is resolved for the target workspace exactly as `POST /api/v3/surveys/import` would in dry-run mode.
+
+        `multipart/form-data` only: a `file` part and a `workspaceId` field, up to 15 MB per file. A request that is not multipart answers **415**; a file the allowlist rejects (unknown type, legacy `.doc`/`.xls`, empty, broken JSON) answers **422**; a file over the cap answers **413**. A file the lane cannot read still answers **200** with `document: null` and the reasons in `report.issues`.
+
+        Self-hosters: a reverse proxy in front of Formbricks must allow request bodies of 16 MB for this endpoint (nginx defaults `client_max_body_size` to 1 MB).
+      tags:
+        - V3 Surveys
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - workspaceId
+                - file
+              properties:
+                workspaceId:
+                  type: string
+                  format: cuid2
+                  description: Target workspace. Requires read/write access.
+                type:
+                  type: string
+                  enum:
+                    - link
+                    - app
+                  description: Survey type hint for lanes that cannot infer it (documents). Ignored by the lossless lane.
+                language:
+                  type: string
+                  description: Language hint (BCP-47) that breaks language-detection ties in the AI lane.
+                file:
+                  type: string
+                  format: binary
+                  description: The survey file. 15 MB maximum.
+              additionalProperties: false
+      responses:
+        '200':
+          description: File converted. The document may be `null` when the report carries errors; nothing was written.
+          headers:
+            X-Request-Id:
+              schema:
+                type: string
+              description: Request correlation ID
+            Cache-Control:
+              schema:
+                type: string
+              example: private, no-store
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SurveyImportConvertResult'
+        '400':
+          description: 'Bad Request — malformed multipart body, missing `file` part or `workspaceId`, or a file kind whose import lane is not available yet (`code: lane_not_available`).'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '401':
+          $ref: '#/components/responses/V3Unauthorized'
+        '403':
+          $ref: '#/components/responses/V3Forbidden'
+        '413':
+          description: Payload Too Large — the request body exceeds 16 MB (15 MB file plus multipart framing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '415':
+          description: Unsupported Media Type — the request body is not `multipart/form-data`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '422':
+          description: 'Unprocessable Content — the uploaded file is not something Formbricks imports: `code: unsupported_source` for an unknown type, empty file or broken JSON, `code: legacy_office_format` for `.doc`/`.xls` (save as `.docx`/`.xlsx`). `invalid_params` names the `file` part.'
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '429':
+          $ref: '#/components/responses/V3TooManyRequests'
+        '500':
+          $ref: '#/components/responses/V3InternalServerError'
+      security:
+        - sessionAuth: []
+        - apiKeyAuth: []
   /api/v3/workflows:
     get:
       operationId: listWorkflowsV3
@@ -2842,12 +2938,16 @@ components:
             - forbidden
             - internal_server_error
             - invalid_workflow_state
+            - lane_not_available
+            - legacy_office_format
             - not_authenticated
             - not_found
             - payload_too_large
             - service_unavailable
             - too_many_requests
             - unprocessable_content
+            - unsupported_media_type
+            - unsupported_source
             - workflow_not_executable
         requestId:
           type: string
@@ -5266,6 +5366,32 @@ components:
           $ref: '#/components/schemas/SurveyResource'
         report:
           $ref: '#/components/schemas/SurveyImportReport'
+      additionalProperties: false
+    SurveyImportConvertResult:
+      type: object
+      description: |
+        A converted file: the resolved document (public shape; `null` when the report has errors), the action-class references it travelled with, the report, the validation and the detected source. Nothing was persisted. To create the survey, send `document` and `references` to `POST /api/v3/surveys/import`.
+      required:
+        - document
+        - references
+        - report
+        - validation
+        - source
+      properties:
+        document:
+          oneOf:
+            - $ref: '#/components/schemas/SurveyExportDocument'
+            - type: 'null'
+        references:
+          oneOf:
+            - $ref: '#/components/schemas/SurveyExportReferences'
+            - type: 'null'
+        report:
+          $ref: '#/components/schemas/SurveyImportReport'
+        validation:
+          $ref: '#/components/schemas/SurveyImportValidation'
+        source:
+          $ref: '#/components/schemas/SurveyImportSource'
       additionalProperties: false
     WorkflowStatus:
       type: string

--- a/docs/api-v3-reference/src/components/schemas/Problem.yml
+++ b/docs/api-v3-reference/src/components/schemas/Problem.yml
@@ -34,12 +34,16 @@ properties:
       - forbidden
       - internal_server_error
       - invalid_workflow_state
+      - lane_not_available
+      - legacy_office_format
       - not_authenticated
       - not_found
       - payload_too_large
       - service_unavailable
       - too_many_requests
       - unprocessable_content
+      - unsupported_media_type
+      - unsupported_source
       - workflow_not_executable
   requestId:
     type: string

--- a/docs/api-v3-reference/src/components/schemas/SurveyImportConvertResult.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyImportConvertResult.yml
@@ -1,0 +1,28 @@
+type: object
+description: >
+  A converted file: the resolved document (public shape; `null` when the report has errors), the
+  action-class references it travelled with, the report, the validation and the detected source.
+  Nothing was persisted. To create the survey, send `document` and `references` to
+  `POST /api/v3/surveys/import`.
+required:
+  - document
+  - references
+  - report
+  - validation
+  - source
+properties:
+  document:
+    oneOf:
+      - $ref: ./SurveyExportDocument.yml
+      - type: "null"
+  references:
+    oneOf:
+      - $ref: ./SurveyExportReferences.yml
+      - type: "null"
+  report:
+    $ref: ./SurveyImportReport.yml
+  validation:
+    $ref: ./SurveyImportValidation.yml
+  source:
+    $ref: ./SurveyImportSource.yml
+additionalProperties: false

--- a/docs/api-v3-reference/src/openapi.yml
+++ b/docs/api-v3-reference/src/openapi.yml
@@ -13,7 +13,9 @@ info:
     /api/v3/surveys/{surveyId}/export**, which returns a portable
     `.formbricks.json` envelope, and **POST /api/v3/surveys/import**, which
     creates a survey from such an envelope or a raw v3 document in any
-    workspace or instance (with a dry-run mode).
+    workspace or instance (with a dry-run mode). **POST
+    /api/v3/surveys/import/convert** turns an uploaded survey file into a
+    reviewed document plus import report without persisting anything.
 
 
     **Workflows extension**: **GET /api/v3/workflows**, **POST
@@ -187,6 +189,8 @@ paths:
     $ref: paths/api_v3_surveys_{surveyId}_export.yml
   /api/v3/surveys/import:
     $ref: paths/api_v3_surveys_import.yml
+  /api/v3/surveys/import/convert:
+    $ref: paths/api_v3_surveys_import_convert.yml
   /api/v3/workflows:
     $ref: paths/api_v3_workflows.yml
   /api/v3/workflows/runs:

--- a/docs/api-v3-reference/src/paths/api_v3_surveys_import_convert.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_surveys_import_convert.yml
@@ -1,0 +1,113 @@
+post:
+  operationId: convertSurveyImportFileV3
+  summary: Convert a survey file for import
+  description: >
+    Turns an uploaded survey file into a reviewed v3 survey document and an import report, without
+    persisting anything. The file is detected by content first, then by extension: a Formbricks
+    export (`.formbricks.json`) or raw v3 document today; Qualtrics `.qsf` and DOCX, PDF, Markdown,
+    TXT, CSV and XLSX documents as their lanes ship (until then those answer `400
+    lane_not_available`). The document is resolved for the target workspace exactly as
+    `POST /api/v3/surveys/import` would in dry-run mode.
+
+
+    `multipart/form-data` only: a `file` part and a `workspaceId` field, up to 15 MB per file. A
+    request that is not multipart answers **415**; a file the allowlist rejects (unknown type,
+    legacy `.doc`/`.xls`, empty, broken JSON) answers **422**; a file over the cap answers **413**.
+    A file the lane cannot read still answers **200** with `document: null` and the reasons in
+    `report.issues`.
+
+
+    Self-hosters: a reverse proxy in front of Formbricks must allow request bodies of 16 MB for this
+    endpoint (nginx defaults `client_max_body_size` to 1 MB).
+  tags:
+    - V3 Surveys
+  requestBody:
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          required:
+            - workspaceId
+            - file
+          properties:
+            workspaceId:
+              type: string
+              format: cuid2
+              description: Target workspace. Requires read/write access.
+            type:
+              type: string
+              enum:
+                - link
+                - app
+              description: Survey type hint for lanes that cannot infer it (documents). Ignored by the lossless lane.
+            language:
+              type: string
+              description: Language hint (BCP-47) that breaks language-detection ties in the AI lane.
+            file:
+              type: string
+              format: binary
+              description: The survey file. 15 MB maximum.
+          additionalProperties: false
+  responses:
+    "200":
+      description: File converted. The document may be `null` when the report carries errors; nothing was written.
+      headers:
+        X-Request-Id:
+          schema:
+            type: string
+          description: Request correlation ID
+        Cache-Control:
+          schema:
+            type: string
+          example: private, no-store
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: ../components/schemas/SurveyImportConvertResult.yml
+    "400":
+      description: >-
+        Bad Request — malformed multipart body, missing `file` part or `workspaceId`, or a file kind
+        whose import lane is not available yet (`code: lane_not_available`).
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+    "401":
+      $ref: ../components/responses/V3Unauthorized.yml
+    "403":
+      $ref: ../components/responses/V3Forbidden.yml
+    "413":
+      description: Payload Too Large — the request body exceeds 16 MB (15 MB file plus multipart framing).
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+    "415":
+      description: Unsupported Media Type — the request body is not `multipart/form-data`.
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+    "422":
+      description: >-
+        Unprocessable Content — the uploaded file is not something Formbricks imports:
+        `code: unsupported_source` for an unknown type, empty file or broken JSON,
+        `code: legacy_office_format` for `.doc`/`.xls` (save as `.docx`/`.xlsx`). `invalid_params`
+        names the `file` part.
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+    "429":
+      $ref: ../components/responses/V3TooManyRequests.yml
+    "500":
+      $ref: ../components/responses/V3InternalServerError.yml
+  security:
+    - sessionAuth: []
+    - apiKeyAuth: []


### PR DESCRIPTION
Fixes ENG-2987

## What & why

**Was:** The v3 wrapper only read JSON bodies (2 MB), so a survey file had no way in.

**Now:** `withV3ApiWrapper` accepts `body: "multipart"` with a `bodyLimitBytes` cap: bytes are counted while reading (never trusting `Content-Length` alone), a non-multipart request answers 415, an oversized one 413, and the handler receives `{ fields, files }`. `POST /api/v3/surveys/import/convert` uses it to turn one uploaded file into a resolved document plus report, never persisting: detect → lane registry → resolver in dry-run mode.

- A file the allowlist rejects is 422 (`unsupported_source` / `legacy_office_format` with a "save as .docx/.xlsx" hint); a kind whose lane has not shipped is 400 `lane_not_available`; a file the lane cannot read is 200 with `document: null` and the reasons in the report.
- New rate-limit bucket `v3SurveyImportConvert` (30/min per user or key).
- JSON routes are byte-identical: the default mode is `json` with the existing 2 MB limit.

Stacked on #9193 (ENG-2986).

## Where to look

- [api-wrapper.ts](apps/web/app/api/v3/lib/api-wrapper.ts) — `readV3Body` / `readMultipartBody`: the byte counting and the 415/413/400 order
- [convert-import.ts](apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts) — detection failure → 422, missing lane → 400, always dry run
- [api_v3_surveys_import_convert.yml](docs/api-v3-reference/src/paths/api_v3_surveys_import_convert.yml) — every rejection path Schemathesis will synthesize

## Breaking changes

- [ ] This PR contains breaking changes

None — new endpoint, new optional wrapper options; `problemBadRequest` gains an optional `code`. Self-hosters only need a proxy body limit of 16 MB to use the new endpoint (documented on it; nothing existing changes).

## Migrations & env

- none (self-hosting docs note on the 16 MB proxy body limit lands with ENG-3011)

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run app/api/v3/lib app/api/v3/surveys/import modules/core/rate-limit/rate-limit-configs.test.ts && pnpm api:v3:check`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Multipart happy path hands fields + files (as Buffers) to the handler; 415 on `text/plain`; 413 on declared length and on counted bytes without a header; 400 on malformed data and on a schema-rejected body; JSON routes unchanged | unit (mutation) | `api-wrapper.test.ts` (new `multipart bodies` block); 5 tests pass, existing 15 unchanged |
| `.formbricks.json` upload → lossless lane → 200 with document, references, report, `trigger_would_be_created`, nothing created; renamed `.txt` detected by content | unit (mutation) | `convert-import.test.ts`; passes |
| `.doc`, `.png`, empty and broken JSON → 422 with the right code; `.csv` → 400 `lane_not_available`; legacy questions → 200 with `document: null`; 403 before the file is read | unit (mutation) | passes |
| Convert body schema: exactly one part named `file`, strict fields | unit (mutation) | passes |
| Rate-limit config registered | unit (guard) | `rate-limit-configs.test.ts` key list updated |
| OpenAPI lints and bundle in sync | unit (guard) | `api:v3:lint` + `api:v3:check` green locally |

**Open gaps**

- Not run against a live instance; Schemathesis on this PR is the first real multipart drive.

**Risks**

- `readMultipartBody` re-wraps the counted bytes in a fresh `Request` for `formData()`; a runtime that changes multipart parsing changes this path too, but the tests exercise it through the real parser.

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
