### PR TITLE
feat(surveys): import analytics events, LLM trace metadata and audit context [ENG-3008]

### DIFF
--- a/apps/web/app/api/internal/surveys/import/lib/operations.test.ts
+++ b/apps/web/app/api/internal/surveys/import/lib/operations.test.ts
@@ -115,7 +115,14 @@ describe("streamImportConversion", () => {
       references: null,
     });
     expect(mocks.assertOrganizationAIConfigured).not.toHaveBeenCalled();
-    expect(mocks.capturePostHogEvent).not.toHaveBeenCalled();
+    expect(mocks.capturePostHogEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.capturePostHogEvent).toHaveBeenCalledWith(
+      "user1",
+      "survey_import_converted",
+      // The event reads the resolved report, which the mocked resolver labels markdown/ai.
+      expect.objectContaining({ source_kind: "markdown", lane: "ai", has_document: true, streamed: true }),
+      expect.objectContaining({ workspaceId })
+    );
   });
 
   test("an AI lane run streams progress per chunk and partials with their block offset", async () => {
@@ -182,6 +189,12 @@ describe("streamImportConversion", () => {
     expect(response.status).toBe(403);
     expect(response.headers.get("Content-Type")).toContain("application/problem+json");
     expect(lane).not.toHaveBeenCalled();
+    expect(mocks.capturePostHogEvent).toHaveBeenCalledWith(
+      "user1",
+      "survey_import_failed",
+      { source_kind: "markdown", lane: "ai", code: "ai_smart_tools_disabled", status: 403, streamed: true },
+      expect.objectContaining({ workspaceId })
+    );
   });
 
   test("a spent AI budget answers 429 with Retry-After before the stream", async () => {
@@ -255,5 +268,11 @@ describe("streamImportConversion", () => {
       retryAfter: 30,
       reference: expect.any(String),
     });
+    expect(mocks.capturePostHogEvent).toHaveBeenCalledWith(
+      "user1",
+      "survey_import_failed",
+      expect.objectContaining({ code: "ai_quota_exceeded", lane: "ai", streamed: true }),
+      expect.anything()
+    );
   });
 });

--- a/apps/web/app/api/internal/surveys/import/lib/operations.ts
+++ b/apps/web/app/api/internal/surveys/import/lib/operations.ts
@@ -19,6 +19,11 @@ import { capturePostHogEvent } from "@/lib/posthog";
 import { detectImportSource } from "@/modules/survey/import/detect";
 import { getImportLaneHandler } from "@/modules/survey/import/lanes";
 import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
