### PR TITLE
feat(surveys): normalize imported hidden field and variable names for Embedded Data [ENG-3013]

### DIFF
--- a/apps/web/modules/survey/import/lanes/qsf/embedded-data.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/embedded-data.ts
@@ -1,38 +1,6 @@
-import { FORBIDDEN_IDS } from "@formbricks/types/surveys/validation";
-
-const FORBIDDEN_LOWER = new Set(FORBIDDEN_IDS.map((id) => id.toLowerCase()));
-const REFUSED_SUFFIX = "_imported";
-
-export type TEmbeddedDataFieldMapping = {
-  source: string;
-  fieldId: string;
-  /** The name was reserved and had to be suffixed. */
-  refused: boolean;
-  /** The name changed in a way other than the reserved-name suffix. */
-  renamed: boolean;
-};
-
-/**
- * Qualtrics embedded-data field → Formbricks hidden field id. One function so the Embedded Data project
- * can repoint it (§8): ids must match `^[a-z][a-z0-9_]*$`, reserved names get a suffix instead of being
- * lost.
- *
- * TODO(embedded-data): when the Embedded Data manager lands, map QSF embedded data onto `ingested`
- * fields and Formbricks variables onto `computed` fields here instead of hidden fields.
- */
-export function mapEmbeddedDataFieldName(source: string): TEmbeddedDataFieldMapping {
-  let fieldId = source
-    .trim()
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9_]+/g, "_")
-    .replaceAll(/_{2,}/g, "_")
-    .replaceAll(/^_+|_+$/g, "");
-
-  if (fieldId.length === 0) fieldId = "field";
-  if (/^\d/.test(fieldId)) fieldId = `f_${fieldId}`;
-
-  const refused = FORBIDDEN_LOWER.has(fieldId);
-  if (refused) fieldId = `${fieldId}${REFUSED_SUFFIX}`;
-
-  return { source, fieldId, refused, renamed: !refused && fieldId !== source };
-}
+// The naming rule lives in the resolver so every lane shares it (ENG-3013); the QSF mapper only needs
+// the function under its historical name.
+export {
+  type TFieldNameMapping as TEmbeddedDataFieldMapping,
+  normalizeFieldName as mapEmbeddedDataFieldName,
+} from "../../resolve/embedded-data";

