### PR TITLE
feat(surveys): QSF structure — pages → blocks, flow order, options, languages, embedded data [ENG-2993]

### DIFF
--- a/apps/web/modules/survey/import/lanes/qsf/__fixtures__/embedded-data.document.snap
+++ b/apps/web/modules/survey/import/lanes/qsf/__fixtures__/embedded-data.document.snap
@@ -1,0 +1,128 @@
+{
+  "document": {
+    "name": "Embedded data",
+    "type": "link",
+    "status": "draft",
+    "metadata": {
+      "title": {
+        "en-US": "Embedded data"
+      }
+    },
+    "defaultLanguage": "en-US",
+    "languages": [
+      {
+        "code": "en-US",
+        "default": true,
+        "enabled": true
+      }
+    ],
+    "welcomeCard": {
+      "enabled": false
+    },
+    "blocks": [
+      {
+        "id": "<cuid>",
+        "name": "Default Question Block",
+        "elements": [
+          {
+            "id": "Q1",
+            "type": "openText",
+            "headline": {
+              "en-US": "Hello ${e://Field/firstName}, how was your visit to ${e://Field/Store-Name}?"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": true,
+            "charLimit": {
+              "enabled": false
+            }
+          },
+          {
+            "id": "Q2",
+            "type": "openText",
+            "headline": {
+              "en-US": "You said: ${q://QID1/ChoiceTextEntryValue}. Anything to add? ${loc://something}"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            }
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←"
+        }
+      }
+    ],
+    "endings": [
+      {
+        "id": "<cuid>",
+        "type": "endScreen",
+        "headline": {
+          "en-US": "Thank you!"
+        }
+      }
+    ],
+    "hiddenFields": {
+      "enabled": true,
+      "fieldIds": [
+        "firstname",
+        "store_name",
+        "userid_imported",
+        "plan_tier"
+      ]
+    },
+    "variables": []
+  },
+  "issues": [
+    {
+      "severity": "info",
+      "code": "field_renamed",
+      "message": "The field 'firstName' was renamed to 'firstname' to follow the naming rules.",
+      "sourceRef": "Embedded Data",
+      "vars": {
+        "sourceRef": "Embedded Data",
+        "from": "firstName",
+        "to": "firstname"
+      }
+    },
+    {
+      "severity": "info",
+      "code": "field_renamed",
+      "message": "The field 'Store-Name' was renamed to 'store_name' to follow the naming rules.",
+      "sourceRef": "Embedded Data",
+      "vars": {
+        "sourceRef": "Embedded Data",
+        "from": "Store-Name",
+        "to": "store_name"
+      }
+    },
+    {
+      "severity": "warning",
+      "code": "embedded_data_name_refused",
+      "message": "The hidden field 'userId' uses a reserved name and was renamed to 'userid_imported'.",
+      "sourceRef": "Embedded Data",
+      "vars": {
+        "sourceRef": "Embedded Data",
+        "name": "userId",
+        "renamed": "userid_imported"
+      }
+    },
+    {
+      "severity": "info",
+      "code": "field_renamed",
+      "message": "The field 'plan tier' was renamed to 'plan_tier' to follow the naming rules.",
+      "sourceRef": "Embedded Data",
+      "vars": {
+        "sourceRef": "Embedded Data",
+        "from": "plan tier",
+        "to": "plan_tier"
+      }
+    }
+  ]
+}

--- a/apps/web/modules/survey/import/lanes/qsf/__fixtures__/logic-skip-display-branch.document.snap
+++ b/apps/web/modules/survey/import/lanes/qsf/__fixtures__/logic-skip-display-branch.document.snap
@@ -1,0 +1,217 @@
+{
+  "document": {
+    "name": "Logic showcase",
+    "type": "link",
+    "status": "draft",
+    "metadata": {
+      "title": {
+        "en-US": "Logic showcase"
+      }
+    },
+    "defaultLanguage": "en-US",
+    "languages": [
+      {
+        "code": "en-US",
+        "default": true,
+        "enabled": true
+      }
+    ],
+    "welcomeCard": {
+      "enabled": false
+    },
+    "blocks": [
+      {
+        "id": "<cuid>",
+        "name": "Usage · Page 1",
+        "elements": [
+          {
+            "id": "Q1",
+            "type": "multipleChoiceSingle",
+            "headline": {
+              "en-US": "Do you use our product?"
+            },
+            "required": true,
+            "choices": [
+              {
+                "id": "choice_1",
+                "label": {
+                  "en-US": "Yes"
+                }
+              },
+              {
+                "id": "choice_2",
+                "label": {
+                  "en-US": "No"
+                }
+              }
+            ]
+          },
+          {
+            "id": "Q2",
+            "type": "multipleChoiceSingle",
+            "headline": {
+              "en-US": "How often?"
+            },
+            "required": false,
+            "choices": [
+              {
+                "id": "choice_1",
+                "label": {
+                  "en-US": "Daily"
+                }
+              },
+              {
+                "id": "choice_2",
+                "label": {
+                  "en-US": "Weekly"
+                }
+              },
+              {
+                "id": "choice_3",
+                "label": {
+                  "en-US": "Rarely"
+                }
+              }
+            ]
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←"
+        }
+      },
+      {
+        "id": "<cuid>",
+        "name": "Usage · Page 2",
+        "elements": [
+          {
+            "id": "Q3",
+            "type": "multipleChoiceSingle",
+            "headline": {
+              "en-US": "Which region are you in?"
+            },
+            "required": false,
+            "choices": [
+              {
+                "id": "choice_1",
+                "label": {
+                  "en-US": "EU"
+                }
+              },
+              {
+                "id": "choice_2",
+                "label": {
+                  "en-US": "US"
+                }
+              },
+              {
+                "id": "choice_3",
+                "label": {
+                  "en-US": "Other"
+                }
+              }
+            ],
+            "displayType": "dropdown"
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←"
+        }
+      },
+      {
+        "id": "<cuid>",
+        "name": "Compliance",
+        "elements": [
+          {
+            "id": "Q4",
+            "type": "multipleChoiceSingle",
+            "headline": {
+              "en-US": "EU: are you GDPR compliant?"
+            },
+            "required": false,
+            "choices": [
+              {
+                "id": "choice_1",
+                "label": {
+                  "en-US": "Yes"
+                }
+              },
+              {
+                "id": "choice_2",
+                "label": {
+                  "en-US": "No"
+                }
+              }
+            ]
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←"
+        }
+      },
+      {
+        "id": "<cuid>",
+        "name": "Wrap up",
+        "elements": [
+          {
+            "id": "Q5",
+            "type": "openText",
+            "headline": {
+              "en-US": "Any final comments?"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": true,
+            "charLimit": {
+              "enabled": false
+            }
+          },
+          {
+            "id": "Q6",
+            "type": "openText",
+            "headline": {
+              "en-US": "Unreadable logic"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            }
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←"
+        }
+      }
+    ],
+    "endings": [
+      {
+        "id": "<cuid>",
+        "type": "endScreen",
+        "headline": {
+          "en-US": "Thank you!"
+        }
+      }
+    ],
+    "hiddenFields": {
+      "enabled": true,
+      "fieldIds": [
+        "region"
+      ]
+    },
+    "variables": []
+  },
+  "issues": []
+}

--- a/apps/web/modules/survey/import/lanes/qsf/__fixtures__/matrix-slider-ranking.document.snap
+++ b/apps/web/modules/survey/import/lanes/qsf/__fixtures__/matrix-slider-ranking.document.snap
@@ -1,0 +1,425 @@
+{
+  "document": {
+    "name": "Advanced types",
+    "type": "link",
+    "status": "draft",
+    "metadata": {
+      "title": {
+        "en-US": "Advanced types"
+      }
+    },
+    "defaultLanguage": "en-US",
+    "languages": [
+      {
+        "code": "en-US",
+        "default": true,
+        "enabled": true
+      }
+    ],
+    "welcomeCard": {
+      "enabled": true,
+      "headline": {
+        "en-US": "Welcome to the advanced section. Item"
+      },
+      "buttonLabel": {
+        "en-US": "Start"
+      },
+      "timeToFinish": false,
+      "showResponseCount": false
+    },
+    "blocks": [
+      {
+        "id": "<cuid>",
+        "name": "Advanced · Page 1",
+        "elements": [
+          {
+            "id": "Q1",
+            "type": "matrix",
+            "headline": {
+              "en-US": "Rate our service"
+            },
+            "required": true,
+            "rows": [
+              {
+                "id": "row_1",
+                "label": {
+                  "en-US": "Speed"
+                }
+              },
+              {
+                "id": "row_2",
+                "label": {
+                  "en-US": "Friendliness"
+                }
+              }
+            ],
+            "columns": [
+              {
+                "id": "column_1",
+                "label": {
+                  "en-US": "Poor"
+                }
+              },
+              {
+                "id": "column_2",
+                "label": {
+                  "en-US": "OK"
+                }
+              },
+              {
+                "id": "column_3",
+                "label": {
+                  "en-US": "Great"
+                }
+              }
+            ],
+            "shuffleOption": "none"
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←"
+        }
+      },
+      {
+        "id": "<cuid>",
+        "name": "Advanced · Page 2",
+        "elements": [
+          {
+            "id": "Q3_1",
+            "type": "rating",
+            "headline": {
+              "en-US": "The product is fast"
+            },
+            "required": false,
+            "scale": "number",
+            "range": 10,
+            "isColorCodingEnabled": false,
+            "subheader": {
+              "en-US": "How much do you agree?"
+            }
+          },
+          {
+            "id": "Q3_2",
+            "type": "rating",
+            "headline": {
+              "en-US": "The product is stable"
+            },
+            "required": false,
+            "scale": "number",
+            "range": 10,
+            "isColorCodingEnabled": false,
+            "subheader": {
+              "en-US": "How much do you agree?"
+            }
+          },
+          {
+            "id": "Q4",
+            "type": "rating",
+            "headline": {
+              "en-US": "Star rating"
+            },
+            "required": false,
+            "scale": "star",
+            "range": 5,
+            "isColorCodingEnabled": false
+          },
+          {
+            "id": "Q5",
+            "type": "ranking",
+            "headline": {
+              "en-US": "Rank these priorities"
+            },
+            "required": false,
+            "choices": [
+              {
+                "id": "choice_1",
+                "label": {
+                  "en-US": "Speed"
+                }
+              },
+              {
+                "id": "choice_2",
+                "label": {
+                  "en-US": "Price"
+                }
+              },
+              {
+                "id": "choice_3",
+                "label": {
+                  "en-US": "Support"
+                }
+              },
+              {
+                "id": "choice_4",
+                "label": {
+                  "en-US": "Design"
+                }
+              }
+            ]
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←"
+        }
+      },
+      {
+        "id": "<cuid>",
+        "name": "Advanced · Page 3",
+        "elements": [
+          {
+            "id": "Q7",
+            "type": "fileUpload",
+            "headline": {
+              "en-US": "Upload a screenshot"
+            },
+            "required": false,
+            "allowMultipleFiles": false
+          },
+          {
+            "id": "Q8_1",
+            "type": "openText",
+            "headline": {
+              "en-US": "First name"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            },
+            "subheader": {
+              "en-US": "Contact details"
+            }
+          },
+          {
+            "id": "Q8_2",
+            "type": "openText",
+            "headline": {
+              "en-US": "Last name"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            },
+            "subheader": {
+              "en-US": "Contact details"
+            }
+          },
+          {
+            "id": "Q8_3",
+            "type": "openText",
+            "headline": {
+              "en-US": "Company"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            },
+            "subheader": {
+              "en-US": "Contact details"
+            }
+          },
+          {
+            "id": "Q12",
+            "type": "ranking",
+            "headline": {
+              "en-US": "Twenty-six options"
+            },
+            "required": false,
+            "choices": [
+              {
+                "id": "choice_1",
+                "label": {
+                  "en-US": "Option 1"
+                }
+              },
+              {
+                "id": "choice_2",
+                "label": {
+                  "en-US": "Option 2"
+                }
+              },
+              {
+                "id": "choice_3",
+                "label": {
+                  "en-US": "Option 3"
+                }
+              },
+              {
+                "id": "choice_4",
+                "label": {
+                  "en-US": "Option 4"
+                }
+              },
+              {
+                "id": "choice_5",
+                "label": {
+                  "en-US": "Option 5"
+                }
+              },
+              {
+                "id": "choice_6",
+                "label": {
+                  "en-US": "Option 6"
+                }
+              },
+              {
+                "id": "choice_7",
+                "label": {
+                  "en-US": "Option 7"
+                }
+              },
+              {
+                "id": "choice_8",
+                "label": {
+                  "en-US": "Option 8"
+                }
+              },
+              {
+                "id": "choice_9",
+                "label": {
+                  "en-US": "Option 9"
+                }
+              },
+              {
+                "id": "choice_10",
+                "label": {
+                  "en-US": "Option 10"
+                }
+              },
+              {
+                "id": "choice_11",
+                "label": {
+                  "en-US": "Option 11"
+                }
+              },
+              {
+                "id": "choice_12",
+                "label": {
+                  "en-US": "Option 12"
+                }
+              },
+              {
+                "id": "choice_13",
+                "label": {
+                  "en-US": "Option 13"
+                }
+              },
+              {
+                "id": "choice_14",
+                "label": {
+                  "en-US": "Option 14"
+                }
+              },
+              {
+                "id": "choice_15",
+                "label": {
+                  "en-US": "Option 15"
+                }
+              },
+              {
+                "id": "choice_16",
+                "label": {
+                  "en-US": "Option 16"
+                }
+              },
+              {
+                "id": "choice_17",
+                "label": {
+                  "en-US": "Option 17"
+                }
+              },
+              {
+                "id": "choice_18",
+                "label": {
+                  "en-US": "Option 18"
+                }
+              },
+              {
+                "id": "choice_19",
+                "label": {
+                  "en-US": "Option 19"
+                }
+              },
+              {
+                "id": "choice_20",
+                "label": {
+                  "en-US": "Option 20"
+                }
+              },
+              {
+                "id": "choice_21",
+                "label": {
+                  "en-US": "Option 21"
+                }
+              },
+              {
+                "id": "choice_22",
+                "label": {
+                  "en-US": "Option 22"
+                }
+              },
+              {
+                "id": "choice_23",
+                "label": {
+                  "en-US": "Option 23"
+                }
+              },
+              {
+                "id": "choice_24",
+                "label": {
+                  "en-US": "Option 24"
+                }
+              },
+              {
+                "id": "choice_25",
+                "label": {
+                  "en-US": "Option 25"
+                }
+              }
+            ]
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←"
+        }
+      }
+    ],
+    "endings": [
+      {
+        "id": "<cuid>",
+        "type": "redirectToUrl",
+        "url": "https://example.com/thanks",
+        "label": "Thank you!"
+      }
+    ],
+    "hiddenFields": {
+      "enabled": false
+    },
+    "variables": []
+  },
+  "issues": [
+    {
+      "severity": "info",
+      "code": "welcome_card_from_descriptive_text",
+      "message": "The first text page became the welcome card.",
+      "sourceRef": "QID6",
+      "vars": {
+        "sourceRef": "QID6"
+      }
+    }
+  ]
+}

--- a/apps/web/modules/survey/import/lanes/qsf/__fixtures__/multilang-en-de.document.snap
+++ b/apps/web/modules/survey/import/lanes/qsf/__fixtures__/multilang-en-de.document.snap
@@ -1,0 +1,155 @@
+{
+  "document": {
+    "name": "Produktfeedback",
+    "type": "link",
+    "status": "draft",
+    "metadata": {
+      "title": {
+        "en-US": "Produktfeedback",
+        "de-DE": "Produktfeedback"
+      }
+    },
+    "defaultLanguage": "en-US",
+    "languages": [
+      {
+        "code": "en-US",
+        "default": true,
+        "enabled": true
+      },
+      {
+        "code": "de-DE",
+        "default": false,
+        "enabled": true
+      }
+    ],
+    "welcomeCard": {
+      "enabled": false
+    },
+    "blocks": [
+      {
+        "id": "<cuid>",
+        "name": "Feedback",
+        "elements": [
+          {
+            "id": "Q1",
+            "type": "multipleChoiceSingle",
+            "headline": {
+              "en-US": "How satisfied are you?",
+              "de-DE": "Wie zufrieden sind Sie?"
+            },
+            "required": true,
+            "choices": [
+              {
+                "id": "choice_1",
+                "label": {
+                  "en-US": "Very satisfied",
+                  "de-DE": "Sehr zufrieden"
+                }
+              },
+              {
+                "id": "choice_2",
+                "label": {
+                  "en-US": "Satisfied",
+                  "de-DE": "Zufrieden"
+                }
+              },
+              {
+                "id": "choice_3",
+                "label": {
+                  "en-US": "Unsatisfied",
+                  "de-DE": "Unzufrieden"
+                }
+              }
+            ]
+          },
+          {
+            "id": "Q2",
+            "type": "openText",
+            "headline": {
+              "en-US": "Anything else?",
+              "de-DE": "Noch etwas?"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": true,
+            "charLimit": {
+              "enabled": false
+            }
+          },
+          {
+            "id": "Q3",
+            "type": "matrix",
+            "headline": {
+              "en-US": "Rate these statements",
+              "de-DE": "Bewerten Sie diese Aussagen"
+            },
+            "required": false,
+            "rows": [
+              {
+                "id": "row_1",
+                "label": {
+                  "en-US": "Easy to use",
+                  "de-DE": "Einfach zu bedienen"
+                }
+              },
+              {
+                "id": "row_2",
+                "label": {
+                  "en-US": "Good value",
+                  "de-DE": "Gutes Preis-Leistungs-Verhältnis"
+                }
+              }
+            ],
+            "columns": [
+              {
+                "id": "column_1",
+                "label": {
+                  "en-US": "Agree",
+                  "de-DE": "Stimme zu"
+                }
+              },
+              {
+                "id": "column_2",
+                "label": {
+                  "en-US": "Neutral",
+                  "de-DE": "Neutral"
+                }
+              },
+              {
+                "id": "column_3",
+                "label": {
+                  "en-US": "Disagree",
+                  "de-DE": "Stimme nicht zu"
+                }
+              }
+            ],
+            "shuffleOption": "none"
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→",
+          "de-DE": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←",
+          "de-DE": "←"
+        }
+      }
+    ],
+    "endings": [
+      {
+        "id": "<cuid>",
+        "type": "endScreen",
+        "headline": {
+          "en-US": "Danke! / Thank you!",
+          "de-DE": "Danke! / Thank you!"
+        }
+      }
+    ],
+    "hiddenFields": {
+      "enabled": false
+    },
+    "variables": []
+  },
+  "issues": []
+}

--- a/apps/web/modules/survey/import/lanes/qsf/__fixtures__/pages-and-blocks.document.snap
+++ b/apps/web/modules/survey/import/lanes/qsf/__fixtures__/pages-and-blocks.document.snap
@@ -1,0 +1,169 @@
+{
+  "document": {
+    "name": "Pages and blocks",
+    "type": "link",
+    "status": "draft",
+    "metadata": {
+      "title": {
+        "en-US": "Pages and blocks"
+      }
+    },
+    "defaultLanguage": "en-US",
+    "languages": [
+      {
+        "code": "en-US",
+        "default": true,
+        "enabled": true
+      }
+    ],
+    "welcomeCard": {
+      "enabled": false
+    },
+    "blocks": [
+      {
+        "id": "<cuid>",
+        "name": "Block B",
+        "elements": [
+          {
+            "id": "Q3",
+            "type": "openText",
+            "headline": {
+              "en-US": "Second block question"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            }
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "Continue"
+        },
+        "backButtonLabel": {
+          "en-US": "Back"
+        }
+      },
+      {
+        "id": "<cuid>",
+        "name": "Block A · Page 1",
+        "elements": [
+          {
+            "id": "Q1",
+            "type": "openText",
+            "headline": {
+              "en-US": "Page one question"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            }
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "Continue"
+        },
+        "backButtonLabel": {
+          "en-US": "Back"
+        }
+      },
+      {
+        "id": "<cuid>",
+        "name": "Block A · Page 2",
+        "elements": [
+          {
+            "id": "Q2",
+            "type": "openText",
+            "headline": {
+              "en-US": "Page two question"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            }
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "Continue"
+        },
+        "backButtonLabel": {
+          "en-US": "Back"
+        }
+      },
+      {
+        "id": "<cuid>",
+        "name": "Not in flow",
+        "elements": [
+          {
+            "id": "Q5",
+            "type": "openText",
+            "headline": {
+              "en-US": "Orphan block question"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            }
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "Continue"
+        },
+        "backButtonLabel": {
+          "en-US": "Back"
+        }
+      }
+    ],
+    "endings": [
+      {
+        "id": "<cuid>",
+        "type": "endScreen",
+        "headline": {
+          "en-US": "Thank you!"
+        }
+      }
+    ],
+    "hiddenFields": {
+      "enabled": false
+    },
+    "variables": []
+  },
+  "issues": [
+    {
+      "severity": "warning",
+      "code": "randomizer_flattened",
+      "message": "Randomized blocks were imported in file order. Randomization is not imported.",
+      "sourceRef": "Survey Flow",
+      "vars": {
+        "sourceRef": "Survey Flow"
+      }
+    },
+    {
+      "severity": "info",
+      "code": "block_not_in_flow",
+      "message": "Block 'Not in flow' is not part of the survey flow and was appended at the end.",
+      "sourceRef": "BL_orphan",
+      "vars": {
+        "sourceRef": "BL_orphan",
+        "block": "Not in flow"
+      }
+    },
+    {
+      "severity": "info",
+      "code": "setting_not_imported",
+      "message": "The setting 'BackButton, ProgressBarDisplay' is not imported. Set it up in the editor.",
+      "sourceRef": "Survey Options",
+      "vars": {
+        "sourceRef": "Survey Options",
+        "setting": "BackButton, ProgressBarDisplay"
+      }
+    }
+  ]
+}

--- a/apps/web/modules/survey/import/lanes/qsf/__fixtures__/simple.document.snap
+++ b/apps/web/modules/survey/import/lanes/qsf/__fixtures__/simple.document.snap
@@ -1,0 +1,146 @@
+{
+  "document": {
+    "name": "Customer feedback",
+    "type": "link",
+    "status": "draft",
+    "metadata": {
+      "title": {
+        "en-US": "Customer feedback"
+      }
+    },
+    "defaultLanguage": "en-US",
+    "languages": [
+      {
+        "code": "en-US",
+        "default": true,
+        "enabled": true
+      }
+    ],
+    "welcomeCard": {
+      "enabled": false
+    },
+    "blocks": [
+      {
+        "id": "<cuid>",
+        "name": "Default Question Block",
+        "elements": [
+          {
+            "id": "Q1",
+            "type": "multipleChoiceSingle",
+            "headline": {
+              "en-US": "How did you hear about us?"
+            },
+            "required": true,
+            "choices": [
+              {
+                "id": "choice_1",
+                "label": {
+                  "en-US": "Search engine"
+                }
+              },
+              {
+                "id": "choice_2",
+                "label": {
+                  "en-US": "A friend"
+                }
+              },
+              {
+                "id": "other",
+                "label": {
+                  "en-US": "Other"
+                }
+              }
+            ],
+            "otherOptionPlaceholder": {
+              "en-US": "Please specify"
+            }
+          },
+          {
+            "id": "Q2",
+            "type": "nps",
+            "headline": {
+              "en-US": "How likely are you to recommend us to a friend?"
+            },
+            "required": true,
+            "isColorCodingEnabled": false
+          },
+          {
+            "id": "Q3",
+            "type": "openText",
+            "headline": {
+              "en-US": "What should we improve?"
+            },
+            "required": false,
+            "inputType": "text",
+            "longAnswer": true,
+            "charLimit": {
+              "enabled": false
+            }
+          },
+          {
+            "id": "Q4",
+            "type": "openText",
+            "headline": {
+              "en-US": "Your email"
+            },
+            "required": false,
+            "inputType": "email",
+            "longAnswer": false,
+            "charLimit": {
+              "enabled": false
+            }
+          },
+          {
+            "id": "Q5",
+            "type": "multipleChoiceMulti",
+            "headline": {
+              "en-US": "Which features do you use?"
+            },
+            "required": false,
+            "choices": [
+              {
+                "id": "choice_1",
+                "label": {
+                  "en-US": "Surveys"
+                }
+              },
+              {
+                "id": "choice_2",
+                "label": {
+                  "en-US": "Contacts"
+                }
+              },
+              {
+                "id": "choice_3",
+                "label": {
+                  "en-US": "Integrations"
+                }
+              }
+            ],
+            "shuffleOption": "all"
+          }
+        ],
+        "buttonLabel": {
+          "en-US": "→"
+        },
+        "backButtonLabel": {
+          "en-US": "←"
+        }
+      }
+    ],
+    "endings": [
+      {
+        "id": "<cuid>",
+        "type": "endScreen",
+        "headline": {
+          "en-US": "Thank you for your feedback!"
+        }
+      }
+    ],
+    "hiddenFields": {
+      "enabled": false
+    },
+    "variables": []
+  },
+  "issues": []
+}

--- a/apps/web/modules/survey/import/lanes/qsf/embedded-data.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/embedded-data.ts
@@ -1,0 +1,38 @@
+import { FORBIDDEN_IDS } from "@formbricks/types/surveys/validation";
+
+const FORBIDDEN_LOWER = new Set(FORBIDDEN_IDS.map((id) => id.toLowerCase()));
+const REFUSED_SUFFIX = "_imported";
+
+export type TEmbeddedDataFieldMapping = {
+  source: string;
+  fieldId: string;
+  /** The name was reserved and had to be suffixed. */
+  refused: boolean;
+  /** The name changed in a way other than the reserved-name suffix. */
+  renamed: boolean;
+};
+
+/**
+ * Qualtrics embedded-data field → Formbricks hidden field id. One function so the Embedded Data project
+ * can repoint it (§8): ids must match `^[a-z][a-z0-9_]*$`, reserved names get a suffix instead of being
+ * lost.
+ *
+ * TODO(embedded-data): when the Embedded Data manager lands, map QSF embedded data onto `ingested`
+ * fields and Formbricks variables onto `computed` fields here instead of hidden fields.
+ */
+export function mapEmbeddedDataFieldName(source: string): TEmbeddedDataFieldMapping {
+  let fieldId = source
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9_]+/g, "_")
+    .replaceAll(/_{2,}/g, "_")
+    .replaceAll(/^_+|_+$/g, "");
+
+  if (fieldId.length === 0) fieldId = "field";
+  if (/^\d/.test(fieldId)) fieldId = `f_${fieldId}`;
+
+  const refused = FORBIDDEN_LOWER.has(fieldId);
+  if (refused) fieldId = `${fieldId}${REFUSED_SUFFIX}`;
+
+  return { source, fieldId, refused, renamed: !refused && fieldId !== source };
+}

--- a/apps/web/modules/survey/import/lanes/qsf/map-structure.test.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/map-structure.test.ts
@@ -1,0 +1,196 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { prepareV3SurveyCreateInput } from "@/app/api/v3/surveys/prepare";
+import { mapEmbeddedDataFieldName } from "./embedded-data";
+import { QsfIdRegistry } from "./id-registry";
+import { type TQsfQuestionMapping, mapQsfQuestion } from "./map-question";
+import { buildQsfDocument } from "./map-structure";
+import { parseQsf } from "./parse-qsf";
+import type { TQsfSurvey } from "./types";
+
+const FIXTURES = join(__dirname, "__fixtures__");
+const WORKSPACE_ID = "clxx1234567890123456789012";
+
+function load(name: string): TQsfSurvey {
+  const result = parseQsf(readFileSync(join(FIXTURES, name)));
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.data;
+}
+
+function build(model: TQsfSurvey) {
+  const ctx = { defaultLanguageCode: model.defaultLanguageCode, languageCodes: model.languageCodes };
+  const registry = new QsfIdRegistry(
+    model.embeddedDataFields.map((field) => mapEmbeddedDataFieldName(field).fieldId)
+  );
+  const mapped = new Map<string, TQsfQuestionMapping>();
+  for (const [qid, question] of model.questions) {
+    mapped.set(qid, mapQsfQuestion(question, { ...ctx, idRegistry: registry }));
+  }
+  return buildQsfDocument(model, mapped, ctx);
+}
+
+/** Ids are random per build; strip them so the golden compares structure, not cuids. */
+function stable(document: Record<string, unknown> | null): unknown {
+  return JSON.parse(
+    JSON.stringify(document, (key, value: unknown) =>
+      key === "id" && typeof value === "string" && /^[a-z0-9]{24}$/.test(value) ? "<cuid>" : value
+    )
+  );
+}
+
+const blocksOf = (document: Record<string, unknown> | null) =>
+  (document?.blocks ?? []) as {
+    id: string;
+    name: string;
+    elements: { id: string }[];
+    buttonLabel?: Record<string, string>;
+  }[];
+
+describe("buildQsfDocument", () => {
+  test.each([
+    "simple.qsf",
+    "multilang-en-de.qsf",
+    "pages-and-blocks.qsf",
+    "embedded-data.qsf",
+    "matrix-slider-ranking.qsf",
+    "logic-skip-display-branch.qsf",
+  ])("%s builds its golden document", async (name) => {
+    const result = build(load(name));
+    await expect(
+      JSON.stringify({ document: stable(result.document), issues: result.issues }, null, 2)
+    ).toMatchFileSnapshot(join(FIXTURES, name.replace(/\.qsf$/, ".document.snap")));
+  });
+
+  test("pages become blocks, the flow order wins, randomizers flatten, orphans append, Trash is skipped", () => {
+    const result = build(load("pages-and-blocks.qsf"));
+    const blocks = blocksOf(result.document);
+
+    expect(blocks.map((block) => block.name)).toEqual([
+      "Block B",
+      "Block A · Page 1",
+      "Block A · Page 2",
+      "Not in flow",
+    ]);
+    expect(blocks.flatMap((block) => block.elements.map((element) => element.id))).toEqual([
+      "Q3",
+      "Q1",
+      "Q2",
+      "Q5",
+    ]);
+    expect(result.qidToBlockId.get("QID4")).toBeUndefined();
+    expect(result.issues.map((issue) => issue.code).sort()).toEqual([
+      "block_not_in_flow",
+      "randomizer_flattened",
+      "setting_not_imported",
+    ]);
+    expect(blocks[0].buttonLabel).toEqual({ "en-US": "Continue" });
+    expect(result.issues.find((issue) => issue.code === "setting_not_imported")?.vars).toMatchObject({
+      setting: "BackButton, ProgressBarDisplay",
+    });
+  });
+
+  test("embedded data becomes hidden fields with normalized ids; reserved names are suffixed", () => {
+    const result = build(load("embedded-data.qsf"));
+
+    expect(result.document?.hiddenFields).toEqual({
+      enabled: true,
+      fieldIds: ["firstname", "store_name", "userid_imported", "plan_tier"],
+    });
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: "embedded_data_name_refused",
+        vars: expect.objectContaining({ name: "userId", renamed: "userid_imported" }),
+      })
+    );
+    expect(result.issues.filter((issue) => issue.code === "field_renamed")).toHaveLength(3);
+  });
+
+  test("two languages are declared and every text carries both", () => {
+    const result = build(load("multilang-en-de.qsf"));
+
+    expect(result.document?.defaultLanguage).toBe("en-US");
+    expect(result.document?.languages).toEqual([
+      { code: "en-US", default: true, enabled: true },
+      { code: "de-DE", default: false, enabled: true },
+    ]);
+    expect((result.document?.metadata as { title: Record<string, string> }).title).toEqual({
+      "en-US": "Produktfeedback",
+      "de-DE": "Produktfeedback",
+    });
+    expect((result.document?.endings as { headline: Record<string, string> }[])[0].headline).toEqual({
+      "en-US": "Danke! / Thank you!",
+      "de-DE": "Danke! / Thank you!",
+    });
+    expect(prepareV3SurveyCreateInput({ workspaceId: WORKSPACE_ID, ...result.document }).ok).toBe(true);
+  });
+
+  test("a leading descriptive text becomes the welcome card and a redirect URL becomes the ending", () => {
+    const result = build(load("matrix-slider-ranking.qsf"));
+
+    expect(result.document?.welcomeCard).toMatchObject({
+      enabled: true,
+      headline: { "en-US": "Welcome to the advanced section. Item" },
+    });
+    expect(result.document?.endings).toEqual([
+      { id: result.endingId, type: "redirectToUrl", url: "https://example.com/thanks", label: "Thank you!" },
+    ]);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ code: "welcome_card_from_descriptive_text", sourceRef: "QID6" })
+    );
+    expect(blocksOf(result.document)[0].elements.map((element) => element.id)).toEqual(["Q1"]);
+    expect(blocksOf(result.document)).toHaveLength(3);
+  });
+
+  test("the ending headline comes from the EOS message and validates as a create body", () => {
+    const result = build(load("simple.qsf"));
+
+    expect((result.document?.endings as { headline: Record<string, string> }[])[0].headline).toEqual({
+      "en-US": "Thank you for your feedback!",
+    });
+    const preparation = prepareV3SurveyCreateInput({ workspaceId: WORKSPACE_ID, ...result.document });
+    expect(preparation.ok, JSON.stringify(preparation.ok ? null : preparation.validation.invalidParams)).toBe(
+      true
+    );
+  });
+
+  test("large-150.qsf builds in under 500 ms and validates", () => {
+    const model = load("large-150.qsf");
+    const started = performance.now();
+    const result = build(model);
+    const elapsed = performance.now() - started;
+
+    expect(result.document).not.toBeNull();
+    expect(blocksOf(result.document)).toHaveLength(30);
+    expect(blocksOf(result.document).flatMap((block) => block.elements).length).toBeGreaterThanOrEqual(135);
+    expect(elapsed).toBeLessThan(500);
+    expect(prepareV3SurveyCreateInput({ workspaceId: WORKSPACE_ID, ...result.document }).ok).toBe(true);
+  });
+
+  test("a file with nothing importable is a fatal nothing_extracted", () => {
+    const model = load("simple.qsf");
+    const mapped = new Map<string, TQsfQuestionMapping>();
+    for (const qid of model.questions.keys()) mapped.set(qid, { elements: [], issues: [], choiceIdMap: {} });
+
+    const result = buildQsfDocument(model, mapped, { defaultLanguageCode: "en-US", languageCodes: [] });
+    expect(result.document).toBeNull();
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ severity: "error", code: "nothing_extracted" })
+    );
+  });
+});
+
+describe("mapEmbeddedDataFieldName", () => {
+  test.each([
+    ["firstName", "firstname", false],
+    ["Store-Name", "store_name", false],
+    ["plan tier", "plan_tier", false],
+    ["  __weird__  ", "weird", false],
+    ["2024_cohort", "f_2024_cohort", false],
+    ["userId", "userid_imported", true],
+    ["END", "end_imported", true],
+    ["", "field", false],
+  ])("%j → %j (refused: %s)", (source, fieldId, refused) => {
+    expect(mapEmbeddedDataFieldName(source)).toMatchObject({ fieldId, refused });
+  });
+});

--- a/apps/web/modules/survey/import/lanes/qsf/map-structure.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/map-structure.ts
@@ -1,0 +1,274 @@
+import { createId } from "@paralleldrive/cuid2";
+import { createZV3TypedSurveyDocumentSchema, formatV3ZodInvalidParams } from "@/app/api/v3/surveys/schemas";
+import { importError, importInfo, importWarning } from "../../report";
+import type { TImportIssue } from "../../types";
+import { mapEmbeddedDataFieldName } from "./embedded-data";
+import type { TQsfI18n, TQsfMappedElement, TQsfQuestionMapping } from "./map-question";
+import { stripHtml } from "./strip-html";
+import type { TQsfBlock, TQsfFlowNode, TQsfSurvey } from "./types";
+
+export type TQsfStructureContext = {
+  defaultLanguageCode: string;
+  languageCodes: readonly string[];
+};
+
+export type TQsfDocumentBuild = {
+  /** The v3 document candidate (public shape), or `null` when it does not validate. */
+  document: Record<string, unknown> | null;
+  issues: TImportIssue[];
+  qidToBlockId: Map<string, string>;
+  qidToElementId: Map<string, string>;
+  /** The single ending every `EndSurvey` node points at. */
+  endingId: string;
+};
+
+type TPage = { blockId: string; description: string; pageIndex: number; pageCount: number; qids: string[] };
+
+const DEFAULT_ENDING_HEADLINE = "Thank you!";
+
+function text(value: string, ctx: TQsfStructureContext): TQsfI18n {
+  const map: TQsfI18n = { [ctx.defaultLanguageCode]: value };
+  for (const code of ctx.languageCodes) map[code] = value;
+  return map;
+}
+
+function pagesOf(block: TQsfBlock): TPage[] {
+  const pages: string[][] = [[]];
+  for (const element of block.elements) {
+    if (element.kind === "pageBreak") pages.push([]);
+    else pages.at(-1)!.push(element.qid);
+  }
+  const nonEmpty = pages.filter((page) => page.length > 0);
+  return nonEmpty.map((qids, index) => ({
+    blockId: block.id,
+    description: block.description,
+    pageIndex: index + 1,
+    pageCount: nonEmpty.length,
+    qids,
+  }));
+}
+
+/** Depth-first flow walk: the order Qualtrics shows blocks in, randomizers and branches flattened. */
+function collectFlowBlockIds(nodes: TQsfFlowNode[], into: string[], issues: TImportIssue[]): void {
+  for (const node of nodes) {
+    switch (node.type) {
+      case "Block":
+      case "Standard":
+        if (!into.includes(node.id)) into.push(node.id);
+        break;
+      case "BlockRandomizer":
+      case "Randomizer":
+        issues.push(importWarning({ code: "randomizer_flattened", sourceRef: "Survey Flow" }));
+        collectFlowBlockIds(node.children, into, issues);
+        break;
+      case "Branch":
+      case "Group":
+        collectFlowBlockIds(node.children, into, issues);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+function blockName(page: TPage, position: number): string {
+  const base = page.description.trim() || `Block ${position}`;
+  return page.pageCount > 1 ? `${base} · Page ${page.pageIndex}` : base;
+}
+
+function buildEnding(
+  model: TQsfSurvey,
+  ctx: TQsfStructureContext,
+  endingId: string
+): Record<string, unknown> {
+  if (model.options.eosRedirectUrl) {
+    return {
+      id: endingId,
+      type: "redirectToUrl",
+      url: model.options.eosRedirectUrl,
+      label: DEFAULT_ENDING_HEADLINE,
+    };
+  }
+  const headline = model.options.eosMessage ? stripHtml(model.options.eosMessage) : "";
+  return {
+    id: endingId,
+    type: "endScreen",
+    headline: text(headline.length > 0 ? headline : DEFAULT_ENDING_HEADLINE, ctx),
+  };
+}
+
+function buildHiddenFields(model: TQsfSurvey, issues: TImportIssue[]): Record<string, unknown> {
+  const fieldIds: string[] = [];
+  for (const source of model.embeddedDataFields) {
+    const mapping = mapEmbeddedDataFieldName(source);
+    if (fieldIds.includes(mapping.fieldId)) continue;
+    fieldIds.push(mapping.fieldId);
+    if (mapping.refused) {
+      issues.push(
+        importWarning({
+          code: "embedded_data_name_refused",
+          sourceRef: "Embedded Data",
+          vars: { name: source, renamed: mapping.fieldId },
+        })
+      );
+    } else if (mapping.renamed) {
+      issues.push(
+        importInfo({
+          code: "field_renamed",
+          sourceRef: "Embedded Data",
+          vars: { from: source, to: mapping.fieldId },
+        })
+      );
+    }
+  }
+  return fieldIds.length > 0 ? { enabled: true, fieldIds } : { enabled: false };
+}
+
+/**
+ * Assemble mapped questions into a v3 survey document: one Formbricks block per Qualtrics page (D5),
+ * in flow order, with a single ending, the welcome card from a leading descriptive text, button labels
+ * from the survey options, every language declared, and embedded data as hidden fields.
+ */
+export function buildQsfDocument(
+  model: TQsfSurvey,
+  mapped: Map<string, TQsfQuestionMapping>,
+  ctx: TQsfStructureContext
+): TQsfDocumentBuild {
+  const issues: TImportIssue[] = [];
+  const qidToBlockId = new Map<string, string>();
+  const qidToElementId = new Map<string, string>();
+  const endingId = createId();
+
+  const flowBlockIds: string[] = [];
+  collectFlowBlockIds(model.flow, flowBlockIds, issues);
+
+  const blocksById = new Map(model.blocks.map((block) => [block.id, block]));
+  const orderedBlocks: TQsfBlock[] = flowBlockIds
+    .map((id) => blocksById.get(id))
+    .filter((block): block is TQsfBlock => block !== undefined && block.type !== "Trash");
+  for (const block of model.blocks) {
+    if (block.type === "Trash" || orderedBlocks.includes(block)) continue;
+    orderedBlocks.push(block);
+    issues.push(
+      importInfo({
+        code: "block_not_in_flow",
+        sourceRef: block.id,
+        vars: { block: block.description || block.id },
+      })
+    );
+  }
+
+  const pages = orderedBlocks.flatMap(pagesOf);
+  const blocks: Record<string, unknown>[] = [];
+  let welcomeCard: Record<string, unknown> = { enabled: false };
+  let isFirstElement = true;
+
+  for (const page of pages) {
+    const blockId = createId();
+    const elements: TQsfMappedElement[] = [];
+
+    for (const qid of page.qids) {
+      const mapping = mapped.get(qid);
+      if (!mapping || mapping.elements.length === 0) continue;
+
+      const question = model.questions.get(qid);
+      if (isFirstElement && question?.type === "DB" && mapping.elements.length === 1) {
+        // A leading descriptive text is the welcome card, not a question.
+        const cta = mapping.elements[0];
+        welcomeCard = {
+          enabled: true,
+          headline: cta.headline,
+          ...(cta.subheader ? { subheader: cta.subheader } : {}),
+          buttonLabel: text("Start", ctx),
+          timeToFinish: false,
+          showResponseCount: false,
+        };
+        issues.push(importInfo({ code: "welcome_card_from_descriptive_text", sourceRef: qid }));
+        isFirstElement = false;
+        continue;
+      }
+      isFirstElement = false;
+
+      qidToBlockId.set(qid, blockId);
+      qidToElementId.set(qid, mapping.elements[0].id);
+      elements.push(...mapping.elements);
+    }
+
+    if (elements.length === 0) continue;
+
+    blocks.push({
+      id: blockId,
+      name: blockName(page, blocks.length + 1),
+      elements,
+      ...(model.options.nextButtonLabel ? { buttonLabel: text(model.options.nextButtonLabel, ctx) } : {}),
+      ...(model.options.previousButtonLabel
+        ? { backButtonLabel: text(model.options.previousButtonLabel, ctx) }
+        : {}),
+    });
+  }
+
+  if (
+    model.options.backButton === true ||
+    (model.options.progressBar && model.options.progressBar !== "None")
+  ) {
+    issues.push(
+      importInfo({
+        code: "setting_not_imported",
+        sourceRef: "Survey Options",
+        vars: {
+          setting: [
+            model.options.backButton === true ? "BackButton" : null,
+            model.options.progressBar && model.options.progressBar !== "None" ? "ProgressBarDisplay" : null,
+          ]
+            .filter(Boolean)
+            .join(", "),
+        },
+      })
+    );
+  }
+
+  const name = model.name.trim() || "Imported Qualtrics survey";
+  const document: Record<string, unknown> = {
+    name,
+    type: "link",
+    status: "draft",
+    metadata: { title: text(name, ctx) },
+    defaultLanguage: ctx.defaultLanguageCode,
+    languages: [
+      { code: ctx.defaultLanguageCode, default: true, enabled: true },
+      ...ctx.languageCodes.map((code) => ({ code, default: false, enabled: true })),
+    ],
+    welcomeCard,
+    blocks,
+    endings: [buildEnding(model, ctx, endingId)],
+    hiddenFields: buildHiddenFields(model, issues),
+    variables: [],
+  };
+
+  if (blocks.length === 0) {
+    issues.push(
+      importError({
+        code: "nothing_extracted",
+        message: "No questions in this Qualtrics file could be imported.",
+      })
+    );
+    return { document: null, issues, qidToBlockId, qidToElementId, endingId };
+  }
+
+  const parsed = createZV3TypedSurveyDocumentSchema().safeParse(document);
+  if (!parsed.success) {
+    for (const param of formatV3ZodInvalidParams(parsed.error, "survey")) {
+      issues.push(
+        importError({
+          code: "invalid_document",
+          path: param.name,
+          message: param.reason,
+          vars: { detail: param.reason },
+        })
+      );
+    }
+    return { document: null, issues, qidToBlockId, qidToElementId, endingId };
+  }
+
+  return { document, issues, qidToBlockId, qidToElementId, endingId };
+}


### PR DESCRIPTION
Fixes ENG-2993

## What & why

**Was:** QSF questions mapped to elements one by one; nothing assembled them into a survey.

**Now:** `buildQsfDocument` turns the parsed model plus the mapped questions into a v3 document candidate: one Formbricks block per Qualtrics page (D5), ordered by the survey flow (randomizers flattened with a warning, branches walked in order, unreferenced blocks appended with a note, the Trash block skipped), one ending (redirect URL or the end-of-survey message), a welcome card from a leading descriptive text, Next/Back labels from the survey options, every language declared, and embedded data as hidden fields with normalized ids.

- Hidden-field names go through one function (`mapEmbeddedDataFieldName`) that enforces `^[a-z][a-z0-9_]*$` and suffixes reserved names instead of dropping the field; the Embedded Data project repoints that function later.
- `BackButton` / `ProgressBarDisplay` are survey settings outside the document (D1) and become one `setting_not_imported` note.
- The output passes the typed v3 document schema before it is returned; a file with nothing importable is a fatal `nothing_extracted`.

Stacked on #9199 (ENG-2992).

## Where to look

- [map-structure.ts](apps/web/modules/survey/import/lanes/qsf/map-structure.ts) — flow walk, page split, welcome-card promotion, ending
- [embedded-data.ts](apps/web/modules/survey/import/lanes/qsf/embedded-data.ts) — the one name rule the Embedded Data project will own
- [__fixtures__/*.document.snap](apps/web/modules/survey/import/lanes/qsf/__fixtures__/pages-and-blocks.document.snap) — golden documents per fixture (cuids masked)

## Breaking changes

- [ ] This PR contains breaking changes

None — internal module.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/import/lanes/qsf`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Six fixtures build their golden document (`*.document.snap`) | unit (guard) | `map-structure.test.ts` |
| pages-and-blocks: two pages → two blocks, flow order over BL order, randomizer flattened, orphan appended, Trash skipped, button labels, settings note | unit (mutation) | passes |
| embedded-data: four fields normalized, `userId` refused and suffixed, renames noted | unit (mutation) | passes |
| multilang: two languages declared, metadata title and ending in both, validates as a create body | unit (mutation) | passes |
| matrix-slider-ranking: leading DB → welcome card, EOS redirect → redirect ending; simple: EOS message → headline | unit (mutation) | passes |
| large-150: builds in < 500 ms (30 blocks, ≥ 135 elements) and validates | unit (guard) | passes locally |

**Open gaps**

- Piped text and the logic report are the next PR; the golden documents still contain raw `${…}` pipes.

**Risks**

- none beyond the module

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
