### PR TITLE
feat(surveys): import rate limits, concurrency guard, one limits module and logging hygiene [ENG-3009]

### DIFF
--- a/apps/web/app/api/internal/surveys/import/lib/operations.test.ts
+++ b/apps/web/app/api/internal/surveys/import/lib/operations.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { OperationNotAllowedError, TooManyRequestsError } from "@formbricks/types/errors";
 import { ZV3SurveyImportConvertBody } from "@/app/api/v3/surveys/import/convert/schemas";
+import { ImportInProgressError } from "@/modules/survey/import/lib/ai-inflight-guard";
 import type { TImportContext, TImportLaneHandler } from "@/modules/survey/import/types";
 import { streamImportConversion } from "./operations";
 
@@ -13,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   getImportLaneHandler: vi.fn(),
   resolveImportCandidate: vi.fn(),
   capturePostHogEvent: vi.fn(),
+  acquireAiImportSlot: vi.fn(),
+  releaseAiImportSlot: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -30,6 +33,10 @@ vi.mock("@/lib/ai/service", async (importOriginal) => ({
   assertOrganizationAIConfigured: mocks.assertOrganizationAIConfigured,
 }));
 vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: mocks.applyRateLimit }));
+vi.mock("@/modules/survey/import/lib/ai-inflight-guard", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/survey/import/lib/ai-inflight-guard")>()),
+  acquireAiImportSlot: mocks.acquireAiImportSlot,
+}));
 vi.mock("@/modules/survey/import/lanes", () => ({ getImportLaneHandler: mocks.getImportLaneHandler }));
 vi.mock("@/modules/survey/import/resolve", () => ({ resolveImportCandidate: mocks.resolveImportCandidate }));
 vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: mocks.capturePostHogEvent }));