--- a/apps/web/modules/survey/import/resolve/embedded-data.test.ts
+++ b/apps/web/modules/survey/import/resolve/embedded-data.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { prepareV3SurveyCreateInput } from "@/app/api/v3/surveys/prepare";
+import { normalizeFieldName, normalizeImportedFieldNames } from "./embedded-data";
+
+const workspaceId = "clxx1234567890123456789012";
+
+const document = () => ({
+  name: "Fields",
+  type: "link",
+  status: "draft",
+  defaultLanguage: "en-US",
+  languages: [{ code: "en-US", default: true, enabled: true }],
+  welcomeCard: { enabled: false },
+  hiddenFields: { enabled: true, fieldIds: ["Customer-ID", "plan", "userId", "2nd_touch"] },
+  variables: [
+    { id: "clvar12345678901234567890", name: "Score Total", type: "number", value: 0 },
+    { id: "clvar12345678901234567891", name: "plan", type: "text", value: "" },
+  ],
+  blocks: [
+    {
+      id: "b1",
+      name: "Block",
+      elements: [
+        {
+          id: "q1",
+          type: "openText",
+          headline: { "en-US": "Hello #recall:Customer-ID/fallback:there#, how is #recall:plan/fallback:#?" },
+          required: false,
+        },
+        { id: "q2", type: "openText", headline: { "en-US": "Second" }, required: false },
+      ],
+      logic: [
+        {
+          id: "l1",
+          conditions: {
+            id: "c1",
+            connector: "and",
+            conditions: [
+              {
+                id: "cc1",
+                leftOperand: { type: "hiddenField", value: "Customer-ID" },
+                operator: "equals",
+                rightOperand: { type: "static", value: "42" },
+              },
+            ],
+          },
+          actions: [{ id: "a1", objective: "jumpToBlock", target: "b2" }],
+        },
+      ],
+    },
+    {
+      id: "b2",
+      name: "Block 2",
+      elements: [{ id: "q3", type: "openText", headline: { "en-US": "Third" }, required: false }],
+    },
+  ],
+  endings: [{ id: "e1", type: "endScreen", headline: { "en-US": "Bye #recall:userId/fallback:#" } }],
+});
+
+describe("normalizeFieldName", () => {
+  test.each([
+    ["plan", "plan", false, false],
+    ["Customer-ID", "customer_id", false, true],
+    ["2nd touch", "f_2nd_touch", false, true],
+    ["userId", "userid_imported", true, false],
+    ["  ", "field", false, true],
+  ])("%s → %s", (source, fieldId, refused, renamed) => {
+    expect(normalizeFieldName(source)).toEqual({ source, fieldId, refused, renamed });
+  });
+});
+
+describe("normalizeImportedFieldNames", () => {
+  test("renames hidden fields and variables, rewrites logic operands and recall strings, reports each change", () => {
+    const doc = document();
+    const issues = normalizeImportedFieldNames(doc);
+
+    expect(doc.hiddenFields.fieldIds).toEqual(["customer_id", "plan", "userid_imported", "f_2nd_touch"]);
+    // A variable that collides with a hidden field name after normalization gets a suffix.
+    expect(doc.variables.map((variable) => variable.name)).toEqual(["score_total", "plan_2"]);
+    expect(doc.blocks[0].logic?.[0].conditions.conditions[0].leftOperand).toEqual({
+      type: "hiddenField",
+      value: "customer_id",
+    });
+    expect(doc.blocks[0].elements[0].headline["en-US"]).toBe(
+      "Hello #recall:customer_id/fallback:there#, how is #recall:plan/fallback:#?"
+    );
+    expect(doc.endings[0].headline["en-US"]).toBe("Bye #recall:userid_imported/fallback:#");
+    expect(issues.map((issue) => [issue.code, issue.vars])).toEqual([
+      ["field_renamed", { from: "Customer-ID", to: "customer_id" }],
+      ["embedded_data_name_refused", { name: "userId", renamed: "userid_imported" }],
+      ["field_renamed", { from: "2nd_touch", to: "f_2nd_touch" }],
+      ["field_renamed", { from: "Score Total", to: "score_total" }],
+      ["field_renamed", { from: "plan", to: "plan_2" }],
+    ]);
+    expect(issues.every((issue) => issue.severity === "warning")).toBe(true);
+
+    const preparation = prepareV3SurveyCreateInput({ workspaceId, ...doc });
+    expect(preparation.ok, JSON.stringify(!preparation.ok && preparation.validation)).toBe(true);
+  });
+
+  test("is idempotent and leaves conforming names alone", () => {
+    const doc = document();
+    normalizeImportedFieldNames(doc);
+    const snapshot = JSON.stringify(doc);
+
+    expect(normalizeImportedFieldNames(doc)).toEqual([]);
+    expect(JSON.stringify(doc)).toBe(snapshot);
+    expect(normalizeImportedFieldNames({ name: "No fields" })).toEqual([]);
+  });
+});

