### PR TITLE
fix(integrations): stop the disabled integration action from navigating [ENG-2608]

### DIFF
--- a/apps/web/modules/ui/components/integration-card/index.tsx
+++ b/apps/web/modules/ui/components/integration-card/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Button } from "@/modules/ui/components/button";
+import { Button, type ButtonProps } from "@/modules/ui/components/button";
 
 interface CardProps {
   connectText?: string;
@@ -15,10 +15,47 @@ interface CardProps {
   icon?: React.ReactNode;
   connected?: boolean;
   statusText?: string;
+  /**
+   * Gates the connect/manage action only. The docs link stays live: it points at public
+   * documentation, so reading it is not a permission a read-only member can lack.
+   */
   disabled?: boolean;
 }
 
 export type { CardProps };
+
+interface CardActionProps {
+  href: string;
+  text?: string;
+  newTab?: boolean;
+  disabled?: boolean;
+  variant?: ButtonProps["variant"];
+}
+
+/**
+ * A disabled button cannot hold a link: `disabled` only suppresses clicks queued on the button
+ * itself, so a nested `<a href>` stays clickable and still navigates. The button read as greyed out
+ * while a read-only member was sent to the integration page anyway. So render no link at all when
+ * disabled — there is then nothing left to click.
+ *
+ * The enabled branch keeps the link nested inside the button rather than collapsing the two with
+ * `asChild`. That looks like the tidier shape, but the button's hover styles are `enabled:hover:*`
+ * variants, which compile to the `:enabled` pseudo-class — and `:enabled` only ever matches form
+ * controls, never an `<a>`. Hoisting the Link into the button's place would therefore drop the
+ * hover state on every enabled card.
+ */
+const CardAction = ({ href, text, newTab, disabled, variant }: Readonly<CardActionProps>) =>
+  disabled ? (
+    <Button disabled size="sm" variant={variant}>
+      {text}
+    </Button>
+  ) : (
+    <Button size="sm" variant={variant}>
+      <Link href={href} target={newTab ? "_blank" : "_self"}>
+        {text}
+      </Link>
+    </Button>
+  );
 
 export const Card: React.FC<CardProps> = ({
   connectText,
@@ -56,19 +93,9 @@ export const Card: React.FC<CardProps> = ({
     <p className="text-xs text-slate-500">{description}</p>
     <div className="mt-4 flex gap-x-2">
       {connectHref && (
-        <Button disabled={disabled} size="sm">
-          <Link href={connectHref} target={connectNewTab ? "_blank" : "_self"}>
-            {connectText}
-          </Link>
-        </Button>
+        <CardAction href={connectHref} text={connectText} newTab={connectNewTab} disabled={disabled} />
       )}
-      {docsHref && (
-        <Button disabled={disabled} size="sm" variant="secondary">
-          <Link href={docsHref} target={docsNewTab ? "_blank" : "_self"}>
-            {docsText}
-          </Link>
-        </Button>
-      )}
+      {docsHref && <CardAction href={docsHref} text={docsText} newTab={docsNewTab} variant="secondary" />}
     </div>
   </div>
 );

--- a/apps/web/modules/ui/components/integration-card/stories.tsx
+++ b/apps/web/modules/ui/components/integration-card/stories.tsx
@@ -104,6 +104,22 @@ export const Disconnected: Story = {
   },
 };
 
+export const Disabled: Story = {
+  args: {
+    label: "Card Label",
+    description: "This is the description of the card.",
+    connectText: "Connect",
+    connectHref: "#",
+    connectNewTab: false,
+    docsText: "Docs",
+    docsHref: "#",
+    docsNewTab: false,
+    connected: false,
+    statusText: "Disconnected",
+    disabled: true,
+  },
+};
+
 export const WithIcon: Story = {
   args: {
     label: "Card Label",


### PR DESCRIPTION
Fixes ENG-2608

## What & why

**Was:** A read-only workspace member saw a greyed-out Connect/Manage button on every integration card, but clicking it still navigated — the destination page then bounced them via its own auth guard.

**Now:** The disabled action renders no link, so there is nothing left to click. Docs is no longer gated: public documentation is not a permission a read-only member can lack.

`disabled` sat on the `<Button>`, but the navigable element was the nested `<Link>`, which does not inherit it. No authorization was crossed; only the affordance lied.

## Where to look

- [index.tsx:29-51](https://github.com/formbricks/formbricks/blob/anshuman/eng-2608-fix-read-only-members-can-click-greyed-out-integration/apps/web/modules/ui/components/integration-card/index.tsx#L29-L51) — why the enabled branch keeps the nested Link
- [index.tsx:98](https://github.com/formbricks/formbricks/blob/anshuman/eng-2608-fix-read-only-members-can-click-greyed-out-integration/apps/web/modules/ui/components/integration-card/index.tsx#L98) — docs action no longer takes `disabled`

## Breaking changes

- [ ] This PR contains breaking changes

None — internal to `apps/web`, and `CardProps` keeps its shape.

## Migrations & env

- none

## How this was tested

Rerun: save the fold's proof as `apps/web/modules/ui/components/integration-card/eng2608-proof.test.tsx`, then `pnpm test --filter=@formbricks/web -- modules/ui/components/integration-card/eng2608-proof.test.tsx`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Read-only: connect exposes nothing navigable | manual | Zero `<a>` for `connectHref`. Pre-fix: `expected <a…> to be null` |
| Read-only: connect is genuinely disabled | manual | `<button disabled>`, no `<a>` child; a11y reports a disabled control |
| Read-only: public docs link still navigates | manual | Keeps its `href`, renders un-greyed |
| Writable: both actions unchanged | manual | Markup byte-identical to `main` |

All `manual`: AGENTS.md forbids `.tsx` unit tests and not to E2E a component, so the proof ran and was deleted.

<details>
<summary>The proof, and why the enabled branch avoids <code>asChild</code></summary>

The `asChild` shape the ticket suggests would have dropped the hover state on every *enabled* card. `buttonVariants` gates hover on the `enabled:` variant, which Tailwind compiles to `:enabled`:

```
.enabled\:hover\:bg-primary\/80:enabled:hover { background-color: … }
```

`:enabled` only matches form controls. Checked in a browser rather than assumed:

```js
document.createElement('a').matches(':enabled')       // false
document.createElement('button').matches(':enabled')  // true
```

That affects the 26 existing `<Button asChild><Link>` call sites too, tracked in ENG-3138.

```tsx
import { render, screen } from "@testing-library/react";
import { describe, expect, test } from "vitest";
import { Card } from "./index";

const card = {
  label: "Google Sheets",
  description: "Sync responses to a sheet",
  connectText: "Manage",
  connectHref: "/workspaces/w1/settings/workspace/integrations/google-sheets",
  connectNewTab: false,
  docsText: "Docs",
  docsHref: "https://formbricks.com/docs",
  docsNewTab: true,
};

describe("ENG-2608", () => {
  test("A (guard) writable member: both actions navigate", () => {
    render(<Card {...card} disabled={false} />);
    expect(screen.getByText("Manage").closest("a")).toHaveAttribute("href", card.connectHref);
    expect(screen.getByText("Docs").closest("a")).toHaveAttribute("href", card.docsHref);
  });

  test("B (fix) read-only member: connect exposes nothing navigable", () => {
    const { container } = render(<Card {...card} disabled={true} />);
    expect(screen.getByText("Manage").closest("a")).toBeNull();
    expect(container.querySelector(`a[href="${card.connectHref}"]`)).toBeNull();
  });

  test("C (fix) read-only member: connect is a genuinely disabled button", () => {
    render(<Card {...card} disabled={true} />);
    const connect = screen.getByRole("button", { name: "Manage" });
    expect(connect).toBeDisabled();
    expect(connect.querySelector("a")).toBeNull();
  });

  test("D (guard) read-only member: the public docs link still works", () => {
    render(<Card {...card} disabled={true} />);
    expect(screen.getByText("Docs").closest("a")).toHaveAttribute("href", card.docsHref);
  });
});
```

Against `origin/main`, B and C fail and A and D pass. With the fix, all four pass.

</details>

**Open gaps**

- Not verified on a running instance as a real read-only member — that seeding needs the SpiceDB projection.
- No before/after screenshots, same reason. The only visual delta is Docs losing its grey.
- Integrations has no Playwright spec; this does not add one.

**Risks**

- A caller relying on `disabled` to also grey Docs would now see it live. `apps/web` has one caller.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.
