### PR TITLE
docs(embedded-data): describe the Metadata popover and drop the removed editor warning

### DIFF
--- a/docs/surveys/embedded-data/migration.mdx
+++ b/docs/surveys/embedded-data/migration.mdx
@@ -52,7 +52,7 @@ The full rule and the refused list are on the [Hidden Fields](/surveys/general-f
 
 Hidden field values passed in a survey link are visible to anyone who sees or shares that link, gets it forwarded, or reads it out of a browser history, a referrer header or a proxy log. **Do not pass email addresses, tokens, account numbers or any other personal identifier that way.**
 
-The editor shows this warning next to the Hidden Fields card, and it is worth taking literally rather than treating as boilerplate:
+This is worth taking literally rather than treating as boilerplate:
 
 - Pass an opaque reference you can resolve on your own side, not the identifier itself.
 - For app surveys, prefer [`setEmbeddedData()`](/surveys/embedded-data/set-embedded-data), which never puts the value in a URL.

--- a/docs/surveys/embedded-data/reserved-fields.mdx
+++ b/docs/surveys/embedded-data/reserved-fields.mdx
@@ -122,7 +122,7 @@ That is deliberate: a recall token can end up interpolated into a redirect URL o
 
 ## Where Reserved Fields Show Up
 
-**On the response card**, `source`, `url`, `country`, `action`, `browser`, `os` and `deviceType` are always listed. The remaining auto-captured fields sit behind a disclosure so the card does not grow a dozen rows.
+**On the response card**, the **Metadata** popover in the card footer lists every auto-captured field the response carries: `source`, `url`, `country`, `action`, `browser`, `os` and `deviceType` first, then the remaining fields below a divider. It opens on click, so the card itself does not grow a dozen rows, and a response that captured none of them shows no popover at all.
 
 **In the response table**, the same seven are visible columns by default, and the other auto-captured fields are real columns that start hidden and can be switched on from the column settings. `responseId`, `surveyId`, `finished`, `language`, `durationSeconds`, `startedAt` and `finishedAt` are not listed as fields on either surface, because the card header and the table's own fixed columns already show them.
 

--- a/docs/surveys/general-features/metadata.mdx
+++ b/docs/surveys/general-features/metadata.mdx
@@ -25,8 +25,8 @@ icon: "user"
 <Note>
   These seven are the ones shown by default. Formbricks captures more than twenty auto-captured fields
   in total, including the page path, the campaign parameters, the screen and viewport size, the time zone
-  and the device locale. They are behind a disclosure on the response card and as switchable columns in the
-  response table. Which of them actually land depends on the survey type and its settings — a mobile app
+  and the device locale. They sit in the response card's **Metadata** popover, below the seven above, and
+  as switchable columns in the response table. Which of them actually land depends on the survey type and its settings — a mobile app
   survey has no host page, so it records nothing for the page and campaign fields. See [Reserved
   Fields](/surveys/embedded-data/reserved-fields) for the full catalog, what each survey type captures, and
   what the **Anonymize responses** toggle suppresses.


### PR DESCRIPTION
No ticket: docs follow-up to #9179, which merged before its docs caught up.

## What & why

**Was:** three doc passages described the response card's "More context" disclosure and an editor warning next to the Hidden Fields card — both removed by #9179.

**Now:** they describe the **Metadata** popover (the seven classic fields first, the rest below a divider), and the URL-privacy section stands on its own without claiming the editor shows it.

## Where to look

- [reserved-fields.mdx](https://github.com/formbricks/formbricks/blob/19f3ed2be1ce675353d80dc55a883e317739d445/docs/surveys/embedded-data/reserved-fields.mdx#L125) — where reserved fields show on the card
- [migration.mdx](https://github.com/formbricks/formbricks/blob/19f3ed2be1ce675353d80dc55a883e317739d445/docs/surveys/embedded-data/migration.mdx#L55) — the editor-warning sentence, dropped
- [metadata.mdx](https://github.com/formbricks/formbricks/blob/19f3ed2be1ce675353d80dc55a883e317739d445/docs/surveys/general-features/metadata.mdx#L28) — the note under the seven classic fields

## Breaking changes

- [ ] This PR contains breaking changes

None — docs only.

## Migrations & env

- none

## How this was tested

Rerun: `git grep -n -i "behind a disclosure\|shows this warning\|device info\|more context" -- 'docs/**/*.mdx' ':!docs/api-*'`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| No doc still describes the removed disclosure, tooltip or editor warning | manual | the grep above returns nothing; these three passages were its only hits |

**Open gaps**

- none

**Risks**

- none — prose only.

---

> [!NOTE]
> **AI model used** — `claude-fable-5-1`, reasoning effort `unknown`.
