### PR TITLE
fix: respect PostgreSQL Helm overrides

### DIFF
--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -62,6 +62,7 @@ jobs:
           }
 
           helm lint "$chart" --set formbricks.webappUrl=https://qa.example.com
+          bash charts/formbricks/tests/postgresql-overrides.sh
           bash charts/formbricks/tests/authzed-operations.sh
 
           helm template qa "$chart" \

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -100,6 +100,17 @@ Helm cannot condition values passed to the PostgreSQL dependency on a sibling va
 baseline remains in effect. Override `authzed.cluster.resources` and `postgresql.primary.resources` to match the
 expected authorization traffic and the other workloads using the bundled database.
 
+The generated Formbricks and SpiceDB connection strings, the SpiceDB database bootstrap, and the installation
+notes follow the bundled PostgreSQL dependency's effective service name, service port, username, and database.
+This includes username, database, and service-port overrides supplied through the dependency's
+`global.postgresql` values.
+
+> [!WARNING]
+> PostgreSQL initializes users and databases only when the data directory is empty. Before applying connection
+> overrides to an existing PVC-backed installation, create the target user and database and migrate the
+> existing Formbricks data. Otherwise, the corrected consumers will point at credentials or data that do not yet
+> exist.
+
 Install only one operator per Kubernetes cluster. When a platform-managed operator already watches the Formbricks
 namespace, keep `authzed.operator.install=false`; the Formbricks release still owns its `SpiceDBCluster`.
 Kubernetes does not upgrade CRDs during a normal Helm upgrade. When changing the bundled operator version, apply

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -100,10 +100,11 @@ Helm cannot condition values passed to the PostgreSQL dependency on a sibling va
 baseline remains in effect. Override `authzed.cluster.resources` and `postgresql.primary.resources` to match the
 expected authorization traffic and the other workloads using the bundled database.
 
-The generated Formbricks and SpiceDB connection strings, the SpiceDB database bootstrap, and the installation
-notes follow the bundled PostgreSQL dependency's effective service name, service port, username, and database.
-This includes username, database, and service-port overrides supplied through the dependency's
-`global.postgresql` values.
+The generated Formbricks `DATABASE_URL` and installation notes follow the bundled PostgreSQL dependency's
+effective service name, service port, username, and database. This includes username, database, and
+service-port overrides supplied through the dependency's `global.postgresql` values. The SpiceDB datastore URI
+and database bootstrap follow the same service name and port while continuing to provision and use the dedicated
+`spicedb` role and database.
 
 > [!WARNING]
 > PostgreSQL initializes users and databases only when the data directory is empty. Before applying connection

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -66,6 +66,10 @@ Formbricks v6 enables AuthZed, `fully_consistent` authorization, and the bundled
 | -------------------------- | ---------- | ---------- | ------------------------------------------------------------------------------- |
 | `authzed.operator.install` | `false`    | `true`     | Set `authzed.operator.install=false` before upgrading to avoid duplicate reconcilers. |
 
+Existing PVC-backed installations that change `postgresql.auth.username` or `postgresql.auth.database` must
+provision the target role and database and migrate existing Formbricks data before upgrading. See the detailed
+warning below.
+
 For a cluster where a compatible operator already watches the Formbricks namespace:
 
 ```yaml

--- a/charts/formbricks/templates/NOTES.txt
+++ b/charts/formbricks/templates/NOTES.txt
@@ -43,13 +43,13 @@ Database (PostgreSQL) Access:
    PostgreSQL is deployed within your cluster.
    Retrieve the password using:
    ```sh
