### PR TITLE
fix(surveys): depth-guard JSON parsing on import and add the security review checklist tests [ENG-3010]

### DIFF
--- a/apps/web/modules/survey/import/detect.ts
+++ b/apps/web/modules/survey/import/detect.ts
@@ -6,6 +6,7 @@ import {
   isImportAllowedExtension,
   isLegacyOfficeExtension,
 } from "./file-types";
+import { parseJsonBounded } from "./lib/json-depth";
 import type { TImportAllowedExtension, TImportSourceKind } from "./types";
 
 export { detectJsonSourceKind, getImportAcceptList, getImportFileExtension };
@@ -68,12 +69,12 @@ function detectTextKind(bytes: Buffer, extension: string | null): TTextDetection
     return { kind: null, invalidJson: false };
   }
 
-  try {
-    const parsed: unknown = JSON.parse(text);
-    return { kind: detectJsonSourceKind(parsed), invalidJson: false };
-  } catch {
+  // Depth-guarded: a pathologically nested file must read as "not a survey", not as a stack overflow.
+  const parsed = parseJsonBounded(text);
+  if (!parsed) {
     return { kind: null, invalidJson: extension === "json" || extension === "qsf" };
   }
+  return { kind: detectJsonSourceKind(parsed.value), invalidJson: false };
 }
 
 /**

--- a/apps/web/modules/survey/import/lanes/formbricks/index.ts
+++ b/apps/web/modules/survey/import/lanes/formbricks/index.ts
@@ -7,6 +7,7 @@ import {
 } from "@/app/api/v3/surveys/export/schemas";
 import { formatV3ZodInvalidParams } from "@/app/api/v3/surveys/schemas";
 import { detectJsonSourceKind } from "../../detect";
+import { isJsonTooDeep, parseJsonBounded } from "../../lib/json-depth";
 import { importError, importInfo } from "../../report";
 import type {
   TImportCandidate,
@@ -42,15 +43,23 @@ function stripBom(text: string): string {
 
 function parseContent(input: TImportLaneInput): { value: unknown } | { error: TImportIssue } {
   const { content } = input;
+  const tooDeep = () =>
+    importError({
+      code: "invalid_document",
+      vars: { detail: "The file is nested too deeply to be a survey." },
+    });
+
   if (content.type === "json") {
-    return { value: content.value };
+    return isJsonTooDeep(content.value) ? { error: tooDeep() } : { value: content.value };
   }
 
-  const text = content.type === "text" ? content.text : content.bytes.toString("utf8");
+  const text = stripBom(content.type === "text" ? content.text : content.bytes.toString("utf8"));
+  if (isJsonTooDeep(text)) {
+    return { error: tooDeep() };
+  }
 
-  try {
-    return { value: JSON.parse(stripBom(text)) };
-  } catch {
+  const parsed = parseJsonBounded(text);
+  if (!parsed) {
     return {
       error: importError({
         code: "invalid_document",
@@ -58,6 +67,7 @@ function parseContent(input: TImportLaneInput): { value: unknown } | { error: TI
       }),
     };
   }
+  return { value: parsed.value };
 }
 
 /** Accept a `GET /api/v3/surveys/{id}` response body as well as the bare document. */

--- a/apps/web/modules/survey/import/lanes/qsf/parse-qsf.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/parse-qsf.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { type Result, err, ok } from "@formbricks/types/error-handlers";
+import { parseJsonBounded } from "../../lib/json-depth";
 import { importError, importInfo } from "../../report";
 import type { TImportIssue } from "../../types";
 import { normalizeQualtricsLanguageCode } from "./language-codes";