--- a/apps/web/modules/survey/import/resolve/embedded-data.ts
+++ b/apps/web/modules/survey/import/resolve/embedded-data.ts
@@ -1,0 +1,158 @@
+import { FORBIDDEN_IDS } from "@formbricks/types/surveys/validation";
+import { importWarning } from "../report";
+import type { TImportIssue } from "../types";
+import { isRecord } from "./paths";
+
+/**
+ * Hidden field ids and variable names on import, aligned with the Embedded Data project (§8): names
+ * must match `^[a-z][a-z0-9_]*$`, reserved names get a suffix instead of a 400 from the create call,
+ * and every reference — logic operands, recall strings — follows the rename. One function for every
+ * lane; the QSF mapper calls the same `normalizeFieldName`.
+ *
+ * TODO(embedded-data): when the Embedded Data manager lands, map QSF embedded data onto `ingested`
+ * fields and Formbricks variables onto `computed` fields here instead of hidden fields and variables.
+ */
+
+const FORBIDDEN_LOWER = new Set(FORBIDDEN_IDS.map((id) => id.toLowerCase()));
+const REFUSED_SUFFIX = "_imported";
+export const FIELD_NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+export type TFieldNameMapping = {
+  source: string;
+  fieldId: string;
+  /** The name was reserved and had to be suffixed. */
+  refused: boolean;
+  /** The name changed in a way other than the reserved-name suffix. */
+  renamed: boolean;
+};
+
+export function normalizeFieldName(source: string): TFieldNameMapping {
+  let fieldId = source
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9_]+/g, "_")
+    .replaceAll(/_{2,}/g, "_")
+    .replaceAll(/^_+|_+$/g, "");
+
+  if (fieldId.length === 0) fieldId = "field";
+  if (/^\d/.test(fieldId)) fieldId = `f_${fieldId}`;
+
+  const refused = FORBIDDEN_LOWER.has(fieldId);
+  if (refused) fieldId = `${fieldId}${REFUSED_SUFFIX}`;
+
+  return { source, fieldId, refused, renamed: !refused && fieldId !== source };
+}
+
+/** Normalizes a list of names, keeping them distinct: a collision after normalization gets `_2`, `_3`, … */
+function buildRenameMap(names: readonly string[], taken: Set<string>): Map<string, TFieldNameMapping> {
+  const map = new Map<string, TFieldNameMapping>();
+  for (const name of names) {
+    if (map.has(name)) continue;
+    const mapping = normalizeFieldName(name);
+    let candidate = mapping.fieldId;
+    let suffix = 2;
+    while (taken.has(candidate)) {
+      candidate = `${mapping.fieldId}_${suffix}`;
+      suffix += 1;
+    }
+    taken.add(candidate);
+    map.set(name, {
+      ...mapping,
+      fieldId: candidate,
+      renamed: mapping.renamed || candidate !== mapping.fieldId,
+    });
+  }
+  return map;
+}
+
+const RECALL_PATTERN = /#recall:([^/#]+)\/fallback:/g;
+
+/** Rewrites `#recall:<id>/fallback:` occurrences and `{ type: "hiddenField", value }` operands through the map. */
+function rewriteReferences(value: unknown, renames: ReadonlyMap<string, string>): unknown {
+  if (typeof value === "string") {
+    return value.includes("#recall:")
+      ? value.replace(RECALL_PATTERN, (match, id: string) =>
+          renames.has(id) ? `#recall:${renames.get(id)}/fallback:` : match
+        )
+      : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => rewriteReferences(entry, renames));
+  }
+  if (isRecord(value)) {
+    if (value.type === "hiddenField" && typeof value.value === "string" && renames.has(value.value)) {
+      return { ...value, value: renames.get(value.value) };
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) out[key] = rewriteReferences(nested, renames);
+    return out;
+  }
+  return value;
+}
+
+function reportMapping(mapping: TFieldNameMapping, path: string, issues: TImportIssue[]): void {
+  if (mapping.refused) {
+    issues.push(
+      importWarning({
+        code: "embedded_data_name_refused",
+        path,
+        vars: { name: mapping.source, renamed: mapping.fieldId },
+      })
+    );
+  } else if (mapping.renamed) {
+    issues.push(
+      importWarning({ code: "field_renamed", path, vars: { from: mapping.source, to: mapping.fieldId } })
+    );
+  }
+}
+
+/**
+ * Mutates `document` in place: hidden field ids and variable names normalized, references rewritten.
+ * Idempotent — a document whose names already follow the rules comes back untouched with no issues.
+ */
+export function normalizeImportedFieldNames(document: Record<string, unknown>): TImportIssue[] {
+  const issues: TImportIssue[] = [];
+  const taken = new Set<string>();
+
+  const hiddenFields = isRecord(document.hiddenFields) ? document.hiddenFields : null;
+  const fieldIds = hiddenFields && Array.isArray(hiddenFields.fieldIds) ? hiddenFields.fieldIds : [];
+  const hiddenRenames = buildRenameMap(
+    fieldIds.filter((id): id is string => typeof id === "string"),
+    taken
+  );
+  const changedHidden = new Map<string, string>();
+  for (const [source, mapping] of hiddenRenames) {
+    if (mapping.fieldId !== source) changedHidden.set(source, mapping.fieldId);
+    reportMapping(mapping, "hiddenFields.fieldIds", issues);
+  }
+  if (hiddenFields && changedHidden.size > 0) {
+    hiddenFields.fieldIds = [
+      ...new Set(
+        fieldIds.map((id) => (typeof id === "string" ? (hiddenRenames.get(id)?.fieldId ?? id) : id))
+      ),
+    ];
+  }
+
+  const variables = Array.isArray(document.variables) ? document.variables : [];
+  const variableNames = variables
+    .filter(isRecord)
+    .map((variable) => variable.name)
+    .filter((name): name is string => typeof name === "string");
+  const variableRenames = buildRenameMap(variableNames, taken);
+  variables.forEach((variable, index) => {
+    if (!isRecord(variable) || typeof variable.name !== "string") return;
+    const mapping = variableRenames.get(variable.name);
+    if (!mapping) return;
+    reportMapping(mapping, `variables.${index}.name`, issues);
+    variable.name = mapping.fieldId;
+  });
+
+  if (changedHidden.size > 0) {
+    // Variables are referenced by id and need no rewrite; hidden fields are referenced by their id-name.
+    for (const key of ["blocks", "endings", "welcomeCard", "metadata"] as const) {
+      if (key in document) document[key] = rewriteReferences(document[key], changedHidden);
+    }
+  }
+
+  return issues;
+}

