### PR TITLE
feat(surveys): import hardening — limits, analytics, security review, Embedded Data names and docs (milestone 6) [ENG-3013, ENG-3009, ENG-3008, ENG-3010, ENG-3011]

### DIFF
--- a/apps/web/app/api/internal/surveys/import/lib/operations.test.ts
+++ b/apps/web/app/api/internal/surveys/import/lib/operations.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { OperationNotAllowedError, TooManyRequestsError } from "@formbricks/types/errors";
 import { ZV3SurveyImportConvertBody } from "@/app/api/v3/surveys/import/convert/schemas";
+import { ImportInProgressError } from "@/modules/survey/import/lib/ai-inflight-guard";
 import type { TImportContext, TImportLaneHandler } from "@/modules/survey/import/types";
 import { streamImportConversion } from "./operations";
 
@@ -13,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   getImportLaneHandler: vi.fn(),
   resolveImportCandidate: vi.fn(),
   capturePostHogEvent: vi.fn(),
+  acquireAiImportSlot: vi.fn(),
+  releaseAiImportSlot: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -30,6 +33,10 @@ vi.mock("@/lib/ai/service", async (importOriginal) => ({
   assertOrganizationAIConfigured: mocks.assertOrganizationAIConfigured,
 }));
 vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: mocks.applyRateLimit }));
+vi.mock("@/modules/survey/import/lib/ai-inflight-guard", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/survey/import/lib/ai-inflight-guard")>()),
+  acquireAiImportSlot: mocks.acquireAiImportSlot,
+}));
 vi.mock("@/modules/survey/import/lanes", () => ({ getImportLaneHandler: mocks.getImportLaneHandler }));
 vi.mock("@/modules/survey/import/resolve", () => ({ resolveImportCandidate: mocks.resolveImportCandidate }));
 vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: mocks.capturePostHogEvent }));