-   kubectl get secret --namespace {{ .Release.Namespace }} {{ include "formbricks.name" . }}-app-secrets -o jsonpath="{.data.POSTGRES_USER_PASSWORD}" | base64 --decode
+   kubectl get secret --namespace {{ .Release.Namespace }} {{ include "formbricks.name" . }}-app-secrets -o jsonpath="{.data.{{ include "formbricks.postgresqlAppPasswordKey" . }}}" | base64 --decode
    ```
    Connection details:
-   - **Host**: `{{ include "formbricks.name" . }}-postgresql`
-   - **Port**: `5432`
-   - **Database**: `{{ .Values.postgresql.auth.database }}`
-   - **Username**: `{{ .Values.postgresql.auth.username }}`
+   - **Host**: `{{ include "formbricks.postgresqlPrimaryHost" . }}`
+   - **Port**: `{{ include "formbricks.postgresqlServicePort" . }}`
+   - **Database**: `{{ include "formbricks.postgresqlDatabase" . }}`
+   - **Username**: `{{ include "formbricks.postgresqlUsername" . }}`
 {{- else if .Values.postgresql.externalDatabaseUrl }}
    You're using an external PostgreSQL database.
    The connection URL is intentionally omitted from these notes because it may contain credentials.

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -136,6 +136,34 @@ If `namespaceOverride` is provided, it will be used; otherwise, it defaults to `
 {{- printf "%s-app-secrets" (include "formbricks.name" .) -}}
 {{- end }}
 
+{{/*
+Resolve bundled PostgreSQL connection details through the dependency's own helpers so every
+consumer follows the same override and global-value precedence as the rendered Service.
+*/}}
+{{- define "formbricks.postgresqlPrimaryHost" -}}
+{{- include "postgresql.v1.primary.fullname" .Subcharts.postgresql -}}
+{{- end }}
+
+{{- define "formbricks.postgresqlServicePort" -}}
+{{- include "postgresql.v1.service.port" .Subcharts.postgresql -}}
+{{- end }}
+
+{{- define "formbricks.postgresqlUsername" -}}
+{{- include "postgresql.v1.username" .Subcharts.postgresql | default "postgres" -}}
+{{- end }}
+
+{{- define "formbricks.postgresqlDatabase" -}}
+{{- include "postgresql.v1.database" .Subcharts.postgresql -}}
+{{- end }}
+
+{{- define "formbricks.postgresqlAppPasswordKey" -}}
+{{- if eq (include "formbricks.postgresqlUsername" .) "postgres" -}}
+{{- "POSTGRES_ADMIN_PASSWORD" -}}
+{{- else -}}
+{{- "POSTGRES_USER_PASSWORD" -}}
+{{- end -}}
+{{- end }}
+
 {{- define "formbricks.authzedClusterName" -}}
 {{- .Values.authzed.cluster.name | default (printf "%s-spicedb" (include "formbricks.name" .)) | trunc 63 | trimSuffix "-" -}}
 {{- end }}

--- a/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
+++ b/charts/formbricks/templates/authzed-postgresql-bootstrap.yaml
@@ -89,7 +89,9 @@ spec:
           env:
             {{- if $bundledBootstrap }}
             - name: PGHOST
-              value: formbricks-postgresql
+              value: {{ include "formbricks.postgresqlPrimaryHost" . | quote }}
+            - name: PGPORT
+              value: {{ include "formbricks.postgresqlServicePort" . | quote }}
             - name: PGUSER
               value: {{ $bundledAdminUsername | quote }}
             - name: PGPASSWORD

--- a/charts/formbricks/templates/authzed-secret.yaml
+++ b/charts/formbricks/templates/authzed-secret.yaml
@@ -16,7 +16,7 @@ stringData:
   {{ .Values.authzed.auth.tokenKey }}: {{ $presharedKey | quote }}
   {{- end }}
   {{- if not .Values.authzed.datastore.existingSecret }}
-  {{ .Values.authzed.datastore.uriKey }}: {{ printf "postgresql://spicedb:%s@formbricks-postgresql:5432/spicedb?sslmode=disable" $databasePassword | quote }}
+  {{ .Values.authzed.datastore.uriKey }}: {{ printf "postgresql://spicedb:%s@%s:%s/spicedb?sslmode=disable" $databasePassword (include "formbricks.postgresqlPrimaryHost" .) (include "formbricks.postgresqlServicePort" .) | quote }}
   database_password: {{ $databasePassword | quote }}
   {{- end }}
 {{- end }}

--- a/charts/formbricks/templates/secrets.yaml
+++ b/charts/formbricks/templates/secrets.yaml
@@ -2,6 +2,10 @@
 
 {{- $postgresAdminPassword := include "formbricks.postgresAdminPassword" . }}
 {{- $postgresUserPassword := include "formbricks.postgresUserPassword" . }}