--- a/apps/web/modules/survey/import/resolve/index.ts
+++ b/apps/web/modules/survey/import/resolve/index.ts
@@ -12,6 +12,7 @@ import type { TImportCandidate, TImportIssue, TImportReport } from "../types";
 import type { TActionClassResolutionDeps } from "./action-classes";
 import { resolveImportActionClasses } from "./action-classes";
 import { applyDocumentHygiene } from "./document";
+import { normalizeImportedFieldNames } from "./embedded-data";
 import { hasImportExternalUrls, stripImportExternalUrls } from "./entitlements";
 import { resolveImportLanguages } from "./languages";
 import { resolveImportMedia } from "./media";
@@ -67,8 +68,8 @@ function invalidParamToIssue(param: InvalidParam): TImportIssue {
 /**
  * Turn a lane's candidate into a document the target workspace can hold, and say what changed.
  *
- * Steps run in a fixed order — hygiene, languages, action classes, targeting, external URLs, media,
- * validation — and each one only appends to the issue list. Resolving an already-resolved document
+ * Steps run in a fixed order — hygiene, field names, languages, action classes, targeting, external URLs,
+ * media, validation — and each one only appends to the issue list. Resolving an already-resolved document
  * adds no issues: ids that exist are kept, nothing left to strip, nothing left to warn about.
  */
 export async function resolveImportCandidate(
@@ -99,6 +100,8 @@ export async function resolveImportCandidate(
     report.summary = summarizeDocument(document);
     return { document: null, createBody: null, report, validation: { valid: false, invalid_params: [] } };
   }
+
+  report.issues.push(...normalizeImportedFieldNames(document));
 
   const languages = resolveImportLanguages(document, await deps.listWorkspaceLanguageCodes(ctx.workspaceId));
   report.issues.push(...languages.issues);


### PR DESCRIPTION
Fixes ENG-3013

Stacked on #9210 (`jojo/eng-3003-dialog-wiring-for-the-ai-lane-progress-ladder-language`). Survey Import & Export, milestone 6.

## What & why

**Was:** Only the Qualtrics lane normalized hidden-field names; a Formbricks export or a document draft carrying `Customer-ID` or a reserved name like `userId` reached the create call unchanged and could fail with a raw 400.

**Now:** The resolver normalizes hidden field ids and variable names for every lane to `^[a-z][a-z0-9_]*$`, suffixes reserved names with `_imported`, keeps names distinct after normalization, and rewrites every reference (logic operands, `#recall:` strings) through the same rename map. Each change is a `field_renamed` or `embedded_data_name_refused` warning in the report.

- One function, `normalizeImportedFieldNames`, in `resolve/embedded-data.ts`; the QSF mapper now calls the shared `normalizeFieldName` instead of its own copy.
- Idempotent: a document whose names already conform comes back untouched.
- The single `TODO(embedded-data)` comment records the later mapping (QSF embedded data → `ingested`, variables → `computed`).

## Where to look

- [embedded-data.ts](apps/web/modules/survey/import/resolve/embedded-data.ts) — rename map, collision suffixing, reference rewrite.
- [resolve/index.ts](apps/web/modules/survey/import/resolve/index.ts) — the step now runs right after hygiene.

## Breaking changes

- [ ] This PR contains a breaking change

Import-time normalization only; export keeps `hiddenFields` and `variables` exactly as the document carries them.

## Migrations & env

None.

## Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| Hidden fields, variables renamed; logic operand and recall strings rewritten; reserved name suffixed; collision → `_2`; result passes `prepareV3SurveyCreateInput` | unit (guard) | `resolve/embedded-data.test.ts` |
| Idempotent; documents without fields untouched | unit (guard) | `resolve/embedded-data.test.ts` |
| QSF embedded data still mapped the same way | unit (guard) | existing `lanes/qsf/*.test.ts` goldens unchanged |

Rerun: `cd apps/web && npx vitest run modules/survey/import`

## Open gaps

- Review by the Embedded Data lead (Anshuman) is part of the ticket's acceptance and still open.
- Round-trip fidelity: a Formbricks export with mixed-case hidden field ids is renamed on import (by design per the ticket); worth a line in the docs ticket.

## Risks

- Renaming a hidden field changes the query parameter a link survey expects (`?customer_id=` instead of `?Customer-ID=`). The warning says so; the docs should too.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>
