### PR TITLE
feat(surveys): AI lane in the convert route with gate, shared rate limit and error mapping [ENG-3001]

### DIFF
--- a/apps/web/app/api/v3/lib/api-wrapper.ts
+++ b/apps/web/app/api/v3/lib/api-wrapper.ts
@@ -134,7 +134,8 @@ function searchParamsToObject(searchParams: URLSearchParams): Record<string, str
   return query;
 }
 
-function getRateLimitIdentifier(authentication: TV3Authentication): string | null {
+/** The rate-limit bucket key for a request: the session user id, else the API key id. */
+export function getRateLimitIdentifier(authentication: TV3Authentication): string | null {
   if (!authentication) {
     return null;
   }

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
@@ -1,10 +1,15 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AIOutputTokenLimitError } from "@formbricks/ai";
 import { prisma } from "@formbricks/database";
+import { OperationNotAllowedError, TooManyRequestsError } from "@formbricks/types/errors";
 import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
 import { problemForbidden } from "@/app/api/v3/lib/response";
 import { getActionClasses } from "@/lib/actionClass/service";
+import { assertOrganizationAIConfigured } from "@/lib/ai/service";
+import { capturePostHogEvent } from "@/lib/posthog";
+import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
 import { createActionClass } from "@/modules/survey/editor/lib/action-class";
 import {
   FIXTURE_APP_SURVEY,
@@ -12,19 +17,32 @@ import {
   FIXTURE_WORKSPACE_ID,
 } from "@/modules/survey/export/__fixtures__/surveys";
 import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
+import { documentLane } from "@/modules/survey/import/lanes/document";
 import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
 import { ZV3SurveyImportConvertBody } from "../schemas";
 import { convertImportFile } from "./convert-import";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@formbricks/logger", () => ({
-  logger: { withContext: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() })) },
+  logger: {
+    withContext: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() })),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
 }));
 vi.mock("@formbricks/database", () => ({ prisma: { language: { findMany: vi.fn() } } }));
 vi.mock("@/app/api/v3/lib/auth", () => ({ requireV3WorkspaceAccess: vi.fn() }));
 vi.mock("@/lib/actionClass/service", () => ({ getActionClasses: vi.fn() }));
 vi.mock("@/modules/survey/editor/lib/action-class", () => ({ createActionClass: vi.fn() }));
 vi.mock("@/modules/survey/lib/permission", () => ({ getExternalUrlsPermission: vi.fn() }));