+{{- $postgresAppPassword := $postgresUserPassword }}
+{{- if and .Values.postgresql.enabled (eq (include "formbricks.postgresqlUsername" .) "postgres") }}
+{{- $postgresAppPassword = $postgresAdminPassword }}
+{{- end }}
 {{- $redisPassword := "" }}
 {{- if and .Values.redis.enabled .Values.redis.auth.enabled }}
 {{- $redisPassword = include "formbricks.redisPassword" . }}
@@ -33,7 +37,7 @@ data:
   REDIS_URL: {{ .Values.redis.externalRedisUrl | b64enc }}
   {{- end }}
   {{- if .Values.postgresql.enabled }}
-  DATABASE_URL: {{ printf "postgresql://formbricks:%s@formbricks-postgresql/formbricks" $postgresUserPassword | b64enc }}
+  DATABASE_URL: {{ printf "postgresql://%s:%s@%s:%s/%s" (include "formbricks.postgresqlUsername" .) $postgresAppPassword (include "formbricks.postgresqlPrimaryHost" .) (include "formbricks.postgresqlServicePort" .) (include "formbricks.postgresqlDatabase" .) | b64enc }}
   {{- else }}
   DATABASE_URL: {{ .Values.postgresql.externalDatabaseUrl | b64enc }}
   {{- end }}

--- a/charts/formbricks/tests/authzed-operations.sh
+++ b/charts/formbricks/tests/authzed-operations.sh
@@ -13,15 +13,12 @@ trap 'rm -rf "${temp_dir}"' EXIT
 # install. Evaluate the real notes through `tpl` in a minimal ConfigMap chart so this contract remains
 # clusterless and release-accurate across supported Helm versions.
 notes_chart="${temp_dir}/notes-chart"