@@ -76,6 +83,7 @@ describe("streamImportConversion", () => {
     mocks.assertOrganizationAIConfigured.mockResolvedValue({});
     mocks.applyRateLimit.mockResolvedValue({});
     mocks.resolveImportCandidate.mockResolvedValue(resolved);
+    mocks.acquireAiImportSlot.mockResolvedValue(mocks.releaseAiImportSlot);
   });
 
   test("a deterministic lane emits start, reading, validating and done — no partials", async () => {
@@ -184,6 +192,24 @@ describe("streamImportConversion", () => {
 
     expect(response.status).toBe(429);
     expect(response.headers.get("Retry-After")).toBe("17");
+  });
+
+  test("a third concurrent AI conversion is a 409 before the stream; the slot is released after the stream", async () => {
+    mocks.acquireAiImportSlot.mockRejectedValueOnce(new ImportInProgressError());
+    mocks.getImportLaneHandler.mockReturnValue(vi.fn());
+    const refused = await call(body("survey.md", readFileSync(join(FIXTURES, "survey.md"))));
+    expect(refused.status).toBe(409);
+    expect(refused.headers.get("Retry-After")).toBe("30");
+
+    mocks.getImportLaneHandler.mockReturnValue(
+      vi.fn(async (input) => ({
+        document: { name: "Doc" },
+        issues: [],
+        source: { lane: "ai" as const, kind: input.kind },
+      }))
+    );
+    await readEvents(await call(body("survey.md", readFileSync(join(FIXTURES, "survey.md")))));
+    expect(mocks.releaseAiImportSlot).toHaveBeenCalledTimes(1);
   });
 
   test("an unsupported file is a 422 problem, a kind without a lane a 400", async () => {

--- a/apps/web/app/api/internal/surveys/import/lib/operations.ts
+++ b/apps/web/app/api/internal/surveys/import/lib/operations.ts
@@ -10,10 +10,15 @@ import {
   problemForImportDetectionFailure,
 } from "@/app/api/v3/surveys/import/convert/lib/convert-import";
 import type { TV3SurveyImportConvertBody } from "@/app/api/v3/surveys/import/convert/schemas";
+import {
+  guardImportWorkspaceBudget,
+  problemImportInProgress,
+} from "@/app/api/v3/surveys/import/lib/import-guards";
 import { getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { detectImportSource } from "@/modules/survey/import/detect";
 import { getImportLaneHandler } from "@/modules/survey/import/lanes";
+import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
 import { resolveImportCandidate } from "@/modules/survey/import/resolve";
 import {
   IMPORT_LANE_BY_KIND,
@@ -71,7 +76,10 @@ export async function streamImportConversion({
   const userId = getSessionUserId(authentication);
   const importRunId = createId();
   const file = body.files[0];
-  const log = logger.withContext({ requestId, importRunId, workspaceId, organizationId });
+  const budget = await guardImportWorkspaceBudget(workspaceId, requestId);
+  if (budget) {
+    return budget;
+  }
 
   const detection = detectImportSource({
     fileName: file.fileName,
@@ -81,6 +89,14 @@ export async function streamImportConversion({
   if (!detection.ok) {
     return problemForImportDetectionFailure(requestId, instance, detection.code);
   }
+  const log = logger.withContext({
+    requestId,
+    importRunId,
+    workspaceId,
+    organizationId,
+    sourceKind: detection.kind,
+    lane: IMPORT_LANE_BY_KIND[detection.kind],
+  });
 
   const lane = getImportLaneHandler(detection.kind);
   if (!lane) {
@@ -92,10 +108,15 @@ export async function streamImportConversion({
   }
 
   const isAiLane = IMPORT_LANE_BY_KIND[detection.kind] === "ai";
+  let releaseSlot: () => Promise<void> = async () => undefined;
   if (isAiLane) {
     try {
       await assertAiImportAllowed(organizationId, authentication);
+      releaseSlot = await acquireAiImportSlot(userId ?? workspaceId);
     } catch (error) {
+      if (error instanceof ImportInProgressError) {
+        return problemImportInProgress(requestId, error, instance);
+      }
       return mapV3SurveyGenerateError(error, { requestId, instance, workspaceId, organizationId });
     }
   }
@@ -194,11 +215,12 @@ export async function streamImportConversion({
         if (isClientAbort(error, abortController.signal)) {
           log.info("Survey import stream aborted by the client");
         } else {
-          log.error({ err: error, sourceKind: detection.kind }, "Survey import stream failed");
+          log.error({ err: error }, "Survey import stream failed");
           emit({ ...toStreamErrorEvent(error), reference: importRunId });
         }
       } finally {
         detach();
+        await releaseSlot();
         if (!closed) {
           closed = true;
           controller.close();
@@ -208,6 +230,7 @@ export async function streamImportConversion({
     cancel() {
       closed = true;
       abortController.abort();
+      void releaseSlot();
       log.info("Survey import stream cancelled by the client");
     },
   });

--- a/apps/web/app/api/v3/lib/response.ts
+++ b/apps/web/app/api/v3/lib/response.ts
@@ -194,6 +194,19 @@ export function problemConflict(requestId: string, detail: string, instance?: st
   });
 }
 
+/** A 409 whose cause clears by itself (a concurrent run finishing): carries `Retry-After` and a specific code. */
+export function problemConflictWithRetry(
+  requestId: string,
+  detail: string,
+  options: { instance?: string; code: string; retryAfter: number }
+): Response {
+  return problemResponse(409, "Conflict", detail, requestId, {
+    code: options.code,
+    instance: options.instance,
+    headers: { "Retry-After": String(options.retryAfter) },
+  });
+}
+
 export function problemBadGateway(requestId: string, detail: string, instance?: string): Response {
   return problemResponse(502, "Bad Gateway", detail, requestId, {
     code: "bad_gateway",

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@/modules/survey/export/__fixtures__/surveys";
 import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
 import { documentLane } from "@/modules/survey/import/lanes/document";
+import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
 import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
 import { ZV3SurveyImportConvertBody } from "../schemas";
 import { convertImportFile } from "./convert-import";
@@ -43,6 +44,10 @@ vi.mock("@/lib/ai/service", async (importOriginal) => ({
 }));
 vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn() }));
 vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: vi.fn() }));
+vi.mock("@/modules/survey/import/lib/ai-inflight-guard", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/survey/import/lib/ai-inflight-guard")>()),
+  acquireAiImportSlot: vi.fn(async () => async () => undefined),
+}));
 vi.mock("@/lib/constants", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/constants")>()),
   WEBAPP_URL: "https://app.formbricks.com",
@@ -248,7 +253,35 @@ describe("convertImportFile", () => {
       expect(response.status).toBe(403);
       expect((await response.json()).code).toBe("ai_features_not_enabled");
       expect(documentLane).not.toHaveBeenCalled();
-      expect(applyRateLimit).not.toHaveBeenCalled();
+      expect(applyRateLimit).not.toHaveBeenCalledWith(
+        expect.objectContaining({ namespace: "api:v3:surveys:generate" }),
+        expect.anything()
+      );
+    });
+
+    test("a third concurrent AI conversion answers 409 import_in_progress with Retry-After", async () => {
+      vi.mocked(acquireAiImportSlot).mockRejectedValueOnce(new ImportInProgressError());
+
+      const response = await convertImportFile({ body: docx(), authentication, requestId, instance });
+
+      expect(response.status).toBe(409);
+      expect((await response.json()).code).toBe("import_in_progress");
+      expect(response.headers.get("Retry-After")).toBe("30");
+      expect(documentLane).not.toHaveBeenCalled();
+    });
+
+    test("the workspace import budget answers 429 before anything else", async () => {
+      vi.mocked(applyRateLimit).mockImplementation(async (config) => {
+        if (config.namespace === "api:v3:surveys:import:workspace")
+          throw new TooManyRequestsError("budget", 900);
+        return {} as never;
+      });
+
+      const response = await convertImportFile({ body: docx(), authentication, requestId, instance });
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get("Retry-After")).toBe("900");
+      expect(assertOrganizationAIConfigured).not.toHaveBeenCalled();
     });
 
     test("an entitled organization gets the AI lane's document, source and a PostHog event", async () => {
@@ -322,7 +355,11 @@ describe("convertImportFile", () => {
 
       expect(response.status).toBe(200);
       expect(assertOrganizationAIConfigured).not.toHaveBeenCalled();
-      expect(applyRateLimit).not.toHaveBeenCalled();
+      expect(applyRateLimit).toHaveBeenCalledTimes(1);
+      expect(applyRateLimit).toHaveBeenCalledWith(
+        expect.objectContaining({ namespace: "api:v3:surveys:import:workspace" }),
+        FIXTURE_WORKSPACE_ID
+      );
     });
   });
 
@@ -338,6 +375,57 @@ describe("convertImportFile", () => {
 
     expect(response.status).toBe(403);
     expect(prisma.language.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("convertImportFile logging", () => {
+  test("no log line carries file names, bytes or document text", async () => {
+    vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(authResult);
+    vi.mocked(prisma.language.findMany).mockResolvedValue([] as never);
+    vi.mocked(getActionClasses).mockResolvedValue([]);
+    vi.mocked(getExternalUrlsPermission).mockResolvedValue(true);
+    vi.mocked(applyRateLimit).mockResolvedValue({} as never);
+    vi.mocked(assertOrganizationAIConfigured).mockResolvedValue({} as never);
+    const { logger } = await import("@formbricks/logger");
+    const contextLogger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    vi.mocked(logger.withContext).mockReturnValue(contextLogger as never);
+
+    await convertImportFile({
+      body: body("in-app.formbricks.json", envelopeBytes(FIXTURE_APP_SURVEY), "application/json"),
+      authentication,
+      requestId,
+      instance,
+    });
+    await convertImportFile({
+      body: body("broken.json", Buffer.from("{ nope")),
+      authentication,
+      requestId,
+      instance,
+    });
+    vi.mocked(documentLane).mockRejectedValueOnce(new Error("provider down"));
+    await convertImportFile({
+      body: body(
+        "questions.docx",
+        readFileSync(
+          join(process.cwd(), "modules/survey/import/lanes/document/__fixtures__/survey-numbered-lists.docx")
+        )
+      ),
+      authentication,
+      requestId,
+      instance,
+    });
+
+    const forbidden = new Set(["text", "bytes", "fileName", "document", "prompt", "content"]);
+    const logged = [
+      ...vi.mocked(logger.withContext).mock.calls.map((call) => call[0]),
+      ...[contextLogger.warn, contextLogger.error, contextLogger.info].flatMap((fn) =>
+        fn.mock.calls.map((call) => call[0])
+      ),
+    ].filter((arg) => typeof arg === "object" && arg !== null) as Record<string, unknown>[];
+    expect(logged.length).toBeGreaterThan(3);
+    for (const entry of logged) {
+      for (const key of Object.keys(entry)) expect(forbidden.has(key), `log key ${key}`).toBe(false);
+    }
   });
 });
 

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
@@ -12,6 +12,10 @@ import {
 } from "@/app/api/v3/lib/response";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
 import { mapV3SurveyGenerateError } from "@/app/api/v3/surveys/generate/error-mapping";
+import {
+  guardImportWorkspaceBudget,
+  problemImportInProgress,
+} from "@/app/api/v3/surveys/import/lib/import-guards";
 import { getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
 import { assertOrganizationAIConfigured } from "@/lib/ai/service";
 import { capturePostHogEvent } from "@/lib/posthog";
@@ -19,6 +23,7 @@ import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { type TImportDetectionFailureCode, detectImportSource } from "@/modules/survey/import/detect";
 import { getImportLaneHandler } from "@/modules/survey/import/lanes";
+import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
 import { resolveImportCandidate } from "@/modules/survey/import/resolve";
 import { IMPORT_LANE_BY_KIND, type TImportContext } from "@/modules/survey/import/types";
 import type { TV3SurveyImportConvertBody } from "../schemas";
@@ -105,6 +110,12 @@ export async function convertImportFile({
       return authResult;
     }
 
+    const budget = await guardImportWorkspaceBudget(authResult.workspaceId, requestId);
+    if (budget) {
+      log.warn({ statusCode: 429 }, "Workspace import budget exhausted");
+      return budget;
+    }
+
     const detection = detectImportSource({
       fileName: file.fileName,
       mimeType: file.mimeType,
@@ -143,9 +154,13 @@ export async function convertImportFile({
     const startedAt = Date.now();
 
     let candidate;
+    let releaseSlot: (() => Promise<void>) | null = null;
     try {
       if (isAiLane) {
         await assertAiImportAllowed(authResult.organizationId, authentication);
+        releaseSlot = await acquireAiImportSlot(
+          getRateLimitIdentifier(authentication) ?? authResult.workspaceId
+        );
       }
 
       candidate = await lane(
@@ -154,8 +169,20 @@ export async function convertImportFile({
       );
     } catch (error) {
       if (!isAiLane) throw error;
-      log.warn({ error, sourceKind: detection.kind }, "AI import lane failed");
+      if (error instanceof ImportInProgressError) {
+        log.warn(
+          { statusCode: 409, sourceKind: detection.kind, lane: "ai" },
+          "AI import already in progress"
+        );
+        return problemImportInProgress(requestId, error, instance);
+      }
+      log.warn(
+        { err: error, statusCode: 502, sourceKind: detection.kind, lane: "ai" },
+        "AI import lane failed"
+      );
       return mapV3SurveyGenerateError(error, aiErrorContext);
+    } finally {
+      await releaseSlot?.();
     }
 
     const resolved = await resolveImportCandidate(candidate, {

--- a/apps/web/app/api/v3/surveys/import/lib/import-guards.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-guards.ts
@@ -1,0 +1,56 @@
+import "server-only";
+import { TooManyRequestsError } from "@formbricks/types/errors";
+import type { InvalidParam } from "@/app/api/v3/lib/response";
+import { problemConflictWithRetry, problemTooManyRequests } from "@/app/api/v3/lib/response";
+import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import { ImportInProgressError } from "@/modules/survey/import/lib/ai-inflight-guard";
+
+/**
+ * The per-workspace import budget (200/hour across convert, stream and import). Returns the 429 to
+ * send, or null when the request may proceed.
+ */
+export async function guardImportWorkspaceBudget(
+  workspaceId: string,
+  requestId: string
+): Promise<Response | null> {
+  try {
+    await applyRateLimit(rateLimitConfigs.api.v3SurveyImportPerWorkspace, workspaceId);
+    return null;
+  } catch (error) {
+    if (error instanceof TooManyRequestsError) {
+      return problemTooManyRequests(
+        requestId,
+        "This workspace has reached its hourly import limit. Try again later.",
+        error.retryAfter
+      );
+    }
+    throw error;
+  }
+}
+
+/** The 409 for a third concurrent AI conversion. */
+export function problemImportInProgress(
+  requestId: string,
+  error: ImportInProgressError,
+  instance: string
+): Response {
+  return problemConflictWithRetry(requestId, error.message, {
+    instance,
+    code: "import_in_progress",
+    retryAfter: error.retryAfter,
+  });
+}
+
+const MAX_LOGGED_REASON_CHARS = 80;
+
+/** Log-safe copy of `invalid_params`: reasons can echo document text, so they are cut at 80 chars. */
+export function redactInvalidParams(params: readonly InvalidParam[]): InvalidParam[] {
+  return params.map((param) => ({
+    ...param,
+    reason:
+      param.reason.length > MAX_LOGGED_REASON_CHARS
+        ? `${param.reason.slice(0, MAX_LOGGED_REASON_CHARS)}…`
+        : param.reason,
+  }));
+}

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
@@ -15,6 +15,7 @@ import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
 import { ZV3SurveyImportBody } from "../schemas";
 import { importV3Survey } from "./import-survey";
 
+vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: vi.fn(async () => ({})) }));
 vi.mock("server-only", () => ({}));
 
 vi.mock("@formbricks/logger", () => ({

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
@@ -18,6 +18,7 @@ import { countIssues } from "@/modules/survey/import/report";
 import { type TResolveImportResult, resolveImportCandidate } from "@/modules/survey/import/resolve";
 import type { TImportCandidate, TImportReport } from "@/modules/survey/import/types";
 import type { TV3SurveyImportBody } from "../schemas";
+import { guardImportWorkspaceBudget } from "./import-guards";
 
 type TImportV3SurveyParams = {
   req: Request;
@@ -107,6 +108,12 @@ export async function importV3Survey({
     );
     if (authResult instanceof Response) {
       return authResult;
+    }
+
+    const budget = await guardImportWorkspaceBudget(authResult.workspaceId, requestId);
+    if (budget) {
+      log.warn({ statusCode: 429 }, "Workspace import budget exhausted");
+      return budget;
     }
 
     const resolved = await runLosslessImport(body, {

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
@@ -95,6 +95,7 @@ describe("rateLimitConfigs", () => {
         "mcpAuth",
         "v3SurveyGenerate",
         "v3SurveyImportConvert",
+        "v3SurveyImportPerWorkspace",
         "internalDatasetPurge",
         "client",
         "clientEnvironment",

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.ts
@@ -26,6 +26,11 @@ export const rateLimitConfigs = {
       allowedPerInterval: 30,
       namespace: "api:v3:surveys:import:convert",
     }, // 30 per minute per user or key — deterministic file conversions; the AI lane additionally spends from v3SurveyGenerate
+    v3SurveyImportPerWorkspace: {
+      interval: 3600,
+      allowedPerInterval: 200,
+      namespace: "api:v3:surveys:import:workspace",
+    }, // 200 per hour per workspace across convert, stream and import — one workspace cannot soak the instance's import capacity
     internalDatasetPurge: {
       interval: 3600,
       allowedPerInterval: 5,

--- a/apps/web/modules/survey/import/lanes/document/chunk.ts
+++ b/apps/web/modules/survey/import/lanes/document/chunk.ts
@@ -1,3 +1,4 @@
+import { IMPORT_MAX_QUESTIONS, IMPORT_MAX_TEXT_CHARS } from "../../limits";
 import { importWarning } from "../../report";
 import type { TImportIssue } from "../../types";
 
@@ -23,8 +24,8 @@ export type TChunkOptions = {
 };
 
 /** Beyond this the remainder is dropped with `text_truncated`: nobody imports a 200-question survey in one go. */
-export const CHUNK_MAX_TOTAL_QUESTIONS = 200;
-export const CHUNK_MAX_TOTAL_CHARS = 400_000;
+export const CHUNK_MAX_TOTAL_QUESTIONS = IMPORT_MAX_QUESTIONS;
+export const CHUNK_MAX_TOTAL_CHARS = IMPORT_MAX_TEXT_CHARS;
 
 // Sized for a 16k output budget with reasoning tokens counted against it: 40/16k overflowed live.
 const QUESTIONS_PER_CALL_BUDGET = 24;

--- a/apps/web/modules/survey/import/lanes/document/extract/types.ts
+++ b/apps/web/modules/survey/import/lanes/document/extract/types.ts
@@ -1,9 +1,10 @@
+import { IMPORT_EXTRACT_TIMEOUT_MS, IMPORT_MAX_TEXT_CHARS } from "../../../limits";
 import type { TImportIssue } from "../../../types";
 
 /** Hard cap on the normalized text handed to the model side (edge case #39). */
-export const EXTRACT_MAX_CHARS = 400_000;
+export const EXTRACT_MAX_CHARS = IMPORT_MAX_TEXT_CHARS;
 /** Parsers run under this budget; a DOCX or PDF that takes longer is reported, not awaited. */
-export const EXTRACT_TIMEOUT_MS = 10_000;
+export const EXTRACT_TIMEOUT_MS = IMPORT_EXTRACT_TIMEOUT_MS;
 /** Zip guards for DOCX and XLSX (both are zip archives): entry count and total uncompressed size. */
 export const ARCHIVE_MAX_ENTRIES = 500;
 export const ARCHIVE_MAX_UNCOMPRESSED_BYTES = 50 * 1024 * 1024;

--- a/apps/web/modules/survey/import/lib/ai-inflight-guard.test.ts
+++ b/apps/web/modules/survey/import/lib/ai-inflight-guard.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { cache } from "@/lib/cache";
+import { ImportInProgressError, acquireAiImportSlot, aiInflightKey } from "./ai-inflight-guard";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@formbricks/logger", () => ({ logger: { warn: vi.fn() } }));
+vi.mock("@/lib/cache", () => ({ cache: { getRedisClient: vi.fn() } }));
+
+const redis = { incr: vi.fn(), expire: vi.fn(), decr: vi.fn(), del: vi.fn() };
+
+describe("acquireAiImportSlot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(cache.getRedisClient).mockResolvedValue(redis as never);
+    redis.expire.mockResolvedValue(1);
+    redis.del.mockResolvedValue(1);
+  });
+
+  test("the first two conversions get a slot, the third is refused with a retry hint", async () => {
+    redis.incr.mockResolvedValueOnce(1).mockResolvedValueOnce(2).mockResolvedValueOnce(3);
+    redis.decr.mockResolvedValue(2);
+
+    await acquireAiImportSlot("user1");
+    await acquireAiImportSlot("user1");
+    await expect(acquireAiImportSlot("user1")).rejects.toMatchObject({
+      name: "ImportInProgressError",
+      retryAfter: 30,
+    });
+
+    expect(redis.incr).toHaveBeenCalledWith(aiInflightKey("user1"));
+    expect(redis.expire).toHaveBeenCalledWith(aiInflightKey("user1"), 120);
+    // The refused request gives its increment back so it does not poison the count.
+    expect(redis.decr).toHaveBeenCalledTimes(1);
+  });
+
+  test("release decrements once, deletes the key at zero and is safe to call twice", async () => {
+    redis.incr.mockResolvedValue(1);
+    redis.decr.mockResolvedValue(0);
+
+    const release = await acquireAiImportSlot("user1");
+    await release();
+    await release();
+
+    expect(redis.decr).toHaveBeenCalledTimes(1);
+    expect(redis.del).toHaveBeenCalledWith(aiInflightKey("user1"));
+  });
+
+  test("without Redis or on Redis failure the guard steps aside", async () => {
+    vi.mocked(cache.getRedisClient).mockResolvedValueOnce(null as never);
+    await expect(acquireAiImportSlot("user1")).resolves.toBeTypeOf("function");
+
+    redis.incr.mockRejectedValueOnce(new Error("down"));
+    const release = await acquireAiImportSlot("user1");
+    await release();
+    expect(redis.decr).not.toHaveBeenCalled();
+  });
+
+  test("ImportInProgressError carries the wait", () => {
+    expect(new ImportInProgressError().retryAfter).toBe(30);
+  });
+});

--- a/apps/web/modules/survey/import/lib/ai-inflight-guard.ts
+++ b/apps/web/modules/survey/import/lib/ai-inflight-guard.ts
@@ -1,0 +1,61 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { cache } from "@/lib/cache";
+import {
+  IMPORT_AI_INFLIGHT_RETRY_AFTER_SECONDS,
+  IMPORT_AI_INFLIGHT_TTL_SECONDS,
+  IMPORT_AI_MAX_INFLIGHT_PER_USER,
+} from "../limits";
+
+export class ImportInProgressError extends Error {
+  retryAfter = IMPORT_AI_INFLIGHT_RETRY_AFTER_SECONDS;
+
+  constructor() {
+    super("Another document import is still running. Wait for it to finish or stop it first.");
+    this.name = "ImportInProgressError";
+  }
+}
+
+export const aiInflightKey = (identifier: string) => `import:ai:inflight:${identifier}`;
+
+/**
+ * At most `IMPORT_AI_MAX_INFLIGHT_PER_USER` AI conversions per user or key at once, counted in Redis so
+ * the guard holds across instances. Returns the release function; call it on done, error and abort.
+ * Without Redis (tests, single-node dev without cache) the guard is a no-op — the rate limits still hold.
+ */
+export async function acquireAiImportSlot(identifier: string): Promise<() => Promise<void>> {
+  const redis = await cache.getRedisClient();
+  if (!redis) {
+    return async () => undefined;
+  }
+
+  const key = aiInflightKey(identifier);
+  let released = false;
+  const release = async () => {
+    if (released) return;
+    released = true;
+    try {
+      const remaining = await redis.decr(key);
+      if (remaining <= 0) await redis.del(key);
+    } catch (error) {
+      logger.warn({ error }, "Failed to release the AI import slot");
+    }
+  };
+
+  let inflight: number;
+  try {
+    inflight = await redis.incr(key);
+    await redis.expire(key, IMPORT_AI_INFLIGHT_TTL_SECONDS);
+  } catch (error) {
+    // Redis trouble must not block imports; the per-user AI rate limit still bounds the spend.
+    logger.warn({ error }, "Failed to count in-flight AI imports");
+    return async () => undefined;
+  }
+
+  if (inflight > IMPORT_AI_MAX_INFLIGHT_PER_USER) {
+    await release();
+    throw new ImportInProgressError();
+  }
+
+  return release;
+}

--- a/apps/web/modules/survey/import/limits.ts
+++ b/apps/web/modules/survey/import/limits.ts
@@ -1,0 +1,20 @@
+/**
+ * Every hard limit of survey import, in one place. The lanes import from here; the docs copy the
+ * numbers from here (ENG-3011). Change a number here and the report messages, the OpenAPI text and
+ * the docs are the places to re-check.
+ */
+
+/** 15 MB per file (D3). The multipart transport adds 1 MB of framing slack on top. */
+export const IMPORT_MAX_FILE_BYTES = 15 * 1024 * 1024;
+/** Normalized document text handed to the model side is cut here (`text_truncated`). */
+export const IMPORT_MAX_TEXT_CHARS = 400_000;
+/** Estimated questions the chunker keeps; the remainder is dropped with `text_truncated`. */
+export const IMPORT_MAX_QUESTIONS = 200;
+/** DOCX / PDF parsers run under this budget. */
+export const IMPORT_EXTRACT_TIMEOUT_MS = 10_000;
+/** In-flight AI conversions one user may run at once; the next one answers 409 `import_in_progress`. */
+export const IMPORT_AI_MAX_INFLIGHT_PER_USER = 2;
+/** Safety net for a slot whose release never ran (crashed worker): seconds until Redis forgets it. */
+export const IMPORT_AI_INFLIGHT_TTL_SECONDS = 120;
+/** What a 409 tells the client to wait before retrying. */
+export const IMPORT_AI_INFLIGHT_RETRY_AFTER_SECONDS = 30;

--- a/apps/web/modules/survey/import/types.ts
+++ b/apps/web/modules/survey/import/types.ts
@@ -37,8 +37,8 @@ export const AI_IMPORT_SOURCE_KINDS: readonly TImportSourceKind[] = IMPORT_SOURC
   (kind) => IMPORT_LANE_BY_KIND[kind] === "ai"
 );
 
-/** 15 MB per file (D3). The transport adds 1 MB of multipart slack on top. */
-export const IMPORT_MAX_FILE_BYTES = 15 * 1024 * 1024;
+// Re-exported so existing imports keep working; the number lives with the other limits.
+export { IMPORT_MAX_FILE_BYTES } from "./limits";
 
 /**
  * Import owns its own allowlist. `ZAllowedFileExtension` (packages/types/storage.ts) is the upload

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -3035,6 +3035,7 @@ components:
             - bad_request
             - conflict
             - forbidden
+            - import_in_progress
             - internal_server_error
             - invalid_workflow_state
             - lane_not_available

--- a/docs/api-v3-reference/src/components/schemas/Problem.yml
+++ b/docs/api-v3-reference/src/components/schemas/Problem.yml
@@ -32,6 +32,7 @@ properties:
       - bad_request
       - conflict
       - forbidden
+      - import_in_progress
       - internal_server_error
       - invalid_workflow_state
       - lane_not_available


### PR DESCRIPTION
Fixes ENG-3009

Stacked on #9211 (`jojo/eng-3013-embedded-data-alignment-hidden-field-and-variable-names-on`). Survey Import & Export, milestone 6.

## What & why

**Was:** Import spend was bounded per user only (30/min convert, 10/min AI); one user could run any number of AI conversions at once, the size and time limits were scattered across five files, and one log line echoed full validation reasons.

**Now:** A per-workspace budget (200/hour across convert, stream and import), a Redis-backed concurrency guard (at most two in-flight AI conversions per user, the third answers 409 `import_in_progress` with `Retry-After: 30`), every limit in `modules/survey/import/limits.ts`, and log lines that carry `importRunId`, `workspaceId`, `sourceKind`, `lane` but never file names, bytes or document text.

- Guards run in order: workspace access → workspace budget → detection → AI gate → AI budget → slot; a refused request never reaches a parser.
- The slot is released on done, error and client abort; a lost release expires after 120 s. Without Redis the guard steps aside and the rate limits still hold.
- `redactInvalidParams` cuts logged reasons at 80 chars.

## Where to look

- [ai-inflight-guard.ts](apps/web/modules/survey/import/lib/ai-inflight-guard.ts) — INCR/EXPIRE/DECR and the fail-open policy.
- [import-guards.ts](apps/web/app/api/v3/surveys/import/lib/import-guards.ts) — the budget and 409 helpers shared by the three routes.
- [limits.ts](apps/web/modules/survey/import/limits.ts) — the numbers the docs will copy.

## Breaking changes

- [ ] This PR contains a breaking change

New limits only tighten abuse cases; a normal workspace imports far fewer than 200 files an hour. Documented 409 is additive.

## Migrations & env

None. Redis is the existing cache client; the guard is a no-op where it is absent.

## Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| Third concurrent AI conversion → 409 + `Retry-After`; release once, delete at zero; fail-open without Redis | unit (guard) | `ai-inflight-guard.test.ts` |
| Convert: workspace budget 429 before the gate; 409 before the lane; deterministic lanes spend only the workspace budget | unit (guard) | `convert-import.test.ts` |
| Stream: 409 before the body opens; slot released after the stream | unit (guard) | `import/lib/operations.test.ts` |
| No import log line carries `text`, `bytes`, `fileName`, `document`, `prompt`, `content` | unit (guard) | `convert-import.test.ts` "no log line carries…" |
| New bucket present in the config list | unit (guard) | `rate-limit-configs.test.ts` |

Rerun: `cd apps/web && npx vitest run app/api/v3/surveys/import app/api/internal/surveys/import modules/survey/import modules/core/rate-limit/rate-limit-configs.test.ts`

## Open gaps

- The 50-request burst check the ticket asks for is a local script against a running instance and was not run here.
- The import route (`POST /api/v3/surveys/import`) gained the workspace budget but its OpenAPI 429 text still describes the generic limit.

## Risks

- The guard keys on the session user or API key id, falling back to the workspace id for anonymous callers, so an API key shared by a team counts as one caller.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>
