### PR TITLE
feat(surveys): QSF piped text → recall; logic reported, not mapped [ENG-2994]

### DIFF
--- a/apps/web/modules/survey/import/lanes/qsf/describe-logic.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/describe-logic.ts
@@ -1,0 +1,217 @@
+import { importInfo } from "../../report";
+import type { TImportIssue } from "../../types";
+import { stripHtml } from "./strip-html";
+import type { TQsfFlowNode, TQsfQuestion, TQsfSurvey } from "./types";
+
+/**
+ * Logic is not imported in v1 (D5). Every skip, display and branch rule is read only to be described
+ * in plain language, so the user can rebuild it in the editor with the report open next to it.
+ */
+
+const UNREADABLE = "(could not be read) — check in Qualtrics";
+
+const OPERATORS: Record<string, string> = {
+  Selected: "=",
+  NotSelected: "≠",
+  EqualTo: "=",
+  NotEqualTo: "≠",
+  GreaterThan: ">",
+  GreaterThanOrEqual: "≥",
+  LessThan: "<",
+  LessThanOrEqual: "≤",
+  Contains: "contains",
+  DoesNotContain: "does not contain",
+  Displayed: "was shown",
+  NotDisplayed: "was not shown",
+  IsEmpty: "is empty",
+  IsNotEmpty: "is not empty",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function questionLabel(model: TQsfSurvey, qid: string): string {
+  const question = model.questions.get(qid);
+  const tag = question?.exportTag ?? qid;
+  const headline = question ? stripHtml(question.text) : "";
+  return headline ? `${tag} '${truncate(headline)}'` : tag;
+}
+
+function truncate(text: string, max = 60): string {
+  return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text;
+}
+
+function choiceLabel(question: TQsfQuestion | undefined, locator: string): string | null {
+  const match = /\/(?:SelectableChoice|SelectableAnswer|ChoiceTextEntryValue)\/(\w+)$/.exec(locator);
+  if (!match) return null;
+  const choice =
+    question?.choices.find((candidate) => candidate.id === match[1]) ??
+    question?.answers.find((candidate) => candidate.id === match[1]);
+  return choice ? `'${stripHtml(choice.display)}'` : `choice ${match[1]}`;
+}
+
+function describeExpression(model: TQsfSurvey, expression: Record<string, unknown>): string | null {
+  const operator = typeof expression.Operator === "string" ? expression.Operator : null;
+  const operatorText = operator
+    ? (OPERATORS[operator] ?? operator.replaceAll(/([a-z])([A-Z])/g, "$1 $2").toLowerCase())
+    : null;
+
+  if (expression.LogicType === "Question" && typeof expression.QuestionID === "string" && operatorText) {
+    const question = model.questions.get(expression.QuestionID);
+    const locator =
+      typeof expression.ChoiceLocator === "string"
+        ? expression.ChoiceLocator
+        : typeof expression.LeftOperand === "string"
+          ? expression.LeftOperand
+          : "";
+    const choice = choiceLabel(question, locator);
+    const right =
+      choice ?? (typeof expression.RightOperand === "string" ? `'${expression.RightOperand}'` : "");
+    return `${questionLabel(model, expression.QuestionID)} ${operatorText}${right ? ` ${right}` : ""}`.trim();
+  }
+
+  if (
+    expression.LogicType === "EmbeddedField" &&
+    typeof expression.LeftOperand === "string" &&
+    operatorText
+  ) {
+    const right = typeof expression.RightOperand === "string" ? ` '${expression.RightOperand}'` : "";
+    return `${expression.LeftOperand} ${operatorText}${right}`;
+  }
+
+  return null;
+}
+
+/** A `BooleanExpression`: numbered groups of numbered expressions, each carrying its `Conjuction`. */
+export function describeBooleanExpression(model: TQsfSurvey, logic: unknown): string | null {
+  if (!isRecord(logic)) return null;
+  const groups = Object.entries(logic)
+    .filter(([key, value]) => /^\d+$/.test(key) && isRecord(value))
+    .map(([, value]) => value as Record<string, unknown>);
+  if (groups.length === 0) return null;
+
+  const parts: string[] = [];
+  for (const group of groups) {
+    const expressions = Object.entries(group)
+      .filter(([key, value]) => /^\d+$/.test(key) && isRecord(value))
+      .map(([, value]) => value as Record<string, unknown>);
+    for (const expression of expressions) {
+      const described = describeExpression(model, expression);
+      if (described === null) return null;
+      const conjunction =
+        typeof expression.Conjuction === "string" ? expression.Conjuction.toLowerCase() : null;
+      parts.push(parts.length > 0 && conjunction ? `${conjunction} ${described}` : described);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+function destinationLabel(model: TQsfSurvey, destination: unknown): string {
+  if (destination === "ENDOFSURVEY") return "the end of the survey";
+  if (destination === "ENDOFBLOCK") return "the end of the block";
+  if (typeof destination === "string") return questionLabel(model, destination);
+  return "an unknown destination";
+}
+
+function describeSkipRules(model: TQsfSurvey, question: TQsfQuestion): string[] {
+  const rules = Array.isArray(question.skipLogic) ? question.skipLogic : [];
+  return rules.map((rule) => {
+    if (!isRecord(rule)) return `${question.exportTag}: skip logic ${UNREADABLE}`;
+    const choice = typeof rule.ChoiceLocator === "string" ? choiceLabel(question, rule.ChoiceLocator) : null;
+    const condition = rule.Condition === "NotSelected" ? "≠" : "=";
+    const destination = destinationLabel(model, rule.SkipToDestination);
+    return choice
+      ? `${question.exportTag}: if '${truncate(stripHtml(question.text))}' ${condition} ${choice}, skip to ${destination}`
+      : `${question.exportTag}: skip logic to ${destination} ${UNREADABLE}`;
+  });
+}
+
+function describeDisplayRule(model: TQsfSurvey, question: TQsfQuestion): string | null {
+  if (question.displayLogic === null || question.displayLogic === undefined) return null;
+  const condition = describeBooleanExpression(model, question.displayLogic);
+  return condition
+    ? `${question.exportTag} shown only if ${condition}`
+    : `${question.exportTag}: display logic ${UNREADABLE}`;
+}
+
+function blockNames(model: TQsfSurvey, nodes: TQsfFlowNode[]): string[] {
+  const names: string[] = [];
+  for (const node of nodes) {
+    if (node.type === "Block" || node.type === "Standard") {
+      const block = model.blocks.find((candidate) => candidate.id === node.id);
+      names.push(block?.description.trim() || node.id);
+    } else if ("children" in node) {
+      names.push(...blockNames(model, node.children));
+    }
+  }
+  return names;
+}
+
+function describeBranches(
+  model: TQsfSurvey,
+  nodes: TQsfFlowNode[],
+  previousBlock: string | null,
+  into: { text: string; ref: string }[]
+): string | null {
+  let last = previousBlock;
+  for (const node of nodes) {
+    if (node.type === "Block" || node.type === "Standard") {
+      last = model.blocks.find((candidate) => candidate.id === node.id)?.description.trim() || node.id;
+      continue;
+    }
+    if (node.type === "Branch") {
+      const condition = describeBooleanExpression(model, node.logic);
+      const shown = blockNames(model, node.children);
+      const where = last ? `Branch after '${last}'` : "Branch at the start";
+      into.push({
+        ref: node.description ?? "Branch",
+        text: condition
+          ? `${where}: if ${condition} show ${shown.length > 0 ? shown.map((name) => `'${name}'`).join(", ") : "nothing"}`
+          : `${where}: branch logic ${UNREADABLE}`,
+      });
+      last = describeBranches(model, node.children, last, into) ?? last;
+      continue;
+    }
+    if ("children" in node) {
+      last = describeBranches(model, node.children, last, into) ?? last;
+    }
+  }
+  return last;
+}
+
+export type TQsfLogicDescription = { issues: TImportIssue[]; count: number };
+
+/** One `logic_dropped` info row per rule, preceded by a summary row when there is anything to list. */
+export function describeQsfLogic(model: TQsfSurvey): TQsfLogicDescription {
+  const rows: { text: string; ref: string }[] = [];
+
+  for (const question of model.questions.values()) {
+    for (const text of describeSkipRules(model, question)) rows.push({ text, ref: question.qid });
+    const display = describeDisplayRule(model, question);
+    if (display) rows.push({ text: display, ref: question.qid });
+  }
+  describeBranches(model, model.flow, null, rows);
+
+  if (rows.length === 0) return { issues: [], count: 0 };
+
+  const summary = importInfo({
+    code: "logic_dropped",
+    sourceRef: "Logic",
+    vars: {
+      detail: `${rows.length} logic ${rows.length === 1 ? "rule was" : "rules were"} not imported. Rebuild them in the editor; each one is listed below.`,
+      count: rows.length,
+    },
+  });
+
+  return {
+    count: rows.length,
+    issues: [
+      summary,
+      ...rows.map((row) =>
+        importInfo({ code: "logic_dropped", sourceRef: row.ref, vars: { detail: row.text } })
+      ),
+    ],
+  };
+}

--- a/apps/web/modules/survey/import/lanes/qsf/logic-and-pipes.test.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/logic-and-pipes.test.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { prepareV3SurveyCreateInput } from "@/app/api/v3/surveys/prepare";
+import { describeBooleanExpression, describeQsfLogic } from "./describe-logic";
+import { mapEmbeddedDataFieldName } from "./embedded-data";
+import { QsfIdRegistry } from "./id-registry";
+import { applyPipedTextToDocument, replacePipedText } from "./map-piped-text";
+import { type TQsfQuestionMapping, mapQsfQuestion } from "./map-question";
+import { buildQsfDocument } from "./map-structure";
+import { parseQsf } from "./parse-qsf";
+import type { TQsfSurvey } from "./types";
+
+const FIXTURES = join(__dirname, "__fixtures__");
+
+function load(name: string): TQsfSurvey {
+  const result = parseQsf(readFileSync(join(FIXTURES, name)));
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return result.data;
+}
+
+function build(model: TQsfSurvey) {
+  const ctx = { defaultLanguageCode: model.defaultLanguageCode, languageCodes: model.languageCodes };
+  const registry = new QsfIdRegistry(
+    model.embeddedDataFields.map((field) => mapEmbeddedDataFieldName(field).fieldId)
+  );
+  const mapped = new Map<string, TQsfQuestionMapping>();
+  for (const [qid, question] of model.questions)
+    mapped.set(qid, mapQsfQuestion(question, { ...ctx, idRegistry: registry }));
+  return buildQsfDocument(model, mapped, ctx);
+}
+
+describe("describeQsfLogic", () => {
+  test("lists every skip, display and branch rule in plain language with its QID, plus a summary row", () => {
+    const model = load("logic-skip-display-branch.qsf");
+    const { issues, count } = describeQsfLogic(model);
+
+    expect(count).toBe(6);
+    expect(issues).toHaveLength(7);
+    expect(issues.every((issue) => issue.severity === "info" && issue.code === "logic_dropped")).toBe(true);
+    expect(issues[0].message).toBe(
+      "6 logic rules were not imported. Rebuild them in the editor; each one is listed below."
+    );
+
+    const byRef = Object.fromEntries(issues.slice(1).map((issue) => [issue.sourceRef, issue.message]));
+    expect(byRef.QID1).toBe("Q1: if 'Do you use our product?' = 'No', skip to the end of the survey");
+    expect(byRef.QID2).toBe("Q2 shown only if Q1 'Do you use our product?' = 'Yes'");
+    expect(byRef.QID3).toBe("Q3: if 'Which region are you in?' = 'Other', skip to Q5 'Any final comments?'");
+    expect(byRef.QID4).toBe("Q4 shown only if region = 'DE'");
+    expect(byRef.QID6).toBe("Q6: display logic (could not be read) — check in Qualtrics");
+    expect(byRef["EU branch"]).toBe(
+      "Branch after 'Usage': if Q3 'Which region are you in?' = 'EU' show 'Compliance'"
+    );
+  });
+
+  test("a survey without logic yields no rows", () => {
+    expect(describeQsfLogic(load("simple.qsf"))).toEqual({ issues: [], count: 0 });
+  });
+
+  test("boolean expressions join conjunctions and translate operators", () => {
+    const model = load("logic-skip-display-branch.qsf");
+    const described = describeBooleanExpression(model, {
+      "0": {
+        "0": {
+          LogicType: "Question",
+          QuestionID: "QID1",
+          ChoiceLocator: "q://QID1/SelectableChoice/1",
+          Operator: "Selected",
+        },
+        "1": {
+          LogicType: "EmbeddedField",
+          LeftOperand: "score",
+          Operator: "GreaterThan",
+          RightOperand: "5",
+          Conjuction: "And",
+        },
+        "2": { LogicType: "Question", QuestionID: "QID5", Operator: "NotEmpty", Conjuction: "Or" },
+        Type: "If",
+      },
+      Type: "BooleanExpression",
+    });
+
+    expect(described).toBe(
+      "Q1 'Do you use our product?' = 'Yes' and score > '5' or Q5 'Any final comments?' not empty"
+    );
+    expect(describeBooleanExpression(model, { Type: "BooleanExpression" })).toBeNull();
+    expect(describeBooleanExpression(model, "nope")).toBeNull();
+  });
+});
+
+describe("replacePipedText", () => {
+  const ctx = {
+    qidToElementId: new Map([["QID1", "Q1"]]),
+    hiddenFieldIds: new Set(["firstname", "store_name"]),
+  };
+
+  test("maps question and embedded-data pipes to recall and strips the rest", () => {
+    expect(
+      replacePipedText("Hello ${e://Field/firstName}, you said ${q://QID1/ChoiceTextEntryValue}", ctx)
+    ).toEqual({
+      text: "Hello #recall:firstname/fallback:#, you said #recall:Q1/fallback:#",
+      stripped: [],
+    });
+    expect(
+      replacePipedText("Store ${e://Field/Store-Name} on ${date://CurrentDate/DMY} ${loc://x}", ctx)
+    ).toEqual({
+      text: "Store #recall:store_name/fallback:# on",
+      stripped: ["${date://CurrentDate/DMY}", "${loc://x}"],
+    });
+  });
+
+  test("a pipe to an unmapped question or unknown field is removed", () => {
+    expect(replacePipedText("${q://QID9/ChoiceGroup/SelectedChoices} and ${e://Field/missing}", ctx)).toEqual(
+      {
+        text: "and",
+        stripped: ["${q://QID9/ChoiceGroup/SelectedChoices}", "${e://Field/missing}"],
+      }
+    );
+  });
+});
+
+describe("applyPipedTextToDocument", () => {
+  test("rewrites every text of the embedded-data fixture and validates with zero invalid params", () => {
+    const model = load("embedded-data.qsf");
+    const built = build(model);
+    const document = built.document!;
+    const hiddenFieldIds = new Set((document.hiddenFields as { fieldIds: string[] }).fieldIds);
+
+    const issues = applyPipedTextToDocument(document, {
+      qidToElementId: built.qidToElementId,
+      hiddenFieldIds,
+    });
+
+    const blocks = document.blocks as { elements: { headline: Record<string, string> }[] }[];
+    expect(blocks[0].elements[0].headline["en-US"]).toBe(
+      "Hello #recall:firstname/fallback:#, how was your visit to #recall:store_name/fallback:#?"
+    );
+    expect(blocks[0].elements[1].headline["en-US"]).toBe("You said: #recall:Q1/fallback:#. Anything to add?");
+    expect(issues).toEqual([
+      expect.objectContaining({
+        code: "pipe_stripped",
+        path: "blocks.0.elements.1.headline",
+        vars: { token: "${loc://something}" },
+      }),
+    ]);
+
+    const preparation = prepareV3SurveyCreateInput({
+      workspaceId: "clxx1234567890123456789012",
+      ...document,
+    });
+    expect(preparation.ok, JSON.stringify(preparation.ok ? null : preparation.validation.invalidParams)).toBe(
+      true
+    );
+    expect(JSON.stringify(document)).not.toContain("${");
+    expect(JSON.stringify(document)).not.toContain('"logic"');
+  });
+});

--- a/apps/web/modules/survey/import/lanes/qsf/map-piped-text.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/map-piped-text.ts
@@ -1,0 +1,107 @@
+import { importInfo } from "../../report";
+import type { TImportIssue } from "../../types";
+import { mapEmbeddedDataFieldName } from "./embedded-data";
+
+export type TPipedTextContext = {
+  /** Qualtrics `QID` → Formbricks element id. */
+  qidToElementId: ReadonlyMap<string, string>;
+  /** Hidden field ids the document declares (normalized). */
+  hiddenFieldIds: ReadonlySet<string>;
+};
+
+const PIPE_PATTERN = /\$\{([a-zA-Z]+):\/\/([^}]*)\}/g;
+
+/**
+ * Qualtrics piped text → Formbricks recall. `${q://QID3/...}` becomes a recall of the element QID3
+ * mapped to; `${e://Field/name}` a recall of the hidden field the embedded-data field became; every
+ * other pipe (`lm://`, `rand://`, `date://`, `loc://`) has no equivalent and is removed.
+ */
+export function replacePipedText(text: string, ctx: TPipedTextContext): { text: string; stripped: string[] } {
+  const stripped: string[] = [];
+
+  const replaced = text.replaceAll(PIPE_PATTERN, (token: string, scheme: string, rest: string) => {
+    if (scheme === "q") {
+      const qid = rest.split("/")[0];
+      const elementId = ctx.qidToElementId.get(qid);
+      if (elementId) return `#recall:${elementId}/fallback:#`;
+    } else if (scheme === "e") {
+      const segments = rest.split("/");
+      if (segments[0] === "Field" && segments[1]) {
+        const fieldId = mapEmbeddedDataFieldName(segments[1]).fieldId;
+        if (ctx.hiddenFieldIds.has(fieldId)) return `#recall:${fieldId}/fallback:#`;
+      }
+    }
+    stripped.push(token);
+    return "";
+  });
+
+  return { text: replaced.replaceAll(/\s{2,}/g, " ").trim(), stripped };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** A translatable map in the public shape: every value a string. */
+function isI18nMap(value: unknown): value is Record<string, string> {
+  return (
+    isRecord(value) &&
+    Object.keys(value).length > 0 &&
+    Object.values(value).every((entry) => typeof entry === "string")
+  );
+}
+
+const TEXT_KEYS = new Set([
+  "headline",
+  "subheader",
+  "placeholder",
+  "label",
+  "buttonLabel",
+  "backButtonLabel",
+  "ctaButtonLabel",
+  "lowerLabel",
+  "upperLabel",
+  "otherOptionPlaceholder",
+  "title",
+  "description",
+]);
+
+function walk(value: unknown, path: string, ctx: TPipedTextContext, stripped: Map<string, string>): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => walk(entry, `${path}.${index}`, ctx, stripped));
+    return;
+  }
+  if (!isRecord(value)) return;
+
+  for (const [key, entry] of Object.entries(value)) {
+    const entryPath = path ? `${path}.${key}` : key;
+    if (TEXT_KEYS.has(key) && isI18nMap(entry)) {
+      for (const [code, text] of Object.entries(entry)) {
+        if (!text.includes("${")) continue;
+        const result = replacePipedText(text, ctx);
+        entry[code] = result.text;
+        for (const token of result.stripped) {
+          if (!stripped.has(token)) stripped.set(token, entryPath);
+        }
+      }
+      continue;
+    }
+    walk(entry, entryPath, ctx, stripped);
+  }
+}
+
+/**
+ * Apply piped-text replacement to every translatable text of the document, in place. One
+ * `pipe_stripped` note per distinct removed token, pointing at the first place it was seen.
+ */
+export function applyPipedTextToDocument(
+  document: Record<string, unknown>,
+  ctx: TPipedTextContext
+): TImportIssue[] {
+  const stripped = new Map<string, string>();
+  walk(document, "", ctx, stripped);
+
+  return Array.from(stripped.entries()).map(([token, path]) =>
+    importInfo({ code: "pipe_stripped", path, vars: { token } })
+  );
+}


### PR DESCRIPTION
Fixes ENG-2994

## What & why

**Was:** Imported QSF texts still carried Qualtrics `${…}` pipes, and the survey's logic vanished without a trace.

**Now:** Two deterministic passes after the structure mapper. `applyPipedTextToDocument` turns `${q://QIDx/…}` into a recall of the element that question became and `${e://Field/name}` into a recall of the matching hidden field; every other pipe (`lm://`, `rand://`, `date://`, `loc://`) is removed with one `pipe_stripped` note per token. `describeQsfLogic` reads every skip, display and branch rule and writes it into the report in plain language ("Q3: if 'Which region are you in?' = 'Other', skip to Q5 'Any final comments?'"), with a summary row on top. Nothing is imported as logic (D5); unreadable conditions say so.

Stacked on #9200 (ENG-2993).

## Where to look

- [describe-logic.ts](apps/web/modules/survey/import/lanes/qsf/describe-logic.ts) — operator table, boolean-expression walk, branch placement ("Branch after 'Usage'")
- [map-piped-text.ts](apps/web/modules/survey/import/lanes/qsf/map-piped-text.ts) — which text keys are rewritten, how unmapped pipes disappear

## Breaking changes

- [ ] This PR contains breaking changes

None — internal module.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/import/lanes/qsf/logic-and-pipes.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| logic fixture: two skips (to end of survey / to Q5), two display rules (question and embedded field), one unreadable rule, one branch — each as a `logic_dropped` row with its QID, plus the summary | unit (mutation) | `logic-and-pipes.test.ts` |
| Boolean expressions: conjunctions, operator translation, unparseable → null | unit (mutation) | passes |
| Pipes: question → element recall, embedded field → hidden field recall, `date://`/`loc://` stripped, unmapped question/field removed | unit (mutation) | passes |
| embedded-data fixture end to end: every text rewritten, one `pipe_stripped`, zero `invalid_params`, no `logic` in the document | unit (guard) | passes |

**Open gaps**

- Wiring into the convert route and the dialog (ENG-2995) is where the report is first seen by a user.

**Risks**

- none beyond the module

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