-mkdir -p "${notes_chart}/templates"
+mkdir -p "${notes_chart}/charts" "${notes_chart}/templates"
+cp "${CHART_DIR}/Chart.yaml" "${notes_chart}/Chart.yaml"
+cp "${CHART_DIR}"/charts/*.tgz "${notes_chart}/charts/"
 cp "${CHART_DIR}/values.yaml" "${notes_chart}/values.yaml"
 cp "${CHART_DIR}/templates/_helpers.tpl" "${notes_chart}/templates/_helpers.tpl"
 cp "${CHART_DIR}/templates/NOTES.txt" "${notes_chart}/notes.txt"
-printf '%s\n' \
-  'apiVersion: v2' \
-  'name: formbricks-notes-contract' \
-  'version: 0.0.0' \
-  'appVersion: 0.0.0' >"${notes_chart}/Chart.yaml"
 printf '%s\n' \
   'apiVersion: v1' \
   'kind: ConfigMap' \
@@ -60,6 +57,27 @@ if grep --fixed-strings "AuthZed / SpiceDB Operations:" <<<"${disabled_notes}" >
   printf '%s\n' "AuthZed operations notes must be hidden when AuthZed is disabled." >&2
   exit 1
 fi
+
+postgresql_override_notes="$(render_notes postgresql-overrides \
+  --set postgresql.fullnameOverride=audit-postgresql \
+  --set postgresql.primary.service.ports.postgresql=5544 \
+  --set postgresql.auth.username=audit_user \
+  --set postgresql.auth.database=audit_db)"
+for expected in \
+  'jsonpath="{.data.POSTGRES_USER_PASSWORD}"' \
+  '**Host**: `audit-postgresql`' \
+  '**Port**: `5544`' \
+  '**Database**: `audit_db`' \
+  '**Username**: `audit_user`'; do
+  if ! grep --fixed-strings "${expected}" <<<"${postgresql_override_notes}" >/dev/null; then
+    printf '%s\n' "PostgreSQL installation notes must contain: ${expected}" >&2
+    exit 1
+  fi
+done
+
+postgres_user_notes="$(render_notes postgresql-postgres-user \
+  --set postgresql.auth.username=postgres)"
+grep --fixed-strings 'jsonpath="{.data.POSTGRES_ADMIN_PASSWORD}"' <<<"${postgres_user_notes}" >/dev/null
 
 external_notes="$(render_notes authzed-external \
   --set authzed.enabled=true \

--- a/charts/formbricks/tests/postgresql-overrides.sh
+++ b/charts/formbricks/tests/postgresql-overrides.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly CHART_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+readonly COMMON_ARGS=(--set formbricks.webappUrl=https://qa.example.com)
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+render_case() {
+  local name="$1"
+  shift
+
+  helm template "postgresql-${name}" "${CHART_DIR}" "${COMMON_ARGS[@]}" "$@" \
+    --show-only charts/postgresql/templates/primary/svc.yaml \
+    --show-only charts/postgresql/templates/primary/statefulset.yaml \
+    --show-only templates/secrets.yaml \
+    --show-only templates/authzed-secret.yaml \
+    --show-only templates/authzed-postgresql-bootstrap.yaml \
+    >"${temp_dir}/${name}.yaml"
+}
+
+extract_first_value() {
+  local key="$1" manifest="$2"
+
+  awk -v target="${key}:" '$1 == target { print $2; exit }' "${manifest}" | tr -d '"'
+}
+
+extract_env_value() {
+  local name="$1" manifest="$2"
+
+  awk -v target="${name}" '
+    $0 ~ "^[[:space:]]*-[[:space:]]+name:[[:space:]]+" target "$" {
+      getline
+      if ($1 == "value:") {
+        gsub(/^"|"$/, "", $2)
+        print $2
+      }
+      exit
+    }
+  ' "${manifest}"
+}
+
+extract_env_secret_key() {
+  local name="$1" manifest="$2"
+
+  awk -v target="${name}" '
+    $0 ~ "^[[:space:]]*-[[:space:]]+name:[[:space:]]+" target "$" {
+      in_target = 1
+      next
+    }
+    in_target && $1 == "key:" {
+      print $2
+      exit
+    }
+    in_target && $0 ~ "^[[:space:]]*-[[:space:]]+name:" {
+      exit
+    }
+  ' "${manifest}"
+}
+
+assert_equal() {
+  local expected="$1" actual="$2" message="$3"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    printf '%s\n' "${message}" >&2
+    exit 1
+  fi
+}
+
+assert_case() {
+  local name="$1" expected_host="$2" expected_port="$3" expected_username="$4"
+  local expected_database="$5" password_key="$6" manifest="${temp_dir}/${name}.yaml"
+  local service_name service_port database_url database_password datastore_uri datastore_password
+  local postgresql_username postgresql_database postgresql_password_key bootstrap_host bootstrap_port
+  local expected_database_url
+
+  service_name="$(
+    awk '/^kind: Service$/ { in_service = 1; next } in_service && /^  name:/ { print $2; exit }' \
+      "${manifest}"
+  )"
+  service_port="$(
+    awk '/^kind: Service$/ { in_service = 1; next } in_service && $1 == "port:" { print $2; exit }' \
+      "${manifest}"
+  )"
+  database_url="$(extract_first_value DATABASE_URL "${manifest}" | base64 --decode)"
+  database_password="$(extract_first_value "${password_key}" "${manifest}" | base64 --decode)"
+  datastore_uri="$(extract_first_value datastore_uri "${manifest}")"
+  datastore_password="$(extract_first_value database_password "${manifest}")"
+  postgresql_username="$(extract_env_value POSTGRES_USER "${manifest}")"
+  postgresql_username="${postgresql_username:-postgres}"
+  postgresql_database="$(extract_env_value POSTGRES_DATABASE "${manifest}")"
+  postgresql_password_key="$(extract_env_secret_key POSTGRES_PASSWORD "${manifest}")"
+  bootstrap_host="$(extract_env_value PGHOST "${manifest}")"
+  bootstrap_port="$(extract_env_value PGPORT "${manifest}")"
+
+  assert_equal "${expected_host}" "${service_name}" "${name}: PostgreSQL Service name is inconsistent."
+  assert_equal "${expected_port}" "${service_port}" "${name}: PostgreSQL Service port is inconsistent."
+  assert_equal "${expected_username}" "${postgresql_username}" "${name}: PostgreSQL username is inconsistent."
+  assert_equal "${expected_database}" "${postgresql_database}" "${name}: PostgreSQL database is inconsistent."
+  assert_equal "${password_key}" "${postgresql_password_key}" "${name}: PostgreSQL password key is inconsistent."
+  expected_database_url="postgresql://${expected_username}:${database_password}"
+  expected_database_url+="@${expected_host}:${expected_port}/${expected_database}"
+  assert_equal \
+    "${expected_database_url}" \
+    "${database_url}" \
+    "${name}: generated DATABASE_URL does not match the PostgreSQL Service and credentials."
+  assert_equal \
+    "postgresql://spicedb:${datastore_password}@${expected_host}:${expected_port}/spicedb?sslmode=disable" \
+    "${datastore_uri}" \
+    "${name}: generated SpiceDB datastore URI does not match the PostgreSQL Service."
+  assert_equal "${expected_host}" "${bootstrap_host}" "${name}: AuthZed bootstrap PGHOST is inconsistent."
+  assert_equal "${expected_port}" "${bootstrap_port}" "${name}: AuthZed bootstrap PGPORT is inconsistent."
+}
+
+render_case default
+assert_case default formbricks-postgresql 5432 formbricks formbricks POSTGRES_USER_PASSWORD
+
+render_case overrides \
+  --set postgresql.fullnameOverride=audit-postgresql \
+  --set postgresql.primary.service.ports.postgresql=5544 \
+  --set postgresql.auth.username=audit_user \
+  --set postgresql.auth.database=audit_db
+assert_case overrides audit-postgresql 5544 audit_user audit_db POSTGRES_USER_PASSWORD
+
+render_case global-overrides \
+  --set postgresql.fullnameOverride=global-postgresql \
+  --set global.postgresql.service.ports.postgresql=6543 \
+  --set global.postgresql.auth.username=global_user \
+  --set global.postgresql.auth.database=global_db
+assert_case global-overrides global-postgresql 6543 global_user global_db POSTGRES_USER_PASSWORD
+
+# The Bitnami subchart treats `postgres` as its administrator rather than a custom user, so the
+# generated application URL must select the administrator password for this supported username.
+render_case postgres-user \
+  --set postgresql.auth.username=postgres \
+  --set postgresql.auth.database=audit_db
+assert_case postgres-user formbricks-postgresql 5432 postgres audit_db POSTGRES_ADMIN_PASSWORD
+
+printf '%s\n' "PostgreSQL override contracts are valid."


### PR DESCRIPTION
Fixes ENG-2923

## What & why

**Was:** PostgreSQL overrides changed the bundled database while Formbricks, SpiceDB, and bootstrap retained default connection values.

**Now:** Formbricks follows effective connection values; SpiceDB follows the endpoint while retaining its dedicated role and database.

## Where to look

- [Dependency-aware values](https://github.com/formbricks/formbricks/blob/0116b78f437f81f4b6ad8d4825e8b5f236e9e45e/charts/formbricks/templates/_helpers.tpl#L139-L165)
- [Generated application connection](https://github.com/formbricks/formbricks/blob/0116b78f437f81f4b6ad8d4825e8b5f236e9e45e/charts/formbricks/templates/secrets.yaml#L3-L40)
- [Override contract](https://github.com/formbricks/formbricks/blob/0116b78f437f81f4b6ad8d4825e8b5f236e9e45e/charts/formbricks/tests/postgresql-overrides.sh#L12-L140)

## Breaking changes

- [x] This PR contains breaking changes

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| Bundled PostgreSQL overrides | Consumers retained defaults | Formbricks follows values; SpiceDB follows endpoint | Existing PVC-backed customized installs | Provision target role/database and migrate data before upgrading |

## Migrations & env

- Existing PVC-backed installs using custom users or databases must provision and migrate them before upgrading.

## How this was tested

Rerun: helm lint charts/formbricks --set formbricks.webappUrl=https://qa.example.com && bash charts/formbricks/tests/postgresql-overrides.sh && bash charts/formbricks/tests/authzed-operations.sh

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Direct and global dependency overrides | unit (red on main) | Service and StatefulSet match configured values |
| Formbricks database URL | unit (red on main) | URL uses effective endpoint and credentials |
| SpiceDB URI and bootstrap | unit (red on main) | Both use the endpoint and dedicated credentials |
| Installation guidance | unit (red on main) | App and SpiceDB credential behavior is distinct |

**Open gaps**

- Disposable-cluster installation smoke was not run because Docker is unavailable.

**Risks**

- Existing PVC contents do not change when connection targets change.
- Future Bitnami helper renames require coordinating the pinned dependency version.

---

> [!NOTE]
> **AI model used** — unknown, reasoning effort unknown.
