### PR TITLE
fix(organization): mirror the server's owner count in the members table [ENG-2616]

### DIFF
--- a/apps/web/modules/ee/role-management/components/edit-membership-role.tsx
+++ b/apps/web/modules/ee/role-management/components/edit-membership-role.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import type { TOrganizationRole } from "@formbricks/types/memberships";
 import { getAccessFlags } from "@/lib/membership/utils";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
+import { isRoleEditDisabled } from "@/modules/ee/role-management/lib/role-edit-rules";
 import { Badge } from "@/modules/ui/components/badge";
 import { Button } from "@/modules/ui/components/button";
 import {
@@ -51,11 +52,15 @@ export function EditMembershipRole({
   const { isOwner, isManager } = getAccessFlags(currentUserRole);
   const isOwnerOrManager = isOwner || isManager;
 
-  const disableRole =
-    isUserManagementDisabledFromUi ||
-    memberId === userId ||
-    (memberRole === "owner" && !doesOrgHaveMoreThanOneOwner) ||
-    (currentUserRole === "manager" && memberRole === "owner");
+  const disableRole = isRoleEditDisabled({
+    isUserManagementDisabledFromUi,
+    currentUserRole,
+    memberRole,
+    memberId,
+    userId,
+    memberAccepted,
+    doesOrgHaveMoreThanOneOwner,
+  });
 
   const handleMemberRoleUpdate = async (role: TOrganizationRole) => {
     setLoading(true);

--- a/apps/web/modules/ee/role-management/lib/role-edit-rules.test.ts
+++ b/apps/web/modules/ee/role-management/lib/role-edit-rules.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import { type TRoleEditContext, isRoleEditDisabled } from "./role-edit-rules";
+
+describe("isRoleEditDisabled", () => {
+  const context = (overrides: Partial<TRoleEditContext> = {}): TRoleEditContext => ({
+    isUserManagementDisabledFromUi: false,
+    currentUserRole: "owner",
+    memberRole: "member",
+    memberId: "target-user",
+    userId: "current-user",
+    memberAccepted: true,
+    doesOrgHaveMoreThanOneOwner: true,
+    ...overrides,
+  });
+
+  test("disables the sole owner's membership row", () => {
+    expect(isRoleEditDisabled(context({ memberRole: "owner", doesOrgHaveMoreThanOneOwner: false }))).toBe(
+      true
+    );
+  });
+
+  test("leaves an owner enabled when the organization has another one", () => {
+    expect(isRoleEditDisabled(context({ memberRole: "owner", doesOrgHaveMoreThanOneOwner: true }))).toBe(
+      false
+    );
+  });
+
+  /**
+   * The regression guard for ENG-2616: an invite row carries `memberAccepted: undefined`. Its role is
+   * changed through `updateInviteAction`, which has no last-owner guard — no membership exists yet — so
+   * a single-owner organization must not disable a pending owner invite's dropdown.
+   */
+  test("leaves a pending owner invite enabled in a single-owner organization", () => {
+    expect(
+      isRoleEditDisabled(
+        context({
+          memberRole: "owner",
+          memberAccepted: undefined,
+          memberId: "",
+          doesOrgHaveMoreThanOneOwner: false,
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("disables your own row", () => {
+    expect(isRoleEditDisabled(context({ memberId: "current-user" }))).toBe(true);
+  });
+
+  test("disables an owner's row for a manager", () => {
+    expect(isRoleEditDisabled(context({ currentUserRole: "manager", memberRole: "owner" }))).toBe(true);
+  });
+
+  test("disables every row when user management is turned off in the UI", () => {
+    expect(isRoleEditDisabled(context({ isUserManagementDisabledFromUi: true }))).toBe(true);
+  });
+
+  test("leaves an ordinary member enabled", () => {
+    expect(isRoleEditDisabled(context())).toBe(false);
+  });
+});

--- a/apps/web/modules/ee/role-management/lib/role-edit-rules.test.ts
+++ b/apps/web/modules/ee/role-management/lib/role-edit-rules.test.ts
@@ -43,6 +43,16 @@ describe("isRoleEditDisabled", () => {
     ).toBe(false);
   });
 
+  // The counterpart: `undefined` is the invite marker, `false` is not. An unaccepted membership row is
+  // still a membership, and the server's owner count does not filter on `accepted` either.
+  test("treats an unaccepted membership row as a membership, not an invite", () => {
+    expect(
+      isRoleEditDisabled(
+        context({ memberRole: "owner", memberAccepted: false, doesOrgHaveMoreThanOneOwner: false })
+      )
+    ).toBe(true);
+  });
+
   test("disables your own row", () => {
     expect(isRoleEditDisabled(context({ memberId: "current-user" }))).toBe(true);
   });

--- a/apps/web/modules/ee/role-management/lib/role-edit-rules.ts
+++ b/apps/web/modules/ee/role-management/lib/role-edit-rules.ts
@@ -24,8 +24,9 @@ export const isRoleEditDisabled = ({
 }: Readonly<TRoleEditContext>): boolean =>
   isUserManagementDisabledFromUi ||
   memberId === userId ||
-  // The last-owner rule belongs to memberships, not invites. `memberAccepted` is `undefined` on invite
-  // rows — the same signal `handleMemberRoleUpdate` uses to route to `updateInviteAction` — and
-  // re-roling a pending owner invite touches no membership, so that action carries no such guard.
-  (Boolean(memberAccepted) && memberRole === "owner" && !doesOrgHaveMoreThanOneOwner) ||
+  // The last-owner rule belongs to memberships, not invites: re-roling a pending owner invite touches
+  // no membership, so `updateInviteAction` carries no such guard. `undefined` is the only invite
+  // marker — an unaccepted membership row is still a membership, and the server counts it, so testing
+  // for `undefined` rather than falsiness keeps this in step with `hasMoreThanOneActiveOwner`.
+  (memberAccepted !== undefined && memberRole === "owner" && !doesOrgHaveMoreThanOneOwner) ||
   (currentUserRole === "manager" && memberRole === "owner");

--- a/apps/web/modules/ee/role-management/lib/role-edit-rules.ts
+++ b/apps/web/modules/ee/role-management/lib/role-edit-rules.ts
@@ -1,0 +1,31 @@
+import type { TOrganizationRole } from "@formbricks/types/memberships";
+
+export interface TRoleEditContext {
+  isUserManagementDisabledFromUi: boolean;
+  currentUserRole: TOrganizationRole;
+  memberRole: TOrganizationRole;
+  /** The target's user id on membership rows, `""` on invite rows. */
+  memberId?: string;
+  /** The id of the user doing the editing. */
+  userId: string;
+  /** `true`/`false` on membership rows, `undefined` on invite rows. */
+  memberAccepted?: boolean;
+  doesOrgHaveMoreThanOneOwner?: boolean;
+}
+
+export const isRoleEditDisabled = ({
+  isUserManagementDisabledFromUi,
+  currentUserRole,
+  memberRole,
+  memberId,
+  userId,
+  memberAccepted,
+  doesOrgHaveMoreThanOneOwner,
+}: Readonly<TRoleEditContext>): boolean =>
+  isUserManagementDisabledFromUi ||
+  memberId === userId ||
+  // The last-owner rule belongs to memberships, not invites. `memberAccepted` is `undefined` on invite
+  // rows — the same signal `handleMemberRoleUpdate` uses to route to `updateInviteAction` — and
+  // re-roling a pending owner invite touches no membership, so that action carries no such guard.
+  (Boolean(memberAccepted) && memberRole === "owner" && !doesOrgHaveMoreThanOneOwner) ||
+  (currentUserRole === "manager" && memberRole === "owner");

--- a/apps/web/modules/organization/settings/teams/components/edit-memberships/members-info.tsx
+++ b/apps/web/modules/organization/settings/teams/components/edit-memberships/members-info.tsx
@@ -8,7 +8,7 @@ import { getAccessFlags } from "@/lib/membership/utils";
 import { formatDateWithOrdinal } from "@/lib/utils/datetime";
 import { EditMembershipRole } from "@/modules/ee/role-management/components/edit-membership-role";
 import { MemberActions } from "@/modules/organization/settings/teams/components/edit-memberships/member-actions";
-import { isInviteExpired } from "@/modules/organization/settings/teams/lib/utils";
+import { hasMoreThanOneActiveOwner, isInviteExpired } from "@/modules/organization/settings/teams/lib/utils";
 import { TInvite } from "@/modules/organization/settings/teams/types/invites";
 import { Badge } from "@/modules/ui/components/badge";
 import { SettingsTable, type TSettingsTableColumn } from "@/modules/ui/components/settings-table";
@@ -227,7 +227,7 @@ export const MembersInfo = ({
   const { isOwner, isManager } = getAccessFlags(currentUserRole);
   const isOwnerOrManager = isOwner || isManager;
 
-  const doesOrgHaveMoreThanOneOwner = allMembers.filter((member) => member.role === "owner").length > 1;
+  const doesOrgHaveMoreThanOneOwner = hasMoreThanOneActiveOwner(members);
 
   return (
     <SettingsTable

--- a/apps/web/modules/organization/settings/teams/lib/utils.test.ts
+++ b/apps/web/modules/organization/settings/teams/lib/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
+import { TMember } from "@formbricks/types/memberships";
 import { TInvite } from "@/modules/organization/settings/teams/types/invites";
-import { isInviteExpired } from "./utils";
+import { hasMoreThanOneActiveOwner, isInviteExpired } from "./utils";
 
 describe("isInviteExpired", () => {
   test("returns true if invite is expired", () => {
@@ -25,5 +26,45 @@ describe("isInviteExpired", () => {
       createdAt: new Date(),
     };
     expect(isInviteExpired(invite)).toBe(false);
+  });
+});
+
+describe("hasMoreThanOneActiveOwner", () => {
+  const member = (overrides: Partial<TMember>): TMember => ({
+    name: "Test",
+    email: "test@example.com",
+    userId: "user-1",
+    accepted: true,
+    role: "owner",
+    isActive: true,
+    ...overrides,
+  });
+
+  test("returns true for two active owners", () => {
+    expect(hasMoreThanOneActiveOwner([member({ userId: "user-1" }), member({ userId: "user-2" })])).toBe(
+      true
+    );
+  });
+
+  test("returns false for a single active owner", () => {
+    expect(hasMoreThanOneActiveOwner([member({}), member({ userId: "user-2", role: "manager" })])).toBe(
+      false
+    );
+  });
+
+  // The server's `getOrganizationOwnerCount` excludes deactivated users because they can never sign in
+  // again, so the sole active owner is still the last owner the guards protect.
+  test("does not count a deactivated owner", () => {
+    expect(hasMoreThanOneActiveOwner([member({}), member({ userId: "user-2", isActive: false })])).toBe(
+      false
+    );
+  });
+
+  test("counts an owner membership regardless of accepted, matching the server", () => {
+    expect(hasMoreThanOneActiveOwner([member({}), member({ userId: "user-2", accepted: false })])).toBe(true);
+  });
+
+  test("returns false for an organization with no owners", () => {
+    expect(hasMoreThanOneActiveOwner([member({ role: "member" }), member({ role: "manager" })])).toBe(false);
   });
 });

--- a/apps/web/modules/organization/settings/teams/lib/utils.ts
+++ b/apps/web/modules/organization/settings/teams/lib/utils.ts
@@ -1,3 +1,4 @@
+import { TMember } from "@formbricks/types/memberships";
 import { TInvite } from "@/modules/organization/settings/teams/types/invites";
 
 export const isInviteExpired = (invite: TInvite) => {
@@ -5,3 +6,19 @@ export const isInviteExpired = (invite: TInvite) => {
   const expiresAt = new Date(invite.expiresAt);
   return now > expiresAt;
 };
+
+/**
+ * Mirrors the server's `getOrganizationOwnerCount`, which every last-owner guard reads: it counts
+ * `Membership` rows, and only those whose user can still sign in. Two things are therefore not owners
+ * for this purpose, and both used to be counted here:
+ *
+ * - a pending owner **invite** — it lives in the separate `Invite` table and has no membership row yet,
+ *   which is why the parameter is `TMember[]` and not the mixed row list the table renders;
+ * - a **deactivated** owner — they can never sign in again, so treating them as a second owner would
+ *   leave the organization with nobody who can actually act as one.
+ *
+ * `accepted` is deliberately not part of this: the server does not filter on it either, and nothing
+ * gates organization access on it (see `lib/authzed/organization-membership.ts`).
+ */
+export const hasMoreThanOneActiveOwner = (members: TMember[]): boolean =>
+  members.filter((member) => member.role === "owner" && member.isActive).length > 1;


### PR DESCRIPTION
Fixes ENG-2616

## What & why

**Was:** the members table counted pending invites and deactivated users as owners. With one active owner and one deactivated owner, the deactivated owner's role dropdown and remove button stayed enabled — the server rejected both, so the user got an error toast where a disabled control was intended.

**Now:** the flag counts active owner memberships only, mirroring `getOrganizationOwnerCount`. Pending owner invites stay editable, because no membership exists for them yet.

- The ticket lists two symptoms. Only the deactivated-owner one is reachable — see the fold.

## Where to look

- [utils.ts:24](https://github.com/formbricks/formbricks/blob/anshuman/eng-2616-members-table-counts-pending-invites-and-deactivated-users/apps/web/modules/organization/settings/teams/lib/utils.ts#L24) — the counting rule, now typed `TMember[]`
- [role-edit-rules.ts:30](https://github.com/formbricks/formbricks/blob/anshuman/eng-2616-members-table-counts-pending-invites-and-deactivated-users/apps/web/modules/ee/role-management/lib/role-edit-rules.ts#L30) — why invite rows are exempt

## Breaking changes

- [ ] This PR contains breaking changes

None. This changes when a button is greyed out. Server behaviour, API, SDK and env surfaces are untouched.

## Migrations & env

- none

## How this was tested

Rerun: `npx vitest run --root apps/web modules/organization/settings/teams/lib/utils.test.ts modules/ee/role-management/lib/role-edit-rules.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Deactivated owner's controls are no longer offered | manual | Pair below: role dropdown and delete go enabled → disabled |
| Pending owner invite stays editable | manual | Same pair, third row identical in both |
| Deactivated owner is not a second owner | unit (mutation) | drop `&& member.isActive` at `utils.ts:24` → *does not count a deactivated owner* fails |
| Last-owner rule skips invites, not unaccepted memberships | unit (mutation) | `role-edit-rules.ts:30` mutates two ways; each turns a different test red |
| Invites cannot reach the counter again | unit (guard) | `hasMoreThanOneActiveOwner` takes `TMember[]`; the mixed list no longer type-checks |

<details>
<summary>Screenshots — one org, three rows, only the middle one changes</summary>

Owner One is the viewer and the only active owner. Owner Two is an owner who has been deactivated. Invited Owner is a pending owner invite.

| Before | After |
| --- | --- |
| ![Deactivated owner's role dropdown and delete button both enabled](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2616/members-before.png) | ![Deactivated owner's role dropdown and delete button both greyed out](https://raw.githubusercontent.com/formbricks/formbricks/assets-pr-screenshots/ENG-2616/members-after.png) |

Row 1 and row 3 are unchanged controls: your own row stays locked, and the pending owner invite keeps an active dropdown and delete. Row 2 is the fix — on main the server rejects both of those controls.

</details>

<details>
<summary>Why these are <code>mutation</code> and not <code>red on main</code></summary>

Both functions are new, so reverting the source makes the tests fail on `Cannot find module './role-edit-rules'` and `hasMoreThanOneActiveOwner is not a function` — red for the wrong reason. On main the same logic is inline in two `.tsx` files, which `AGENTS.md` puts out of reach of a unit test.

So the bug itself is proven separately, by running main's two expressions against the server's rule over the same fixtures.

```
### 1 active owner + pending OWNER INVITE
    main's flag = true   |   server owner count = 1
      member A                     dropdown=false remove=false  ok
      invite inv1 (owner)          dropdown=true  remove=true   ok

### 1 active owner + DEACTIVATED owner
    main's flag = true   |   server owner count = 1
      member A                     dropdown=false remove=false  ok
      member B [deactivated]       dropdown=true  remove=true   <-- BUG: dropdown offered, server
                                                                    rejects demote; remove offered,
                                                                    server rejects

### 2 active owners (control)
    main's flag = true   |   server owner count = 2
      member A                     dropdown=false remove=false  ok
      member B                     dropdown=true  remove=true   ok
```

Note the first block. The ticket's pending-invite symptom does not reproduce: the sole owner is the viewer, and `memberId === userId` already disables their own row, so the wrong count never reaches a control. It is a real counting error with no affordance behind it — worth fixing, but it is not what a user hits.

The deactivated-owner block is the one that bites, and it needs no unusual setup: promote a second owner, then deactivate them.

Second half — why the `memberAccepted` gate is load-bearing rather than defensive. Same scenario, asking whether a pending owner invite's dropdown is disabled:

```
  main                      flag=true   disabled=false   <- correct, invites are editable
  step 1 only               flag=false  disabled=true    <- REGRESSION
  step 1 + step 2 (this PR) flag=false  disabled=false   <- correct
```

The counting fix on its own would grey out a control that works today.
</details>

**Open gaps**

- No e2e. `AGENTS.md` routes UI detail below journey level to manual QA, not a new spec.
- The deactivated owner was seeded directly; `isActive` is reachable only through the v2 management API.

**Risks**

- `doesOrgHaveMoreThanOneOwner` keeps its name while its meaning narrowed. Both call sites updated.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `xhigh`.