+vi.mock("@/modules/survey/import/lanes/document", () => ({ documentLane: vi.fn() }));
+vi.mock("@/lib/ai/service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/ai/service")>()),
+  assertOrganizationAIConfigured: vi.fn(),
+}));
+vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn() }));
+vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: vi.fn() }));
 vi.mock("@/lib/constants", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/constants")>()),
   WEBAPP_URL: "https://app.formbricks.com",
@@ -61,6 +79,8 @@ describe("convertImportFile", () => {
     vi.mocked(prisma.language.findMany).mockResolvedValue([] as never);
     vi.mocked(getActionClasses).mockResolvedValue([]);
     vi.mocked(getExternalUrlsPermission).mockResolvedValue(true);
+    vi.mocked(assertOrganizationAIConfigured).mockResolvedValue({} as never);
+    vi.mocked(applyRateLimit).mockResolvedValue({} as never);
   });
 
   test("converts a .formbricks.json upload through the lossless lane without persisting", async () => {
@@ -181,18 +201,129 @@ describe("convertImportFile", () => {
     );
   });
 
-  test("answers 400 lane_not_available for a kind whose lane has not shipped", async () => {
-    const response = await convertImportFile({
-      body: body("questions.csv", Buffer.from("Question;Type\nHow?;openText"), "text/csv"),
-      authentication,
-      requestId,
-      instance,
+  describe("AI lane", () => {
+    const docx = () =>
+      body(
+        "questions.docx",
+        readFileSync(
+          join(process.cwd(), "modules/survey/import/lanes/document/__fixtures__/survey-numbered-lists.docx")
+        )
+      );
+    const aiCandidate = {
+      document: {
+        name: "From a document",
+        type: "link",
+        status: "draft",
+        defaultLanguage: "en-US",
+        languages: [{ code: "en-US", default: true, enabled: true }],
+        welcomeCard: { enabled: false },
+        blocks: [
+          {
+            id: "b1",
+            name: "Block",
+            elements: [{ id: "q1", type: "openText", headline: { "en-US": "How was it?" }, required: false }],
+          },
+        ],
+        endings: [{ id: "e1", type: "endScreen", headline: { "en-US": "Thanks" } }],
+        hiddenFields: { enabled: false },
+        variables: [],
+      },
+      issues: [],
+      source: {
+        lane: "ai" as const,
+        kind: "docx" as const,
+        fileName: "questions.docx",
+        chunks: 2,
+        detectedLanguages: [{ code: "en-US", confidence: 0.9 }],
+      },
+    };
+
+    test("an organization without AI gets 403 before the file is read", async () => {
+      vi.mocked(assertOrganizationAIConfigured).mockRejectedValue(
+        new OperationNotAllowedError("ai_features_not_enabled")
+      );
+
+      const response = await convertImportFile({ body: docx(), authentication, requestId, instance });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).code).toBe("ai_features_not_enabled");
+      expect(documentLane).not.toHaveBeenCalled();
+      expect(applyRateLimit).not.toHaveBeenCalled();
     });
 
-    expect(response.status).toBe(400);
-    const json = await response.json();
-    expect(json.code).toBe("lane_not_available");
-    expect(json.invalid_params[0]).toMatchObject({ name: "file", reason: expect.stringContaining("csv") });
+    test("an entitled organization gets the AI lane's document, source and a PostHog event", async () => {
+      vi.mocked(documentLane).mockResolvedValue(aiCandidate);
+
+      const response = await convertImportFile({ body: docx(), authentication, requestId, instance });
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.data.source).toMatchObject({ lane: "ai", kind: "docx", chunks: 2 });
+      expect(json.data.document).toMatchObject({ name: "From a document" });
+      expect(json.data.validation.valid).toBe(true);
+      expect(applyRateLimit).toHaveBeenCalledWith(
+        expect.objectContaining({ namespace: "api:v3:surveys:generate" }),
+        "user_1"
+      );
+      expect(capturePostHogEvent).toHaveBeenCalledWith(
+        "user_1",
+        "ai_survey_imported",
+        expect.objectContaining({
+          source_kind: "docx",
+          chunk_count: 2,
+          question_count: 1,
+          language_count: 1,
+        }),
+        expect.objectContaining({ workspaceId: FIXTURE_WORKSPACE_ID })
+      );
+    });
+
+    test("the output token limit maps to 422 ai_output_too_long", async () => {
+      vi.mocked(documentLane).mockRejectedValue(new AIOutputTokenLimitError());
+
+      const response = await convertImportFile({ body: docx(), authentication, requestId, instance });
+
+      expect(response.status).toBe(422);
+      expect((await response.json()).code).toBe("ai_output_too_long");
+    });
+
+    test("the shared AI budget answers 429 with Retry-After", async () => {
+      vi.mocked(applyRateLimit).mockRejectedValue(new TooManyRequestsError("slow down", 42));
+
+      const response = await convertImportFile({ body: docx(), authentication, requestId, instance });
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get("Retry-After")).toBe("42");
+      expect(documentLane).not.toHaveBeenCalled();
+    });
+
+    test("an unexpected provider failure is a 502, not a 500", async () => {
+      vi.mocked(documentLane).mockRejectedValue(new Error("provider down"));
+
+      const response = await convertImportFile({ body: docx(), authentication, requestId, instance });
+
+      expect(response.status).toBe(502);
+    });
+
+    test("deterministic lanes never touch the AI gate", async () => {
+      vi.mocked(assertOrganizationAIConfigured).mockRejectedValue(
+        new OperationNotAllowedError("ai_features_not_enabled")
+      );
+      const qsf = readFileSync(
+        join(process.cwd(), "modules/survey/import/lanes/qsf/__fixtures__/simple.qsf")
+      );
+
+      const response = await convertImportFile({
+        body: body("survey.qsf", qsf),
+        authentication,
+        requestId,
+        instance,
+      });
+
+      expect(response.status).toBe(200);
+      expect(assertOrganizationAIConfigured).not.toHaveBeenCalled();
+      expect(applyRateLimit).not.toHaveBeenCalled();
+    });
   });
 
   test("returns the authorization response before touching the file", async () => {

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { createId } from "@paralleldrive/cuid2";
 import { logger } from "@formbricks/logger";
 import { DatabaseError } from "@formbricks/types/errors";
+import { getRateLimitIdentifier } from "@/app/api/v3/lib/api-wrapper";
 import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
 import {
   problemBadRequest,
@@ -10,11 +11,16 @@ import {
   successResponse,
 } from "@/app/api/v3/lib/response";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
+import { mapV3SurveyGenerateError } from "@/app/api/v3/surveys/generate/error-mapping";
 import { getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
+import { assertOrganizationAIConfigured } from "@/lib/ai/service";
+import { capturePostHogEvent } from "@/lib/posthog";
+import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { type TImportDetectionFailureCode, detectImportSource } from "@/modules/survey/import/detect";
 import { getImportLaneHandler } from "@/modules/survey/import/lanes";
 import { resolveImportCandidate } from "@/modules/survey/import/resolve";
-import type { TImportContext } from "@/modules/survey/import/types";
+import { IMPORT_LANE_BY_KIND, type TImportContext } from "@/modules/survey/import/types";
 import type { TV3SurveyImportConvertBody } from "../schemas";
 
 type TConvertImportParams = {
@@ -103,11 +109,36 @@ export async function convertImportFile({
       importRunId,
       languageHint: body.fields.language,
     };
+    const isAiLane = IMPORT_LANE_BY_KIND[detection.kind] === "ai";
+    const aiErrorContext = {
+      requestId,
+      instance,
+      workspaceId: authResult.workspaceId,
+      organizationId: authResult.organizationId,
+    };
+    const startedAt = Date.now();
 
-    const candidate = await lane(
-      { kind: detection.kind, fileName: file.fileName, content: { type: "bytes", bytes: file.bytes } },
-      ctx
-    );
+    let candidate;
+    try {
+      if (isAiLane) {
+        // Gate and shared AI budget come before the file is read: an org without AI never pays for
+        // extraction, and prompt-create and import spend from the same 10/min bucket.
+        await assertOrganizationAIConfigured(authResult.organizationId);
+        const identifier = getRateLimitIdentifier(authentication);
+        if (identifier) {
+          await applyRateLimit(rateLimitConfigs.api.v3SurveyGenerate, identifier);
+        }
+      }
+
+      candidate = await lane(
+        { kind: detection.kind, fileName: file.fileName, content: { type: "bytes", bytes: file.bytes } },
+        ctx
+      );
+    } catch (error) {
+      if (!isAiLane) throw error;
+      log.warn({ error, sourceKind: detection.kind }, "AI import lane failed");
+      return mapV3SurveyGenerateError(error, aiErrorContext);
+    }
 
     const resolved = await resolveImportCandidate(candidate, {
       workspaceId: authResult.workspaceId,
@@ -126,6 +157,22 @@ export async function convertImportFile({
       },
       "Import file converted"
     );
+
+    if (isAiLane && ctx.userId && resolved.document) {
+      capturePostHogEvent(
+        ctx.userId,
+        "ai_survey_imported",
+        {
+          source_kind: detection.kind,
+          chunk_count: resolved.report.source.chunks ?? 1,
+          question_count: resolved.report.summary.elements,
+          language_count: resolved.report.summary.languages.length,
+          chars: file.bytes.byteLength,
+          duration_ms: Date.now() - startedAt,
+        },
+        { organizationId: authResult.organizationId, workspaceId: authResult.workspaceId }
+      );
+    }
 
     return successResponse(
       {

--- a/apps/web/modules/survey/import/lanes/index.ts
+++ b/apps/web/modules/survey/import/lanes/index.ts
@@ -4,6 +4,7 @@ import {
   type TImportLaneHandler,
   type TImportSourceKind,
 } from "../types";
+import { documentLane } from "./document";
 import { formbricksLane } from "./formbricks";
 import { qsfLane } from "./qsf";
 
@@ -14,13 +15,14 @@ import { qsfLane } from "./qsf";
 const LANE_HANDLERS: Partial<Record<TImportLane, TImportLaneHandler>> = {
   lossless: formbricksLane,
   structured: qsfLane,
+  ai: documentLane,
 };
 
 export function getImportLaneHandler(kind: TImportSourceKind): TImportLaneHandler | null {
   return LANE_HANDLERS[IMPORT_LANE_BY_KIND[kind]] ?? null;
 }
 
-/** Test seam and future registration point for the structured and AI lanes. */
+/** Test seam: swap a lane handler for a stub. */
 export function registerImportLane(lane: TImportLane, handler: TImportLaneHandler): void {
   LANE_HANDLERS[lane] = handler;
 }

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -1574,7 +1574,36 @@ paths:
         '401':
           $ref: '#/components/responses/V3Unauthorized'
         '403':
-          $ref: '#/components/responses/V3Forbidden'
+          description: Forbidden — no access to the workspace, or (documents only) AI smart tools are not available to the organization. Formbricks exports and Qualtrics files never hit the AI gate.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+              examples:
+                forbidden:
+                  summary: No workspace access
+                  value:
+                    title: Forbidden
+                    status: 403
+                    detail: You are not authorized to access this resource
+                    code: forbidden
+                    requestId: req_123
+                aiDisabled:
+                  summary: AI smart tools disabled
+                  value:
+                    title: AI Unavailable
+                    status: 403
+                    detail: AI smart tools are disabled for this organization.
+                    code: ai_smart_tools_disabled
+                    requestId: req_123
+                aiNotInPlan:
+                  summary: AI features not enabled for the plan
+                  value:
+                    title: AI Unavailable
+                    status: 403
+                    detail: AI smart tools are not available for this organization.
+                    code: ai_features_not_enabled
+                    requestId: req_123
         '413':
           description: Payload Too Large — the request body exceeds 16 MB (15 MB file plus multipart framing).
           content:
@@ -1588,15 +1617,85 @@ paths:
               schema:
                 $ref: '#/components/schemas/Problem'
         '422':
-          description: 'Unprocessable Content — the uploaded file is not something Formbricks imports: `code: unsupported_source` for an unknown type, empty file or broken JSON, `code: legacy_office_format` for `.doc`/`.xls` (save as `.docx`/`.xlsx`). `invalid_params` names the `file` part.'
+          description: 'Unprocessable Content — the uploaded file is not something Formbricks imports: `code: unsupported_source` for an unknown type, empty file or broken JSON, `code: legacy_office_format` for `.doc`/`.xls` (save as `.docx`/`.xlsx`). `invalid_params` names the `file` part. For documents, `code: ai_generated_payload_invalid` when the model''s draft failed create validation and `code: ai_output_too_long` when it hit the output token limit.'
           content:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+              examples:
+                unsupportedSource:
+                  summary: Unsupported file
+                  value:
+                    title: Unprocessable Content
+                    status: 422
+                    detail: This file type is not supported.
+                    code: unsupported_source
+                    requestId: req_123
+                    invalid_params:
+                      - name: file
+                        reason: This file type is not supported.
+                invalidGeneratedPayload:
+                  summary: Invalid generated payload
+                  value:
+                    title: Unprocessable Content
+                    status: 422
+                    detail: 'Generated survey payload is invalid: generatedSurvey.blocks: Too small'
+                    code: ai_generated_payload_invalid
+                    requestId: req_123
+                    invalid_params:
+                      - name: generatedSurvey.blocks
+                        reason: Too small
+                aiOutputTooLong:
+                  summary: Output token limit reached
+                  value:
+                    title: Unprocessable Content
+                    status: 422
+                    detail: The generated survey exceeded the AI output token limit.
+                    code: ai_output_too_long
+                    requestId: req_123
         '429':
-          $ref: '#/components/responses/V3TooManyRequests'
+          description: Too Many Requests — 30 conversions per minute per user or key; documents additionally spend from the shared AI budget (10 per minute, shared with survey generation) and surface provider quota exhaustion here. `Retry-After` says when to try again.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds until the next request is allowed
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         '500':
           $ref: '#/components/responses/V3InternalServerError'
+        '502':
+          description: The configured AI provider failed while reading a document
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+              examples:
+                providerFailed:
+                  summary: AI provider failed
+                  value:
+                    title: Bad Gateway
+                    status: 502
+                    detail: The AI provider could not generate a valid survey draft. Try again or add more detail.
+                    code: bad_gateway
+                    requestId: req_123
+        '503':
+          description: AI is not configured on this Formbricks instance (documents only)
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+              examples:
+                instanceNotConfigured:
+                  summary: AI instance configuration missing
+                  value:
+                    title: AI Unavailable
+                    status: 503
+                    detail: AI is not configured for this Formbricks instance.
+                    code: ai_instance_not_configured
+                    requestId: req_123
       security:
         - sessionAuth: []
         - apiKeyAuth: []

--- a/docs/api-v3-reference/src/paths/api_v3_surveys_import_convert.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_surveys_import_convert.yml
@@ -81,7 +81,38 @@ post:
     "401":
       $ref: ../components/responses/V3Unauthorized.yml
     "403":
-      $ref: ../components/responses/V3Forbidden.yml
+      description: >-
+        Forbidden — no access to the workspace, or (documents only) AI smart tools are not available
+        to the organization. Formbricks exports and Qualtrics files never hit the AI gate.
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+          examples:
+            forbidden:
+              summary: No workspace access
+              value:
+                title: Forbidden
+                status: 403
+                detail: You are not authorized to access this resource
+                code: forbidden
+                requestId: req_123
+            aiDisabled:
+              summary: AI smart tools disabled
+              value:
+                title: AI Unavailable
+                status: 403
+                detail: AI smart tools are disabled for this organization.
+                code: ai_smart_tools_disabled
+                requestId: req_123
+            aiNotInPlan:
+              summary: AI features not enabled for the plan
+              value:
+                title: AI Unavailable
+                status: 403
+                detail: AI smart tools are not available for this organization.
+                code: ai_features_not_enabled
+                requestId: req_123
     "413":
       description: Payload Too Large — the request body exceeds 16 MB (15 MB file plus multipart framing).
       content:
@@ -99,15 +130,89 @@ post:
         Unprocessable Content — the uploaded file is not something Formbricks imports:
         `code: unsupported_source` for an unknown type, empty file or broken JSON,
         `code: legacy_office_format` for `.doc`/`.xls` (save as `.docx`/`.xlsx`). `invalid_params`
-        names the `file` part.
+        names the `file` part. For documents, `code: ai_generated_payload_invalid` when the model's
+        draft failed create validation and `code: ai_output_too_long` when it hit the output token limit.
       content:
         application/problem+json:
           schema:
             $ref: ../components/schemas/Problem.yml
+          examples:
+            unsupportedSource:
+              summary: Unsupported file
+              value:
+                title: Unprocessable Content
+                status: 422
+                detail: This file type is not supported.
+                code: unsupported_source
+                requestId: req_123
+                invalid_params:
+                  - name: file
+                    reason: This file type is not supported.
+            invalidGeneratedPayload:
+              summary: Invalid generated payload
+              value:
+                title: Unprocessable Content
+                status: 422
+                detail: "Generated survey payload is invalid: generatedSurvey.blocks: Too small"
+                code: ai_generated_payload_invalid
+                requestId: req_123
+                invalid_params:
+                  - name: generatedSurvey.blocks
+                    reason: Too small
+            aiOutputTooLong:
+              summary: Output token limit reached
+              value:
+                title: Unprocessable Content
+                status: 422
+                detail: The generated survey exceeded the AI output token limit.
+                code: ai_output_too_long
+                requestId: req_123
     "429":
-      $ref: ../components/responses/V3TooManyRequests.yml
+      description: >-
+        Too Many Requests — 30 conversions per minute per user or key; documents additionally spend
+        from the shared AI budget (10 per minute, shared with survey generation) and surface provider
+        quota exhaustion here. `Retry-After` says when to try again.
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Seconds until the next request is allowed
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
     "500":
       $ref: ../components/responses/V3InternalServerError.yml
+    "502":
+      description: The configured AI provider failed while reading a document
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+          examples:
+            providerFailed:
+              summary: AI provider failed
+              value:
+                title: Bad Gateway
+                status: 502
+                detail: The AI provider could not generate a valid survey draft. Try again or add more detail.
+                code: bad_gateway
+                requestId: req_123
+    "503":
+      description: AI is not configured on this Formbricks instance (documents only)
+      content:
+        application/problem+json:
+          schema:
+            $ref: ../components/schemas/Problem.yml
+          examples:
+            instanceNotConfigured:
+              summary: AI instance configuration missing
+              value:
+                title: AI Unavailable
+                status: 503
+                detail: AI is not configured for this Formbricks instance.
+                code: ai_instance_not_configured
+                requestId: req_123
   security:
     - sessionAuth: []
     - apiKeyAuth: []


### PR DESCRIPTION
Fixes ENG-3001

Stacked on #9207 (`jojo/eng-3000-chunking-for-long-documents-and-the-document-lane`). Survey Import & Export, milestone 4.

## What & why

**Was:** `POST /api/v3/surveys/import/convert` answered `lane_not_available` for DOCX, PDF, Markdown, TXT, CSV and XLSX.

**Now:** Those kinds run through the AI document lane with the same guards Create with AI has. The entitlement gate runs before the file is read, the request spends from the shared 10/min AI budget on top of the 30/min convert limit, and provider failures map to the same problem codes (403/503 unavailable, 422 `ai_output_too_long` / `ai_generated_payload_invalid`, 429 with `Retry-After`, 502).

- Formbricks exports and Qualtrics files never touch the gate or the AI budget.
- Adapter-level failures (unreadable, encrypted, nothing extracted) stay 200 with `document: null` and the reason in the report, like every other convert failure.
- PostHog `ai_survey_imported` for session users with source kind, chunk count, question and language counts, bytes and duration.

## Where to look

- [convert-import.ts](apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts) — the gate/budget block and the AI-only error mapping around the lane call.
- [api_v3_surveys_import_convert.yml](docs/api-v3-reference/src/paths/api_v3_surveys_import_convert.yml) — the documented 403/422/429/502/503 shapes.

## Breaking changes

- [ ] This PR contains a breaking change

Additive: a previously 400 `lane_not_available` path now succeeds; documented responses only gain cases.

## Migrations & env

None. The AI lane needs the instance's existing AI configuration; without it documents answer 503 `ai_instance_not_configured`.

## Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| Org without AI → 403 before the lane runs; QSF ignores the gate | unit (guard) | `convert-import.test.ts` "AI lane" |
| Entitled org → 200, `source.lane === "ai"`, shared budget applied, PostHog event | unit (guard) | `convert-import.test.ts` |
| Token limit → 422; budget exhausted → 429 + `Retry-After`; provider failure → 502 | unit (guard) | `convert-import.test.ts` |
| OpenAPI bundle valid | manual | `pnpm api:v3:bundle && pnpm api:v3:lint` |

Rerun: `cd apps/web && npx vitest run app/api/v3/surveys/import`

## Open gaps

- Contract tests (Schemathesis) not run locally; the documented 403/503 need an instance without AI to be exercised.
- The `ai_survey_imported` event is not yet in the analytics event catalog, if one exists outside the code.

## Risks

- The AI budget is checked before the lane runs, so an upload that then fails in extraction still spends one slot.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>
