### PR TITLE
feat(surveys): draft schema factory and multilingual text adapter [ENG-2997]

### DIFF
--- a/apps/web/app/api/v3/surveys/generate/__snapshots__/generated-survey-draft-for-ai.schema.snap
+++ b/apps/web/app/api/v3/surveys/generate/__snapshots__/generated-survey-draft-for-ai.schema.snap
@@ -1,0 +1,372 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "language": {
+      "type": "string",
+      "enum": [
+        "de-DE",
+        "en-US",
+        "es-ES",
+        "fr-FR",
+        "hu-HU",
+        "ja-JP",
+        "nl-NL",
+        "pt-BR",
+        "pt-PT",
+        "ro-RO",
+        "ru-RU",
+        "sv-SE",
+        "tr-TR",
+        "zh-Hans-CN",
+        "zh-Hant-TW"
+      ]
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 220
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 320
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "welcomeCard": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "headline": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 220
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "subheader": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 320
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "buttonLabel": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 220
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "enabled",
+            "headline",
+            "subheader",
+            "buttonLabel"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ending": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "headline": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 220
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "subheader": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 320
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "headline",
+            "subheader"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "blocks": {
+      "minItems": 1,
+      "maxItems": 8,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 220
+          },
+          "questions": {
+            "minItems": 1,
+            "maxItems": 4,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "openText",
+                    "multipleChoiceSingle",
+                    "multipleChoiceMulti",
+                    "nps",
+                    "rating",
+                    "csat",
+                    "ces",
+                    "ranking",
+                    "matrix",
+                    "date"
+                  ]
+                },
+                "headline": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 220
+                },
+                "subheader": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 320
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "placeholder": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 120
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "longAnswer": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "choices": {
+                  "anyOf": [
+                    {
+                      "minItems": 2,
+                      "maxItems": 8,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 80
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "rows": {
+                  "anyOf": [
+                    {
+                      "minItems": 2,
+                      "maxItems": 8,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 80
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "columns": {
+                  "anyOf": [
+                    {
+                      "minItems": 2,
+                      "maxItems": 8,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 80
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "lowerLabel": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 60
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "upperLabel": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 60
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "scale": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "number",
+                        "smiley",
+                        "star"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "format": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "M-d-y",
+                        "d-M-y",
+                        "y-M-d"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "range": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "5",
+                        "7",
+                        "10"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "type",
+                "headline",
+                "subheader",
+                "required",
+                "placeholder",
+                "longAnswer",
+                "choices",
+                "lowerLabel",
+                "upperLabel",
+                "scale",
+                "range"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "name",
+          "questions"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "language",
+    "name",
+    "description",
+    "welcomeCard",
+    "ending",
+    "blocks"
+  ],
+  "additionalProperties": false
+}

--- a/apps/web/app/api/v3/surveys/generate/constants.ts
+++ b/apps/web/app/api/v3/surveys/generate/constants.ts
@@ -9,6 +9,22 @@ export const GENERATED_SURVEY_MIN_BLOCKS = 1;
 export const GENERATED_SURVEY_MAX_BLOCKS = 8;
 export const GENERATED_SURVEY_MIN_QUESTIONS_PER_BLOCK = 1;
 export const GENERATED_SURVEY_MAX_QUESTIONS_PER_BLOCK = 4;
+export const GENERATED_SURVEY_MAX_CHOICES = 8;
+
+/** Import variant (D4): caps doubled, chunking handles anything longer. */
+export const IMPORTED_SURVEY_MAX_BLOCKS = 16;
+export const IMPORTED_SURVEY_MAX_QUESTIONS_PER_BLOCK = 8;
+export const IMPORTED_SURVEY_MAX_CHOICES = 8;
+
+export const IMPORT_ADDRESS_FIELDS = [
+  "addressLine1",
+  "addressLine2",
+  "city",
+  "state",
+  "zip",
+  "country",
+] as const;
+export const IMPORT_CONTACT_INFO_FIELDS = ["firstName", "lastName", "email", "phone", "company"] as const;
 export const GENERATED_SURVEY_ELEMENT_TYPES = [
   TSurveyElementTypeEnum.OpenText,
   TSurveyElementTypeEnum.MultipleChoiceSingle,
@@ -20,4 +36,16 @@ export const GENERATED_SURVEY_ELEMENT_TYPES = [
   TSurveyElementTypeEnum.Ranking,
   TSurveyElementTypeEnum.Matrix,
   TSurveyElementTypeEnum.Date,
+] as const;
+
+/**
+ * The import draft adds the four types a document is likely to hold. `pictureSelection`, `fileUpload`
+ * and `cal` stay out (nearest type + `type_approximated`).
+ */
+export const IMPORTED_SURVEY_ELEMENT_TYPES = [
+  ...GENERATED_SURVEY_ELEMENT_TYPES,
+  TSurveyElementTypeEnum.CTA,
+  TSurveyElementTypeEnum.Consent,
+  TSurveyElementTypeEnum.Address,
+  TSurveyElementTypeEnum.ContactInfo,
 ] as const;

--- a/apps/web/app/api/v3/surveys/generate/constants.ts
+++ b/apps/web/app/api/v3/surveys/generate/constants.ts
@@ -11,9 +11,13 @@ export const GENERATED_SURVEY_MIN_QUESTIONS_PER_BLOCK = 1;
 export const GENERATED_SURVEY_MAX_QUESTIONS_PER_BLOCK = 4;
 export const GENERATED_SURVEY_MAX_CHOICES = 8;
 
-/** Import variant (D4): caps doubled, chunking handles anything longer. */
+/**
+ * Import variant (D4): chunking handles anything longer. A block may hold a whole chunk (24 questions):
+ * documents keep their own sections, and the model was refused live for putting a 15-question
+ * section into one block when the cap was 8. v3 has no per-block element limit.
+ */
 export const IMPORTED_SURVEY_MAX_BLOCKS = 16;
-export const IMPORTED_SURVEY_MAX_QUESTIONS_PER_BLOCK = 8;
+export const IMPORTED_SURVEY_MAX_QUESTIONS_PER_BLOCK = 24;
 export const IMPORTED_SURVEY_MAX_CHOICES = 8;
 
 export const IMPORT_ADDRESS_FIELDS = [

--- a/apps/web/app/api/v3/surveys/generate/constants.ts
+++ b/apps/web/app/api/v3/surveys/generate/constants.ts
@@ -16,7 +16,8 @@ export const GENERATED_SURVEY_MAX_CHOICES = 8;
  * documents keep their own sections, and the model was refused live for putting a 15-question
  * section into one block when the cap was 8. v3 has no per-block element limit.
  */
-export const IMPORTED_SURVEY_MAX_BLOCKS = 16;
+// One block per question is a legitimate layout (a "Block #" column), so the cap equals a chunk's questions.
+export const IMPORTED_SURVEY_MAX_BLOCKS = 24;
 export const IMPORTED_SURVEY_MAX_QUESTIONS_PER_BLOCK = 24;
 export const IMPORTED_SURVEY_MAX_CHOICES = 8;
 

--- a/apps/web/app/api/v3/surveys/generate/schema-snapshot.test.ts
+++ b/apps/web/app/api/v3/surveys/generate/schema-snapshot.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { ZGeneratedSurveyDraftForAI } from "./schemas";
+
+/**
+ * The provider-facing JSON schema for Create with AI is pinned. The import lane reuses the draft
+ * schema through a factory (D2); this snapshot proves that refactor left the prompt-create schema
+ * byte-identical, so the model keeps seeing exactly what it saw before.
+ */
+describe("ZGeneratedSurveyDraftForAI provider schema", () => {
+  test("is byte-identical to the pinned JSON schema", async () => {
+    const jsonSchema = z.toJSONSchema(ZGeneratedSurveyDraftForAI, { target: "draft-7", io: "input" });
+    await expect(JSON.stringify(jsonSchema, null, 2)).toMatchFileSnapshot(
+      "./__snapshots__/generated-survey-draft-for-ai.schema.snap"
+    );
+  });
+});

--- a/apps/web/app/api/v3/surveys/generate/schemas.ts
+++ b/apps/web/app/api/v3/surveys/generate/schemas.ts
@@ -4,9 +4,12 @@ import { ZUserLocale } from "@formbricks/types/user";
 import {
   GENERATED_SURVEY_ELEMENT_TYPES,
   GENERATED_SURVEY_MAX_BLOCKS,
+  GENERATED_SURVEY_MAX_CHOICES,
   GENERATED_SURVEY_MAX_QUESTIONS_PER_BLOCK,
   GENERATED_SURVEY_MIN_BLOCKS,
   GENERATED_SURVEY_MIN_QUESTIONS_PER_BLOCK,
+  IMPORT_ADDRESS_FIELDS,
+  IMPORT_CONTACT_INFO_FIELDS,
   V3_SURVEY_GENERATE_PROMPT_MAX_LENGTH,
   V3_SURVEY_GENERATE_PROMPT_MIN_LENGTH,
 } from "./constants";
@@ -66,38 +69,83 @@ export const ZV3SurveyGenerateBody = z
   })
   .strict();
 
-const ZGeneratedText = z.string().trim().min(1).max(220);
-const ZGeneratedDescription = z.string().trim().min(1).max(320);
-const ZGeneratedChoice = z.string().trim().min(1).max(80);
-const ZGeneratedChoiceList = z.array(ZGeneratedChoice).min(2).max(8);
+// ---------------------------------------------------------------------------------------------------
+// Draft schema factory (D2). Create with AI instantiates it with plain strings; the import lane with
+// localized text arrays and its own limits, languages and element types. The default instantiation is
+// byte-identical to the schema Create with AI shipped with (see schema-snapshot.test.ts).
+// ---------------------------------------------------------------------------------------------------
+
+export const GENERATED_TEXT_MAX_LENGTH = 220;
+export const GENERATED_DESCRIPTION_MAX_LENGTH = 320;
+export const GENERATED_CHOICE_MAX_LENGTH = 80;
+
+const ZGeneratedText = z.string().trim().min(1).max(GENERATED_TEXT_MAX_LENGTH);
+const ZGeneratedDescription = z.string().trim().min(1).max(GENERATED_DESCRIPTION_MAX_LENGTH);
+const ZGeneratedChoice = z.string().trim().min(1).max(GENERATED_CHOICE_MAX_LENGTH);
 const ZGeneratedRatingRangeForAI = z.enum(["5", "7", "10"]);
 const ZGeneratedRatingRange = z.preprocess(
   (value) => (typeof value === "number" ? String(value) : value),
   ZGeneratedRatingRangeForAI.transform((value) => Number(value) as 5 | 7 | 10)
 );
 
-const generatedSurveyElementShape = {
-  type: z.enum(GENERATED_SURVEY_ELEMENT_TYPES),
-  headline: ZGeneratedText,
-  subheader: ZGeneratedDescription.nullable(),
-  required: z.boolean(),
-  placeholder: z.string().trim().min(1).max(120).nullable(),
-  longAnswer: z.boolean().nullable(),
-  choices: ZGeneratedChoiceList.nullable(),
-  rows: ZGeneratedChoiceList.nullable().optional(),
-  columns: ZGeneratedChoiceList.nullable().optional(),
-  lowerLabel: z.string().trim().min(1).max(60).nullable(),
-  upperLabel: z.string().trim().min(1).max(60).nullable(),
-  scale: z.enum(["number", "smiley", "star"]).nullable(),
-  format: z.enum(["M-d-y", "d-M-y", "y-M-d"]).nullable().optional(),
-} as const;
+/**
+ * `[{ languageCode, text }]`, one entry per language, the enum built per call from the detected codes
+ * so the model cannot invent a third language (D2). Never `V3_SURVEY_GENERATE_ALLOWED_LOCALES`.
+ */
+export function createLocalizedText(languageCodes: readonly [string, ...string[]], maxLength: number) {
+  return z
+    .array(
+      z
+        .object({
+          languageCode: z.enum(languageCodes),
+          text: z.string().trim().min(1).max(maxLength),
+        })
+        .strict()
+    )
+    .min(1);
+}
+
+export type TGeneratedLocalizedText = { languageCode: string; text: string }[];
+export type TGeneratedDraftText = string | TGeneratedLocalizedText;
+
+export type TGeneratedSurveyDraftLimits = {
+  maxBlocks: number;
+  maxQuestionsPerBlock: number;
+  maxChoices: number;
+};
+
+export const DEFAULT_GENERATED_SURVEY_DRAFT_LIMITS: TGeneratedSurveyDraftLimits = {
+  maxBlocks: GENERATED_SURVEY_MAX_BLOCKS,
+  maxQuestionsPerBlock: GENERATED_SURVEY_MAX_QUESTIONS_PER_BLOCK,
+  maxChoices: GENERATED_SURVEY_MAX_CHOICES,
+};
+
+export type TGeneratedSurveyDraftSchemaOptions<
+  TText extends z.ZodTypeAny = typeof ZGeneratedText,
+  TDescription extends z.ZodTypeAny = typeof ZGeneratedDescription,
+  TChoice extends z.ZodTypeAny = typeof ZGeneratedChoice,
+> = {
+  /** Schema for a headline-sized text. Default: a plain string. */
+  text?: TText;
+  /** Schema for a description-sized text. Default: a plain string. */
+  description?: TDescription;
+  /** Schema for a choice label. Default: a plain string. */
+  choice?: TChoice;
+  limits?: Partial<TGeneratedSurveyDraftLimits>;
+  elementTypes?: readonly [string, ...string[]];
+  /**
+   * Import only: the language codes the draft may use. Adds `defaultLanguage`, restricts `language` to
+   * these codes and unlocks the import-only element fields. Absent for Create with AI.
+   */
+  languageCodes?: readonly [string, ...string[]];
+};
 
 function validateGeneratedSurveyElement(
   element: {
     type: string;
-    choices: string[] | null;
-    rows?: string[] | null;
-    columns?: string[] | null;
+    choices: unknown[] | null;
+    rows?: unknown[] | null;
+    columns?: unknown[] | null;
     range?: string | number | null;
   },
   ctx: z.RefinementCtx
@@ -156,81 +204,175 @@ function validateGeneratedSurveyElement(
   }
 }
 
-export const ZGeneratedSurveyElementForAI = z
-  .object({
-    ...generatedSurveyElementShape,
-    range: ZGeneratedRatingRangeForAI.nullable(),
-  })
-  .strict()
-  .superRefine(validateGeneratedSurveyElement);
+export function createGeneratedSurveyDraftSchema<
+  TText extends z.ZodTypeAny = typeof ZGeneratedText,
+  TDescription extends z.ZodTypeAny = typeof ZGeneratedDescription,
+  TChoice extends z.ZodTypeAny = typeof ZGeneratedChoice,
+>(options: TGeneratedSurveyDraftSchemaOptions<TText, TDescription, TChoice> = {}) {
+  // The defaults are the generic defaults, so the casts only apply when a caller omitted the option.
+  const text = (options.text ?? ZGeneratedText) as TText;
+  const description = (options.description ?? ZGeneratedDescription) as TDescription;
+  const choice = (options.choice ?? ZGeneratedChoice) as TChoice;
+  const limits = { ...DEFAULT_GENERATED_SURVEY_DRAFT_LIMITS, ...options.limits };
+  const elementTypes = options.elementTypes ?? GENERATED_SURVEY_ELEMENT_TYPES;
+  const isImport = options.languageCodes !== undefined;
+  const choiceList = z.array(choice).min(2).max(limits.maxChoices);
 
-const ZGeneratedSurveyElement = z
-  .object({
-    ...generatedSurveyElementShape,
-    range: ZGeneratedRatingRange.nullable(),
-  })
-  .strict()
-  .superRefine(validateGeneratedSurveyElement);
+  const importElementFields = {
+    /** cta: the button text; consent: the checkbox label. */
+    buttonLabel: text.nullable().optional(),
+    /** cta only. The resolver's external-URL check applies on import. */
+    buttonUrl: z.string().trim().url().nullable().optional(),
+    /** consent: the statement the respondent agrees to. */
+    label: description.nullable().optional(),
+    /** address / contactInfo: which sub-fields to show. */
+    fields: z
+      .array(z.enum([...IMPORT_ADDRESS_FIELDS, ...IMPORT_CONTACT_INFO_FIELDS] as [string, ...string[]]))
+      .nullable()
+      .optional(),
+    /** The source's original type name when it was approximated, or anything worth reporting. */
+    notes: z.array(z.string().trim().min(1).max(200)).nullable().optional(),
+  };
 
-const ZGeneratedSurveyBlockForAI = z
-  .object({
-    name: ZGeneratedText,
-    questions: z
-      .array(ZGeneratedSurveyElementForAI)
-      .min(GENERATED_SURVEY_MIN_QUESTIONS_PER_BLOCK)
-      .max(GENERATED_SURVEY_MAX_QUESTIONS_PER_BLOCK),
-  })
-  .strict();
+  // Key order is part of the provider-facing schema; the import-only fields come last.
+  const elementShape = {
+    type: z.enum(elementTypes),
+    headline: text,
+    subheader: description.nullable(),
+    required: z.boolean(),
+    placeholder: z.string().trim().min(1).max(120).nullable(),
+    longAnswer: z.boolean().nullable(),
+    choices: choiceList.nullable(),
+    rows: choiceList.nullable().optional(),
+    columns: choiceList.nullable().optional(),
+    lowerLabel: z.string().trim().min(1).max(60).nullable(),
+    upperLabel: z.string().trim().min(1).max(60).nullable(),
+    scale: z.enum(["number", "smiley", "star"]).nullable(),
+    format: z.enum(["M-d-y", "d-M-y", "y-M-d"]).nullable().optional(),
+    // Absent at runtime for Create with AI (strict mode rejects them); typed as optional either way so the
+    // output type of both variants is one structural shape.
+    ...((isImport ? importElementFields : {}) as typeof importElementFields),
+  };
 
-const ZGeneratedSurveyBlock = z
-  .object({
-    name: ZGeneratedText,
-    questions: z
-      .array(ZGeneratedSurveyElement)
-      .min(GENERATED_SURVEY_MIN_QUESTIONS_PER_BLOCK)
-      .max(GENERATED_SURVEY_MAX_QUESTIONS_PER_BLOCK),
-  })
-  .strict();
-
-const generatedSurveyDraftShape = {
-  language: ZV3SurveyGenerateAllowedLocale,
-  name: ZGeneratedText,
-  description: ZGeneratedDescription.nullable(),
-  welcomeCard: z
-    .object({
-      enabled: z.boolean(),
-      headline: ZGeneratedText.nullable(),
-      subheader: ZGeneratedDescription.nullable(),
-      buttonLabel: ZGeneratedText.nullable(),
-    })
+  const elementForAI = z
+    .object({ ...elementShape, range: ZGeneratedRatingRangeForAI.nullable() })
     .strict()
-    .nullable(),
-  ending: z
-    .object({
-      headline: ZGeneratedText.nullable(),
-      subheader: ZGeneratedDescription.nullable(),
-    })
+    .superRefine(validateGeneratedSurveyElement);
+  const elementInternal = z
+    .object({ ...elementShape, range: ZGeneratedRatingRange.nullable() })
     .strict()
-    .nullable(),
-} as const;
+    .superRefine(validateGeneratedSurveyElement);
 
-export const ZGeneratedSurveyDraftForAI = z
-  .object({
-    ...generatedSurveyDraftShape,
-    blocks: z
-      .array(ZGeneratedSurveyBlockForAI)
-      .min(GENERATED_SURVEY_MIN_BLOCKS)
-      .max(GENERATED_SURVEY_MAX_BLOCKS),
-  })
-  .strict();
+  const blockOf = <TElement extends z.ZodTypeAny>(element: TElement) =>
+    z
+      .object({
+        name: text,
+        questions: z
+          .array(element)
+          .min(GENERATED_SURVEY_MIN_QUESTIONS_PER_BLOCK)
+          .max(limits.maxQuestionsPerBlock),
+      })
+      .strict();
 
-export const ZGeneratedSurveyDraft = z
-  .object({
-    ...generatedSurveyDraftShape,
-    blocks: z.array(ZGeneratedSurveyBlock).min(GENERATED_SURVEY_MIN_BLOCKS).max(GENERATED_SURVEY_MAX_BLOCKS),
-  })
-  .strict();
+  const languageSchema = options.languageCodes
+    ? z.enum(options.languageCodes)
+    : ZV3SurveyGenerateAllowedLocale;
+
+  // Required at runtime for imports, absent for Create with AI; typed optional so both variants share one
+  // output shape (same idea as importElementFields above).
+  const defaultLanguageField = (options.languageCodes
+    ? { defaultLanguage: z.enum(options.languageCodes) }
+    : {}) as unknown as { defaultLanguage: z.ZodOptional<z.ZodEnum<Record<string, string>>> };
+  const rootNotesField = (
+    isImport ? { notes: z.array(z.string().trim().min(1).max(300)).nullable().optional() } : {}
+  ) as { notes: z.ZodOptional<z.ZodNullable<z.ZodArray<z.ZodString>>> };
+
+  const draftShape = {
+    language: languageSchema,
+    ...defaultLanguageField,
+    name: text,
+    description: description.nullable(),
+    welcomeCard: z
+      .object({
+        enabled: z.boolean(),
+        headline: text.nullable(),
+        subheader: description.nullable(),
+        buttonLabel: text.nullable(),
+      })
+      .strict()
+      .nullable(),
+    ending: z
+      .object({
+        headline: text.nullable(),
+        subheader: description.nullable(),
+      })
+      .strict()
+      .nullable(),
+    ...rootNotesField,
+  };
+
+  const blocksOf = <TElement extends z.ZodTypeAny>(element: TElement) =>
+    z.array(blockOf(element)).min(GENERATED_SURVEY_MIN_BLOCKS).max(limits.maxBlocks);
+
+  return {
+    /** Handed to the provider: string ranges, no `z.preprocess` (it does not survive JSON-Schema conversion). */
+    forAI: z.object({ ...draftShape, blocks: blocksOf(elementForAI) }).strict(),
+    /** Used after the fact: ranges coerced to numbers. */
+    internal: z.object({ ...draftShape, blocks: blocksOf(elementInternal) }).strict(),
+    limits,
+    elementTypes,
+  };
+}
+
+const defaultDraftSchema = createGeneratedSurveyDraftSchema();
+
+export const ZGeneratedSurveyDraftForAI = defaultDraftSchema.forAI;
+export const ZGeneratedSurveyDraft = defaultDraftSchema.internal;
 
 export type TV3SurveyGenerateBody = z.infer<typeof ZV3SurveyGenerateBody>;
 export type TGeneratedSurveyDraft = z.infer<typeof ZGeneratedSurveyDraft>;
-export type TGeneratedSurveyElement = z.infer<typeof ZGeneratedSurveyElement>;
+export type TGeneratedSurveyElement = z.infer<
+  typeof ZGeneratedSurveyDraft
+>["blocks"][number]["questions"][number];
+
+/**
+ * Structural type every instantiation of the draft satisfies once parsed: texts may be strings or
+ * localized arrays, ranges are numbers, and the import-only fields are optional.
+ */
+export type TGeneratedDraftElementLike = {
+  type: string;
+  headline: TGeneratedDraftText;
+  subheader?: TGeneratedDraftText | null;
+  required: boolean;
+  placeholder?: string | null;
+  longAnswer?: boolean | null;
+  choices?: TGeneratedDraftText[] | null;
+  rows?: TGeneratedDraftText[] | null;
+  columns?: TGeneratedDraftText[] | null;
+  lowerLabel?: string | null;
+  upperLabel?: string | null;
+  scale?: "number" | "smiley" | "star" | null;
+  format?: "M-d-y" | "d-M-y" | "y-M-d" | null;
+  range?: 5 | 7 | 10 | null;
+  buttonLabel?: TGeneratedDraftText | null;
+  buttonUrl?: string | null;
+  label?: TGeneratedDraftText | null;
+  fields?: string[] | null;
+  notes?: string[] | null;
+};
+
+export type TGeneratedDraftLike = {
+  language: string;
+  defaultLanguage?: string;
+  name: TGeneratedDraftText;
+  description?: TGeneratedDraftText | null;
+  welcomeCard?: {
+    enabled: boolean;
+    headline?: TGeneratedDraftText | null;
+    subheader?: TGeneratedDraftText | null;
+    buttonLabel?: TGeneratedDraftText | null;
+  } | null;
+  ending?: { headline?: TGeneratedDraftText | null; subheader?: TGeneratedDraftText | null } | null;
+  blocks: { name: TGeneratedDraftText; questions: TGeneratedDraftElementLike[] }[];
+  notes?: string[] | null;
+};

--- a/apps/web/app/api/v3/surveys/generate/schemas.ts
+++ b/apps/web/app/api/v3/surveys/generate/schemas.ts
@@ -91,18 +91,20 @@ const ZGeneratedRatingRange = z.preprocess(
 /**
  * `[{ languageCode, text }]`, one entry per language, the enum built per call from the detected codes
  * so the model cannot invent a third language (D2). Never `V3_SURVEY_GENERATE_ALLOWED_LOCALES`.
+ *
+ * Deliberately no `.min(1)`: models answer "no text here" with `[]` (a later chunk has no survey name,
+ * a question has no subheader), and the SDK validates the whole object against this schema — a
+ * minimum would turn that into a failed chunk. The finalizer decides what an empty text means.
  */
 export function createLocalizedText(languageCodes: readonly [string, ...string[]], maxLength: number) {
-  return z
-    .array(
-      z
-        .object({
-          languageCode: z.enum(languageCodes),
-          text: z.string().trim().min(1).max(maxLength),
-        })
-        .strict()
-    )
-    .min(1);
+  return z.array(
+    z
+      .object({
+        languageCode: z.enum(languageCodes),
+        text: z.string().trim().min(1).max(maxLength),
+      })
+      .strict()
+  );
 }
 
 export type TGeneratedLocalizedText = { languageCode: string; text: string }[];
@@ -263,14 +265,14 @@ export function createGeneratedSurveyDraftSchema<
     .strict()
     .superRefine(validateGeneratedSurveyElement);
 
+  // Import: a chunk may legitimately hold no questions (a title page) and the finalizer drops empty
+  // blocks; the SDK would otherwise reject the object before our code sees it.
+  const minQuestionsPerBlock = isImport ? 0 : GENERATED_SURVEY_MIN_QUESTIONS_PER_BLOCK;
   const blockOf = <TElement extends z.ZodTypeAny>(element: TElement) =>
     z
       .object({
         name: text,
-        questions: z
-          .array(element)
-          .min(GENERATED_SURVEY_MIN_QUESTIONS_PER_BLOCK)
-          .max(limits.maxQuestionsPerBlock),
+        questions: z.array(element).min(minQuestionsPerBlock).max(limits.maxQuestionsPerBlock),
       })
       .strict();
 
@@ -312,7 +314,10 @@ export function createGeneratedSurveyDraftSchema<
   };
 
   const blocksOf = <TElement extends z.ZodTypeAny>(element: TElement) =>
-    z.array(blockOf(element)).min(GENERATED_SURVEY_MIN_BLOCKS).max(limits.maxBlocks);
+    z
+      .array(blockOf(element))
+      .min(isImport ? 0 : GENERATED_SURVEY_MIN_BLOCKS)
+      .max(limits.maxBlocks);
 
   return {
     /** Handed to the provider: string ranges, no `z.preprocess` (it does not survive JSON-Schema conversion). */

--- a/apps/web/app/api/v3/surveys/generate/schemas.ts
+++ b/apps/web/app/api/v3/surveys/generate/schemas.ts
@@ -256,10 +256,16 @@ export function createGeneratedSurveyDraftSchema<
     ...((isImport ? importElementFields : {}) as typeof importElementFields),
   };
 
-  const elementForAI = z
+  // Import: the provider-facing schema stays structural. The cross-field rules (choices for choice
+  // questions, rows and columns for a matrix, csat/ces ranges) are repaired by the import finalizer with a
+  // report line each, because the SDK rejects the whole chunk on the first violation — a picture-choice
+  // row without labels used to take 16 other questions down with it. The internal schema keeps the rules.
+  const elementForAIShape = z
     .object({ ...elementShape, range: ZGeneratedRatingRangeForAI.nullable() })
-    .strict()
-    .superRefine(validateGeneratedSurveyElement);
+    .strict();
+  const elementForAI = isImport
+    ? elementForAIShape
+    : elementForAIShape.superRefine(validateGeneratedSurveyElement);
   const elementInternal = z
     .object({ ...elementShape, range: ZGeneratedRatingRange.nullable() })
     .strict()

--- a/apps/web/app/api/v3/surveys/generate/service-import.test.ts
+++ b/apps/web/app/api/v3/surveys/generate/service-import.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test, vi } from "vitest";
+import { prepareV3SurveyCreateInput } from "../prepare";
+import {
+  IMPORTED_SURVEY_ELEMENT_TYPES,
+  IMPORTED_SURVEY_MAX_BLOCKS,
+  IMPORTED_SURVEY_MAX_QUESTIONS_PER_BLOCK,
+} from "./constants";
+import { createGeneratedSurveyDraftSchema, createLocalizedText } from "./schemas";
+import {
+  V3SurveyGeneratedPayloadValidationError,
+  buildV3SurveyCreatePayloadFromDraft,
+  createSurveyDraftGenerationRequest,
+} from "./service";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/ai/service", () => ({ generateOrganizationAIObject: vi.fn() }));
+
+const workspaceId = "clxx1234567890123456789012";
+const input = { workspaceId, type: "link" as const };
+const codes = ["en-US", "de-DE"] as const;
+
+const importSchema = createGeneratedSurveyDraftSchema({
+  text: createLocalizedText(codes, 220),
+  description: createLocalizedText(codes, 320),
+  choice: createLocalizedText(codes, 80),
+  limits: {
+    maxBlocks: IMPORTED_SURVEY_MAX_BLOCKS,
+    maxQuestionsPerBlock: IMPORTED_SURVEY_MAX_QUESTIONS_PER_BLOCK,
+  },
+  elementTypes: IMPORTED_SURVEY_ELEMENT_TYPES,
+  languageCodes: codes,
+});
+
+const bilingual = (en: string, de?: string) => [
+  { languageCode: "en-US", text: en },
+  ...(de ? [{ languageCode: "de-DE", text: de }] : []),
+];
+
+const element = (
+  type: string,
+  headline: ReturnType<typeof bilingual>,
+  extra: Record<string, unknown> = {}
+) => ({
+  type,
+  headline,
+  subheader: null,
+  required: false,
+  placeholder: null,
+  longAnswer: null,
+  choices: null,
+  lowerLabel: null,
+  upperLabel: null,
+  scale: null,
+  range: null,
+  ...extra,
+});
+
+const draft = (elements: ReturnType<typeof element>[], overrides: Record<string, unknown> = {}) => ({
+  language: "en-US",
+  defaultLanguage: "en-US",
+  name: bilingual("Feedback", "Feedback"),
+  description: null,
+  welcomeCard: null,
+  ending: null,
+  blocks: [{ name: bilingual("Block", "Block"), questions: elements }],
+  ...overrides,
+});
+
+const languages = { defaultLanguage: "en-US", codes: [...codes] };
+const build = (value: unknown) =>
+  buildV3SurveyCreatePayloadFromDraft(input, value, { schema: importSchema.internal, languages });
+
+describe("buildV3SurveyCreatePayloadFromDraft with languages", () => {
+  test("a bilingual draft produces a payload declaring both languages and public locale maps", () => {
+    const result = build(
+      draft([element("openText", bilingual("How was it?", "Wie war es?"), { longAnswer: true })])
+    );
+
+    expect(result.payload.defaultLanguage).toBe("en-US");
+    expect(result.payload.languages).toEqual([
+      { code: "en-US", default: true, enabled: true },
+      { code: "de-DE", default: false, enabled: true },
+    ]);
+    expect(result.payload.blocks[0].elements[0].headline).toEqual({
+      "en-US": "How was it?",
+      "de-DE": "Wie war es?",
+    });
+    expect(result.payload.name).toBe("Feedback");
+    expect(result.translationFills).toEqual([]);
+    expect(result.validation.valid).toBe(true);
+  });
+
+  test("a text missing a declared language is filled from the default and recorded", () => {
+    const result = build(draft([element("nps", bilingual("Recommend us?"))]));
+
+    const headline = result.payload.blocks[0].elements[0].headline;
+    expect(headline).toEqual({ "en-US": "Recommend us?", "de-DE": "Recommend us?" });
+    expect(result.translationFills).toEqual([
+      expect.objectContaining({ languageCode: "de-DE", path: expect.stringContaining("headline") }),
+    ]);
+    expect(result.validation.valid).toBe(true);
+  });
+
+  test("a language code outside the declared set is rejected by the import schema", () => {
+    const bad = draft([
+      element("openText", [
+        { languageCode: "en-US", text: "Q" },
+        { languageCode: "fr-FR", text: "Q" },
+      ]),
+    ]);
+
+    expect(() => build(bad)).toThrow(V3SurveyGeneratedPayloadValidationError);
+    expect(
+      importSchema.internal.safeParse({ ...draft([]), blocks: [], defaultLanguage: "fr-FR" }).success
+    ).toBe(false);
+  });
+
+  test("a 16-block × 8-question draft is accepted by the import variant only", () => {
+    const question = element("openText", bilingual("Q", "F"));
+    const big = draft([], {
+      blocks: Array.from({ length: 16 }, (_, index) => ({
+        name: bilingual(`Block ${index + 1}`, `Block ${index + 1}`),
+        questions: Array.from({ length: 8 }, () => question),
+      })),
+    });
+
+    expect(importSchema.internal.safeParse(big).success).toBe(true);
+    expect(createGeneratedSurveyDraftSchema().internal.safeParse(big).success).toBe(false);
+    expect(build(big).payload.blocks).toHaveLength(16);
+  });
+
+  test("cta, consent, address and contactInfo build create-valid elements", () => {
+    const result = build(
+      draft([
+        element("cta", bilingual("Read the docs", "Lies die Doku"), {
+          buttonLabel: bilingual("Open", "Öffnen"),
+          buttonUrl: "https://formbricks.com/docs",
+        }),
+        element("consent", bilingual("Terms", "Bedingungen"), {
+          label: bilingual("I accept the terms", "Ich akzeptiere die Bedingungen"),
+          required: true,
+        }),
+        element("address", bilingual("Where do you live?", "Wo wohnst du?"), {
+          fields: ["addressLine1", "city", "country"],
+          required: true,
+        }),
+        element("contactInfo", bilingual("How can we reach you?", "Wie erreichen wir dich?"), {
+          fields: ["email"],
+        }),
+      ])
+    );
+
+    const [cta, consent, address, contactInfo] = result.payload.blocks[0].elements as Array<
+      Record<string, unknown>
+    >;
+    expect(cta).toMatchObject({
+      type: "cta",
+      buttonExternal: true,
+      buttonUrl: "https://formbricks.com/docs",
+      ctaButtonLabel: { "en-US": "Open", "de-DE": "Öffnen" },
+    });
+    expect(consent).toMatchObject({ type: "consent", label: { "en-US": "I accept the terms" } });
+    expect(address).toMatchObject({
+      type: "address",
+      addressLine1: { show: true, required: true },
+      addressLine2: { show: false, required: false },
+      country: { show: true, required: true },
+    });
+    expect(contactInfo).toMatchObject({
+      type: "contactInfo",
+      email: { show: true, required: false },
+      phone: { show: false, required: false },
+    });
+    expect(prepareV3SurveyCreateInput(result.payload).ok).toBe(true);
+  });
+
+  test("the default (Create with AI) variant rejects the import-only element types", () => {
+    const parsed = createGeneratedSurveyDraftSchema().internal.safeParse({
+      language: "en-US",
+      name: "Feedback",
+      description: null,
+      welcomeCard: null,
+      ending: null,
+      blocks: [
+        {
+          name: "Block",
+          questions: [
+            {
+              type: "cta",
+              headline: "Read the docs",
+              subheader: null,
+              required: false,
+              placeholder: null,
+              longAnswer: null,
+              choices: null,
+              lowerLabel: null,
+              upperLabel: null,
+              scale: null,
+              range: null,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("createSurveyDraftGenerationRequest", () => {
+  test("shares the model knobs and passes prompts through", () => {
+    const request = createSurveyDraftGenerationRequest({
+      schema: importSchema.forAI,
+      schemaName: "ImportedSurveyDraft",
+      schemaDescription: "d",
+      system: "s",
+      prompt: "p",
+    });
+
+    expect(request).toMatchObject({
+      schemaName: "ImportedSurveyDraft",
+      system: "s",
+      prompt: "p",
+      temperature: 0.2,
+      maxOutputTokens: 8192,
+      timeout: 45_000,
+    });
+    expect(request.schema).toBe(importSchema.forAI);
+  });
+});

--- a/apps/web/app/api/v3/surveys/generate/service.ts
+++ b/apps/web/app/api/v3/surveys/generate/service.ts
@@ -1,5 +1,7 @@
 import "server-only";
 import { createId } from "@paralleldrive/cuid2";
+import type { z } from "zod";
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/canonical";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
 import type { InvalidParam } from "@/app/api/v3/lib/response";
 import { generateOrganizationAIObject } from "@/lib/ai/service";
@@ -7,13 +9,16 @@ import { AI_TRACING_FEATURE } from "@/lib/posthog/ai-tracing-feature";
 import { type TV3SurveyPrepareResult, prepareV3SurveyCreateInput } from "../prepare";
 import { DEFAULT_V3_SURVEY_LANGUAGE, type TV3CreateSurveyBody, formatV3ZodInvalidParams } from "../schemas";
 import {
+  IMPORT_ADDRESS_FIELDS,
+  IMPORT_CONTACT_INFO_FIELDS,
   V3_SURVEY_GENERATE_PROMPT_DETAIL_MIN_LENGTH,
   V3_SURVEY_GENERATE_PROMPT_DETAIL_MIN_WORDS,
 } from "./constants";
 import { buildV3SurveyGenerationPrompt, buildV3SurveyGenerationSystemPrompt } from "./prompt";
 import {
-  type TGeneratedSurveyDraft,
-  type TGeneratedSurveyElement,
+  type TGeneratedDraftElementLike,
+  type TGeneratedDraftLike,
+  type TGeneratedDraftText,
   type TV3SurveyGenerateBody,
   V3_SURVEY_GENERATE_ALLOWED_LOCALES,
   ZGeneratedSurveyDraft,
@@ -26,10 +31,15 @@ export type TV3SurveyGenerateValidation = {
   languages: Array<{ code: string; default: boolean; enabled: boolean }>;
 };
 
+/** A translation the adapter had to fill from the default language (D2 completeness rule). */
+export type TV3SurveyTranslationFill = { path: string; languageCode: string };
+
 export type TV3SurveyGenerateResult = {
   language: string;
   payload: TV3CreateSurveyBody;
   validation: TV3SurveyGenerateValidation;
+  /** Empty for Create with AI; the import lane turns these into `translation_filled` warnings. */
+  translationFills: TV3SurveyTranslationFill[];
 };
 
 const V3_SURVEY_GENERATION_TIMEOUT_MS = 45_000;
@@ -65,8 +75,69 @@ export class V3SurveyGeneratedPayloadValidationError extends Error {
   }
 }
 
-function text(value: string, language: string): Record<string, string> {
-  return { [language]: value.trim() };
+/**
+ * Turns a draft text (a string, or `[{ languageCode, text }]` for imports) into the public locale map
+ * the create payload carries. `path` names the field for the completeness warnings.
+ */
+export type TDraftTextResolver = (value: TGeneratedDraftText, path: string) => Record<string, string>;
+
+export type TDraftLanguages = {
+  defaultLanguage: string;
+  /** Every language the survey declares, default included, as canonical BCP-47 tags. */
+  codes: string[];
+};
+
+/** Create with AI: one language, the text as it came. */
+function createSingleLanguageResolver(language: string): TDraftTextResolver {
+  return (value) => ({ [language]: (typeof value === "string" ? value : (value[0]?.text ?? "")).trim() });
+}
+
+/**
+ * Import: every declared language gets an entry. A text missing one of them is filled from the default
+ * language and recorded, because v3 rejects `missing_translation` and the adapter must never fail.
+ */
+export function createMultilingualResolver(
+  languages: TDraftLanguages,
+  fills: TV3SurveyTranslationFill[]
+): TDraftTextResolver {
+  const canonical = (code: string) => normalizeLanguageCode(code) ?? code;
+  const defaultCode = canonical(languages.defaultLanguage);
+  const codes = Array.from(new Set([defaultCode, ...languages.codes.map(canonical)]));
+
+  return (value, path) => {
+    // A plain string here is one of the adapter's own fallbacks ("Start", "Thanks for your feedback"):
+    // it is not a missing translation, so it fans out to every language without a fill.
+    if (typeof value === "string") {
+      return Object.fromEntries(codes.map((code) => [code, value.trim()]));
+    }
+
+    const entries = value;
+    const byCode = new Map<string, string>();
+    for (const entry of entries) {
+      const code = canonical(entry.languageCode);
+      if (!byCode.has(code)) byCode.set(code, entry.text.trim());
+    }
+
+    const defaultText = byCode.get(defaultCode) ?? entries[0]?.text.trim() ?? "";
+    const map: Record<string, string> = {};
+    for (const code of codes) {
+      const text = byCode.get(code);
+      if (text === undefined || text.length === 0) {
+        map[code] = defaultText;
+        if (code !== defaultCode || byCode.get(defaultCode) === undefined) {
+          fills.push({ path, languageCode: code });
+        }
+      } else {
+        map[code] = text;
+      }
+    }
+    return map;
+  };
+}
+
+function firstText(value: TGeneratedDraftText | null | undefined): string {
+  if (!value) return "";
+  return typeof value === "string" ? value : (value[0]?.text ?? "");
 }
 
 function getPromptInvalidParams(prompt: string): InvalidParam[] {
@@ -89,43 +160,40 @@ function getPromptInvalidParams(prompt: string): InvalidParam[] {
   ];
 }
 
-function createChoice(
-  label: string,
-  index: number,
-  language: string
-): { id: string; label: Record<string, string> } {
-  return createLabeledItem("choice", label, index, language);
-}
+type TBuildContext = { resolve: TDraftTextResolver; defaultLanguage: string };
 
 function createLabeledItem(
   prefix: string,
-  label: string,
+  label: TGeneratedDraftText,
   index: number,
-  language: string
+  ctx: TBuildContext,
+  path: string
 ): { id: string; label: Record<string, string> } {
   return {
     id: `${prefix}_${index + 1}`,
-    label: text(label, language),
+    label: ctx.resolve(label, `${path}.${index}`),
   };
 }
 
 function translatedField<TName extends string>(
   name: TName,
-  value: string | null | undefined,
-  language: string
+  value: TGeneratedDraftText | null | undefined,
+  ctx: TBuildContext,
+  path: string
 ): Partial<Record<TName, Record<string, string>>> {
-  if (!value) {
+  if (!value || (typeof value !== "string" && value.length === 0)) {
     return {};
   }
 
-  return { [name]: text(value, language) } as Record<TName, Record<string, string>>;
+  return { [name]: ctx.resolve(value, path) } as Record<TName, Record<string, string>>;
 }
 
-function buildBaseElement(element: TGeneratedSurveyElement, index: number, language: string) {
+function buildBaseElement(element: TGeneratedDraftElementLike, index: number, ctx: TBuildContext) {
+  const path = `blocks.elements.${index}`;
   return {
     id: `q_${index + 1}_${createId().slice(0, 8)}`,
-    headline: text(element.headline, language),
-    ...translatedField("subheader", element.subheader, language),
+    headline: ctx.resolve(element.headline, `${path}.headline`),
+    ...translatedField("subheader", element.subheader, ctx, `${path}.subheader`),
     required: element.required,
     isDraft: true,
   };
@@ -133,60 +201,82 @@ function buildBaseElement(element: TGeneratedSurveyElement, index: number, langu
 
 type TBaseElement = ReturnType<typeof buildBaseElement>;
 
-function buildOpenTextElement(baseElement: TBaseElement, element: TGeneratedSurveyElement, language: string) {
+function buildOpenTextElement(
+  baseElement: TBaseElement,
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
+) {
   return {
     ...baseElement,
     type: "openText" as const,
-    ...translatedField("placeholder", element.placeholder, language),
+    ...translatedField("placeholder", element.placeholder, ctx, `${baseElement.id}.placeholder`),
     longAnswer: element.longAnswer ?? false,
     inputType: "text" as const,
     charLimit: { enabled: false },
   };
 }
 
-function buildChoiceElement(baseElement: TBaseElement, element: TGeneratedSurveyElement, language: string) {
+function buildChoiceElement(
+  baseElement: TBaseElement,
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
+) {
   return {
     ...baseElement,
     type: element.type as "multipleChoiceSingle" | "multipleChoiceMulti",
     choices: (element.choices ?? []).map((choice, choiceIndex) =>
-      createChoice(choice, choiceIndex, language)
+      createLabeledItem("choice", choice, choiceIndex, ctx, `${baseElement.id}.choices`)
     ),
     shuffleOption: "none" as const,
     displayType: "list" as const,
   };
 }
 
-function buildRankingElement(baseElement: TBaseElement, element: TGeneratedSurveyElement, language: string) {
+function buildRankingElement(
+  baseElement: TBaseElement,
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
+) {
   return {
     ...baseElement,
     type: "ranking" as const,
     choices: (element.choices ?? []).map((choice, choiceIndex) =>
-      createChoice(choice, choiceIndex, language)
+      createLabeledItem("choice", choice, choiceIndex, ctx, `${baseElement.id}.choices`)
     ),
     shuffleOption: "none" as const,
   };
 }
 
-function buildMatrixElement(baseElement: TBaseElement, element: TGeneratedSurveyElement, language: string) {
+function buildMatrixElement(
+  baseElement: TBaseElement,
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
+) {
   return {
     ...baseElement,
     type: "matrix" as const,
-    rows: (element.rows ?? []).map((row, rowIndex) => createLabeledItem("row", row, rowIndex, language)),
+    rows: (element.rows ?? []).map((row, rowIndex) =>
+      createLabeledItem("row", row, rowIndex, ctx, `${baseElement.id}.rows`)
+    ),
     columns: (element.columns ?? []).map((column, columnIndex) =>
-      createLabeledItem("column", column, columnIndex, language)
+      createLabeledItem("column", column, columnIndex, ctx, `${baseElement.id}.columns`)
     ),
     shuffleOption: "none" as const,
   };
 }
 
-function buildScaleLabels(element: TGeneratedSurveyElement, language: string) {
+function buildScaleLabels(
+  baseElement: TBaseElement,
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
+) {
   return {
-    ...translatedField("lowerLabel", element.lowerLabel, language),
-    ...translatedField("upperLabel", element.upperLabel, language),
+    ...translatedField("lowerLabel", element.lowerLabel, ctx, `${baseElement.id}.lowerLabel`),
+    ...translatedField("upperLabel", element.upperLabel, ctx, `${baseElement.id}.upperLabel`),
   };
 }
 
-function getSatisfactionQuestionRange(element: TGeneratedSurveyElement): 5 | 7 | 10 {
+function getSatisfactionQuestionRange(element: TGeneratedDraftElementLike): 5 | 7 | 10 {
   if (element.range) {
     return element.range;
   }
@@ -198,67 +288,180 @@ function getSatisfactionQuestionRange(element: TGeneratedSurveyElement): 5 | 7 |
   return 5;
 }
 
-function buildNpsElement(baseElement: TBaseElement, element: TGeneratedSurveyElement, language: string) {
+function buildNpsElement(baseElement: TBaseElement, element: TGeneratedDraftElementLike, ctx: TBuildContext) {
   return {
     ...baseElement,
     type: "nps" as const,
-    ...buildScaleLabels(element, language),
+    ...buildScaleLabels(baseElement, element, ctx),
     isColorCodingEnabled: false,
   };
 }
 
 function buildSatisfactionElement(
   baseElement: TBaseElement,
-  element: TGeneratedSurveyElement,
-  language: string
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
 ) {
   return {
     ...baseElement,
     type: element.type as "csat" | "ces",
     scale: element.scale ?? "number",
     range: getSatisfactionQuestionRange(element),
-    ...buildScaleLabels(element, language),
+    ...buildScaleLabels(baseElement, element, ctx),
     isColorCodingEnabled: false,
   };
 }
 
-function buildRatingElement(baseElement: TBaseElement, element: TGeneratedSurveyElement, language: string) {
+function buildRatingElement(
+  baseElement: TBaseElement,
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
+) {
   return {
     ...baseElement,
     type: "rating" as const,
     scale: element.scale ?? "number",
     range: element.range ?? 5,
-    ...buildScaleLabels(element, language),
+    ...buildScaleLabels(baseElement, element, ctx),
     isColorCodingEnabled: false,
   };
 }
 
-function buildElement(element: TGeneratedSurveyElement, index: number, language: string) {
-  const baseElement = buildBaseElement(element, index, language);
+// --- Import-only element types (D2 refinements, decided 2026-09-08) ---
+
+function buildCtaElement(baseElement: TBaseElement, element: TGeneratedDraftElementLike, ctx: TBuildContext) {
+  const hasUrl = typeof element.buttonUrl === "string" && element.buttonUrl.length > 0;
+  return {
+    ...baseElement,
+    type: "cta" as const,
+    buttonExternal: hasUrl,
+    ...(hasUrl ? { buttonUrl: element.buttonUrl } : {}),
+    ctaButtonLabel: ctx.resolve(element.buttonLabel ?? "Next", `${baseElement.id}.ctaButtonLabel`),
+  };
+}
+
+function buildConsentElement(
+  baseElement: TBaseElement,
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
+) {
+  return {
+    ...baseElement,
+    type: "consent" as const,
+    label: ctx.resolve(element.label ?? element.buttonLabel ?? "I agree", `${baseElement.id}.label`),
+  };
+}
+
+function buildToggleInputs(
+  fieldNames: readonly string[],
+  shown: readonly string[] | null | undefined,
+  required: boolean,
+  ctx: TBuildContext,
+  path: string,
+  placeholders: Record<string, string>
+) {
+  const visible = new Set(shown && shown.length > 0 ? shown : fieldNames);
+  return Object.fromEntries(
+    fieldNames.map((field) => [
+      field,
+      {
+        show: visible.has(field),
+        required: required && visible.has(field),
+        placeholder: ctx.resolve(placeholders[field] ?? field, `${path}.${field}.placeholder`),
+      },
+    ])
+  );
+}
+
+const ADDRESS_PLACEHOLDERS: Record<string, string> = {
+  addressLine1: "Address line 1",
+  addressLine2: "Address line 2",
+  city: "City",
+  state: "State",
+  zip: "ZIP",
+  country: "Country",
+};
+
+const CONTACT_INFO_PLACEHOLDERS: Record<string, string> = {
+  firstName: "First name",
+  lastName: "Last name",
+  email: "Email",
+  phone: "Phone",
+  company: "Company",
+};
+
+function buildAddressElement(
+  baseElement: TBaseElement,
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
+) {
+  return {
+    ...baseElement,
+    type: "address" as const,
+    ...buildToggleInputs(
+      IMPORT_ADDRESS_FIELDS,
+      element.fields,
+      element.required,
+      ctx,
+      baseElement.id,
+      ADDRESS_PLACEHOLDERS
+    ),
+  };
+}
+
+function buildContactInfoElement(
+  baseElement: TBaseElement,
+  element: TGeneratedDraftElementLike,
+  ctx: TBuildContext
+) {
+  return {
+    ...baseElement,
+    type: "contactInfo" as const,
+    ...buildToggleInputs(
+      IMPORT_CONTACT_INFO_FIELDS,
+      element.fields,
+      element.required,
+      ctx,
+      baseElement.id,
+      CONTACT_INFO_PLACEHOLDERS
+    ),
+  };
+}
+
+function buildElement(element: TGeneratedDraftElementLike, index: number, ctx: TBuildContext) {
+  const baseElement = buildBaseElement(element, index, ctx);
 
   switch (element.type) {
     case "openText":
-      return buildOpenTextElement(baseElement, element, language);
+      return buildOpenTextElement(baseElement, element, ctx);
     case "multipleChoiceSingle":
     case "multipleChoiceMulti":
-      return buildChoiceElement(baseElement, element, language);
+      return buildChoiceElement(baseElement, element, ctx);
     case "ranking":
-      return buildRankingElement(baseElement, element, language);
+      return buildRankingElement(baseElement, element, ctx);
     case "matrix":
-      return buildMatrixElement(baseElement, element, language);
+      return buildMatrixElement(baseElement, element, ctx);
     case "date":
       return { ...baseElement, type: "date" as const, format: element.format ?? "M-d-y" };
     case "nps":
-      return buildNpsElement(baseElement, element, language);
+      return buildNpsElement(baseElement, element, ctx);
     case "csat":
     case "ces":
-      return buildSatisfactionElement(baseElement, element, language);
+      return buildSatisfactionElement(baseElement, element, ctx);
+    case "cta":
+      return buildCtaElement(baseElement, element, ctx);
+    case "consent":
+      return buildConsentElement(baseElement, element, ctx);
+    case "address":
+      return buildAddressElement(baseElement, element, ctx);
+    case "contactInfo":
+      return buildContactInfoElement(baseElement, element, ctx);
     default:
-      return buildRatingElement(baseElement, element, language);
+      return buildRatingElement(baseElement, element, ctx);
   }
 }
 
-const RATING_LIKE_GENERATED_ELEMENT_TYPES = new Set<TGeneratedSurveyElement["type"]>([
+const RATING_LIKE_GENERATED_ELEMENT_TYPES = new Set<string>([
   TSurveyElementTypeEnum.Rating,
   TSurveyElementTypeEnum.CSAT,
   TSurveyElementTypeEnum.CES,
@@ -267,11 +470,14 @@ const RATING_LIKE_GENERATED_ELEMENT_TYPES = new Set<TGeneratedSurveyElement["typ
   TSurveyElementTypeEnum.Ranking,
 ]);
 
-function isRatingLikeGeneratedElement(element: TGeneratedSurveyElement): boolean {
+function isRatingLikeGeneratedElement(element: TGeneratedDraftElementLike): boolean {
   return RATING_LIKE_GENERATED_ELEMENT_TYPES.has(element.type);
 }
 
-function normalizeGeneratedSurveyBlocks(generatedSurvey: TGeneratedSurveyDraft): TGeneratedSurveyDraft {
+/** Rating-like questions render alone; split mixed blocks so each such question gets its own block. */
+export function normalizeGeneratedSurveyBlocks<TDraft extends TGeneratedDraftLike>(
+  generatedSurvey: TDraft
+): TDraft {
   return {
     ...generatedSurvey,
     blocks: generatedSurvey.blocks.flatMap((block) => {
@@ -279,8 +485,8 @@ function normalizeGeneratedSurveyBlocks(generatedSurvey: TGeneratedSurveyDraft):
         return [block];
       }
 
-      const normalizedBlocks: TGeneratedSurveyDraft["blocks"] = [];
-      let pendingNonRatingQuestions: TGeneratedSurveyElement[] = [];
+      const normalizedBlocks: TGeneratedDraftLike["blocks"] = [];
+      let pendingNonRatingQuestions: TGeneratedDraftElementLike[] = [];
 
       const flushPendingNonRatingQuestions = () => {
         if (pendingNonRatingQuestions.length === 0) {
@@ -314,46 +520,63 @@ function normalizeGeneratedSurveyBlocks(generatedSurvey: TGeneratedSurveyDraft):
   };
 }
 
-function buildCreatePayload(input: TV3SurveyGenerateBody, generatedSurvey: TGeneratedSurveyDraft): unknown {
+type TBuildCreatePayloadInput = Pick<TV3SurveyGenerateBody, "workspaceId" | "type">;
+
+function buildCreatePayload(
+  input: TBuildCreatePayloadInput,
+  generatedSurvey: TGeneratedDraftLike,
+  languages: TDraftLanguages,
+  ctx: TBuildContext
+): unknown {
   const welcomeCard = generatedSurvey.welcomeCard;
   const welcomeHeadline = welcomeCard?.headline ?? generatedSurvey.name;
-  const language = generatedSurvey.language;
   let questionIndex = 0;
 
   return {
     workspaceId: input.workspaceId,
     type: input.type,
-    name: generatedSurvey.name,
+    name: firstText(generatedSurvey.name),
     status: "draft",
-    defaultLanguage: language,
-    languages: [{ code: language, default: true, enabled: true }],
+    defaultLanguage: languages.defaultLanguage,
+    languages: languages.codes.map((code) => ({
+      code,
+      default: code === languages.defaultLanguage,
+      enabled: true,
+    })),
     metadata: {
-      title: text(generatedSurvey.name, language),
-      ...(generatedSurvey.description ? { description: text(generatedSurvey.description, language) } : {}),
+      title: ctx.resolve(generatedSurvey.name, "metadata.title"),
+      ...(generatedSurvey.description
+        ? { description: ctx.resolve(generatedSurvey.description, "metadata.description") }
+        : {}),
     },
     welcomeCard:
       welcomeCard?.enabled === true
         ? {
             enabled: true,
-            headline: text(welcomeHeadline, language),
-            ...(welcomeCard.subheader ? { subheader: text(welcomeCard.subheader, language) } : {}),
-            buttonLabel: text(welcomeCard.buttonLabel ?? "Start", language),
+            headline: ctx.resolve(welcomeHeadline, "welcomeCard.headline"),
+            ...(welcomeCard.subheader
+              ? { subheader: ctx.resolve(welcomeCard.subheader, "welcomeCard.subheader") }
+              : {}),
+            buttonLabel: ctx.resolve(welcomeCard.buttonLabel ?? "Start", "welcomeCard.buttonLabel"),
             timeToFinish: true,
             showResponseCount: false,
           }
         : { enabled: false },
     blocks: generatedSurvey.blocks.map((block) => ({
       id: createId(),
-      name: block.name,
-      elements: block.questions.map((element) => buildElement(element, questionIndex++, language)),
+      name: firstText(block.name),
+      elements: block.questions.map((element) => buildElement(element, questionIndex++, ctx)),
     })),
     endings: [
       {
         id: createId(),
         type: "endScreen",
-        headline: text(generatedSurvey.ending?.headline ?? "Thanks for your feedback", language),
+        headline: ctx.resolve(
+          generatedSurvey.ending?.headline ?? "Thanks for your feedback",
+          "endings.0.headline"
+        ),
         ...(generatedSurvey.ending?.subheader
-          ? { subheader: text(generatedSurvey.ending.subheader, language) }
+          ? { subheader: ctx.resolve(generatedSurvey.ending.subheader, "endings.0.subheader") }
           : {}),
       },
     ],
@@ -389,6 +612,37 @@ export function assertV3SurveyGeneratePrompt(prompt: string): void {
   }
 }
 
+export type TSurveyDraftGenerationRequest<TSchema extends z.ZodTypeAny> = {
+  schema: TSchema;
+  schemaName: string;
+  schemaDescription: string;
+  system: string;
+  prompt: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+  timeout?: number;
+};
+
+/**
+ * The model call shape shared by every draft source: Create with AI and the import lane pass their
+ * own schema and prompts and inherit the temperature, output budget and timeout, so a streamed draft,
+ * a blocking one and an imported one cannot drift on a hand-copied number.
+ */
+export function createSurveyDraftGenerationRequest<TSchema extends z.ZodTypeAny>(
+  request: TSurveyDraftGenerationRequest<TSchema>
+) {
+  return {
+    schema: request.schema,
+    schemaName: request.schemaName,
+    schemaDescription: request.schemaDescription,
+    system: request.system,
+    prompt: request.prompt,
+    temperature: request.temperature ?? 0.2,
+    maxOutputTokens: request.maxOutputTokens ?? V3_SURVEY_GENERATION_MAX_OUTPUT_TOKENS,
+    timeout: request.timeout ?? V3_SURVEY_GENERATION_TIMEOUT_MS,
+  };
+}
+
 /**
  * The exact model call both the blocking public route and the streaming internal route make. Every
  * field is common to `TGenerateObjectOptions` and `TStreamObjectOptions`, so both spread it — which
@@ -396,7 +650,7 @@ export function assertV3SurveyGeneratePrompt(prompt: string): void {
  * hand-copied temperature.
  */
 export function buildV3SurveyGenerationRequest(input: TV3SurveyGenerateBody) {
-  return {
+  return createSurveyDraftGenerationRequest({
     // Deliberately the *ForAI* schema (string ranges), not ZGeneratedSurveyDraft, which
     // z.preprocess-coerces them to numbers. z.preprocess does not survive JSON-Schema conversion,
     // so swapping the two here breaks provider structured output.
@@ -410,10 +664,7 @@ export function buildV3SurveyGenerationRequest(input: TV3SurveyGenerateBody) {
       input.language ?? DEFAULT_V3_SURVEY_LANGUAGE,
       V3_SURVEY_GENERATE_ALLOWED_LOCALES
     ),
-    temperature: 0.2,
-    maxOutputTokens: V3_SURVEY_GENERATION_MAX_OUTPUT_TOKENS,
-    timeout: V3_SURVEY_GENERATION_TIMEOUT_MS,
-  };
+  });
 }
 
 /** Tracing context, shared so both routes report under the same PostHog feature. */
@@ -427,6 +678,13 @@ export function buildV3SurveyGenerationTracing(params: { workspaceId: string; us
     : undefined;
 }
 
+export type TBuildDraftPayloadOptions = {
+  /** The parsed-draft schema of the source (`internal` from the factory). Default: Create with AI's. */
+  schema?: z.ZodType<TGeneratedDraftLike>;
+  /** Import: the languages the payload must declare. Default: the draft's single `language`. */
+  languages?: TDraftLanguages;
+};
+
 /**
  * Converts a raw model draft into a v3 create payload. Pure and synchronous — no I/O, no AI call.
  * Both the blocking and the streaming route converge here, so a regression in this function breaks
@@ -437,10 +695,12 @@ export function buildV3SurveyGenerationTracing(params: { workspaceId: string; us
  *   a terminal draft should ever reach this.
  */
 export function buildV3SurveyCreatePayloadFromDraft(
-  input: TV3SurveyGenerateBody,
-  draft: unknown
+  input: TBuildCreatePayloadInput,
+  draft: unknown,
+  options: TBuildDraftPayloadOptions = {}
 ): TV3SurveyGenerateResult {
-  const generatedSurvey = ZGeneratedSurveyDraft.safeParse(draft);
+  const schema = options.schema ?? (ZGeneratedSurveyDraft as unknown as z.ZodType<TGeneratedDraftLike>);
+  const generatedSurvey = schema.safeParse(draft);
   if (!generatedSurvey.success) {
     throw new V3SurveyGeneratedPayloadValidationError(
       formatV3ZodInvalidParams(generatedSurvey.error, "generatedSurvey")
@@ -448,16 +708,29 @@ export function buildV3SurveyCreatePayloadFromDraft(
   }
 
   const normalizedGeneratedSurvey = normalizeGeneratedSurveyBlocks(generatedSurvey.data);
-  const createPayload = buildCreatePayload(input, normalizedGeneratedSurvey);
+  const fills: TV3SurveyTranslationFill[] = [];
+  const languages: TDraftLanguages = options.languages ?? {
+    defaultLanguage: normalizedGeneratedSurvey.language,
+    codes: [normalizedGeneratedSurvey.language],
+  };
+  const resolve = options.languages
+    ? createMultilingualResolver(languages, fills)
+    : createSingleLanguageResolver(languages.defaultLanguage);
+
+  const createPayload = buildCreatePayload(input, normalizedGeneratedSurvey, languages, {
+    resolve,
+    defaultLanguage: languages.defaultLanguage,
+  });
   const preparation = prepareV3SurveyCreateInput(createPayload);
   if (!preparation.ok) {
     throw new V3SurveyGeneratedPayloadValidationError(preparation.validation.invalidParams);
   }
 
   return {
-    language: normalizedGeneratedSurvey.language,
+    language: languages.defaultLanguage,
     payload: createPayload as TV3CreateSurveyBody,
     validation: serializeValidation(preparation),
+    translationFills: fills,
   };
 }
 


### PR DESCRIPTION
Fixes ENG-2997

Stacked on #9203 (`jojo/eng-2996-docs-migrate-from-qualtrics`). Part of the Survey Import & Export stack; milestone 4 (document lane) starts here.

## What & why

**Was:** The Create-with-AI draft schema and its payload adapter were hard-wired to one language, plain-string texts and ten element types, so an imported document could not reuse them.

**Now:** `createGeneratedSurveyDraftSchema(...)` builds the draft schema from options (text schemas, limits, element types, language codes) and `buildV3SurveyCreatePayloadFromDraft` takes a schema and a language list, emitting a multilingual v3 payload. Create with AI is the default instantiation and stays byte-identical.

- Import-only fields unlock with `languageCodes`: `defaultLanguage`, element `buttonLabel`/`buttonUrl`/`label`/`fields`/`notes`, plus cta/consent/address/contactInfo builders.
- Completeness rule (D2): a text missing a declared language is filled from the default and returned as `translationFills`, so v3 never sees `missing_translation`.
- `createSurveyDraftGenerationRequest` shares temperature, output budget and timeout between Create with AI and the coming import lane.
- Live-run follow-ups (2026-09-09): the import variant allows 24 questions per block (a 15-question section in one block was refused at 8), and empty localized arrays / empty block lists parse — the finalizer decides what they mean. The Create-with-AI snapshot is unchanged.


- The provider-facing import schema is purely structural: the cross-field rules (choices for choice questions, rows/columns for a matrix, csat/ces ranges) moved to the import finalizer, because the SDK rejects a whole chunk on the first violation — a picture-choice row without labels took 16 questions down with it. `internal` keeps the rules; Create with AI is unchanged. Import blocks per chunk: 24 (one block per question is a legitimate layout).

## Where to look

- [schemas.ts](apps/web/app/api/v3/surveys/generate/schemas.ts) — the factory and the optional-typing trick for import-only fields.
- [service.ts](apps/web/app/api/v3/surveys/generate/service.ts) — `createMultilingualResolver` and the new element builders.
- [schema-snapshot.test.ts](apps/web/app/api/v3/surveys/generate/schema-snapshot.test.ts) — pins the provider-facing JSON schema of the default variant.

## Breaking changes

- [ ] This PR contains a breaking change

Additive refactor; the public generate endpoint's request and response are unchanged and the JSON schema handed to the provider is pinned by snapshot.

## Migrations & env

None.

## Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| Default draft JSON schema unchanged after refactor | unit (guard) | `schema-snapshot.test.ts` |
| Bilingual draft → `defaultLanguage` + `languages[]` + locale maps | unit (mutation) | `service-import.test.ts` "a bilingual draft…" — mutate `createMultilingualResolver` codes loop in service.ts |
| Missing translation filled + recorded | unit (mutation) | `service-import.test.ts` "a text missing a declared language…" |
| Code outside declared enum rejected; 16×8 import-only limits | unit (guard) | `service-import.test.ts` |
| cta/consent/address/contactInfo pass `prepareV3SurveyCreateInput`; default variant rejects them | unit (guard) | `service-import.test.ts` |
| Existing Create with AI behaviour | unit (guard) | `service.test.ts`, `schemas.test.ts`, internal stream tests |

Rerun: `cd apps/web && npx vitest run app/api/v3/surveys/generate app/api/internal/surveys/generate`

## Open gaps

- No consumer of the import variant yet; the document lane (ENG-2999/3000) wires it.
- Manual QA of Create with AI in the app pending (only unit-level proof that the default variant is unchanged).

## Risks

- The generic factory types import-only fields as optional on both variants; runtime `strict()` still rejects them for Create with AI.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>