+import {
+  buildImportConvertedProperties,
+  buildImportFailedProperties,
+  readProblemCode,
+} from "@/modules/survey/import/lib/import-analytics";
 import { resolveImportCandidate } from "@/modules/survey/import/resolve";
 import {
   IMPORT_LANE_BY_KIND,
@@ -54,7 +59,31 @@ interface TStreamImportParams {
  * mid-conversion failures become in-band `error` events. Deterministic lanes emit start → progress
  * reading → progress validating → done with no partials.
  */
-export async function streamImportConversion({
+export async function streamImportConversion(params: TStreamImportParams): Promise<Response> {
+  const response = await streamImportConversionInner(params);
+  const userId = getSessionUserId(params.authentication);
+  // Pre-stream refusals (gate, budget, unsupported file) are problem responses; in-band errors are
+  // reported where they are emitted.
+  if (!response.ok && userId) {
+    const file = params.body.files[0];
+    const kind = detectImportSource({ fileName: file.fileName, mimeType: file.mimeType, bytes: file.bytes });
+    capturePostHogEvent(
+      userId,
+      "survey_import_failed",
+      buildImportFailedProperties({
+        sourceKind: kind.ok ? kind.kind : null,
+        lane: kind.ok ? IMPORT_LANE_BY_KIND[kind.kind] : null,
+        code: await readProblemCode(response),
+        status: response.status,
+        streamed: true,
+      }),
+      { workspaceId: params.body.fields.workspaceId }
+    );
+  }
+  return response;
+}
+
+async function streamImportConversionInner({
   req,
   authentication,
   body,
@@ -195,6 +224,19 @@ export async function streamImportConversion({
           report: resolved.report,
         });
 
+        if (userId) {
+          capturePostHogEvent(
+            userId,
+            "survey_import_converted",
+            buildImportConvertedProperties(resolved.report, {
+              durationMs: Date.now() - startedAt,
+              hasDocument: resolved.document !== null,
+              streamed: true,
+            }),
+            { organizationId, workspaceId }
+          );
+        }
+
         if (isAiLane && userId && resolved.document) {
           capturePostHogEvent(
             userId,
@@ -216,7 +258,21 @@ export async function streamImportConversion({
           log.info("Survey import stream aborted by the client");
         } else {
           log.error({ err: error }, "Survey import stream failed");
-          emit({ ...toStreamErrorEvent(error), reference: importRunId });
+          const failure = { ...toStreamErrorEvent(error), reference: importRunId };
+          emit(failure);
+          if (userId) {
+            capturePostHogEvent(
+              userId,
+              "survey_import_failed",
+              buildImportFailedProperties({
+                sourceKind: detection.kind,
+                lane: source.lane,
+                code: failure.code,
+                streamed: true,
+              }),
+              { organizationId, workspaceId }
+            );
+          }
         }
       } finally {
         detach();

--- a/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.test.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.test.ts
@@ -113,7 +113,12 @@ describe("exportV3Survey", () => {
     expect(auditLog).toMatchObject({
       targetId: FIXTURE_APP_SURVEY.id,
       organizationId: "org_1",
-      newObject: { exportFormat: 1, workspaceId: FIXTURE_WORKSPACE_ID },
+      newObject: {
+        exportFormat: 1,
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        surveyId: FIXTURE_APP_SURVEY.id,
+        surveyType: "app",
+      },
     });
     expect(capturePostHogEvent).toHaveBeenCalledWith(
       "user_1",

--- a/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts
@@ -69,6 +69,8 @@ export async function exportV3Survey({
       auditLog.newObject = {
         exportFormat: envelope.formbricks.exportFormat,
         workspaceId: survey.workspaceId,
+        surveyId: survey.id,
+        surveyType: survey.type,
       };
     }
 

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
@@ -110,6 +110,18 @@ describe("convertImportFile", () => {
       "trigger_would_be_created"
     );
     expect(createActionClass).not.toHaveBeenCalled();
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      "user_1",
+      "survey_import_converted",
+      expect.objectContaining({
+        source_kind: "formbricks-export",
+        lane: "lossless",
+        has_document: true,
+        error_count: 0,
+        import_warning_codes: expect.any(Array),
+      }),
+      expect.objectContaining({ workspaceId: FIXTURE_WORKSPACE_ID })
+    );
   });
 
   test("a raw v3 document renamed to .txt is still detected by content", async () => {
@@ -177,6 +189,12 @@ describe("convertImportFile", () => {
     expect(json.code).toBe(code);
     expect(json.detail).toContain(detail);
     expect(json.invalid_params[0].name).toBe("file");
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      "user_1",
+      "survey_import_failed",
+      { source_kind: null, lane: null, code, status: 422 },
+      expect.objectContaining({ workspaceId: FIXTURE_WORKSPACE_ID })
+    );
   });
 
   test("converts a Qualtrics .qsf through the structured lane and reports its logic", async () => {
@@ -252,6 +270,12 @@ describe("convertImportFile", () => {
 
       expect(response.status).toBe(403);
       expect((await response.json()).code).toBe("ai_features_not_enabled");
+      expect(capturePostHogEvent).toHaveBeenCalledWith(
+        "user_1",
+        "survey_import_failed",
+        { source_kind: "docx", lane: "ai", code: "ai_features_not_enabled", status: 403 },
+        expect.anything()
+      );
       expect(documentLane).not.toHaveBeenCalled();
       expect(applyRateLimit).not.toHaveBeenCalledWith(
         expect.objectContaining({ namespace: "api:v3:surveys:generate" }),

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
@@ -24,8 +24,18 @@ import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { type TImportDetectionFailureCode, detectImportSource } from "@/modules/survey/import/detect";
 import { getImportLaneHandler } from "@/modules/survey/import/lanes";
 import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
+import {
+  buildImportConvertedProperties,
+  buildImportFailedProperties,
+  readProblemCode,
+} from "@/modules/survey/import/lib/import-analytics";
 import { resolveImportCandidate } from "@/modules/survey/import/resolve";
-import { IMPORT_LANE_BY_KIND, type TImportContext } from "@/modules/survey/import/types";
+import {
+  IMPORT_LANE_BY_KIND,
+  type TImportContext,
+  type TImportLane,
+  type TImportSourceKind,
+} from "@/modules/survey/import/types";
 import type { TV3SurveyImportConvertBody } from "../schemas";
 
 type TConvertImportParams = {
@@ -72,21 +82,43 @@ export async function assertAiImportAllowed(
   }
 }
 
+type TConvertTelemetry = { sourceKind: TImportSourceKind | null; lane: TImportLane | null };
+
 /**
  * `POST /api/v3/surveys/import/convert` — turn a file into a reviewed survey document without
  * persisting anything. Detect → lane → resolve (always dry run: creating is the import route's job).
  *
- * A file the allowlist rejects is a 422 (the request was well-formed; the file is not something we
- * take), a non-multipart request is a 415 (wrapper), a lane that has not shipped is a 400
- * `lane_not_available`. A file the lane cannot read still answers 200 with `document: null` and
- * the reasons in `report` — the dialog shows them; the 422 belongs to the persisting endpoint.
+ * A file the allowlist rejects is a 422, a non-multipart request a 415 (wrapper), a lane that has not
+ * shipped a 400 `lane_not_available`. A file the lane cannot read still answers 200 with
+ * `document: null` and the reasons in `report`. Every non-2xx answer is reported as
+ * `survey_import_failed` for session users (ENG-3008), here, in exactly one place.
  */
-export async function convertImportFile({
-  body,
-  authentication,
-  requestId,
-  instance,
-}: TConvertImportParams): Promise<Response> {
+export async function convertImportFile(params: TConvertImportParams): Promise<Response> {
+  const telemetry: TConvertTelemetry = { sourceKind: null, lane: null };
+  const response = await convertImportFileInner(params, telemetry);
+
+  const userId = getSessionUserId(params.authentication);
+  if (!response.ok && userId) {
+    capturePostHogEvent(
+      userId,
+      "survey_import_failed",
+      buildImportFailedProperties({
+        sourceKind: telemetry.sourceKind,
+        lane: telemetry.lane,
+        code: await readProblemCode(response),
+        status: response.status,
+      }),
+      { workspaceId: params.body.fields.workspaceId }
+    );
+  }
+
+  return response;
+}
+
+async function convertImportFileInner(
+  { body, authentication, requestId, instance }: TConvertImportParams,
+  telemetry: TConvertTelemetry
+): Promise<Response> {
   const importRunId = createId();
   const file = body.files[0];
   const extension = file.fileName.split(".").pop()?.toLowerCase() ?? null;
@@ -126,6 +158,8 @@ export async function convertImportFile({
       return problemForImportDetectionFailure(requestId, instance, detection.code);
     }
 
+    telemetry.sourceKind = detection.kind;
+    telemetry.lane = IMPORT_LANE_BY_KIND[detection.kind];
     const lane = getImportLaneHandler(detection.kind);
     if (!lane) {
       log.warn({ statusCode: 400, sourceKind: detection.kind }, "Import lane not available");
@@ -202,6 +236,18 @@ export async function convertImportFile({
       },
       "Import file converted"
     );
+
+    if (ctx.userId) {
+      capturePostHogEvent(
+        ctx.userId,
+        "survey_import_converted",
+        buildImportConvertedProperties(resolved.report, {
+          durationMs: Date.now() - startedAt,
+          hasDocument: resolved.document !== null,
+        }),
+        { organizationId: authResult.organizationId, workspaceId: authResult.workspaceId }
+      );
+    }
 
     if (isAiLane && ctx.userId && resolved.document) {
       capturePostHogEvent(

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
@@ -15,6 +15,7 @@ import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
 import { ZV3SurveyImportBody } from "../schemas";
 import { importV3Survey } from "./import-survey";
 
+vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn() }));
 vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: vi.fn(async () => ({})) }));
 vi.mock("server-only", () => ({}));
 

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
@@ -13,8 +13,12 @@ import {
 } from "@/app/api/v3/lib/response";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
 import { createV3SurveyResponse, getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { formbricksLane } from "@/modules/survey/import/lanes/formbricks";
-import { countIssues } from "@/modules/survey/import/report";
+import {
+  buildImportCreatedProperties,
+  buildImportFailedProperties,
+} from "@/modules/survey/import/lib/import-analytics";
 import { type TResolveImportResult, resolveImportCandidate } from "@/modules/survey/import/resolve";
 import type { TImportCandidate, TImportReport } from "@/modules/survey/import/types";
 import type { TV3SurveyImportBody } from "../schemas";
@@ -33,18 +37,6 @@ export function reportErrorsToInvalidParams(report: TImportReport): InvalidParam
   return report.issues
     .filter((issue) => issue.severity === "error")
     .map((issue) => ({ name: issue.path ?? "document", reason: issue.message }));
-}
-
-/** The `survey_created` properties product reads import adoption from. */
-export function buildImportAnalyticsProperties(report: TImportReport) {
-  const counts = countIssues(report.issues);
-  return {
-    import_source: report.source.kind,
-    import_lane: report.source.lane,
-    import_ai_used: report.source.lane === "ai",
-    import_warning_count: counts.warning,
-    import_chunk_count: report.source.chunks ?? 0,
-  };
 }
 
 async function runLosslessImport(
@@ -145,6 +137,21 @@ export async function importV3Survey({
         { statusCode: 422, sourceKind: resolved.report.source.kind, invalidParamCount: invalidParams.length },
         "Survey import refused"
       );
+      const refusedBy = getSessionUserId(authentication);
+      if (refusedBy) {
+        capturePostHogEvent(
+          refusedBy,
+          "survey_import_failed",
+          buildImportFailedProperties({
+            sourceKind: resolved.report.source.kind,
+            lane: resolved.report.source.lane,
+            code:
+              resolved.report.issues.find((issue) => issue.severity === "error")?.code ?? "invalid_document",
+            status: 422,
+          }),
+          { organizationId: authResult.organizationId, workspaceId: authResult.workspaceId }
+        );
+      }
       return problemUnprocessableContent(requestId, "The survey could not be imported", {
         instance,
         invalid_params: invalidParams,
@@ -164,12 +171,19 @@ export async function importV3Survey({
       authResult,
       createdFrom: "import",
       createOptions: { skipExternalUrlPermissionCheck: true },
-      analyticsProperties: buildImportAnalyticsProperties(resolved.report),
+      analyticsProperties: buildImportCreatedProperties(resolved.report),
     });
 
     if (auditLog) {
       auditLog.status = createResponse.ok ? "success" : "failure";
       if (!createResponse.ok) auditLog.eventId = requestId;
+      // The audit row names the import run and its source so an operator can trace a survey back to its file.
+      if (auditLog?.newObject && typeof auditLog.newObject === "object") {
+        auditLog.newObject = {
+          ...(auditLog.newObject as Record<string, unknown>),
+          import: { importRunId, sourceKind: resolved.report.source.kind, lane: resolved.report.source.lane },
+        };
+      }
       await queueV3AuditLog(auditLog, requestId, log);
     }
 

--- a/apps/web/lib/posthog/ai-tracing.ts
+++ b/apps/web/lib/posthog/ai-tracing.ts
@@ -11,6 +11,8 @@ export interface AITracingContext {
   traceId?: string;
   organizationId?: string;
   workspaceId?: string;
+  /** Extra trace properties (an import run id, a chunk index) next to `feature`. */
+  properties?: Record<string, string | number | boolean>;
 }
 
 const buildGroups = (context: AITracingContext): Record<string, string> | undefined => {
@@ -37,7 +39,7 @@ export function wrapAiModelWithTracing(
       posthogDistinctId: context.distinctId,
       posthogTraceId: context.traceId,
       posthogGroups: buildGroups(context),
-      posthogProperties: { feature: context.feature },
+      posthogProperties: { feature: context.feature, ...context.properties },
       posthogPrivacyMode: true,
     });
   } catch (error) {

--- a/apps/web/lib/posthog/capture.ts
+++ b/apps/web/lib/posthog/capture.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { logger } from "@formbricks/logger";
 import { posthogServerClient } from "./server";
 
-type PostHogEventProperties = Record<string, string | number | boolean | null | undefined>;
+type PostHogEventProperties = Record<string, string | number | boolean | string[] | null | undefined>;
 
 export type PostHogGroupContext = {
   organizationId?: string;

--- a/apps/web/modules/survey/import/components/import-survey-dialog.tsx
+++ b/apps/web/modules/survey/import/components/import-survey-dialog.tsx
@@ -14,6 +14,11 @@ import { ImportDropzone } from "@/modules/survey/import/components/import-dropzo
 import { ImportFacts } from "@/modules/survey/import/components/import-facts";
 import { ImportProgressLadder } from "@/modules/survey/import/components/import-progress-ladder";
 import { ImportReport } from "@/modules/survey/import/components/import-report";
+import {
+  IMPORT_KIND_BY_EXTENSION,
+  getImportFileExtension,
+  isImportAllowedExtension,
+} from "@/modules/survey/import/file-types";
 import { useImportSurvey } from "@/modules/survey/import/hooks/use-import-survey";
 import { formatFileSize } from "@/modules/survey/import/lib/import-file-checks";
 import { Alert, AlertDescription, AlertTitle } from "@/modules/ui/components/alert";
@@ -112,8 +117,10 @@ export const ImportSurveyDialog = ({
   };
 
   const handleFileSelect = (file: File) => {
+    const extension = getImportFileExtension(file.name);
     capture("survey_import_source_selected", {
-      extension: file.name.split(".").pop()?.toLowerCase() ?? null,
+      extension,
+      kind: extension && isImportAllowedExtension(extension) ? IMPORT_KIND_BY_EXTENSION[extension] : null,
     });
     importer.selectFile(file);
   };

--- a/apps/web/modules/survey/import/lanes/document/detect-languages.ts
+++ b/apps/web/modules/survey/import/lanes/document/detect-languages.ts
@@ -189,6 +189,8 @@ export type TDetectDocumentLanguagesParams = {
   workspaceId: string;
   userId?: string | null;
   languageHint?: string;
+  /** Trace id shared by every model call of one import run. */
+  importRunId?: string;
   signal?: AbortSignal;
 };
 
@@ -210,6 +212,11 @@ export async function detectDocumentLanguages(
           distinctId: params.userId,
           feature: AI_TRACING_FEATURE.SurveyImport,
           workspaceId: params.workspaceId,
+          traceId: params.importRunId,
+          properties: {
+            step: "detect_languages",
+            ...(params.importRunId ? { importRunId: params.importRunId } : {}),
+          },
         }
       : undefined,
     schema: ZLanguageDetection,

--- a/apps/web/modules/survey/import/lanes/document/extract-survey.ts
+++ b/apps/web/modules/survey/import/lanes/document/extract-survey.ts
@@ -71,6 +71,8 @@ export type TExtractSurveyDraftParams = {
   workspaceId: string;
   userId?: string | null;
   part?: TImportPromptPart;
+  /** Trace id shared by every model call of one import run; the part index becomes `chunkIndex`. */
+  importRunId?: string;
   signal?: AbortSignal;
 };
 
@@ -93,9 +95,21 @@ export function buildImportDraftRequest(
   });
 }
 
-function buildTracing(params: Pick<TExtractSurveyDraftParams, "userId" | "workspaceId">) {
+function buildTracing(
+  params: Pick<TExtractSurveyDraftParams, "userId" | "workspaceId" | "importRunId" | "part">
+) {
   return params.userId
-    ? { distinctId: params.userId, feature: AI_TRACING_FEATURE.SurveyImport, workspaceId: params.workspaceId }
+    ? {
+        distinctId: params.userId,
+        feature: AI_TRACING_FEATURE.SurveyImport,
+        workspaceId: params.workspaceId,
+        traceId: params.importRunId,
+        properties: {
+          step: "extract_survey",
+          chunkIndex: params.part?.index ?? 1,
+          ...(params.importRunId ? { importRunId: params.importRunId } : {}),
+        },
+      }
     : undefined;
 }
 

--- a/apps/web/modules/survey/import/lanes/document/index.ts
+++ b/apps/web/modules/survey/import/lanes/document/index.ts
@@ -96,6 +96,7 @@ async function extractChunk(
     workspaceId: ctx.workspaceId,
     userId: ctx.userId,
     part: chunk.total > 1 ? { index: chunk.index, total: chunk.total } : undefined,
+    importRunId: ctx.importRunId,
     signal: ctx.signal,
   };
 
@@ -141,6 +142,7 @@ export const documentLane: TImportLaneHandler = async (input, ctx) => {
     workspaceId: ctx.workspaceId,
     userId: ctx.userId,
     languageHint: ctx.languageHint,
+    importRunId: ctx.importRunId,
     signal: ctx.signal,
   });
 

--- a/apps/web/modules/survey/import/lib/import-analytics.test.ts
+++ b/apps/web/modules/survey/import/lib/import-analytics.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import type { TImportReport } from "../types";
+import {
+  buildImportConvertedProperties,
+  buildImportCreatedProperties,
+  buildImportFailedProperties,
+  readProblemCode,
+} from "./import-analytics";
+
+const report: TImportReport = {
+  source: { lane: "ai", kind: "docx", fileName: "q.docx", chunks: 3 },
+  summary: {
+    blocks: 4,
+    elements: 21,
+    endings: 1,
+    languages: ["en-US", "de-DE"],
+    logicRules: 0,
+    logicRulesReported: 0,
+    hiddenFields: 0,
+  },
+  issues: [
+    { severity: "warning", code: "translation_filled", message: "" },
+    { severity: "warning", code: "translation_filled", message: "" },
+    { severity: "warning", code: "chunk_failed", message: "" },
+    { severity: "info", code: "chunked", message: "" },
+    { severity: "error", code: "nothing_extracted", message: "" },
+  ],
+};
+
+describe("import analytics properties", () => {
+  test("survey_import_converted carries counts, distinct warning codes and the source", () => {
+    expect(
+      buildImportConvertedProperties(report, { durationMs: 1234, hasDocument: true, streamed: true })
+    ).toEqual({
+      source_kind: "docx",
+      lane: "ai",
+      question_count: 21,
+      language_count: 2,
+      warning_count: 3,
+      error_count: 1,
+      import_warning_codes: ["chunk_failed", "translation_filled"],
+      has_document: true,
+      duration_ms: 1234,
+      streamed: true,
+    });
+    expect(buildImportConvertedProperties(report, { durationMs: 1, hasDocument: false })).not.toHaveProperty(
+      "streamed"
+    );
+  });
+
+  test("survey_import_failed defaults unknown source and lane to null", () => {
+    expect(buildImportFailedProperties({ code: "unsupported_source", status: 422 })).toEqual({
+      source_kind: null,
+      lane: null,
+      code: "unsupported_source",
+      status: 422,
+    });
+    expect(
+      buildImportFailedProperties({ sourceKind: "qsf", lane: "structured", code: "x", streamed: true })
+    ).toMatchObject({
+      source_kind: "qsf",
+      lane: "structured",
+      status: null,
+      streamed: true,
+    });
+  });
+
+  test("survey_created import properties", () => {
+    expect(buildImportCreatedProperties(report)).toEqual({
+      import_source: "docx",
+      import_lane: "ai",
+      import_ai_used: true,
+      import_warning_count: 3,
+      import_chunk_count: 3,
+    });
+  });
+
+  test("readProblemCode reads the code without consuming the response", async () => {
+    const response = new Response(JSON.stringify({ code: "lane_not_available" }), { status: 400 });
+    expect(await readProblemCode(response)).toBe("lane_not_available");
+    expect((await response.json()).code).toBe("lane_not_available");
+    expect(await readProblemCode(new Response("nope", { status: 500 }))).toBe("http_500");
+  });
+});

--- a/apps/web/modules/survey/import/lib/import-analytics.ts
+++ b/apps/web/modules/survey/import/lib/import-analytics.ts
@@ -1,0 +1,96 @@
+import { countIssues } from "../report";
+import type { TImportLane, TImportReport, TImportSourceKind } from "../types";
+
+/**
+ * Property sets of the server-side import events, in one place so the convert route, the stream
+ * route and the import route report the same shape (ENG-3008). Event names:
+ *
+ * - `survey_import_converted` — every convert/stream `done`, whether or not a document came out.
+ * - `survey_import_failed` — every fatal answer (400/409/413/415/422/429/5xx) and in-band `error` event.
+ * - `survey_created` with `created_from: "import"` carries `buildImportCreatedProperties`.
+ * - `ai_survey_imported` — the AI lane's own event (chunks, languages, duration).
+ */
+
+export type TImportConvertedProperties = {
+  source_kind: TImportSourceKind;
+  lane: TImportLane;
+  question_count: number;
+  language_count: number;
+  warning_count: number;
+  error_count: number;
+  /** Distinct warning codes, for the "what do imports lose" histogram. */
+  import_warning_codes: string[];
+  has_document: boolean;
+  duration_ms: number;
+  streamed?: boolean;
+};
+
+export function buildImportConvertedProperties(
+  report: TImportReport,
+  options: { durationMs: number; hasDocument: boolean; streamed?: boolean }
+): TImportConvertedProperties {
+  const counts = countIssues(report.issues);
+  return {
+    source_kind: report.source.kind,
+    lane: report.source.lane,
+    question_count: report.summary.elements,
+    language_count: report.summary.languages.length,
+    warning_count: counts.warning,
+    error_count: counts.error,
+    import_warning_codes: [
+      ...new Set(report.issues.filter((issue) => issue.severity === "warning").map((issue) => issue.code)),
+    ].sort(),
+    has_document: options.hasDocument,
+    duration_ms: options.durationMs,
+    ...(options.streamed === undefined ? {} : { streamed: options.streamed }),
+  };
+}
+
+export type TImportFailedProperties = {
+  source_kind: TImportSourceKind | null;
+  lane: TImportLane | null;
+  /** The problem code (`unsupported_source`, `ai_quota_exceeded`, …) or the fatal report code. */
+  code: string;
+  status: number | null;
+  streamed?: boolean;
+};
+
+export function buildImportFailedProperties(params: {
+  sourceKind?: TImportSourceKind | null;
+  lane?: TImportLane | null;
+  code: string;
+  status?: number | null;
+  streamed?: boolean;
+}): TImportFailedProperties {
+  return {
+    source_kind: params.sourceKind ?? null,
+    lane: params.lane ?? null,
+    code: params.code,
+    status: params.status ?? null,
+    ...(params.streamed === undefined ? {} : { streamed: params.streamed }),
+  };
+}
+
+/** The extra properties `survey_created` carries when `created_from` is `import`. */
+export function buildImportCreatedProperties(
+  report: TImportReport
+): Record<string, string | number | boolean> {
+  const counts = countIssues(report.issues);
+  return {
+    import_source: report.source.kind,
+    import_lane: report.source.lane,
+    import_ai_used: report.source.lane === "ai",
+    import_warning_count: counts.warning,
+    import_chunk_count: report.source.chunks ?? 0,
+  };
+}
+
+/** Reads the problem code out of a problem+json Response without consuming the caller's copy. */
+export async function readProblemCode(response: Response): Promise<string> {
+  try {
+    const body = (await response.clone().json()) as { code?: unknown };
+    return typeof body.code === "string" ? body.code : `http_${response.status}`;
+  } catch {
+    return `http_${response.status}`;
+  }
+}


### PR DESCRIPTION
Fixes ENG-3008

Stacked on #9212 (`jojo/eng-3009-rate-limits-concurrency-guard-size-limits-logging-hygiene`). Survey Import & Export, milestone 6.

## What & why

**Was:** Import reported `survey_created` (with import properties) and the AI lane's `ai_survey_imported`, but nothing for conversions that never became a survey, nothing for failures, and the model calls carried no run or chunk identity in LLM tracing.

**Now:** Every convert and stream run reports `survey_import_converted`; every refusal (400/403/409/413/415/422/429, in-band `error`) reports `survey_import_failed`; the language-detection and extraction calls carry `importRunId` as trace id plus `chunkIndex` / `step` as trace properties; the audit rows name the survey (`exported`) and the import run and source (`created`).

## Events (for the insights)

| Event | Properties |
| --- | --- |
| `survey_exported` | `survey_id, survey_type, workspace_id, organization_id, question_count, language_count` (unchanged) |
| `survey_created` (`created_from: "import"`) | `+ import_source, import_lane, import_ai_used, import_warning_count, import_chunk_count` (unchanged) |
| `survey_import_converted` | `source_kind, lane, question_count, language_count, warning_count, error_count, import_warning_codes[], has_document, duration_ms, streamed?` |
| `survey_import_failed` | `source_kind|null, lane|null, code, status|null, streamed?` |
| `ai_survey_imported` | `source_kind, chunk_count, question_count, language_count, chars, duration_ms, streamed?` (unchanged) |
| client | `survey_import_dialog_opened {entry_point}`, `survey_import_source_selected {extension, kind}`, `survey_import_stopped`, `survey_import_regenerated`, `survey_import_created {entry_point}` |

Suggested insights: funnel dialog opened → converted → created split by `source_kind`; top `code` from `survey_import_failed`; histogram of `import_warning_codes`.

## Where to look

- [import-analytics.ts](apps/web/modules/survey/import/lib/import-analytics.ts) — the property builders all three routes share.
- [convert-import.ts](apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts) — the wrapper that reports every non-2xx once.
- [ai-tracing.ts](apps/web/lib/posthog/ai-tracing.ts) — `properties` on the tracing context.

## Breaking changes

- [ ] This PR contains a breaking change

Analytics and audit metadata only.

## Migrations & env

None.

## Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| Property sets of converted / failed / created events | unit (guard) | `import-analytics.test.ts` |
| Convert: `survey_import_converted` on 200, `survey_import_failed` on 422 detection and 403 gate with source kind when known | unit (guard) | `convert-import.test.ts` |
| Stream: converted for a deterministic lane, failed for a pre-stream 403 and an in-band error, `streamed: true` | unit (guard) | `import/lib/operations.test.ts` |
| Export audit row carries `surveyId` and `surveyType` | unit (guard) | `export-survey.test.ts` |
| Tracing context forwards extra properties | unit (guard) | existing `ai-tracing.test.ts` (feature-only case unchanged) |

Rerun: `cd apps/web && npx vitest run app/api/v3/surveys/import app/api/internal/surveys/import modules/survey/import/lib/import-analytics.test.ts`

## Open gaps

- The `created` audit row's import context lives inside `newObject.import` because the audit log type has no metadata field; confirm it renders acceptably in the organization audit log view (manual).
- Event names are not yet registered in any analytics catalog outside the code.

## Risks

- `survey_import_failed` fires for API-key callers only when a session user is present (same rule as every other server event), so machine traffic is invisible in the funnel by design.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>