@@ -302,12 +303,11 @@ function collectEmbeddedDataFields(nodes: TQsfFlowNode[], into: string[]): void 
 export function parseQsf(input: Buffer | string): Result<TQsfSurvey, TImportIssue[]> {
   const text = stripBom(typeof input === "string" ? input : input.toString("utf8"));
 
-  let raw: unknown;
-  try {
-    raw = JSON.parse(text);
-  } catch {
+  const parsed = parseJsonBounded(text);
+  if (!parsed) {
     return err([importError({ code: "invalid_document", vars: { detail: "The file is not valid JSON." } })]);
   }
+  const raw: unknown = parsed.value;
 
   const file = ZQsfFile.safeParse(raw);
   if (!file.success) {

--- a/apps/web/modules/survey/import/lib/json-depth.test.ts
+++ b/apps/web/modules/survey/import/lib/json-depth.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { isJsonTooDeep, measureJsonTextDepth, measureJsonValueDepth, parseJsonBounded } from "./json-depth";
+
+describe("json depth guard", () => {
+  test("measures nesting and ignores brackets inside strings", () => {
+    expect(measureJsonTextDepth('{"a":[1,{"b":"[[[[\\"]]"}]}')).toBe(3);
+    expect(measureJsonValueDepth({ a: [1, { b: "x" }] })).toBe(3);
+    expect(measureJsonValueDepth("flat")).toBe(0);
+  });
+
+  test("stops early past the limit so a 2 MB file costs one scan", () => {
+    const deep = "[".repeat(300_000) + "]".repeat(300_000);
+    expect(isJsonTooDeep(deep)).toBe(true);
+    expect(parseJsonBounded(deep)).toBeNull();
+    expect(measureJsonTextDepth(deep, 10)).toBe(11);
+  });
+
+  test("parses normal documents and rejects broken ones", () => {
+    expect(parseJsonBounded('{"name":"x"}')).toEqual({ value: { name: "x" } });
+    expect(parseJsonBounded("{ nope")).toBeNull();
+    let value: unknown = "leaf";
+    for (let index = 0; index < 100; index += 1) value = [value];
+    expect(isJsonTooDeep(value)).toBe(true);
+    expect(isJsonTooDeep({ blocks: [{ elements: [{ choices: [{ label: { "en-US": "x" } }] }] }] })).toBe(
+      false
+    );
+  });
+});

--- a/apps/web/modules/survey/import/lib/json-depth.ts
+++ b/apps/web/modules/survey/import/lib/json-depth.ts
@@ -1,0 +1,71 @@
+/**
+ * JSON nesting guard. V8's `JSON.parse` recurses per nesting level, so a few hundred thousand `[`
+ * characters (a 2 MB file) throw a `RangeError` deep inside whatever touched the value first — a
+ * crash that reads as a 500 instead of "this is not a survey". Depth is measured by a linear scan
+ * before parsing, and iteratively on already-parsed values, so neither path recurses.
+ */
+
+/** Deeper than any survey document: blocks → elements → choices → labels is four levels. */
+export const IMPORT_MAX_JSON_DEPTH = 64;
+
+/** Maximum bracket nesting of a JSON text, ignoring brackets inside strings. Stops early past `limit`. */
+export function measureJsonTextDepth(text: string, limit = IMPORT_MAX_JSON_DEPTH): number {
+  let depth = 0;
+  let max = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === "{" || char === "[") {
+      depth += 1;
+      if (depth > max) max = depth;
+      if (max > limit) return max;
+    } else if (char === "}" || char === "]") depth -= 1;
+  }
+
+  return max;
+}
+
+/** Maximum nesting of a parsed value, measured with an explicit stack. Stops early past `limit`. */
+export function measureJsonValueDepth(value: unknown, limit = IMPORT_MAX_JSON_DEPTH): number {
+  const stack: { value: unknown; depth: number }[] = [{ value, depth: 0 }];
+  let max = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current.value === null || typeof current.value !== "object") continue;
+    const depth = current.depth + 1;
+    if (depth > max) max = depth;
+    if (max > limit) return max;
+    for (const nested of Object.values(current.value as Record<string, unknown>)) {
+      if (nested !== null && typeof nested === "object") stack.push({ value: nested, depth });
+    }
+  }
+
+  return max;
+}
+
+export function isJsonTooDeep(input: string | unknown, limit = IMPORT_MAX_JSON_DEPTH): boolean {
+  return (
+    (typeof input === "string" ? measureJsonTextDepth(input, limit) : measureJsonValueDepth(input, limit)) >
+    limit
+  );
+}
+
+/** `JSON.parse` behind the depth guard; returns null for anything that is not parseable or too deep. */
+export function parseJsonBounded(text: string, limit = IMPORT_MAX_JSON_DEPTH): { value: unknown } | null {
+  if (measureJsonTextDepth(text, limit) > limit) return null;
+  try {
+    return { value: JSON.parse(text) };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/modules/survey/import/security.test.ts
+++ b/apps/web/modules/survey/import/security.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Security review checklist (ENG-3010): each test is one item of the review with a claim a reviewer
+ * can rerun. Items that live in other suites are referenced from the ticket comment, not duplicated.
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import { FIXTURE_LINK_SURVEY, FIXTURE_WORKSPACE_ID } from "@/modules/survey/export/__fixtures__/surveys";
+import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
+import { extractDocumentText } from "./lanes/document/extract";
+import { formbricksLane } from "./lanes/formbricks";
+import { stripHtml } from "./lanes/qsf/strip-html";
+import { type TResolveImportDeps, resolveImportCandidate } from "./resolve";
+import type { TImportContext } from "./types";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@formbricks/database", () => ({ prisma: {} }));
+vi.mock("@/lib/actionClass/service", () => ({ getActionClasses: vi.fn() }));
+vi.mock("@/modules/survey/editor/lib/action-class", () => ({ createActionClass: vi.fn() }));
+vi.mock("@/modules/survey/lib/permission", () => ({ getExternalUrlsPermission: vi.fn() }));
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  WEBAPP_URL: "https://app.formbricks.com",
+}));
+
+const FIXTURES = join(__dirname, "lanes/document/__fixtures__");
+const laneCtx: TImportContext = {
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  organizationId: "org_1",
+  userId: "user_1",
+  requestId: "req_1",
+  importRunId: "run_1",
+};
+const resolveCtx = { ...laneCtx, dryRun: true };
+const deps: TResolveImportDeps = {
+  listActionClasses: async () => [],
+  createActionClass: vi.fn(),
+  listWorkspaceLanguageCodes: async () => ["en-US", "de-DE"],
+  isExternalUrlAllowed: async () => true,
+  instanceUrl: "https://app.formbricks.com",
+};
+
+function exportEnvelope(): Record<string, unknown> {
+  const result = buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, {
+    appVersion: "6.2.0",
+    publicUrl: "https://x",
+  });
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return JSON.parse(JSON.stringify(result.data));
+}
+
+describe("files", () => {
+  test("a truncated DOCX fails within the timeout with a clean error, no hang", async () => {
+    const whole = readFileSync(join(FIXTURES, "survey-numbered-lists.docx"));
+    const truncated = whole.subarray(0, Math.floor(whole.length / 2));
+    const started = Date.now();
+
+    const result = await extractDocumentText("docx", truncated);
+
+    expect(Date.now() - started).toBeLessThan(10_000);
+    expect(result.text).toBe("");
+    expect(result.issues[0]).toMatchObject({ severity: "error", code: "document_unreadable" });
+  });
+
+  test("binary garbage with a .md extension is treated as text and never parsed as anything else", async () => {
+    const garbage = Buffer.from(Array.from({ length: 4096 }, (_, index) => (index * 7919) % 256));
+    const result = await extractDocumentText("markdown", garbage);
+    expect(result.issues.filter((issue) => issue.severity === "error")).toEqual([]);
+    expect(typeof result.text).toBe("string");
+  });
+
+  test("a 2 MB deeply nested JSON document does not crash the lossless lane", async () => {
+    const depth = 250_000;
+    const nested = `{"name":"x","blocks":${"[".repeat(depth)}${"]".repeat(depth)}}`;
+    expect(nested.length).toBeGreaterThan(400_000);
+
+    const candidate = await formbricksLane(
+      { kind: "v3-document", fileName: "deep.json", content: { type: "bytes", bytes: Buffer.from(nested) } },
+      laneCtx
+    );
+
+    expect(candidate.document).toBeNull();
+    expect(candidate.issues[0].severity).toBe("error");
+  });
+
+  test("nothing in the import module fetches a URL from a document (media URLs stay strings)", () => {
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const path = join(dir, entry);
+        if (statSync(path).isDirectory()) {
+          if (entry !== "__fixtures__" && entry !== "__snapshots__") walk(path);
+          continue;
+        }
+        if (!entry.endsWith(".ts") || entry.endsWith(".test.ts")) continue;
+        // The two browser clients call our own API; everything else must not reach the network.
+        if (entry === "import-client.ts" || entry === "import-stream-client.ts") continue;
+        const source = readFileSync(path, "utf8");
+        if (/\bfetch\s*\(|new\s+XMLHttpRequest|https?\.request\(|axios/.test(source)) offenders.push(path);
+      }
+    };
+    walk(__dirname);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("content", () => {
+  test("hostile HTML in QSF text loses scripts, event handlers and javascript: links", () => {
+    const hostile =
+      '<p>Rate <script>alert(1)</script>us <img src=x onerror="alert(1)"> <a href="javascript:steal()">here</a> &lt;b&gt;</p>';
+    const clean = stripHtml(hostile);
+
+    expect(clean).not.toMatch(/<script|onerror|javascript:|<img|<a /i);
+    expect(clean).toContain("Rate");
+    expect(clean).toContain("here");
+  });
+
+  test("a recall that points at a forbidden or unknown id is caught by the reference validator", async () => {
+    const envelope = exportEnvelope();
+    const survey = envelope.survey as { blocks: { elements: { headline: Record<string, string> }[] }[] };
+    survey.blocks[0].elements[0].headline["en-US"] =
+      "Hi #recall:userId/fallback:#, and #recall:nope123/fallback:#";
+    survey.blocks[0].elements[0].headline["de-DE"] = "Hallo #recall:userId/fallback:#";
+
+    const candidate = await formbricksLane(
+      {
+        kind: "formbricks-export",
+        fileName: "x.formbricks.json",
+        content: { type: "json", value: envelope },
+      },
+      laneCtx
+    );
+    const resolved = await resolveImportCandidate(candidate, resolveCtx, deps);
+
+    expect(resolved.document).toBeNull();
+    expect(resolved.createBody).toBeNull();
+    expect(resolved.report.issues.some((issue) => issue.severity === "error")).toBe(true);
+  });
+
+  test("instance-bound and pre-D1 fields in a hand-crafted export never reach the create payload", async () => {
+    const envelope = exportEnvelope();
+    Object.assign(envelope.survey as Record<string, unknown>, {
+      id: "clsurvey0000000000000000001",
+      workspaceId: "clother00000000000000000001",
+      createdBy: "someone",
+      archivedAt: "2026-01-01T00:00:00.000Z",
+      customHeadScripts: "<script>alert(1)</script>",
+      customHeadScriptsMode: "all",
+      slug: "stolen-slug",
+      publishOn: "2026-01-01T00:00:00.000Z",
+      closeOn: "2026-02-01T00:00:00.000Z",
+      segmentId: "clsegment00000000000000001",
+      followUps: [{ id: "f1" }],
+      styling: { brandColor: "#000" },
+      targeting: { segment: { filters: [{ x: 1 }] } },
+      status: "inProgress",
+    });
+
+    const candidate = await formbricksLane(
+      {
+        kind: "formbricks-export",
+        fileName: "x.formbricks.json",
+        content: { type: "json", value: envelope },
+      },
+      laneCtx
+    );
+    const resolved = await resolveImportCandidate(candidate, resolveCtx, deps);
+
+    expect(resolved.createBody, JSON.stringify(resolved.report.issues)).not.toBeNull();
+    const keys = Object.keys(resolved.createBody as object);
+    for (const forbidden of [
+      "id",
+      "createdBy",
+      "archivedAt",
+      "customHeadScripts",
+      "customHeadScriptsMode",
+      "slug",
+      "publishOn",
+      "closeOn",
+      "segmentId",
+      "followUps",
+      "styling",
+      "targeting",
+    ]) {
+      expect(keys, forbidden).not.toContain(forbidden);
+    }
+    expect(resolved.createBody?.workspaceId).toBe(FIXTURE_WORKSPACE_ID);
+    expect(resolved.createBody?.status).toBe("draft");
+    expect(resolved.report.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        "slug_not_imported",
+        "schedule_cleared",
+        "status_reset",
+        "unknown_field_stripped",
+      ])
+    );
+    expect(deps.createActionClass).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes ENG-3010

Stacked on #9213 (`jojo/eng-3008-analytics-events-llm-tracing-feature-audit-log-completeness`). Survey Import & Export, milestone 6.

## What & why

**Was:** The security checklist for import had claims without tests behind several of them, and one real gap: a deeply nested JSON file (2 MB of `[`) hit V8's recursive `JSON.parse` and surfaced as a stack overflow, i.e. a 500 instead of "not a survey".

**Now:** Every JSON parse in the import module goes through a depth-guarded parser (`json-depth.ts`, limit 64 levels, linear scan before parsing, iterative measure for already-parsed bodies), and the review checklist lives as `security.test.ts`: one test per claim a reviewer can rerun. The full pass/fail list with test names is the review comment on the ticket.

- Truncated DOCX, garbage `.md`, deep JSON: clean errors within the timeout, no hang, no 5xx.
- Hostile QSF HTML loses scripts, event handlers and `javascript:` links; a recall to a forbidden or unknown id is caught by the reference validator.
- Instance-bound and pre-D1 fields in a hand-crafted export never reach the create payload; nothing in the module fetches a URL.

## Where to look

- [json-depth.ts](apps/web/modules/survey/import/lib/json-depth.ts) — the guard and why it scans before it parses.
- [security.test.ts](apps/web/modules/survey/import/security.test.ts) — the checklist.

## Breaking changes

- [ ] This PR contains a breaking change

A JSON file nested deeper than 64 levels is now refused as `invalid_document`; no survey document comes close.

## Migrations & env

None.

## Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| 2 MB deeply nested JSON → `invalid_document`, no stack overflow | unit (red on main) | `security.test.ts` "a 2 MB deeply nested JSON document…" |
| Depth measured with brackets-in-strings ignored; early stop past the limit | unit (mutation) | `json-depth.test.ts` — mutate the `inString` branch |
| Truncated DOCX / garbage `.md` clean errors within timeout | unit (guard) | `security.test.ts` files block |
| Hostile HTML stripped; forbidden recall caught; instance-bound and pre-D1 fields never in the create payload; no `fetch` in the module | unit (guard) | `security.test.ts` content block |
| Zip bomb, 413 by declared and counted bytes, 403 authorization, dry run writes nothing | unit (guard) | existing: `extract.test.ts`, `api-wrapper.test.ts`, `import-survey.test.ts`, `export-survey.test.ts`, `convert-import.test.ts` |

Rerun: `cd apps/web && npx vitest run modules/survey/import app/api/v3/surveys/import`

## Open gaps

- Prompt-injection fixtures in a hidden DOCX paragraph and PDF metadata, and the 50-request burst, need a live provider and a running instance; recorded as open in the ticket comment.
- The repo's `/security-review` skill was not run over the whole stack in this session; the checklist above is the manual equivalent.

## Risks

- None known beyond the depth limit stated above.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>