@@ -76,6 +83,7 @@ describe("streamImportConversion", () => {
     mocks.assertOrganizationAIConfigured.mockResolvedValue({});
     mocks.applyRateLimit.mockResolvedValue({});
     mocks.resolveImportCandidate.mockResolvedValue(resolved);
+    mocks.acquireAiImportSlot.mockResolvedValue(mocks.releaseAiImportSlot);
   });
 
   test("a deterministic lane emits start, reading, validating and done — no partials", async () => {
@@ -184,6 +192,24 @@ describe("streamImportConversion", () => {
 
     expect(response.status).toBe(429);
     expect(response.headers.get("Retry-After")).toBe("17");
+  });
+
+  test("a third concurrent AI conversion is a 409 before the stream; the slot is released after the stream", async () => {
+    mocks.acquireAiImportSlot.mockRejectedValueOnce(new ImportInProgressError());
+    mocks.getImportLaneHandler.mockReturnValue(vi.fn());
+    const refused = await call(body("survey.md", readFileSync(join(FIXTURES, "survey.md"))));
+    expect(refused.status).toBe(409);
+    expect(refused.headers.get("Retry-After")).toBe("30");
+
+    mocks.getImportLaneHandler.mockReturnValue(
+      vi.fn(async (input) => ({
+        document: { name: "Doc" },
+        issues: [],
+        source: { lane: "ai" as const, kind: input.kind },
+      }))
+    );
+    await readEvents(await call(body("survey.md", readFileSync(join(FIXTURES, "survey.md")))));
+    expect(mocks.releaseAiImportSlot).toHaveBeenCalledTimes(1);
   });
 
   test("an unsupported file is a 422 problem, a kind without a lane a 400", async () => {

--- a/apps/web/app/api/internal/surveys/import/lib/operations.test.ts
+++ b/apps/web/app/api/internal/surveys/import/lib/operations.test.ts
@@ -115,7 +115,14 @@ describe("streamImportConversion", () => {
       references: null,
     });
     expect(mocks.assertOrganizationAIConfigured).not.toHaveBeenCalled();
-    expect(mocks.capturePostHogEvent).not.toHaveBeenCalled();
+    expect(mocks.capturePostHogEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.capturePostHogEvent).toHaveBeenCalledWith(
+      "user1",
+      "survey_import_converted",
+      // The event reads the resolved report, which the mocked resolver labels markdown/ai.
+      expect.objectContaining({ source_kind: "markdown", lane: "ai", has_document: true, streamed: true }),
+      expect.objectContaining({ workspaceId })
+    );
   });
 
   test("an AI lane run streams progress per chunk and partials with their block offset", async () => {
@@ -182,6 +189,12 @@ describe("streamImportConversion", () => {
     expect(response.status).toBe(403);
     expect(response.headers.get("Content-Type")).toContain("application/problem+json");
     expect(lane).not.toHaveBeenCalled();
+    expect(mocks.capturePostHogEvent).toHaveBeenCalledWith(
+      "user1",
+      "survey_import_failed",
+      { source_kind: "markdown", lane: "ai", code: "ai_smart_tools_disabled", status: 403, streamed: true },
+      expect.objectContaining({ workspaceId })
+    );
   });
 
   test("a spent AI budget answers 429 with Retry-After before the stream", async () => {
@@ -255,5 +268,11 @@ describe("streamImportConversion", () => {
       retryAfter: 30,
       reference: expect.any(String),
     });
+    expect(mocks.capturePostHogEvent).toHaveBeenCalledWith(
+      "user1",
+      "survey_import_failed",
+      expect.objectContaining({ code: "ai_quota_exceeded", lane: "ai", streamed: true }),
+      expect.anything()
+    );
   });
 });

--- a/apps/web/app/api/internal/surveys/import/lib/operations.ts
+++ b/apps/web/app/api/internal/surveys/import/lib/operations.ts
@@ -10,10 +10,15 @@ import {
   problemForImportDetectionFailure,
 } from "@/app/api/v3/surveys/import/convert/lib/convert-import";
 import type { TV3SurveyImportConvertBody } from "@/app/api/v3/surveys/import/convert/schemas";
+import {
+  guardImportWorkspaceBudget,
+  problemImportInProgress,
+} from "@/app/api/v3/surveys/import/lib/import-guards";
 import { getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { detectImportSource } from "@/modules/survey/import/detect";
 import { getImportLaneHandler } from "@/modules/survey/import/lanes";
+import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
 import { resolveImportCandidate } from "@/modules/survey/import/resolve";
 import {
   IMPORT_LANE_BY_KIND,
@@ -71,7 +76,10 @@ export async function streamImportConversion({
   const userId = getSessionUserId(authentication);
   const importRunId = createId();
   const file = body.files[0];
-  const log = logger.withContext({ requestId, importRunId, workspaceId, organizationId });
+  const budget = await guardImportWorkspaceBudget(workspaceId, requestId);
+  if (budget) {
+    return budget;
+  }
 
   const detection = detectImportSource({
     fileName: file.fileName,
@@ -81,6 +89,14 @@ export async function streamImportConversion({
   if (!detection.ok) {
     return problemForImportDetectionFailure(requestId, instance, detection.code);
   }
+  const log = logger.withContext({
+    requestId,
+    importRunId,
+    workspaceId,
+    organizationId,
+    sourceKind: detection.kind,
+    lane: IMPORT_LANE_BY_KIND[detection.kind],
+  });
 
   const lane = getImportLaneHandler(detection.kind);
   if (!lane) {
@@ -92,10 +108,15 @@ export async function streamImportConversion({
   }
 
   const isAiLane = IMPORT_LANE_BY_KIND[detection.kind] === "ai";
+  let releaseSlot: () => Promise<void> = async () => undefined;
   if (isAiLane) {
     try {
       await assertAiImportAllowed(organizationId, authentication);
+      releaseSlot = await acquireAiImportSlot(userId ?? workspaceId);
     } catch (error) {
+      if (error instanceof ImportInProgressError) {
+        return problemImportInProgress(requestId, error, instance);
+      }
       return mapV3SurveyGenerateError(error, { requestId, instance, workspaceId, organizationId });
     }
   }
@@ -194,11 +215,12 @@ export async function streamImportConversion({
         if (isClientAbort(error, abortController.signal)) {
           log.info("Survey import stream aborted by the client");
         } else {
-          log.error({ err: error, sourceKind: detection.kind }, "Survey import stream failed");
+          log.error({ err: error }, "Survey import stream failed");
           emit({ ...toStreamErrorEvent(error), reference: importRunId });
         }
       } finally {
         detach();
+        await releaseSlot();
         if (!closed) {
           closed = true;
           controller.close();
@@ -208,6 +230,7 @@ export async function streamImportConversion({
     cancel() {
       closed = true;
       abortController.abort();
+      void releaseSlot();
       log.info("Survey import stream cancelled by the client");
     },
   });

--- a/apps/web/app/api/internal/surveys/import/lib/operations.ts
+++ b/apps/web/app/api/internal/surveys/import/lib/operations.ts
@@ -19,6 +19,11 @@ import { capturePostHogEvent } from "@/lib/posthog";
 import { detectImportSource } from "@/modules/survey/import/detect";
 import { getImportLaneHandler } from "@/modules/survey/import/lanes";
 import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
+import {
+  buildImportConvertedProperties,
+  buildImportFailedProperties,
+  readProblemCode,
+} from "@/modules/survey/import/lib/import-analytics";
 import { resolveImportCandidate } from "@/modules/survey/import/resolve";
 import {
   IMPORT_LANE_BY_KIND,
@@ -54,7 +59,31 @@ interface TStreamImportParams {
  * mid-conversion failures become in-band `error` events. Deterministic lanes emit start → progress
  * reading → progress validating → done with no partials.
  */
-export async function streamImportConversion({
+export async function streamImportConversion(params: TStreamImportParams): Promise<Response> {
+  const response = await streamImportConversionInner(params);
+  const userId = getSessionUserId(params.authentication);
+  // Pre-stream refusals (gate, budget, unsupported file) are problem responses; in-band errors are
+  // reported where they are emitted.
+  if (!response.ok && userId) {
+    const file = params.body.files[0];
+    const kind = detectImportSource({ fileName: file.fileName, mimeType: file.mimeType, bytes: file.bytes });
+    capturePostHogEvent(
+      userId,
+      "survey_import_failed",
+      buildImportFailedProperties({
+        sourceKind: kind.ok ? kind.kind : null,
+        lane: kind.ok ? IMPORT_LANE_BY_KIND[kind.kind] : null,
+        code: await readProblemCode(response),
+        status: response.status,
+        streamed: true,
+      }),
+      { workspaceId: params.body.fields.workspaceId }
+    );
+  }
+  return response;
+}
+
+async function streamImportConversionInner({
   req,
   authentication,
   body,
@@ -195,6 +224,19 @@ export async function streamImportConversion({
           report: resolved.report,
         });
 
+        if (userId) {
+          capturePostHogEvent(
+            userId,
+            "survey_import_converted",
+            buildImportConvertedProperties(resolved.report, {
+              durationMs: Date.now() - startedAt,
+              hasDocument: resolved.document !== null,
+              streamed: true,
+            }),
+            { organizationId, workspaceId }
+          );
+        }
+
         if (isAiLane && userId && resolved.document) {
           capturePostHogEvent(
             userId,
@@ -216,7 +258,21 @@ export async function streamImportConversion({
           log.info("Survey import stream aborted by the client");
         } else {
           log.error({ err: error }, "Survey import stream failed");
-          emit({ ...toStreamErrorEvent(error), reference: importRunId });
+          const failure = { ...toStreamErrorEvent(error), reference: importRunId };
+          emit(failure);
+          if (userId) {
+            capturePostHogEvent(
+              userId,
+              "survey_import_failed",
+              buildImportFailedProperties({
+                sourceKind: detection.kind,
+                lane: source.lane,
+                code: failure.code,
+                streamed: true,
+              }),
+              { organizationId, workspaceId }
+            );
+          }
         }
       } finally {
         detach();

--- a/apps/web/app/api/v3/lib/response.ts
+++ b/apps/web/app/api/v3/lib/response.ts
@@ -194,6 +194,19 @@ export function problemConflict(requestId: string, detail: string, instance?: st
   });
 }
 
+/** A 409 whose cause clears by itself (a concurrent run finishing): carries `Retry-After` and a specific code. */
+export function problemConflictWithRetry(
+  requestId: string,
+  detail: string,
+  options: { instance?: string; code: string; retryAfter: number }
+): Response {
+  return problemResponse(409, "Conflict", detail, requestId, {
+    code: options.code,
+    instance: options.instance,
+    headers: { "Retry-After": String(options.retryAfter) },
+  });
+}
+
 export function problemBadGateway(requestId: string, detail: string, instance?: string): Response {
   return problemResponse(502, "Bad Gateway", detail, requestId, {
     code: "bad_gateway",

--- a/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.test.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.test.ts
@@ -113,7 +113,12 @@ describe("exportV3Survey", () => {
     expect(auditLog).toMatchObject({
       targetId: FIXTURE_APP_SURVEY.id,
       organizationId: "org_1",
-      newObject: { exportFormat: 1, workspaceId: FIXTURE_WORKSPACE_ID },
+      newObject: {
+        exportFormat: 1,
+        workspaceId: FIXTURE_WORKSPACE_ID,
+        surveyId: FIXTURE_APP_SURVEY.id,
+        surveyType: "app",
+      },
     });
     expect(capturePostHogEvent).toHaveBeenCalledWith(
       "user_1",

--- a/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts
+++ b/apps/web/app/api/v3/surveys/[surveyId]/export/lib/export-survey.ts
@@ -69,6 +69,8 @@ export async function exportV3Survey({
       auditLog.newObject = {
         exportFormat: envelope.formbricks.exportFormat,
         workspaceId: survey.workspaceId,
+        surveyId: survey.id,
+        surveyType: survey.type,
       };
     }
 

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@/modules/survey/export/__fixtures__/surveys";
 import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
 import { documentLane } from "@/modules/survey/import/lanes/document";
+import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
 import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
 import { ZV3SurveyImportConvertBody } from "../schemas";
 import { convertImportFile } from "./convert-import";
@@ -43,6 +44,10 @@ vi.mock("@/lib/ai/service", async (importOriginal) => ({
 }));
 vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn() }));
 vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: vi.fn() }));
+vi.mock("@/modules/survey/import/lib/ai-inflight-guard", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/survey/import/lib/ai-inflight-guard")>()),
+  acquireAiImportSlot: vi.fn(async () => async () => undefined),
+}));
 vi.mock("@/lib/constants", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/constants")>()),
   WEBAPP_URL: "https://app.formbricks.com",
@@ -248,7 +253,35 @@ describe("convertImportFile", () => {
       expect(response.status).toBe(403);
       expect((await response.json()).code).toBe("ai_features_not_enabled");
       expect(documentLane).not.toHaveBeenCalled();
-      expect(applyRateLimit).not.toHaveBeenCalled();
+      expect(applyRateLimit).not.toHaveBeenCalledWith(
+        expect.objectContaining({ namespace: "api:v3:surveys:generate" }),
+        expect.anything()
+      );
+    });
+
+    test("a third concurrent AI conversion answers 409 import_in_progress with Retry-After", async () => {
+      vi.mocked(acquireAiImportSlot).mockRejectedValueOnce(new ImportInProgressError());
+
+      const response = await convertImportFile({ body: docx(), authentication, requestId, instance });
+
+      expect(response.status).toBe(409);
+      expect((await response.json()).code).toBe("import_in_progress");
+      expect(response.headers.get("Retry-After")).toBe("30");
+      expect(documentLane).not.toHaveBeenCalled();
+    });
+
+    test("the workspace import budget answers 429 before anything else", async () => {
+      vi.mocked(applyRateLimit).mockImplementation(async (config) => {
+        if (config.namespace === "api:v3:surveys:import:workspace")
+          throw new TooManyRequestsError("budget", 900);
+        return {} as never;
+      });
+
+      const response = await convertImportFile({ body: docx(), authentication, requestId, instance });
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get("Retry-After")).toBe("900");
+      expect(assertOrganizationAIConfigured).not.toHaveBeenCalled();
     });
 
     test("an entitled organization gets the AI lane's document, source and a PostHog event", async () => {
@@ -322,7 +355,11 @@ describe("convertImportFile", () => {
 
       expect(response.status).toBe(200);
       expect(assertOrganizationAIConfigured).not.toHaveBeenCalled();
-      expect(applyRateLimit).not.toHaveBeenCalled();
+      expect(applyRateLimit).toHaveBeenCalledTimes(1);
+      expect(applyRateLimit).toHaveBeenCalledWith(
+        expect.objectContaining({ namespace: "api:v3:surveys:import:workspace" }),
+        FIXTURE_WORKSPACE_ID
+      );
     });
   });
 
@@ -338,6 +375,57 @@ describe("convertImportFile", () => {
 
     expect(response.status).toBe(403);
     expect(prisma.language.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("convertImportFile logging", () => {
+  test("no log line carries file names, bytes or document text", async () => {
+    vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(authResult);
+    vi.mocked(prisma.language.findMany).mockResolvedValue([] as never);
+    vi.mocked(getActionClasses).mockResolvedValue([]);
+    vi.mocked(getExternalUrlsPermission).mockResolvedValue(true);
+    vi.mocked(applyRateLimit).mockResolvedValue({} as never);
+    vi.mocked(assertOrganizationAIConfigured).mockResolvedValue({} as never);
+    const { logger } = await import("@formbricks/logger");
+    const contextLogger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    vi.mocked(logger.withContext).mockReturnValue(contextLogger as never);
+
+    await convertImportFile({
+      body: body("in-app.formbricks.json", envelopeBytes(FIXTURE_APP_SURVEY), "application/json"),
+      authentication,
+      requestId,
+      instance,
+    });
+    await convertImportFile({
+      body: body("broken.json", Buffer.from("{ nope")),
+      authentication,
+      requestId,
+      instance,
+    });
+    vi.mocked(documentLane).mockRejectedValueOnce(new Error("provider down"));
+    await convertImportFile({
+      body: body(
+        "questions.docx",
+        readFileSync(
+          join(process.cwd(), "modules/survey/import/lanes/document/__fixtures__/survey-numbered-lists.docx")
+        )
+      ),
+      authentication,
+      requestId,
+      instance,
+    });
+
+    const forbidden = new Set(["text", "bytes", "fileName", "document", "prompt", "content"]);
+    const logged = [
+      ...vi.mocked(logger.withContext).mock.calls.map((call) => call[0]),
+      ...[contextLogger.warn, contextLogger.error, contextLogger.info].flatMap((fn) =>
+        fn.mock.calls.map((call) => call[0])
+      ),
+    ].filter((arg) => typeof arg === "object" && arg !== null) as Record<string, unknown>[];
+    expect(logged.length).toBeGreaterThan(3);
+    for (const entry of logged) {
+      for (const key of Object.keys(entry)) expect(forbidden.has(key), `log key ${key}`).toBe(false);
+    }
   });
 });
 

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.test.ts
@@ -110,6 +110,18 @@ describe("convertImportFile", () => {
       "trigger_would_be_created"
     );
     expect(createActionClass).not.toHaveBeenCalled();
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      "user_1",
+      "survey_import_converted",
+      expect.objectContaining({
+        source_kind: "formbricks-export",
+        lane: "lossless",
+        has_document: true,
+        error_count: 0,
+        import_warning_codes: expect.any(Array),
+      }),
+      expect.objectContaining({ workspaceId: FIXTURE_WORKSPACE_ID })
+    );
   });
 
   test("a raw v3 document renamed to .txt is still detected by content", async () => {
@@ -177,6 +189,12 @@ describe("convertImportFile", () => {
     expect(json.code).toBe(code);
     expect(json.detail).toContain(detail);
     expect(json.invalid_params[0].name).toBe("file");
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      "user_1",
+      "survey_import_failed",
+      { source_kind: null, lane: null, code, status: 422 },
+      expect.objectContaining({ workspaceId: FIXTURE_WORKSPACE_ID })
+    );
   });
 
   test("converts a Qualtrics .qsf through the structured lane and reports its logic", async () => {
@@ -252,6 +270,12 @@ describe("convertImportFile", () => {
 
       expect(response.status).toBe(403);
       expect((await response.json()).code).toBe("ai_features_not_enabled");
+      expect(capturePostHogEvent).toHaveBeenCalledWith(
+        "user_1",
+        "survey_import_failed",
+        { source_kind: "docx", lane: "ai", code: "ai_features_not_enabled", status: 403 },
+        expect.anything()
+      );
       expect(documentLane).not.toHaveBeenCalled();
       expect(applyRateLimit).not.toHaveBeenCalledWith(
         expect.objectContaining({ namespace: "api:v3:surveys:generate" }),

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
@@ -24,8 +24,18 @@ import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { type TImportDetectionFailureCode, detectImportSource } from "@/modules/survey/import/detect";
 import { getImportLaneHandler } from "@/modules/survey/import/lanes";
 import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
+import {
+  buildImportConvertedProperties,
+  buildImportFailedProperties,
+  readProblemCode,
+} from "@/modules/survey/import/lib/import-analytics";
 import { resolveImportCandidate } from "@/modules/survey/import/resolve";
-import { IMPORT_LANE_BY_KIND, type TImportContext } from "@/modules/survey/import/types";
+import {
+  IMPORT_LANE_BY_KIND,
+  type TImportContext,
+  type TImportLane,
+  type TImportSourceKind,
+} from "@/modules/survey/import/types";
 import type { TV3SurveyImportConvertBody } from "../schemas";
 
 type TConvertImportParams = {
@@ -72,21 +82,43 @@ export async function assertAiImportAllowed(
   }
 }
 
+type TConvertTelemetry = { sourceKind: TImportSourceKind | null; lane: TImportLane | null };
+
 /**
  * `POST /api/v3/surveys/import/convert` — turn a file into a reviewed survey document without
  * persisting anything. Detect → lane → resolve (always dry run: creating is the import route's job).
  *
- * A file the allowlist rejects is a 422 (the request was well-formed; the file is not something we
- * take), a non-multipart request is a 415 (wrapper), a lane that has not shipped is a 400
- * `lane_not_available`. A file the lane cannot read still answers 200 with `document: null` and
- * the reasons in `report` — the dialog shows them; the 422 belongs to the persisting endpoint.
+ * A file the allowlist rejects is a 422, a non-multipart request a 415 (wrapper), a lane that has not
+ * shipped a 400 `lane_not_available`. A file the lane cannot read still answers 200 with
+ * `document: null` and the reasons in `report`. Every non-2xx answer is reported as
+ * `survey_import_failed` for session users (ENG-3008), here, in exactly one place.
  */
-export async function convertImportFile({
-  body,
-  authentication,
-  requestId,
-  instance,
-}: TConvertImportParams): Promise<Response> {
+export async function convertImportFile(params: TConvertImportParams): Promise<Response> {
+  const telemetry: TConvertTelemetry = { sourceKind: null, lane: null };
+  const response = await convertImportFileInner(params, telemetry);
+
+  const userId = getSessionUserId(params.authentication);
+  if (!response.ok && userId) {
+    capturePostHogEvent(
+      userId,
+      "survey_import_failed",
+      buildImportFailedProperties({
+        sourceKind: telemetry.sourceKind,
+        lane: telemetry.lane,
+        code: await readProblemCode(response),
+        status: response.status,
+      }),
+      { workspaceId: params.body.fields.workspaceId }
+    );
+  }
+
+  return response;
+}
+
+async function convertImportFileInner(
+  { body, authentication, requestId, instance }: TConvertImportParams,
+  telemetry: TConvertTelemetry
+): Promise<Response> {
   const importRunId = createId();
   const file = body.files[0];
   const extension = file.fileName.split(".").pop()?.toLowerCase() ?? null;
@@ -126,6 +158,8 @@ export async function convertImportFile({
       return problemForImportDetectionFailure(requestId, instance, detection.code);
     }
 
+    telemetry.sourceKind = detection.kind;
+    telemetry.lane = IMPORT_LANE_BY_KIND[detection.kind];
     const lane = getImportLaneHandler(detection.kind);
     if (!lane) {
       log.warn({ statusCode: 400, sourceKind: detection.kind }, "Import lane not available");
@@ -202,6 +236,18 @@ export async function convertImportFile({
       },
       "Import file converted"
     );
+
+    if (ctx.userId) {
+      capturePostHogEvent(
+        ctx.userId,
+        "survey_import_converted",
+        buildImportConvertedProperties(resolved.report, {
+          durationMs: Date.now() - startedAt,
+          hasDocument: resolved.document !== null,
+        }),
+        { organizationId: authResult.organizationId, workspaceId: authResult.workspaceId }
+      );
+    }
 
     if (isAiLane && ctx.userId && resolved.document) {
       capturePostHogEvent(

--- a/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
+++ b/apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts
@@ -12,6 +12,10 @@ import {
 } from "@/app/api/v3/lib/response";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
 import { mapV3SurveyGenerateError } from "@/app/api/v3/surveys/generate/error-mapping";
+import {
+  guardImportWorkspaceBudget,
+  problemImportInProgress,
+} from "@/app/api/v3/surveys/import/lib/import-guards";
 import { getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
 import { assertOrganizationAIConfigured } from "@/lib/ai/service";
 import { capturePostHogEvent } from "@/lib/posthog";
@@ -19,6 +23,7 @@ import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { type TImportDetectionFailureCode, detectImportSource } from "@/modules/survey/import/detect";
 import { getImportLaneHandler } from "@/modules/survey/import/lanes";
+import { ImportInProgressError, acquireAiImportSlot } from "@/modules/survey/import/lib/ai-inflight-guard";
 import { resolveImportCandidate } from "@/modules/survey/import/resolve";
 import { IMPORT_LANE_BY_KIND, type TImportContext } from "@/modules/survey/import/types";
 import type { TV3SurveyImportConvertBody } from "../schemas";
@@ -105,6 +110,12 @@ export async function convertImportFile({
       return authResult;
     }
 
+    const budget = await guardImportWorkspaceBudget(authResult.workspaceId, requestId);
+    if (budget) {
+      log.warn({ statusCode: 429 }, "Workspace import budget exhausted");
+      return budget;
+    }
+
     const detection = detectImportSource({
       fileName: file.fileName,
       mimeType: file.mimeType,
@@ -143,9 +154,13 @@ export async function convertImportFile({
     const startedAt = Date.now();
 
     let candidate;
+    let releaseSlot: (() => Promise<void>) | null = null;
     try {
       if (isAiLane) {
         await assertAiImportAllowed(authResult.organizationId, authentication);
+        releaseSlot = await acquireAiImportSlot(
+          getRateLimitIdentifier(authentication) ?? authResult.workspaceId
+        );
       }
 
       candidate = await lane(
@@ -154,8 +169,20 @@ export async function convertImportFile({
       );
     } catch (error) {
       if (!isAiLane) throw error;
-      log.warn({ error, sourceKind: detection.kind }, "AI import lane failed");
+      if (error instanceof ImportInProgressError) {
+        log.warn(
+          { statusCode: 409, sourceKind: detection.kind, lane: "ai" },
+          "AI import already in progress"
+        );
+        return problemImportInProgress(requestId, error, instance);
+      }
+      log.warn(
+        { err: error, statusCode: 502, sourceKind: detection.kind, lane: "ai" },
+        "AI import lane failed"
+      );
       return mapV3SurveyGenerateError(error, aiErrorContext);
+    } finally {
+      await releaseSlot?.();
     }
 
     const resolved = await resolveImportCandidate(candidate, {

--- a/apps/web/app/api/v3/surveys/import/lib/import-guards.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-guards.ts
@@ -1,0 +1,56 @@
+import "server-only";
+import { TooManyRequestsError } from "@formbricks/types/errors";
+import type { InvalidParam } from "@/app/api/v3/lib/response";
+import { problemConflictWithRetry, problemTooManyRequests } from "@/app/api/v3/lib/response";
+import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import { ImportInProgressError } from "@/modules/survey/import/lib/ai-inflight-guard";
+
+/**
+ * The per-workspace import budget (200/hour across convert, stream and import). Returns the 429 to
+ * send, or null when the request may proceed.
+ */
+export async function guardImportWorkspaceBudget(
+  workspaceId: string,
+  requestId: string
+): Promise<Response | null> {
+  try {
+    await applyRateLimit(rateLimitConfigs.api.v3SurveyImportPerWorkspace, workspaceId);
+    return null;
+  } catch (error) {
+    if (error instanceof TooManyRequestsError) {
+      return problemTooManyRequests(
+        requestId,
+        "This workspace has reached its hourly import limit. Try again later.",
+        error.retryAfter
+      );
+    }
+    throw error;
+  }
+}
+
+/** The 409 for a third concurrent AI conversion. */
+export function problemImportInProgress(
+  requestId: string,
+  error: ImportInProgressError,
+  instance: string
+): Response {
+  return problemConflictWithRetry(requestId, error.message, {
+    instance,
+    code: "import_in_progress",
+    retryAfter: error.retryAfter,
+  });
+}
+
+const MAX_LOGGED_REASON_CHARS = 80;
+
+/** Log-safe copy of `invalid_params`: reasons can echo document text, so they are cut at 80 chars. */
+export function redactInvalidParams(params: readonly InvalidParam[]): InvalidParam[] {
+  return params.map((param) => ({
+    ...param,
+    reason:
+      param.reason.length > MAX_LOGGED_REASON_CHARS
+        ? `${param.reason.slice(0, MAX_LOGGED_REASON_CHARS)}…`
+        : param.reason,
+  }));
+}

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
@@ -15,6 +15,7 @@ import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
 import { ZV3SurveyImportBody } from "../schemas";
 import { importV3Survey } from "./import-survey";
 
+vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn() }));
 vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: vi.fn(async () => ({})) }));
 vi.mock("server-only", () => ({}));
 

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.test.ts
@@ -15,6 +15,7 @@ import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
 import { ZV3SurveyImportBody } from "../schemas";
 import { importV3Survey } from "./import-survey";
 
+vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: vi.fn(async () => ({})) }));
 vi.mock("server-only", () => ({}));
 
 vi.mock("@formbricks/logger", () => ({

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
@@ -13,8 +13,12 @@ import {
 } from "@/app/api/v3/lib/response";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
 import { createV3SurveyResponse, getSessionUserId } from "@/app/api/v3/surveys/lib/operations";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { formbricksLane } from "@/modules/survey/import/lanes/formbricks";
-import { countIssues } from "@/modules/survey/import/report";
+import {
+  buildImportCreatedProperties,
+  buildImportFailedProperties,
+} from "@/modules/survey/import/lib/import-analytics";
 import { type TResolveImportResult, resolveImportCandidate } from "@/modules/survey/import/resolve";
 import type { TImportCandidate, TImportReport } from "@/modules/survey/import/types";
 import type { TV3SurveyImportBody } from "../schemas";
@@ -33,18 +37,6 @@ export function reportErrorsToInvalidParams(report: TImportReport): InvalidParam
   return report.issues
     .filter((issue) => issue.severity === "error")
     .map((issue) => ({ name: issue.path ?? "document", reason: issue.message }));
-}
-
-/** The `survey_created` properties product reads import adoption from. */
-export function buildImportAnalyticsProperties(report: TImportReport) {
-  const counts = countIssues(report.issues);
-  return {
-    import_source: report.source.kind,
-    import_lane: report.source.lane,
-    import_ai_used: report.source.lane === "ai",
-    import_warning_count: counts.warning,
-    import_chunk_count: report.source.chunks ?? 0,
-  };
 }
 
 async function runLosslessImport(
@@ -145,6 +137,21 @@ export async function importV3Survey({
         { statusCode: 422, sourceKind: resolved.report.source.kind, invalidParamCount: invalidParams.length },
         "Survey import refused"
       );
+      const refusedBy = getSessionUserId(authentication);
+      if (refusedBy) {
+        capturePostHogEvent(
+          refusedBy,
+          "survey_import_failed",
+          buildImportFailedProperties({
+            sourceKind: resolved.report.source.kind,
+            lane: resolved.report.source.lane,
+            code:
+              resolved.report.issues.find((issue) => issue.severity === "error")?.code ?? "invalid_document",
+            status: 422,
+          }),
+          { organizationId: authResult.organizationId, workspaceId: authResult.workspaceId }
+        );
+      }
       return problemUnprocessableContent(requestId, "The survey could not be imported", {
         instance,
         invalid_params: invalidParams,
@@ -164,12 +171,19 @@ export async function importV3Survey({
       authResult,
       createdFrom: "import",
       createOptions: { skipExternalUrlPermissionCheck: true },
-      analyticsProperties: buildImportAnalyticsProperties(resolved.report),
+      analyticsProperties: buildImportCreatedProperties(resolved.report),
     });
 
     if (auditLog) {
       auditLog.status = createResponse.ok ? "success" : "failure";
       if (!createResponse.ok) auditLog.eventId = requestId;
+      // The audit row names the import run and its source so an operator can trace a survey back to its file.
+      if (auditLog?.newObject && typeof auditLog.newObject === "object") {
+        auditLog.newObject = {
+          ...(auditLog.newObject as Record<string, unknown>),
+          import: { importRunId, sourceKind: resolved.report.source.kind, lane: resolved.report.source.lane },
+        };
+      }
       await queueV3AuditLog(auditLog, requestId, log);
     }
 

--- a/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
+++ b/apps/web/app/api/v3/surveys/import/lib/import-survey.ts
@@ -18,6 +18,7 @@ import { countIssues } from "@/modules/survey/import/report";
 import { type TResolveImportResult, resolveImportCandidate } from "@/modules/survey/import/resolve";
 import type { TImportCandidate, TImportReport } from "@/modules/survey/import/types";
 import type { TV3SurveyImportBody } from "../schemas";
+import { guardImportWorkspaceBudget } from "./import-guards";
 
 type TImportV3SurveyParams = {
   req: Request;
@@ -107,6 +108,12 @@ export async function importV3Survey({
     );
     if (authResult instanceof Response) {
       return authResult;
+    }
+
+    const budget = await guardImportWorkspaceBudget(authResult.workspaceId, requestId);
+    if (budget) {
+      log.warn({ statusCode: 429 }, "Workspace import budget exhausted");
+      return budget;
     }
 
     const resolved = await runLosslessImport(body, {

--- a/apps/web/lib/posthog/ai-tracing.ts
+++ b/apps/web/lib/posthog/ai-tracing.ts
@@ -11,6 +11,8 @@ export interface AITracingContext {
   traceId?: string;
   organizationId?: string;
   workspaceId?: string;
+  /** Extra trace properties (an import run id, a chunk index) next to `feature`. */
+  properties?: Record<string, string | number | boolean>;
 }
 
 const buildGroups = (context: AITracingContext): Record<string, string> | undefined => {
@@ -37,7 +39,7 @@ export function wrapAiModelWithTracing(
       posthogDistinctId: context.distinctId,
       posthogTraceId: context.traceId,
       posthogGroups: buildGroups(context),
-      posthogProperties: { feature: context.feature },
+      posthogProperties: { feature: context.feature, ...context.properties },
       posthogPrivacyMode: true,
     });
   } catch (error) {

--- a/apps/web/lib/posthog/capture.ts
+++ b/apps/web/lib/posthog/capture.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { logger } from "@formbricks/logger";
 import { posthogServerClient } from "./server";
 
-type PostHogEventProperties = Record<string, string | number | boolean | null | undefined>;
+type PostHogEventProperties = Record<string, string | number | boolean | string[] | null | undefined>;
 
 export type PostHogGroupContext = {
   organizationId?: string;

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
@@ -95,6 +95,7 @@ describe("rateLimitConfigs", () => {
         "mcpAuth",
         "v3SurveyGenerate",
         "v3SurveyImportConvert",
+        "v3SurveyImportPerWorkspace",
         "internalDatasetPurge",
         "client",
         "clientEnvironment",

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.ts
@@ -26,6 +26,11 @@ export const rateLimitConfigs = {
       allowedPerInterval: 30,
       namespace: "api:v3:surveys:import:convert",
     }, // 30 per minute per user or key — deterministic file conversions; the AI lane additionally spends from v3SurveyGenerate
+    v3SurveyImportPerWorkspace: {
+      interval: 3600,
+      allowedPerInterval: 200,
+      namespace: "api:v3:surveys:import:workspace",
+    }, // 200 per hour per workspace across convert, stream and import — one workspace cannot soak the instance's import capacity
     internalDatasetPurge: {
       interval: 3600,
       allowedPerInterval: 5,

--- a/apps/web/modules/survey/import/components/import-survey-dialog.tsx
+++ b/apps/web/modules/survey/import/components/import-survey-dialog.tsx
@@ -14,6 +14,11 @@ import { ImportDropzone } from "@/modules/survey/import/components/import-dropzo
 import { ImportFacts } from "@/modules/survey/import/components/import-facts";
 import { ImportProgressLadder } from "@/modules/survey/import/components/import-progress-ladder";
 import { ImportReport } from "@/modules/survey/import/components/import-report";
+import {
+  IMPORT_KIND_BY_EXTENSION,
+  getImportFileExtension,
+  isImportAllowedExtension,
+} from "@/modules/survey/import/file-types";
 import { useImportSurvey } from "@/modules/survey/import/hooks/use-import-survey";
 import { formatFileSize } from "@/modules/survey/import/lib/import-file-checks";
 import { Alert, AlertDescription, AlertTitle } from "@/modules/ui/components/alert";
@@ -112,8 +117,10 @@ export const ImportSurveyDialog = ({
   };
 
   const handleFileSelect = (file: File) => {
+    const extension = getImportFileExtension(file.name);
     capture("survey_import_source_selected", {
-      extension: file.name.split(".").pop()?.toLowerCase() ?? null,
+      extension,
+      kind: extension && isImportAllowedExtension(extension) ? IMPORT_KIND_BY_EXTENSION[extension] : null,
     });
     importer.selectFile(file);
   };

--- a/apps/web/modules/survey/import/detect.ts
+++ b/apps/web/modules/survey/import/detect.ts
@@ -6,6 +6,7 @@ import {
   isImportAllowedExtension,
   isLegacyOfficeExtension,
 } from "./file-types";
+import { parseJsonBounded } from "./lib/json-depth";
 import type { TImportAllowedExtension, TImportSourceKind } from "./types";
 
 export { detectJsonSourceKind, getImportAcceptList, getImportFileExtension };
@@ -68,12 +69,12 @@ function detectTextKind(bytes: Buffer, extension: string | null): TTextDetection
     return { kind: null, invalidJson: false };
   }
 
-  try {
-    const parsed: unknown = JSON.parse(text);
-    return { kind: detectJsonSourceKind(parsed), invalidJson: false };
-  } catch {
+  // Depth-guarded: a pathologically nested file must read as "not a survey", not as a stack overflow.
+  const parsed = parseJsonBounded(text);
+  if (!parsed) {
     return { kind: null, invalidJson: extension === "json" || extension === "qsf" };
   }
+  return { kind: detectJsonSourceKind(parsed.value), invalidJson: false };
 }
 
 /**

--- a/apps/web/modules/survey/import/lanes/document/chunk.ts
+++ b/apps/web/modules/survey/import/lanes/document/chunk.ts
@@ -1,3 +1,4 @@
+import { IMPORT_MAX_QUESTIONS, IMPORT_MAX_TEXT_CHARS } from "../../limits";
 import { importWarning } from "../../report";
 import type { TImportIssue } from "../../types";
 
@@ -23,8 +24,8 @@ export type TChunkOptions = {
 };
 
 /** Beyond this the remainder is dropped with `text_truncated`: nobody imports a 200-question survey in one go. */
-export const CHUNK_MAX_TOTAL_QUESTIONS = 200;
-export const CHUNK_MAX_TOTAL_CHARS = 400_000;
+export const CHUNK_MAX_TOTAL_QUESTIONS = IMPORT_MAX_QUESTIONS;
+export const CHUNK_MAX_TOTAL_CHARS = IMPORT_MAX_TEXT_CHARS;
 
 // Sized for a 16k output budget with reasoning tokens counted against it: 40/16k overflowed live.
 const QUESTIONS_PER_CALL_BUDGET = 24;

--- a/apps/web/modules/survey/import/lanes/document/detect-languages.ts
+++ b/apps/web/modules/survey/import/lanes/document/detect-languages.ts
@@ -189,6 +189,8 @@ export type TDetectDocumentLanguagesParams = {
   workspaceId: string;
   userId?: string | null;
   languageHint?: string;
+  /** Trace id shared by every model call of one import run. */
+  importRunId?: string;
   signal?: AbortSignal;
 };
 
@@ -210,6 +212,11 @@ export async function detectDocumentLanguages(
           distinctId: params.userId,
           feature: AI_TRACING_FEATURE.SurveyImport,
           workspaceId: params.workspaceId,
+          traceId: params.importRunId,
+          properties: {
+            step: "detect_languages",
+            ...(params.importRunId ? { importRunId: params.importRunId } : {}),
+          },
         }
       : undefined,
     schema: ZLanguageDetection,

--- a/apps/web/modules/survey/import/lanes/document/extract-survey.ts
+++ b/apps/web/modules/survey/import/lanes/document/extract-survey.ts
@@ -71,6 +71,8 @@ export type TExtractSurveyDraftParams = {
   workspaceId: string;
   userId?: string | null;
   part?: TImportPromptPart;
+  /** Trace id shared by every model call of one import run; the part index becomes `chunkIndex`. */
+  importRunId?: string;
   signal?: AbortSignal;
 };
 
@@ -93,9 +95,21 @@ export function buildImportDraftRequest(
   });
 }
 
-function buildTracing(params: Pick<TExtractSurveyDraftParams, "userId" | "workspaceId">) {
+function buildTracing(
+  params: Pick<TExtractSurveyDraftParams, "userId" | "workspaceId" | "importRunId" | "part">
+) {
   return params.userId
-    ? { distinctId: params.userId, feature: AI_TRACING_FEATURE.SurveyImport, workspaceId: params.workspaceId }
+    ? {
+        distinctId: params.userId,
+        feature: AI_TRACING_FEATURE.SurveyImport,
+        workspaceId: params.workspaceId,
+        traceId: params.importRunId,
+        properties: {
+          step: "extract_survey",
+          chunkIndex: params.part?.index ?? 1,
+          ...(params.importRunId ? { importRunId: params.importRunId } : {}),
+        },
+      }
     : undefined;
 }
 

--- a/apps/web/modules/survey/import/lanes/document/extract/types.ts
+++ b/apps/web/modules/survey/import/lanes/document/extract/types.ts
@@ -1,9 +1,10 @@
+import { IMPORT_EXTRACT_TIMEOUT_MS, IMPORT_MAX_TEXT_CHARS } from "../../../limits";
 import type { TImportIssue } from "../../../types";
 
 /** Hard cap on the normalized text handed to the model side (edge case #39). */
-export const EXTRACT_MAX_CHARS = 400_000;
+export const EXTRACT_MAX_CHARS = IMPORT_MAX_TEXT_CHARS;
 /** Parsers run under this budget; a DOCX or PDF that takes longer is reported, not awaited. */
-export const EXTRACT_TIMEOUT_MS = 10_000;
+export const EXTRACT_TIMEOUT_MS = IMPORT_EXTRACT_TIMEOUT_MS;
 /** Zip guards for DOCX and XLSX (both are zip archives): entry count and total uncompressed size. */
 export const ARCHIVE_MAX_ENTRIES = 500;
 export const ARCHIVE_MAX_UNCOMPRESSED_BYTES = 50 * 1024 * 1024;

--- a/apps/web/modules/survey/import/lanes/document/index.ts
+++ b/apps/web/modules/survey/import/lanes/document/index.ts
@@ -96,6 +96,7 @@ async function extractChunk(
     workspaceId: ctx.workspaceId,
     userId: ctx.userId,
     part: chunk.total > 1 ? { index: chunk.index, total: chunk.total } : undefined,
+    importRunId: ctx.importRunId,
     signal: ctx.signal,
   };
 
@@ -141,6 +142,7 @@ export const documentLane: TImportLaneHandler = async (input, ctx) => {
     workspaceId: ctx.workspaceId,
     userId: ctx.userId,
     languageHint: ctx.languageHint,
+    importRunId: ctx.importRunId,
     signal: ctx.signal,
   });
 

--- a/apps/web/modules/survey/import/lanes/formbricks/index.ts
+++ b/apps/web/modules/survey/import/lanes/formbricks/index.ts
@@ -7,6 +7,7 @@ import {
 } from "@/app/api/v3/surveys/export/schemas";
 import { formatV3ZodInvalidParams } from "@/app/api/v3/surveys/schemas";
 import { detectJsonSourceKind } from "../../detect";
+import { isJsonTooDeep, parseJsonBounded } from "../../lib/json-depth";
 import { importError, importInfo } from "../../report";
 import type {
   TImportCandidate,
@@ -42,15 +43,23 @@ function stripBom(text: string): string {
 
 function parseContent(input: TImportLaneInput): { value: unknown } | { error: TImportIssue } {
   const { content } = input;
+  const tooDeep = () =>
+    importError({
+      code: "invalid_document",
+      vars: { detail: "The file is nested too deeply to be a survey." },
+    });
+
   if (content.type === "json") {
-    return { value: content.value };
+    return isJsonTooDeep(content.value) ? { error: tooDeep() } : { value: content.value };
   }
 
-  const text = content.type === "text" ? content.text : content.bytes.toString("utf8");
+  const text = stripBom(content.type === "text" ? content.text : content.bytes.toString("utf8"));
+  if (isJsonTooDeep(text)) {
+    return { error: tooDeep() };
+  }
 
-  try {
-    return { value: JSON.parse(stripBom(text)) };
-  } catch {
+  const parsed = parseJsonBounded(text);
+  if (!parsed) {
     return {
       error: importError({
         code: "invalid_document",
@@ -58,6 +67,7 @@ function parseContent(input: TImportLaneInput): { value: unknown } | { error: TI
       }),
     };
   }
+  return { value: parsed.value };
 }
 
 /** Accept a `GET /api/v3/surveys/{id}` response body as well as the bare document. */

--- a/apps/web/modules/survey/import/lanes/qsf/embedded-data.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/embedded-data.ts
@@ -1,38 +1,6 @@
-import { FORBIDDEN_IDS } from "@formbricks/types/surveys/validation";
-
-const FORBIDDEN_LOWER = new Set(FORBIDDEN_IDS.map((id) => id.toLowerCase()));
-const REFUSED_SUFFIX = "_imported";
-
-export type TEmbeddedDataFieldMapping = {
-  source: string;
-  fieldId: string;
-  /** The name was reserved and had to be suffixed. */
-  refused: boolean;
-  /** The name changed in a way other than the reserved-name suffix. */
-  renamed: boolean;
-};
-
-/**
- * Qualtrics embedded-data field → Formbricks hidden field id. One function so the Embedded Data project
- * can repoint it (§8): ids must match `^[a-z][a-z0-9_]*$`, reserved names get a suffix instead of being
- * lost.
- *
- * TODO(embedded-data): when the Embedded Data manager lands, map QSF embedded data onto `ingested`
- * fields and Formbricks variables onto `computed` fields here instead of hidden fields.
- */
-export function mapEmbeddedDataFieldName(source: string): TEmbeddedDataFieldMapping {
-  let fieldId = source
-    .trim()
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9_]+/g, "_")
-    .replaceAll(/_{2,}/g, "_")
-    .replaceAll(/^_+|_+$/g, "");
-
-  if (fieldId.length === 0) fieldId = "field";
-  if (/^\d/.test(fieldId)) fieldId = `f_${fieldId}`;
-
-  const refused = FORBIDDEN_LOWER.has(fieldId);
-  if (refused) fieldId = `${fieldId}${REFUSED_SUFFIX}`;
-
-  return { source, fieldId, refused, renamed: !refused && fieldId !== source };
-}
+// The naming rule lives in the resolver so every lane shares it (ENG-3013); the QSF mapper only needs
+// the function under its historical name.
+export {
+  type TFieldNameMapping as TEmbeddedDataFieldMapping,
+  normalizeFieldName as mapEmbeddedDataFieldName,
+} from "../../resolve/embedded-data";

--- a/apps/web/modules/survey/import/lanes/qsf/parse-qsf.ts
+++ b/apps/web/modules/survey/import/lanes/qsf/parse-qsf.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { type Result, err, ok } from "@formbricks/types/error-handlers";
+import { parseJsonBounded } from "../../lib/json-depth";
 import { importError, importInfo } from "../../report";
 import type { TImportIssue } from "../../types";
 import { normalizeQualtricsLanguageCode } from "./language-codes";
@@ -302,12 +303,11 @@ function collectEmbeddedDataFields(nodes: TQsfFlowNode[], into: string[]): void 
 export function parseQsf(input: Buffer | string): Result<TQsfSurvey, TImportIssue[]> {
   const text = stripBom(typeof input === "string" ? input : input.toString("utf8"));
 
-  let raw: unknown;
-  try {
-    raw = JSON.parse(text);
-  } catch {
+  const parsed = parseJsonBounded(text);
+  if (!parsed) {
     return err([importError({ code: "invalid_document", vars: { detail: "The file is not valid JSON." } })]);
   }
+  const raw: unknown = parsed.value;
 
   const file = ZQsfFile.safeParse(raw);
   if (!file.success) {

--- a/apps/web/modules/survey/import/lib/ai-inflight-guard.test.ts
+++ b/apps/web/modules/survey/import/lib/ai-inflight-guard.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { cache } from "@/lib/cache";
+import { ImportInProgressError, acquireAiImportSlot, aiInflightKey } from "./ai-inflight-guard";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@formbricks/logger", () => ({ logger: { warn: vi.fn() } }));
+vi.mock("@/lib/cache", () => ({ cache: { getRedisClient: vi.fn() } }));
+
+const redis = { incr: vi.fn(), expire: vi.fn(), decr: vi.fn(), del: vi.fn() };
+
+describe("acquireAiImportSlot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(cache.getRedisClient).mockResolvedValue(redis as never);
+    redis.expire.mockResolvedValue(1);
+    redis.del.mockResolvedValue(1);
+  });
+
+  test("the first two conversions get a slot, the third is refused with a retry hint", async () => {
+    redis.incr.mockResolvedValueOnce(1).mockResolvedValueOnce(2).mockResolvedValueOnce(3);
+    redis.decr.mockResolvedValue(2);
+
+    await acquireAiImportSlot("user1");
+    await acquireAiImportSlot("user1");
+    await expect(acquireAiImportSlot("user1")).rejects.toMatchObject({
+      name: "ImportInProgressError",
+      retryAfter: 30,
+    });
+
+    expect(redis.incr).toHaveBeenCalledWith(aiInflightKey("user1"));
+    expect(redis.expire).toHaveBeenCalledWith(aiInflightKey("user1"), 120);
+    // The refused request gives its increment back so it does not poison the count.
+    expect(redis.decr).toHaveBeenCalledTimes(1);
+  });
+
+  test("release decrements once, deletes the key at zero and is safe to call twice", async () => {
+    redis.incr.mockResolvedValue(1);
+    redis.decr.mockResolvedValue(0);
+
+    const release = await acquireAiImportSlot("user1");
+    await release();
+    await release();
+
+    expect(redis.decr).toHaveBeenCalledTimes(1);
+    expect(redis.del).toHaveBeenCalledWith(aiInflightKey("user1"));
+  });
+
+  test("without Redis or on Redis failure the guard steps aside", async () => {
+    vi.mocked(cache.getRedisClient).mockResolvedValueOnce(null as never);
+    await expect(acquireAiImportSlot("user1")).resolves.toBeTypeOf("function");
+
+    redis.incr.mockRejectedValueOnce(new Error("down"));
+    const release = await acquireAiImportSlot("user1");
+    await release();
+    expect(redis.decr).not.toHaveBeenCalled();
+  });
+
+  test("ImportInProgressError carries the wait", () => {
+    expect(new ImportInProgressError().retryAfter).toBe(30);
+  });
+});

--- a/apps/web/modules/survey/import/lib/ai-inflight-guard.ts
+++ b/apps/web/modules/survey/import/lib/ai-inflight-guard.ts
@@ -1,0 +1,61 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { cache } from "@/lib/cache";
+import {
+  IMPORT_AI_INFLIGHT_RETRY_AFTER_SECONDS,
+  IMPORT_AI_INFLIGHT_TTL_SECONDS,
+  IMPORT_AI_MAX_INFLIGHT_PER_USER,
+} from "../limits";
+
+export class ImportInProgressError extends Error {
+  retryAfter = IMPORT_AI_INFLIGHT_RETRY_AFTER_SECONDS;
+
+  constructor() {
+    super("Another document import is still running. Wait for it to finish or stop it first.");
+    this.name = "ImportInProgressError";
+  }
+}
+
+export const aiInflightKey = (identifier: string) => `import:ai:inflight:${identifier}`;
+
+/**
+ * At most `IMPORT_AI_MAX_INFLIGHT_PER_USER` AI conversions per user or key at once, counted in Redis so
+ * the guard holds across instances. Returns the release function; call it on done, error and abort.
+ * Without Redis (tests, single-node dev without cache) the guard is a no-op — the rate limits still hold.
+ */
+export async function acquireAiImportSlot(identifier: string): Promise<() => Promise<void>> {
+  const redis = await cache.getRedisClient();
+  if (!redis) {
+    return async () => undefined;
+  }
+
+  const key = aiInflightKey(identifier);
+  let released = false;
+  const release = async () => {
+    if (released) return;
+    released = true;
+    try {
+      const remaining = await redis.decr(key);
+      if (remaining <= 0) await redis.del(key);
+    } catch (error) {
+      logger.warn({ error }, "Failed to release the AI import slot");
+    }
+  };
+
+  let inflight: number;
+  try {
+    inflight = await redis.incr(key);
+    await redis.expire(key, IMPORT_AI_INFLIGHT_TTL_SECONDS);
+  } catch (error) {
+    // Redis trouble must not block imports; the per-user AI rate limit still bounds the spend.
+    logger.warn({ error }, "Failed to count in-flight AI imports");
+    return async () => undefined;
+  }
+
+  if (inflight > IMPORT_AI_MAX_INFLIGHT_PER_USER) {
+    await release();
+    throw new ImportInProgressError();
+  }
+
+  return release;
+}

--- a/apps/web/modules/survey/import/lib/import-analytics.test.ts
+++ b/apps/web/modules/survey/import/lib/import-analytics.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import type { TImportReport } from "../types";
+import {
+  buildImportConvertedProperties,
+  buildImportCreatedProperties,
+  buildImportFailedProperties,
+  readProblemCode,
+} from "./import-analytics";
+
+const report: TImportReport = {
+  source: { lane: "ai", kind: "docx", fileName: "q.docx", chunks: 3 },
+  summary: {
+    blocks: 4,
+    elements: 21,
+    endings: 1,
+    languages: ["en-US", "de-DE"],
+    logicRules: 0,
+    logicRulesReported: 0,
+    hiddenFields: 0,
+  },
+  issues: [
+    { severity: "warning", code: "translation_filled", message: "" },
+    { severity: "warning", code: "translation_filled", message: "" },
+    { severity: "warning", code: "chunk_failed", message: "" },
+    { severity: "info", code: "chunked", message: "" },
+    { severity: "error", code: "nothing_extracted", message: "" },
+  ],
+};
+
+describe("import analytics properties", () => {
+  test("survey_import_converted carries counts, distinct warning codes and the source", () => {
+    expect(
+      buildImportConvertedProperties(report, { durationMs: 1234, hasDocument: true, streamed: true })
+    ).toEqual({
+      source_kind: "docx",
+      lane: "ai",
+      question_count: 21,
+      language_count: 2,
+      warning_count: 3,
+      error_count: 1,
+      import_warning_codes: ["chunk_failed", "translation_filled"],
+      has_document: true,
+      duration_ms: 1234,
+      streamed: true,
+    });
+    expect(buildImportConvertedProperties(report, { durationMs: 1, hasDocument: false })).not.toHaveProperty(
+      "streamed"
+    );
+  });
+
+  test("survey_import_failed defaults unknown source and lane to null", () => {
+    expect(buildImportFailedProperties({ code: "unsupported_source", status: 422 })).toEqual({
+      source_kind: null,
+      lane: null,
+      code: "unsupported_source",
+      status: 422,
+    });
+    expect(
+      buildImportFailedProperties({ sourceKind: "qsf", lane: "structured", code: "x", streamed: true })
+    ).toMatchObject({
+      source_kind: "qsf",
+      lane: "structured",
+      status: null,
+      streamed: true,
+    });
+  });
+
+  test("survey_created import properties", () => {
+    expect(buildImportCreatedProperties(report)).toEqual({
+      import_source: "docx",
+      import_lane: "ai",
+      import_ai_used: true,
+      import_warning_count: 3,
+      import_chunk_count: 3,
+    });
+  });
+
+  test("readProblemCode reads the code without consuming the response", async () => {
+    const response = new Response(JSON.stringify({ code: "lane_not_available" }), { status: 400 });
+    expect(await readProblemCode(response)).toBe("lane_not_available");
+    expect((await response.json()).code).toBe("lane_not_available");
+    expect(await readProblemCode(new Response("nope", { status: 500 }))).toBe("http_500");
+  });
+});

--- a/apps/web/modules/survey/import/lib/import-analytics.ts
+++ b/apps/web/modules/survey/import/lib/import-analytics.ts
@@ -1,0 +1,96 @@
+import { countIssues } from "../report";
+import type { TImportLane, TImportReport, TImportSourceKind } from "../types";
+
+/**
+ * Property sets of the server-side import events, in one place so the convert route, the stream
+ * route and the import route report the same shape (ENG-3008). Event names:
+ *
+ * - `survey_import_converted` — every convert/stream `done`, whether or not a document came out.
+ * - `survey_import_failed` — every fatal answer (400/409/413/415/422/429/5xx) and in-band `error` event.
+ * - `survey_created` with `created_from: "import"` carries `buildImportCreatedProperties`.
+ * - `ai_survey_imported` — the AI lane's own event (chunks, languages, duration).
+ */
+
+export type TImportConvertedProperties = {
+  source_kind: TImportSourceKind;
+  lane: TImportLane;
+  question_count: number;
+  language_count: number;
+  warning_count: number;
+  error_count: number;
+  /** Distinct warning codes, for the "what do imports lose" histogram. */
+  import_warning_codes: string[];
+  has_document: boolean;
+  duration_ms: number;
+  streamed?: boolean;
+};
+
+export function buildImportConvertedProperties(
+  report: TImportReport,
+  options: { durationMs: number; hasDocument: boolean; streamed?: boolean }
+): TImportConvertedProperties {
+  const counts = countIssues(report.issues);
+  return {
+    source_kind: report.source.kind,
+    lane: report.source.lane,
+    question_count: report.summary.elements,
+    language_count: report.summary.languages.length,
+    warning_count: counts.warning,
+    error_count: counts.error,
+    import_warning_codes: [
+      ...new Set(report.issues.filter((issue) => issue.severity === "warning").map((issue) => issue.code)),
+    ].sort(),
+    has_document: options.hasDocument,
+    duration_ms: options.durationMs,
+    ...(options.streamed === undefined ? {} : { streamed: options.streamed }),
+  };
+}
+
+export type TImportFailedProperties = {
+  source_kind: TImportSourceKind | null;
+  lane: TImportLane | null;
+  /** The problem code (`unsupported_source`, `ai_quota_exceeded`, …) or the fatal report code. */
+  code: string;
+  status: number | null;
+  streamed?: boolean;
+};
+
+export function buildImportFailedProperties(params: {
+  sourceKind?: TImportSourceKind | null;
+  lane?: TImportLane | null;
+  code: string;
+  status?: number | null;
+  streamed?: boolean;
+}): TImportFailedProperties {
+  return {
+    source_kind: params.sourceKind ?? null,
+    lane: params.lane ?? null,
+    code: params.code,
+    status: params.status ?? null,
+    ...(params.streamed === undefined ? {} : { streamed: params.streamed }),
+  };
+}
+
+/** The extra properties `survey_created` carries when `created_from` is `import`. */
+export function buildImportCreatedProperties(
+  report: TImportReport
+): Record<string, string | number | boolean> {
+  const counts = countIssues(report.issues);
+  return {
+    import_source: report.source.kind,
+    import_lane: report.source.lane,
+    import_ai_used: report.source.lane === "ai",
+    import_warning_count: counts.warning,
+    import_chunk_count: report.source.chunks ?? 0,
+  };
+}
+
+/** Reads the problem code out of a problem+json Response without consuming the caller's copy. */
+export async function readProblemCode(response: Response): Promise<string> {
+  try {
+    const body = (await response.clone().json()) as { code?: unknown };
+    return typeof body.code === "string" ? body.code : `http_${response.status}`;
+  } catch {
+    return `http_${response.status}`;
+  }
+}

--- a/apps/web/modules/survey/import/lib/json-depth.test.ts
+++ b/apps/web/modules/survey/import/lib/json-depth.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { isJsonTooDeep, measureJsonTextDepth, measureJsonValueDepth, parseJsonBounded } from "./json-depth";
+
+describe("json depth guard", () => {
+  test("measures nesting and ignores brackets inside strings", () => {
+    expect(measureJsonTextDepth('{"a":[1,{"b":"[[[[\\"]]"}]}')).toBe(3);
+    expect(measureJsonValueDepth({ a: [1, { b: "x" }] })).toBe(3);
+    expect(measureJsonValueDepth("flat")).toBe(0);
+  });
+
+  test("stops early past the limit so a 2 MB file costs one scan", () => {
+    const deep = "[".repeat(300_000) + "]".repeat(300_000);
+    expect(isJsonTooDeep(deep)).toBe(true);
+    expect(parseJsonBounded(deep)).toBeNull();
+    expect(measureJsonTextDepth(deep, 10)).toBe(11);
+  });
+
+  test("parses normal documents and rejects broken ones", () => {
+    expect(parseJsonBounded('{"name":"x"}')).toEqual({ value: { name: "x" } });
+    expect(parseJsonBounded("{ nope")).toBeNull();
+    let value: unknown = "leaf";
+    for (let index = 0; index < 100; index += 1) value = [value];
+    expect(isJsonTooDeep(value)).toBe(true);
+    expect(isJsonTooDeep({ blocks: [{ elements: [{ choices: [{ label: { "en-US": "x" } }] }] }] })).toBe(
+      false
+    );
+  });
+});

--- a/apps/web/modules/survey/import/lib/json-depth.ts
+++ b/apps/web/modules/survey/import/lib/json-depth.ts
@@ -1,0 +1,71 @@
+/**
+ * JSON nesting guard. V8's `JSON.parse` recurses per nesting level, so a few hundred thousand `[`
+ * characters (a 2 MB file) throw a `RangeError` deep inside whatever touched the value first — a
+ * crash that reads as a 500 instead of "this is not a survey". Depth is measured by a linear scan
+ * before parsing, and iteratively on already-parsed values, so neither path recurses.
+ */
+
+/** Deeper than any survey document: blocks → elements → choices → labels is four levels. */
+export const IMPORT_MAX_JSON_DEPTH = 64;
+
+/** Maximum bracket nesting of a JSON text, ignoring brackets inside strings. Stops early past `limit`. */
+export function measureJsonTextDepth(text: string, limit = IMPORT_MAX_JSON_DEPTH): number {
+  let depth = 0;
+  let max = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === "{" || char === "[") {
+      depth += 1;
+      if (depth > max) max = depth;
+      if (max > limit) return max;
+    } else if (char === "}" || char === "]") depth -= 1;
+  }
+
+  return max;
+}
+
+/** Maximum nesting of a parsed value, measured with an explicit stack. Stops early past `limit`. */
+export function measureJsonValueDepth(value: unknown, limit = IMPORT_MAX_JSON_DEPTH): number {
+  const stack: { value: unknown; depth: number }[] = [{ value, depth: 0 }];
+  let max = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current.value === null || typeof current.value !== "object") continue;
+    const depth = current.depth + 1;
+    if (depth > max) max = depth;
+    if (max > limit) return max;
+    for (const nested of Object.values(current.value as Record<string, unknown>)) {
+      if (nested !== null && typeof nested === "object") stack.push({ value: nested, depth });
+    }
+  }
+
+  return max;
+}
+
+export function isJsonTooDeep(input: string | unknown, limit = IMPORT_MAX_JSON_DEPTH): boolean {
+  return (
+    (typeof input === "string" ? measureJsonTextDepth(input, limit) : measureJsonValueDepth(input, limit)) >
+    limit
+  );
+}
+
+/** `JSON.parse` behind the depth guard; returns null for anything that is not parseable or too deep. */
+export function parseJsonBounded(text: string, limit = IMPORT_MAX_JSON_DEPTH): { value: unknown } | null {
+  if (measureJsonTextDepth(text, limit) > limit) return null;
+  try {
+    return { value: JSON.parse(text) };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/modules/survey/import/limits.ts
+++ b/apps/web/modules/survey/import/limits.ts
@@ -1,0 +1,20 @@
+/**
+ * Every hard limit of survey import, in one place. The lanes import from here; the docs copy the
+ * numbers from here (ENG-3011). Change a number here and the report messages, the OpenAPI text and
+ * the docs are the places to re-check.
+ */
+
+/** 15 MB per file (D3). The multipart transport adds 1 MB of framing slack on top. */
+export const IMPORT_MAX_FILE_BYTES = 15 * 1024 * 1024;
+/** Normalized document text handed to the model side is cut here (`text_truncated`). */
+export const IMPORT_MAX_TEXT_CHARS = 400_000;
+/** Estimated questions the chunker keeps; the remainder is dropped with `text_truncated`. */
+export const IMPORT_MAX_QUESTIONS = 200;
+/** DOCX / PDF parsers run under this budget. */
+export const IMPORT_EXTRACT_TIMEOUT_MS = 10_000;
+/** In-flight AI conversions one user may run at once; the next one answers 409 `import_in_progress`. */
+export const IMPORT_AI_MAX_INFLIGHT_PER_USER = 2;
+/** Safety net for a slot whose release never ran (crashed worker): seconds until Redis forgets it. */
+export const IMPORT_AI_INFLIGHT_TTL_SECONDS = 120;
+/** What a 409 tells the client to wait before retrying. */
+export const IMPORT_AI_INFLIGHT_RETRY_AFTER_SECONDS = 30;

--- a/apps/web/modules/survey/import/resolve/embedded-data.test.ts
+++ b/apps/web/modules/survey/import/resolve/embedded-data.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { prepareV3SurveyCreateInput } from "@/app/api/v3/surveys/prepare";
+import { normalizeFieldName, normalizeImportedFieldNames } from "./embedded-data";
+
+const workspaceId = "clxx1234567890123456789012";
+
+const document = () => ({
+  name: "Fields",
+  type: "link",
+  status: "draft",
+  defaultLanguage: "en-US",
+  languages: [{ code: "en-US", default: true, enabled: true }],
+  welcomeCard: { enabled: false },
+  hiddenFields: { enabled: true, fieldIds: ["Customer-ID", "plan", "userId", "2nd_touch"] },
+  variables: [
+    { id: "clvar12345678901234567890", name: "Score Total", type: "number", value: 0 },
+    { id: "clvar12345678901234567891", name: "plan", type: "text", value: "" },
+  ],
+  blocks: [
+    {
+      id: "b1",
+      name: "Block",
+      elements: [
+        {
+          id: "q1",
+          type: "openText",
+          headline: { "en-US": "Hello #recall:Customer-ID/fallback:there#, how is #recall:plan/fallback:#?" },
+          required: false,
+        },
+        { id: "q2", type: "openText", headline: { "en-US": "Second" }, required: false },
+      ],
+      logic: [
+        {
+          id: "l1",
+          conditions: {
+            id: "c1",
+            connector: "and",
+            conditions: [
+              {
+                id: "cc1",
+                leftOperand: { type: "hiddenField", value: "Customer-ID" },
+                operator: "equals",
+                rightOperand: { type: "static", value: "42" },
+              },
+            ],
+          },
+          actions: [{ id: "a1", objective: "jumpToBlock", target: "b2" }],
+        },
+      ],
+    },
+    {
+      id: "b2",
+      name: "Block 2",
+      elements: [{ id: "q3", type: "openText", headline: { "en-US": "Third" }, required: false }],
+    },
+  ],
+  endings: [{ id: "e1", type: "endScreen", headline: { "en-US": "Bye #recall:userId/fallback:#" } }],
+});
+
+describe("normalizeFieldName", () => {
+  test.each([
+    ["plan", "plan", false, false],
+    ["Customer-ID", "customer_id", false, true],
+    ["2nd touch", "f_2nd_touch", false, true],
+    ["userId", "userid_imported", true, false],
+    ["  ", "field", false, true],
+  ])("%s → %s", (source, fieldId, refused, renamed) => {
+    expect(normalizeFieldName(source)).toEqual({ source, fieldId, refused, renamed });
+  });
+});
+
+describe("normalizeImportedFieldNames", () => {
+  test("renames hidden fields and variables, rewrites logic operands and recall strings, reports each change", () => {
+    const doc = document();
+    const issues = normalizeImportedFieldNames(doc);
+
+    expect(doc.hiddenFields.fieldIds).toEqual(["customer_id", "plan", "userid_imported", "f_2nd_touch"]);
+    // A variable that collides with a hidden field name after normalization gets a suffix.
+    expect(doc.variables.map((variable) => variable.name)).toEqual(["score_total", "plan_2"]);
+    expect(doc.blocks[0].logic?.[0].conditions.conditions[0].leftOperand).toEqual({
+      type: "hiddenField",
+      value: "customer_id",
+    });
+    expect(doc.blocks[0].elements[0].headline["en-US"]).toBe(
+      "Hello #recall:customer_id/fallback:there#, how is #recall:plan/fallback:#?"
+    );
+    expect(doc.endings[0].headline["en-US"]).toBe("Bye #recall:userid_imported/fallback:#");
+    expect(issues.map((issue) => [issue.code, issue.vars])).toEqual([
+      ["field_renamed", { from: "Customer-ID", to: "customer_id" }],
+      ["embedded_data_name_refused", { name: "userId", renamed: "userid_imported" }],
+      ["field_renamed", { from: "2nd_touch", to: "f_2nd_touch" }],
+      ["field_renamed", { from: "Score Total", to: "score_total" }],
+      ["field_renamed", { from: "plan", to: "plan_2" }],
+    ]);
+    expect(issues.every((issue) => issue.severity === "warning")).toBe(true);
+
+    const preparation = prepareV3SurveyCreateInput({ workspaceId, ...doc });
+    expect(preparation.ok, JSON.stringify(!preparation.ok && preparation.validation)).toBe(true);
+  });
+
+  test("is idempotent and leaves conforming names alone", () => {
+    const doc = document();
+    normalizeImportedFieldNames(doc);
+    const snapshot = JSON.stringify(doc);
+
+    expect(normalizeImportedFieldNames(doc)).toEqual([]);
+    expect(JSON.stringify(doc)).toBe(snapshot);
+    expect(normalizeImportedFieldNames({ name: "No fields" })).toEqual([]);
+  });
+});

--- a/apps/web/modules/survey/import/resolve/embedded-data.ts
+++ b/apps/web/modules/survey/import/resolve/embedded-data.ts
@@ -1,0 +1,158 @@
+import { FORBIDDEN_IDS } from "@formbricks/types/surveys/validation";
+import { importWarning } from "../report";
+import type { TImportIssue } from "../types";
+import { isRecord } from "./paths";
+
+/**
+ * Hidden field ids and variable names on import, aligned with the Embedded Data project (§8): names
+ * must match `^[a-z][a-z0-9_]*$`, reserved names get a suffix instead of a 400 from the create call,
+ * and every reference — logic operands, recall strings — follows the rename. One function for every
+ * lane; the QSF mapper calls the same `normalizeFieldName`.
+ *
+ * TODO(embedded-data): when the Embedded Data manager lands, map QSF embedded data onto `ingested`
+ * fields and Formbricks variables onto `computed` fields here instead of hidden fields and variables.
+ */
+
+const FORBIDDEN_LOWER = new Set(FORBIDDEN_IDS.map((id) => id.toLowerCase()));
+const REFUSED_SUFFIX = "_imported";
+export const FIELD_NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+export type TFieldNameMapping = {
+  source: string;
+  fieldId: string;
+  /** The name was reserved and had to be suffixed. */
+  refused: boolean;
+  /** The name changed in a way other than the reserved-name suffix. */
+  renamed: boolean;
+};
+
+export function normalizeFieldName(source: string): TFieldNameMapping {
+  let fieldId = source
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9_]+/g, "_")
+    .replaceAll(/_{2,}/g, "_")
+    .replaceAll(/^_+|_+$/g, "");
+
+  if (fieldId.length === 0) fieldId = "field";
+  if (/^\d/.test(fieldId)) fieldId = `f_${fieldId}`;
+
+  const refused = FORBIDDEN_LOWER.has(fieldId);
+  if (refused) fieldId = `${fieldId}${REFUSED_SUFFIX}`;
+
+  return { source, fieldId, refused, renamed: !refused && fieldId !== source };
+}
+
+/** Normalizes a list of names, keeping them distinct: a collision after normalization gets `_2`, `_3`, … */
+function buildRenameMap(names: readonly string[], taken: Set<string>): Map<string, TFieldNameMapping> {
+  const map = new Map<string, TFieldNameMapping>();
+  for (const name of names) {
+    if (map.has(name)) continue;
+    const mapping = normalizeFieldName(name);
+    let candidate = mapping.fieldId;
+    let suffix = 2;
+    while (taken.has(candidate)) {
+      candidate = `${mapping.fieldId}_${suffix}`;
+      suffix += 1;
+    }
+    taken.add(candidate);
+    map.set(name, {
+      ...mapping,
+      fieldId: candidate,
+      renamed: mapping.renamed || candidate !== mapping.fieldId,
+    });
+  }
+  return map;
+}
+
+const RECALL_PATTERN = /#recall:([^/#]+)\/fallback:/g;
+
+/** Rewrites `#recall:<id>/fallback:` occurrences and `{ type: "hiddenField", value }` operands through the map. */
+function rewriteReferences(value: unknown, renames: ReadonlyMap<string, string>): unknown {
+  if (typeof value === "string") {
+    return value.includes("#recall:")
+      ? value.replace(RECALL_PATTERN, (match, id: string) =>
+          renames.has(id) ? `#recall:${renames.get(id)}/fallback:` : match
+        )
+      : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => rewriteReferences(entry, renames));
+  }
+  if (isRecord(value)) {
+    if (value.type === "hiddenField" && typeof value.value === "string" && renames.has(value.value)) {
+      return { ...value, value: renames.get(value.value) };
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) out[key] = rewriteReferences(nested, renames);
+    return out;
+  }
+  return value;
+}
+
+function reportMapping(mapping: TFieldNameMapping, path: string, issues: TImportIssue[]): void {
+  if (mapping.refused) {
+    issues.push(
+      importWarning({
+        code: "embedded_data_name_refused",
+        path,
+        vars: { name: mapping.source, renamed: mapping.fieldId },
+      })
+    );
+  } else if (mapping.renamed) {
+    issues.push(
+      importWarning({ code: "field_renamed", path, vars: { from: mapping.source, to: mapping.fieldId } })
+    );
+  }
+}
+
+/**
+ * Mutates `document` in place: hidden field ids and variable names normalized, references rewritten.
+ * Idempotent — a document whose names already follow the rules comes back untouched with no issues.
+ */
+export function normalizeImportedFieldNames(document: Record<string, unknown>): TImportIssue[] {
+  const issues: TImportIssue[] = [];
+  const taken = new Set<string>();
+
+  const hiddenFields = isRecord(document.hiddenFields) ? document.hiddenFields : null;
+  const fieldIds = hiddenFields && Array.isArray(hiddenFields.fieldIds) ? hiddenFields.fieldIds : [];
+  const hiddenRenames = buildRenameMap(
+    fieldIds.filter((id): id is string => typeof id === "string"),
+    taken
+  );
+  const changedHidden = new Map<string, string>();
+  for (const [source, mapping] of hiddenRenames) {
+    if (mapping.fieldId !== source) changedHidden.set(source, mapping.fieldId);
+    reportMapping(mapping, "hiddenFields.fieldIds", issues);
+  }
+  if (hiddenFields && changedHidden.size > 0) {
+    hiddenFields.fieldIds = [
+      ...new Set(
+        fieldIds.map((id) => (typeof id === "string" ? (hiddenRenames.get(id)?.fieldId ?? id) : id))
+      ),
+    ];
+  }
+
+  const variables = Array.isArray(document.variables) ? document.variables : [];
+  const variableNames = variables
+    .filter(isRecord)
+    .map((variable) => variable.name)
+    .filter((name): name is string => typeof name === "string");
+  const variableRenames = buildRenameMap(variableNames, taken);
+  variables.forEach((variable, index) => {
+    if (!isRecord(variable) || typeof variable.name !== "string") return;
+    const mapping = variableRenames.get(variable.name);
+    if (!mapping) return;
+    reportMapping(mapping, `variables.${index}.name`, issues);
+    variable.name = mapping.fieldId;
+  });
+
+  if (changedHidden.size > 0) {
+    // Variables are referenced by id and need no rewrite; hidden fields are referenced by their id-name.
+    for (const key of ["blocks", "endings", "welcomeCard", "metadata"] as const) {
+      if (key in document) document[key] = rewriteReferences(document[key], changedHidden);
+    }
+  }
+
+  return issues;
+}

--- a/apps/web/modules/survey/import/resolve/index.ts
+++ b/apps/web/modules/survey/import/resolve/index.ts
@@ -12,6 +12,7 @@ import type { TImportCandidate, TImportIssue, TImportReport } from "../types";
 import type { TActionClassResolutionDeps } from "./action-classes";
 import { resolveImportActionClasses } from "./action-classes";
 import { applyDocumentHygiene } from "./document";
+import { normalizeImportedFieldNames } from "./embedded-data";
 import { hasImportExternalUrls, stripImportExternalUrls } from "./entitlements";
 import { resolveImportLanguages } from "./languages";
 import { resolveImportMedia } from "./media";
@@ -67,8 +68,8 @@ function invalidParamToIssue(param: InvalidParam): TImportIssue {
 /**
  * Turn a lane's candidate into a document the target workspace can hold, and say what changed.
  *
- * Steps run in a fixed order — hygiene, languages, action classes, targeting, external URLs, media,
- * validation — and each one only appends to the issue list. Resolving an already-resolved document
+ * Steps run in a fixed order — hygiene, field names, languages, action classes, targeting, external URLs,
+ * media, validation — and each one only appends to the issue list. Resolving an already-resolved document
  * adds no issues: ids that exist are kept, nothing left to strip, nothing left to warn about.
  */
 export async function resolveImportCandidate(
@@ -99,6 +100,8 @@ export async function resolveImportCandidate(
     report.summary = summarizeDocument(document);
     return { document: null, createBody: null, report, validation: { valid: false, invalid_params: [] } };
   }
+
+  report.issues.push(...normalizeImportedFieldNames(document));
 
   const languages = resolveImportLanguages(document, await deps.listWorkspaceLanguageCodes(ctx.workspaceId));
   report.issues.push(...languages.issues);

--- a/apps/web/modules/survey/import/security.test.ts
+++ b/apps/web/modules/survey/import/security.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Security review checklist (ENG-3010): each test is one item of the review with a claim a reviewer
+ * can rerun. Items that live in other suites are referenced from the ticket comment, not duplicated.
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import { FIXTURE_LINK_SURVEY, FIXTURE_WORKSPACE_ID } from "@/modules/survey/export/__fixtures__/surveys";
+import { buildSurveyExportEnvelope } from "@/modules/survey/export/build-export-envelope";
+import { extractDocumentText } from "./lanes/document/extract";
+import { formbricksLane } from "./lanes/formbricks";
+import { stripHtml } from "./lanes/qsf/strip-html";
+import { type TResolveImportDeps, resolveImportCandidate } from "./resolve";
+import type { TImportContext } from "./types";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@formbricks/database", () => ({ prisma: {} }));
+vi.mock("@/lib/actionClass/service", () => ({ getActionClasses: vi.fn() }));
+vi.mock("@/modules/survey/editor/lib/action-class", () => ({ createActionClass: vi.fn() }));
+vi.mock("@/modules/survey/lib/permission", () => ({ getExternalUrlsPermission: vi.fn() }));
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  WEBAPP_URL: "https://app.formbricks.com",
+}));
+
+const FIXTURES = join(__dirname, "lanes/document/__fixtures__");
+const laneCtx: TImportContext = {
+  workspaceId: FIXTURE_WORKSPACE_ID,
+  organizationId: "org_1",
+  userId: "user_1",
+  requestId: "req_1",
+  importRunId: "run_1",
+};
+const resolveCtx = { ...laneCtx, dryRun: true };
+const deps: TResolveImportDeps = {
+  listActionClasses: async () => [],
+  createActionClass: vi.fn(),
+  listWorkspaceLanguageCodes: async () => ["en-US", "de-DE"],
+  isExternalUrlAllowed: async () => true,
+  instanceUrl: "https://app.formbricks.com",
+};
+
+function exportEnvelope(): Record<string, unknown> {
+  const result = buildSurveyExportEnvelope(FIXTURE_LINK_SURVEY, {
+    appVersion: "6.2.0",
+    publicUrl: "https://x",
+  });
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+  return JSON.parse(JSON.stringify(result.data));
+}
+
+describe("files", () => {
+  test("a truncated DOCX fails within the timeout with a clean error, no hang", async () => {
+    const whole = readFileSync(join(FIXTURES, "survey-numbered-lists.docx"));
+    const truncated = whole.subarray(0, Math.floor(whole.length / 2));
+    const started = Date.now();
+
+    const result = await extractDocumentText("docx", truncated);
+
+    expect(Date.now() - started).toBeLessThan(10_000);
+    expect(result.text).toBe("");
+    expect(result.issues[0]).toMatchObject({ severity: "error", code: "document_unreadable" });
+  });
+
+  test("binary garbage with a .md extension is treated as text and never parsed as anything else", async () => {
+    const garbage = Buffer.from(Array.from({ length: 4096 }, (_, index) => (index * 7919) % 256));
+    const result = await extractDocumentText("markdown", garbage);
+    expect(result.issues.filter((issue) => issue.severity === "error")).toEqual([]);
+    expect(typeof result.text).toBe("string");
+  });
+
+  test("a 2 MB deeply nested JSON document does not crash the lossless lane", async () => {
+    const depth = 250_000;
+    const nested = `{"name":"x","blocks":${"[".repeat(depth)}${"]".repeat(depth)}}`;
+    expect(nested.length).toBeGreaterThan(400_000);
+
+    const candidate = await formbricksLane(
+      { kind: "v3-document", fileName: "deep.json", content: { type: "bytes", bytes: Buffer.from(nested) } },
+      laneCtx
+    );
+
+    expect(candidate.document).toBeNull();
+    expect(candidate.issues[0].severity).toBe("error");
+  });
+
+  test("nothing in the import module fetches a URL from a document (media URLs stay strings)", () => {
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const path = join(dir, entry);
+        if (statSync(path).isDirectory()) {
+          if (entry !== "__fixtures__" && entry !== "__snapshots__") walk(path);
+          continue;
+        }
+        if (!entry.endsWith(".ts") || entry.endsWith(".test.ts")) continue;
+        // The two browser clients call our own API; everything else must not reach the network.
+        if (entry === "import-client.ts" || entry === "import-stream-client.ts") continue;
+        const source = readFileSync(path, "utf8");
+        if (/\bfetch\s*\(|new\s+XMLHttpRequest|https?\.request\(|axios/.test(source)) offenders.push(path);
+      }
+    };
+    walk(__dirname);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("content", () => {
+  test("hostile HTML in QSF text loses scripts, event handlers and javascript: links", () => {
+    const hostile =
+      '<p>Rate <script>alert(1)</script>us <img src=x onerror="alert(1)"> <a href="javascript:steal()">here</a> &lt;b&gt;</p>';
+    const clean = stripHtml(hostile);
+
+    expect(clean).not.toMatch(/<script|onerror|javascript:|<img|<a /i);
+    expect(clean).toContain("Rate");
+    expect(clean).toContain("here");
+  });
+
+  test("a recall that points at a forbidden or unknown id is caught by the reference validator", async () => {
+    const envelope = exportEnvelope();
+    const survey = envelope.survey as { blocks: { elements: { headline: Record<string, string> }[] }[] };
+    survey.blocks[0].elements[0].headline["en-US"] =
+      "Hi #recall:userId/fallback:#, and #recall:nope123/fallback:#";
+    survey.blocks[0].elements[0].headline["de-DE"] = "Hallo #recall:userId/fallback:#";
+
+    const candidate = await formbricksLane(
+      {
+        kind: "formbricks-export",
+        fileName: "x.formbricks.json",
+        content: { type: "json", value: envelope },
+      },
+      laneCtx
+    );
+    const resolved = await resolveImportCandidate(candidate, resolveCtx, deps);
+
+    expect(resolved.document).toBeNull();
+    expect(resolved.createBody).toBeNull();
+    expect(resolved.report.issues.some((issue) => issue.severity === "error")).toBe(true);
+  });
+
+  test("instance-bound and pre-D1 fields in a hand-crafted export never reach the create payload", async () => {
+    const envelope = exportEnvelope();
+    Object.assign(envelope.survey as Record<string, unknown>, {
+      id: "clsurvey0000000000000000001",
+      workspaceId: "clother00000000000000000001",
+      createdBy: "someone",
+      archivedAt: "2026-01-01T00:00:00.000Z",
+      customHeadScripts: "<script>alert(1)</script>",
+      customHeadScriptsMode: "all",
+      slug: "stolen-slug",
+      publishOn: "2026-01-01T00:00:00.000Z",
+      closeOn: "2026-02-01T00:00:00.000Z",
+      segmentId: "clsegment00000000000000001",
+      followUps: [{ id: "f1" }],
+      styling: { brandColor: "#000" },
+      targeting: { segment: { filters: [{ x: 1 }] } },
+      status: "inProgress",
+    });
+
+    const candidate = await formbricksLane(
+      {
+        kind: "formbricks-export",
+        fileName: "x.formbricks.json",
+        content: { type: "json", value: envelope },
+      },
+      laneCtx
+    );
+    const resolved = await resolveImportCandidate(candidate, resolveCtx, deps);
+
+    expect(resolved.createBody, JSON.stringify(resolved.report.issues)).not.toBeNull();
+    const keys = Object.keys(resolved.createBody as object);
+    for (const forbidden of [
+      "id",
+      "createdBy",
+      "archivedAt",
+      "customHeadScripts",
+      "customHeadScriptsMode",
+      "slug",
+      "publishOn",
+      "closeOn",
+      "segmentId",
+      "followUps",
+      "styling",
+      "targeting",
+    ]) {
+      expect(keys, forbidden).not.toContain(forbidden);
+    }
+    expect(resolved.createBody?.workspaceId).toBe(FIXTURE_WORKSPACE_ID);
+    expect(resolved.createBody?.status).toBe("draft");
+    expect(resolved.report.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        "slug_not_imported",
+        "schedule_cleared",
+        "status_reset",
+        "unknown_field_stripped",
+      ])
+    );
+    expect(deps.createActionClass).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/survey/import/types.ts
+++ b/apps/web/modules/survey/import/types.ts
@@ -37,8 +37,8 @@ export const AI_IMPORT_SOURCE_KINDS: readonly TImportSourceKind[] = IMPORT_SOURC
   (kind) => IMPORT_LANE_BY_KIND[kind] === "ai"
 );
 
-/** 15 MB per file (D3). The transport adds 1 MB of multipart slack on top. */
-export const IMPORT_MAX_FILE_BYTES = 15 * 1024 * 1024;
+// Re-exported so existing imports keep working; the number lives with the other limits.
+export { IMPORT_MAX_FILE_BYTES } from "./limits";
 
 /**
  * Import owns its own allowlist. `ZAllowedFileExtension` (packages/types/storage.ts) is the upload

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -3035,6 +3035,7 @@ components:
             - bad_request
             - conflict
             - forbidden
+            - import_in_progress
             - internal_server_error
             - invalid_workflow_state
             - lane_not_available

--- a/docs/api-v3-reference/src/components/schemas/Problem.yml
+++ b/docs/api-v3-reference/src/components/schemas/Problem.yml
@@ -32,6 +32,7 @@ properties:
       - bad_request
       - conflict
       - forbidden
+      - import_in_progress
       - internal_server_error
       - invalid_workflow_state
       - lane_not_available

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -119,6 +119,7 @@
                   "surveys/general-features/limit-submissions",
                   "surveys/general-features/survey-scheduling",
                   "surveys/general-features/multi-language-surveys",
+                  "surveys/general-features/import-and-export",
                   "surveys/general-features/migrate-from-qualtrics",
                   "surveys/general-features/partial-submissions",
                   "surveys/general-features/recall",

--- a/docs/platform/features/ai-features.mdx
+++ b/docs/platform/features/ai-features.mdx
@@ -45,6 +45,15 @@ training input.
   auto-translate survey questions, options, and prompts into enabled languages.
 - **[AI Chart Creation](/unify-feedback/dashboards-charts#ai-builder)**:
   describe a chart in natural language and Formbricks generates the underlying query.
+- **AI Survey Creation** (**New survey → Create with AI**): describe the survey you need and review a
+  streamed draft — questions, blocks, welcome card and ending — before it is created. The draft follows the
+  same validation as the survey editor; nothing is created until you open it in the editor.
+- **[AI Survey Import](/surveys/general-features/import-and-export#import-from-a-file)**: drop a Word, PDF,
+  Markdown, CSV or Excel questionnaire and the model transcribes it into a draft, language by language, with an
+  import report of everything it approximated. Formbricks JSON and Qualtrics QSF imports need no AI.
+
+Both need the organization toggle above, a plan that includes AI smart tools, and — on self-hosted instances —
+a [configured AI provider](/self-hosting/advanced/enterprise-features/ai-features).
 
 ### Data AI
 

--- a/docs/self-hosting/advanced/enterprise-features/ai-features.mdx
+++ b/docs/self-hosting/advanced/enterprise-features/ai-features.mdx
@@ -26,6 +26,20 @@ Wiring up an LLM takes two steps:
   </Step>
 </Steps>
 
+## What needs a provider
+
+Every Smart Functionality feature calls the configured model: AI survey translation, AI chart creation, Create
+with AI, and the document lane of survey import (Word, PDF, Markdown, CSV, Excel). Survey import from a
+Formbricks JSON export or a Qualtrics QSF file works without any AI configuration, and no S3 or other object
+storage is needed for import — files are read in memory and never stored.
+
+<Warning>
+  File import accepts uploads of up to 15 MB (16 MB including multipart framing). A reverse proxy in front of
+  Formbricks must allow request bodies of that size: nginx defaults `client_max_body_size` to 1 MB and would
+  answer a bare 413 without the problem+json body the dialog expects. Set `client_max_body_size 16m;` (or the
+  equivalent on your proxy) for `/api/v3/surveys/import` and `/api/internal/surveys/import`.
+</Warning>
+
 ## Choosing a provider
 
 `AI_PROVIDER` accepts four values. Set only the variables for the provider you use — the rest can be omitted.

--- a/docs/self-hosting/configuration/environment-variables.mdx
+++ b/docs/self-hosting/configuration/environment-variables.mdx
@@ -13,7 +13,7 @@ These variables are present inside your machine's docker-compose file. Restart t
   Formbricks v5 makes Hub part of the standard self-hosted runtime and changes how rate limiting is enforced.
 </Note>
 
-For the `AI_*` variables, see [AI Features](/self-hosting/advanced/enterprise-features/ai-features) — it walks through each provider and the credentials it needs. Set only the variables for the provider you use; unused provider variables can be omitted.
+For the `AI_*` variables, see [AI Features](/self-hosting/advanced/enterprise-features/ai-features) — it walks through each provider and the credentials it needs. Set only the variables for the provider you use; unused provider variables can be omitted. The document lane of survey import (Word, PDF, Markdown, CSV, Excel) needs a provider; Formbricks JSON and Qualtrics QSF imports do not. File import also needs your reverse proxy to accept 16 MB request bodies — see the note on that page.
 
 {/* prettier-ignore-start */}
 

--- a/docs/surveys/general-features/import-and-export.mdx
+++ b/docs/surveys/general-features/import-and-export.mdx
@@ -1,0 +1,126 @@
+---
+title: "Import & Export"
+description: "Move surveys between workspaces, organizations and instances as a Formbricks JSON file, or bring a questionnaire in from Qualtrics, Word, PDF, Markdown, CSV or Excel."
+icon: "arrow-right-arrow-left"
+---
+
+A survey can leave Formbricks as a `.formbricks.json` file and come back exactly as it was, in any workspace of any Formbricks instance. Other sources come in through the same dialog: a Qualtrics `.qsf` is converted deterministically, and a document — Word, PDF, Markdown, CSV or Excel — is read with AI. Whatever the source, you review the draft and its **Import report** before a survey is created.
+
+---
+
+## Export a survey as JSON
+
+<Steps>
+  <Step title="Open the survey menu">
+    In **Surveys**, open the **⋯** menu of a survey and choose **Export as JSON**. The download starts at once.
+  </Step>
+
+  <Step title="Keep the file as it is">
+    The file is named after the survey (`customer-onboarding.formbricks.json`). It is plain JSON you can read and version, but hand edits are validated on import — anything the create API would reject is reported, not silently dropped.
+  </Step>
+</Steps>
+
+### What the file contains
+
+Everything that defines what a respondent sees: questions and blocks, block logic and fallbacks, the welcome card and endings, all survey languages with their translations, hidden fields, variables, and the survey metadata. Triggers of an app survey travel as references to their action classes, so the importing workspace can match them by key or recreate them.
+
+### What the file leaves out
+
+| Not exported                                                                   | Why                                                                                                   |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Styling                                                                        | Styling moves to the workspace **Brand Kit**; the imported survey uses the target workspace's look. |
+| Follow-ups                                                                     | Follow-ups are being deprecated in favour of Workflows.                                             |
+| Survey settings: PIN, single-use links, reCAPTCHA, closed message, slug, schedule, custom scripts | Instance-bound or a minute to redo in the editor; the report lists what to check.  |
+| Quotas and targeting segments                                                  | They point at data the target workspace does not have.                                             |
+| Responses and the media files themselves                                       | Image and video URLs stay in the file as links; the files are not copied.                          |
+
+<Note>
+  The export is the `GET /api/v3/surveys/{id}` resource with the instance-bound fields removed. Anything you can send to `POST /api/v3/surveys` round-trips; the file carries an `exportFormat` number so a newer instance can read an older file.
+</Note>
+
+---
+
+## Import from a file
+
+<Steps>
+  <Step title="Open the import dialog">
+    In **Surveys**, open the **New survey** menu and choose **Import survey**, or use the **Import survey** card on the templates page.
+  </Step>
+
+  <Step title="Drop the file">
+    One survey per file, up to 15 MB. Formbricks detects the format from the content, so a Formbricks export saved as `.txt` still works.
+  </Step>
+
+  <Step title="Watch it convert">
+    A Formbricks or Qualtrics file converts in a second or two. A document shows a progress ladder — read file, detected languages, extracting questions, validating — and questions appear in the list while the model reads. **Stop** keeps what has come through.
+  </Step>
+
+  <Step title="Review and open in editor">
+    Check the facts row (questions, blocks, languages, source), read the report, rename the survey if you like, and click **Open in editor**. The survey is created as a draft; nothing is published.
+  </Step>
+</Steps>
+
+### Formats
+
+| Format                       | Lane        | What to expect                                                                                                       |
+| ---------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------- |
+| Formbricks JSON (`.json`)    | Exact       | Everything in the file, unchanged. Triggers are matched to the workspace's action classes or recreated.              |
+| Qualtrics QSF (`.qsf`)       | Structured  | Questions, pages, translations, embedded data and piped text; logic is listed in the report. See [Migrate from Qualtrics](/surveys/general-features/migrate-from-qualtrics). |
+| Word (`.docx`)               | AI          | Numbered questions with their options, tables (also two-column bilingual layouts), page breaks as blocks.             |
+| PDF (`.pdf`)                 | AI          | Text PDFs only; scanned PDFs need OCR first.                                                                          |
+| Markdown, text (`.md`, `.txt`) | AI        | Headings, numbered questions, lists.                                                                                  |
+| CSV, Excel (`.csv`, `.xlsx`) | AI          | One question per row; a header like `Question | Type | Options | Required` is recognised.                            |
+
+The AI lane needs **AI smart tools** enabled for the organization (and, on self-hosted instances, an AI provider configured). Without it the document formats are shown muted and the dialog explains what to enable; JSON and QSF always work.
+
+### What makes a good source document
+
+- One question per line or paragraph, numbered (`1.`, `Q1`, `Question 1`).
+- Options as a list under the question; scale anchors written out (`1 = strongly disagree, 5 = strongly agree`).
+- Required questions marked with `*` or the word *required*.
+- Headings or page breaks where you want blocks; an introduction before the first question becomes the welcome card, a closing paragraph the ending.
+- For bilingual files, a two-column table with one language per column. Every language in the document becomes a survey language.
+
+The model transcribes; it does not invent. Wording is kept verbatim per language, and anything it could not map to a Formbricks question type is noted in the report with the original type name.
+
+---
+
+## The import report
+
+Every import ends with a report. Read it before you open the editor.
+
+| Severity    | Meaning                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| **Error**   | Nothing was imported. The file could not be read, or the result would not be a valid survey. |
+| **Warning** | Something changed on the way in — check it in the editor.                                  |
+| **Note**    | Information only, nothing to do.                                                           |
+
+The codes you will see most often:
+
+- **Logic dropped** (QSF): a skip, display or branch rule is described in the report and not imported. Rebuild it with the editor's logic.
+- **Trigger created / would be created** (app surveys): an action class from the source did not exist in this workspace and was created with an `(imported)` suffix, or would be on a real import.
+- **Translation filled** (documents): the document had no text in one of its languages for a field; the default-language text was copied so the survey stays valid.
+- **Type approximated**: the source question type has no exact match; the closest Formbricks type was used and the original name is in the note.
+- **Field renamed**: a hidden field or variable name did not follow the naming rules (`lowercase_with_underscores`) or was reserved, and was renamed. Links that pass the field as a URL parameter must use the new name.
+- **Settings not exported** (Formbricks JSON): the reminder that styling and survey settings are not in the file.
+- **Language ambiguous** (documents): the model could not tell the languages apart; only the primary language was imported.
+
+<Tip>
+  Scripting a migration? `POST /api/v3/surveys/import/convert` returns the converted document and the report without creating anything; `POST /api/v3/surveys/import` creates the survey from a file or a reviewed document. Both are in the API reference.
+</Tip>
+
+---
+
+## Limits
+
+| Limit                                 | Value                                            |
+| ------------------------------------- | ------------------------------------------------ |
+| File size                             | 15 MB per file                                   |
+| Document text read by the model       | 400,000 characters; the rest is dropped with a warning |
+| Questions per document import         | 200; the rest is dropped with a warning          |
+| Time to read a Word or PDF file       | 10 seconds, then the file is reported as unreadable |
+| Concurrent document imports per user  | 2                                                |
+| Imports per workspace                 | 200 per hour                                     |
+| AI conversions per user               | 10 per minute, shared with Create with AI        |
+
+Long documents are read in parts; a 150-question Word file takes several model calls and a minute or two.

--- a/docs/surveys/overview.mdx
+++ b/docs/surveys/overview.mdx
@@ -33,6 +33,9 @@ Each survey has a built-in summary view and response table. For cross-survey ana
   <Card title="Best Practices" icon="lightbulb" href="/surveys/best-practices/understanding-survey-types">
     Templates and proven survey patterns.
   </Card>
+  <Card title="Import & export" icon="arrow-right-arrow-left" href="/surveys/general-features/import-and-export">
+    Move surveys as JSON, or import a questionnaire from a Word, PDF or spreadsheet file.
+  </Card>
   <Card title="Migrate from Qualtrics" icon="file-import" href="/surveys/general-features/migrate-from-qualtrics">
     Import a QSF export with questions, pages, translations and piped text.
   </Card>


### PR DESCRIPTION
Fixes ENG-3013
Fixes ENG-3009
Fixes ENG-3008
Fixes ENG-3010
Fixes ENG-3011

Stacked on #9210. Last code milestone (Linear milestone 6); per-ticket descriptions are in the fold at the bottom. ENG-3012 (QA matrix) and ENG-3014 (close-out) are human tasks and stay separate.

## What & why

**Was:** Import spend was bounded per user only, failures and conversions left no analytics, a 2 MB deeply nested JSON file crashed the parser into a 500, hidden-field names were normalized for Qualtrics only, and the docs covered the Qualtrics migration alone.

**Now:** A per-workspace budget (200/hour), at most two in-flight AI conversions per user (409 with `Retry-After`), every limit in one module, log lines without file content. Every conversion and refusal is a PostHog event, model calls carry the run id in LLM tracing, audit rows name run and source. Every JSON parse is depth-guarded and the security checklist lives as tests. Hidden field and variable names are normalized for every lane with a `field_renamed` line. Docs: *Import & Export* page, AI-features entries, self-hosting notes.

## Where to look

- [limits.ts](apps/web/modules/survey/import/limits.ts) — every size, time and count limit, also copied into the docs
- [json-depth.ts](apps/web/modules/survey/import/lib/json-depth.ts) — the depth guard in front of every `JSON.parse`
- [security.test.ts](apps/web/modules/survey/import/security.test.ts) — one test per checklist claim

## Breaking changes

- [ ] This PR contains breaking changes

None — new limits apply to the new endpoints only; a hidden field with a mixed-case id is renamed on import with a report line, by design (ENG-3013).

## Migrations & env

- none. Self-hosting docs note that a reverse proxy needs a body limit of at least 16 MB for 15 MB imports.

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/import app/api/v3/surveys/import app/api/internal/surveys/import modules/core/rate-limit/rate-limit-configs.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Third concurrent AI conversion → 409 + `Retry-After`; slot released; fail-open without Redis; workspace budget 429 before the gate | unit (guard) | `ai-inflight-guard.test.ts`, `convert-import.test.ts`, `operations.test.ts` |
| No import log line carries text, bytes, file name, document or prompt | unit (guard) | `convert-import.test.ts` "no log line carries…" |
| `survey_import_converted` / `survey_import_failed` on every outcome, trace ids on model calls, audit rows for export and import | unit (guard) | `import-analytics.test.ts`, `convert-import.test.ts`, `export-survey.test.ts` |
| 2 MB deeply nested JSON → `invalid_document`, no stack overflow; depth measured with brackets in strings ignored | unit (red on main) + unit (mutation) | `security.test.ts`, `json-depth.test.ts` |
| Hidden fields and variables renamed with references rewritten; reserved names suffixed; idempotent | unit (guard) | `resolve/embedded-data.test.ts` |
| Docs pages render, limits match `limits.ts`, wide tables fit | manual | limits checked against the source; Mintlify render pending |

**Open gaps**

- The 50-request burst check and prompt-injection fixtures in hidden DOCX paragraphs need a running instance and a live provider.
- Embedded Data lead review (Anshuman) for the name rules and product review of the docs wording are still open.
- Docs screenshots from the Northwind tenant are not included.

**Risks**

- The 200/hour workspace budget also covers `POST /api/v3/surveys/import`; a heavy API integration hits it first — the 429 carries `Retry-After`.

<details>
<summary>Per-ticket notes (ENG-3013, ENG-3009, ENG-3008, ENG-3010, ENG-3011) — the original per-ticket PR descriptions, kept for the evidence</summary>


### ENG-3013 — feat(surveys): normalize imported hidden field and variable names for Embedded Data

#### What & why

**Was:** Only the Qualtrics lane normalized hidden-field names; a Formbricks export or a document draft carrying `Customer-ID` or a reserved name like `userId` reached the create call unchanged and could fail with a raw 400.

**Now:** The resolver normalizes hidden field ids and variable names for every lane to `^[a-z][a-z0-9_]*$`, suffixes reserved names with `_imported`, keeps names distinct after normalization, and rewrites every reference (logic operands, `#recall:` strings) through the same rename map. Each change is a `field_renamed` or `embedded_data_name_refused` warning in the report.

- One function, `normalizeImportedFieldNames`, in `resolve/embedded-data.ts`; the QSF mapper now calls the shared `normalizeFieldName` instead of its own copy.
- Idempotent: a document whose names already conform comes back untouched.
- The single `TODO(embedded-data)` comment records the later mapping (QSF embedded data → `ingested`, variables → `computed`).

#### Where to look

- [embedded-data.ts](apps/web/modules/survey/import/resolve/embedded-data.ts) — rename map, collision suffixing, reference rewrite.
- [resolve/index.ts](apps/web/modules/survey/import/resolve/index.ts) — the step now runs right after hygiene.

#### Breaking changes

- [ ] This PR contains a breaking change

Import-time normalization only; export keeps `hiddenFields` and `variables` exactly as the document carries them.

#### Migrations & env

None.

#### Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| Hidden fields, variables renamed; logic operand and recall strings rewritten; reserved name suffixed; collision → `_2`; result passes `prepareV3SurveyCreateInput` | unit (guard) | `resolve/embedded-data.test.ts` |
| Idempotent; documents without fields untouched | unit (guard) | `resolve/embedded-data.test.ts` |
| QSF embedded data still mapped the same way | unit (guard) | existing `lanes/qsf/*.test.ts` goldens unchanged |

Rerun: `cd apps/web && npx vitest run modules/survey/import`

#### Open gaps

- Review by the Embedded Data lead (Anshuman) is part of the ticket's acceptance and still open.
- Round-trip fidelity: a Formbricks export with mixed-case hidden field ids is renamed on import (by design per the ticket); worth a line in the docs ticket.

#### Risks

- Renaming a hidden field changes the query parameter a link survey expects (`?customer_id=` instead of `?Customer-ID=`). The warning says so; the docs should too.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>


### ENG-3009 — feat(surveys): import rate limits, concurrency guard, one limits module and logging hygiene

#### What & why

**Was:** Import spend was bounded per user only (30/min convert, 10/min AI); one user could run any number of AI conversions at once, the size and time limits were scattered across five files, and one log line echoed full validation reasons.

**Now:** A per-workspace budget (200/hour across convert, stream and import), a Redis-backed concurrency guard (at most two in-flight AI conversions per user, the third answers 409 `import_in_progress` with `Retry-After: 30`), every limit in `modules/survey/import/limits.ts`, and log lines that carry `importRunId`, `workspaceId`, `sourceKind`, `lane` but never file names, bytes or document text.

- Guards run in order: workspace access → workspace budget → detection → AI gate → AI budget → slot; a refused request never reaches a parser.
- The slot is released on done, error and client abort; a lost release expires after 120 s. Without Redis the guard steps aside and the rate limits still hold.
- `redactInvalidParams` cuts logged reasons at 80 chars.

#### Where to look

- [ai-inflight-guard.ts](apps/web/modules/survey/import/lib/ai-inflight-guard.ts) — INCR/EXPIRE/DECR and the fail-open policy.
- [import-guards.ts](apps/web/app/api/v3/surveys/import/lib/import-guards.ts) — the budget and 409 helpers shared by the three routes.
- [limits.ts](apps/web/modules/survey/import/limits.ts) — the numbers the docs will copy.

#### Breaking changes

- [ ] This PR contains a breaking change

New limits only tighten abuse cases; a normal workspace imports far fewer than 200 files an hour. Documented 409 is additive.

#### Migrations & env

None. Redis is the existing cache client; the guard is a no-op where it is absent.

#### Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| Third concurrent AI conversion → 409 + `Retry-After`; release once, delete at zero; fail-open without Redis | unit (guard) | `ai-inflight-guard.test.ts` |
| Convert: workspace budget 429 before the gate; 409 before the lane; deterministic lanes spend only the workspace budget | unit (guard) | `convert-import.test.ts` |
| Stream: 409 before the body opens; slot released after the stream | unit (guard) | `import/lib/operations.test.ts` |
| No import log line carries `text`, `bytes`, `fileName`, `document`, `prompt`, `content` | unit (guard) | `convert-import.test.ts` "no log line carries…" |
| New bucket present in the config list | unit (guard) | `rate-limit-configs.test.ts` |

Rerun: `cd apps/web && npx vitest run app/api/v3/surveys/import app/api/internal/surveys/import modules/survey/import modules/core/rate-limit/rate-limit-configs.test.ts`

#### Open gaps

- The 50-request burst check the ticket asks for is a local script against a running instance and was not run here.
- The import route (`POST /api/v3/surveys/import`) gained the workspace budget but its OpenAPI 429 text still describes the generic limit.

#### Risks

- The guard keys on the session user or API key id, falling back to the workspace id for anonymous callers, so an API key shared by a team counts as one caller.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>


### ENG-3008 — feat(surveys): import analytics events, LLM trace metadata and audit context

#### What & why

**Was:** Import reported `survey_created` (with import properties) and the AI lane's `ai_survey_imported`, but nothing for conversions that never became a survey, nothing for failures, and the model calls carried no run or chunk identity in LLM tracing.

**Now:** Every convert and stream run reports `survey_import_converted`; every refusal (400/403/409/413/415/422/429, in-band `error`) reports `survey_import_failed`; the language-detection and extraction calls carry `importRunId` as trace id plus `chunkIndex` / `step` as trace properties; the audit rows name the survey (`exported`) and the import run and source (`created`).

#### Events (for the insights)

| Event | Properties |
| --- | --- |
| `survey_exported` | `survey_id, survey_type, workspace_id, organization_id, question_count, language_count` (unchanged) |
| `survey_created` (`created_from: "import"`) | `+ import_source, import_lane, import_ai_used, import_warning_count, import_chunk_count` (unchanged) |
| `survey_import_converted` | `source_kind, lane, question_count, language_count, warning_count, error_count, import_warning_codes[], has_document, duration_ms, streamed?` |
| `survey_import_failed` | `source_kind|null, lane|null, code, status|null, streamed?` |
| `ai_survey_imported` | `source_kind, chunk_count, question_count, language_count, chars, duration_ms, streamed?` (unchanged) |
| client | `survey_import_dialog_opened {entry_point}`, `survey_import_source_selected {extension, kind}`, `survey_import_stopped`, `survey_import_regenerated`, `survey_import_created {entry_point}` |

Suggested insights: funnel dialog opened → converted → created split by `source_kind`; top `code` from `survey_import_failed`; histogram of `import_warning_codes`.

#### Where to look

- [import-analytics.ts](apps/web/modules/survey/import/lib/import-analytics.ts) — the property builders all three routes share.
- [convert-import.ts](apps/web/app/api/v3/surveys/import/convert/lib/convert-import.ts) — the wrapper that reports every non-2xx once.
- [ai-tracing.ts](apps/web/lib/posthog/ai-tracing.ts) — `properties` on the tracing context.

#### Breaking changes

- [ ] This PR contains a breaking change

Analytics and audit metadata only.

#### Migrations & env

None.

#### Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| Property sets of converted / failed / created events | unit (guard) | `import-analytics.test.ts` |
| Convert: `survey_import_converted` on 200, `survey_import_failed` on 422 detection and 403 gate with source kind when known | unit (guard) | `convert-import.test.ts` |
| Stream: converted for a deterministic lane, failed for a pre-stream 403 and an in-band error, `streamed: true` | unit (guard) | `import/lib/operations.test.ts` |
| Export audit row carries `surveyId` and `surveyType` | unit (guard) | `export-survey.test.ts` |
| Tracing context forwards extra properties | unit (guard) | existing `ai-tracing.test.ts` (feature-only case unchanged) |

Rerun: `cd apps/web && npx vitest run app/api/v3/surveys/import app/api/internal/surveys/import modules/survey/import/lib/import-analytics.test.ts`

#### Open gaps

- The `created` audit row's import context lives inside `newObject.import` because the audit log type has no metadata field; confirm it renders acceptably in the organization audit log view (manual).
- Event names are not yet registered in any analytics catalog outside the code.

#### Risks

- `survey_import_failed` fires for API-key callers only when a session user is present (same rule as every other server event), so machine traffic is invisible in the funnel by design.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>


### ENG-3010 — fix(surveys): depth-guard JSON parsing on import and add the security review checklist tests

#### What & why

**Was:** The security checklist for import had claims without tests behind several of them, and one real gap: a deeply nested JSON file (2 MB of `[`) hit V8's recursive `JSON.parse` and surfaced as a stack overflow, i.e. a 500 instead of "not a survey".

**Now:** Every JSON parse in the import module goes through a depth-guarded parser (`json-depth.ts`, limit 64 levels, linear scan before parsing, iterative measure for already-parsed bodies), and the review checklist lives as `security.test.ts`: one test per claim a reviewer can rerun. The full pass/fail list with test names is the review comment on the ticket.

- Truncated DOCX, garbage `.md`, deep JSON: clean errors within the timeout, no hang, no 5xx.
- Hostile QSF HTML loses scripts, event handlers and `javascript:` links; a recall to a forbidden or unknown id is caught by the reference validator.
- Instance-bound and pre-D1 fields in a hand-crafted export never reach the create payload; nothing in the module fetches a URL.

#### Where to look

- [json-depth.ts](apps/web/modules/survey/import/lib/json-depth.ts) — the guard and why it scans before it parses.
- [security.test.ts](apps/web/modules/survey/import/security.test.ts) — the checklist.

#### Breaking changes

- [ ] This PR contains a breaking change

A JSON file nested deeper than 64 levels is now refused as `invalid_document`; no survey document comes close.

#### Migrations & env

None.

#### Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| 2 MB deeply nested JSON → `invalid_document`, no stack overflow | unit (red on main) | `security.test.ts` "a 2 MB deeply nested JSON document…" |
| Depth measured with brackets-in-strings ignored; early stop past the limit | unit (mutation) | `json-depth.test.ts` — mutate the `inString` branch |
| Truncated DOCX / garbage `.md` clean errors within timeout | unit (guard) | `security.test.ts` files block |
| Hostile HTML stripped; forbidden recall caught; instance-bound and pre-D1 fields never in the create payload; no `fetch` in the module | unit (guard) | `security.test.ts` content block |
| Zip bomb, 413 by declared and counted bytes, 403 authorization, dry run writes nothing | unit (guard) | existing: `extract.test.ts`, `api-wrapper.test.ts`, `import-survey.test.ts`, `export-survey.test.ts`, `convert-import.test.ts` |

Rerun: `cd apps/web && npx vitest run modules/survey/import app/api/v3/surveys/import`

#### Open gaps

- Prompt-injection fixtures in a hidden DOCX paragraph and PDF metadata, and the 50-request burst, need a live provider and a running instance; recorded as open in the ticket comment.
- The repo's `/security-review` skill was not run over the whole stack in this session; the checklist above is the manual equivalent.

#### Risks

- None known beyond the depth limit stated above.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>


### ENG-3011 — docs(surveys): import & export page, AI feature entries and self-hosting notes

#### What & why

**Was:** The docs described the Qualtrics migration only; nothing explained the JSON export, the document lane, the import report or what a self-hoster needs.

**Now:** A new *Import & Export* page under General Features covers export (what the file keeps and leaves out, and why), import (format table with lanes, what a good source document looks like), the report (severities and the common codes in plain words) and the limits copied from `modules/survey/import/limits.ts`. The AI features page gains *AI Survey Creation* and *AI Survey Import*; the self-hosting AI page and the environment-variables page say which lanes need a provider, that no S3 is needed, and that the reverse proxy must allow 16 MB bodies (nginx defaults to 1 MB). The v3 overview prose mentions export, import and convert.

#### Where to look

- [import-and-export.mdx](docs/surveys/general-features/import-and-export.mdx) — the page; the *Limits* table must match `limits.ts`.
- [ai-features.mdx](docs/self-hosting/advanced/enterprise-features/ai-features.mdx) — the new *What needs a provider* section with the proxy warning.

#### Breaking changes

- [ ] This PR contains a breaking change

Docs only.

#### Migrations & env

None.

#### Coverage

| Behaviour | Level | Test |
| --- | --- | --- |
| Page registered in `docs.json`, cards and links resolve | manual | pending — Mintlify local render |
| Limits match `limits.ts` (15 MB, 400 000 chars, 200 questions, 10 s, 2 concurrent, 200/hour, 10/min) | manual | checked against the source in this PR |
| Wide tables fit the ~640 px well | manual | pending — Mintlify local render |

#### Open gaps

- Screenshots from the docs screenshot tenant (Northwind) are not included; they need a running instance with the stack deployed.
- Product review of the wording is part of the ticket's acceptance and still open.
- The v3 API reference stays unlisted per the Docs Refresh decision; only the overview prose changed.

#### Risks

- None; documentation only.

<details><summary>Agent note</summary>

Written with `claude-fable-5-1`, effort `unknown`.

</details>


</details>

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
