### PR TITLE
fix: terminate AuthZed health CLI after failures

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -204,6 +204,29 @@ jobs:
           test "$status" -eq 1
           test "$output" = '{"status":"disabled"}'
 
+          UNREACHABLE_TOKEN="authzed-cli-validation-secret"
+          set +e
+          unreachable_output="$(timeout 10s docker run --rm \
+            --entrypoint formbricks-authzed \
+            "${AUTHZED_CLI_ENV[@]}" \
+            -e AUTHZED_ENABLED="true" \
+            -e AUTHZED_ENDPOINT="192.0.2.1:50051" \
+            -e AUTHZED_INSECURE="true" \
+            -e AUTHZED_SYSTEM_KEY="formbricks" \
+            -e AUTHZED_TOKEN="$UNREACHABLE_TOKEN" \
+            "$IMAGE" health 2>&1)"
+          unreachable_status=$?
+          set -e
+
+          test "$unreachable_status" -eq 1
+          test "$(printf '%s\n' "$unreachable_output" | wc -l)" -eq 1
+          ! printf '%s' "$unreachable_output" | grep -F "$UNREACHABLE_TOKEN"
+          printf '%s' "$unreachable_output" | jq -e '
+            .status == "unhealthy" and
+            .retryable == true and
+            (.latencyMs | type == "number")
+          ' >/dev/null
+
           set +e
           upgrade_output="$(docker run --rm \
             --entrypoint formbricks-authzed \

--- a/apps/web/scripts/authzed-entrypoints.test.ts
+++ b/apps/web/scripts/authzed-entrypoints.test.ts
@@ -5,11 +5,15 @@ import { INVALID_CONFIGURATION_RESULT, INVALID_REQUEST_RESULT } from "./authzed-
 
 const webRoot = fileURLToPath(new URL("../", import.meta.url));
 const tsxExecutable = fileURLToPath(new URL("../../../node_modules/.bin/tsx", import.meta.url));
+const keepProcessAliveModule = `data:text/javascript,${encodeURIComponent(
+  "setInterval(() => process.uptime(), 60_000);"
+)}`;
 
 const runEntrypoint = (
   script: string,
   args: ReadonlyArray<string>,
-  environment: Readonly<Record<string, string>> = {}
+  environment: Readonly<Record<string, string>> = {},
+  timeout = 10_000
 ) =>
   spawnSync(tsxExecutable, ["--tsconfig", "tsconfig.json", script, ...args], {
     cwd: webRoot,
@@ -24,6 +28,7 @@ const runEntrypoint = (
       NODE_OPTIONS: "--conditions=react-server",
       ...environment,
     },
+    timeout,
   });
 
 const expectSingleJsonFailure = (
@@ -105,5 +110,43 @@ describe("AuthZed script entrypoints", () => {
     },
   ])("$name sanitizes runtime-loading failures", ({ args, expected, script }) => {
     expectSingleJsonFailure(runEntrypoint(script, args), expected);
+  });
+
+  test.each([
+    { args: [], name: "development health", script: "scripts/authzed-health.ts" },
+    { args: ["health"], name: "packaged health", script: "scripts/docker/authzed-cli.ts" },
+  ])("$name exits after an unreachable endpoint returns", ({ args, script }) => {
+    const token = "authzed-entrypoint-secret";
+    const result = runEntrypoint(
+      script,
+      args,
+      {
+        AUTHZED_ENDPOINT: "192.0.2.1:50051",
+        AUTHZED_INSECURE: "true",
+        AUTHZED_TOKEN: token,
+        CUBEJS_API_SECRET: "test-cube-secret",
+        CUBEJS_API_URL: "http://192.0.2.1:4000",
+        DATABASE_URL: "postgresql://test:test@192.0.2.1:5432/formbricks",
+        ENCRYPTION_KEY: "test-encryption-key",
+        HUB_API_KEY: "test-hub-key",
+        HUB_API_URL: "http://192.0.2.1:4000",
+        NODE_OPTIONS: `--conditions=react-server --import=${keepProcessAliveModule}`,
+        REDIS_URL: "redis://192.0.2.1:6379",
+      },
+      8_000
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain(token);
+
+    const outputLines = result.stdout.trimEnd().split("\n");
+    expect(outputLines).toHaveLength(1);
+    expect(JSON.parse(outputLines[0])).toMatchObject({
+      latencyMs: expect.any(Number),
+      retryable: true,
+      status: "unhealthy",
+    });
   });
 });

--- a/apps/web/scripts/authzed-entrypoints.test.ts
+++ b/apps/web/scripts/authzed-entrypoints.test.ts
@@ -115,37 +115,21 @@ describe("AuthZed script entrypoints", () => {
   test.each([
     { args: [], name: "development health", script: "scripts/authzed-health.ts" },
     { args: ["health"], name: "packaged health", script: "scripts/docker/authzed-cli.ts" },
-  ])("$name exits after an unreachable endpoint returns", ({ args, script }) => {
-    const token = "authzed-entrypoint-secret";
+  ])("$name exits after a sanitized failure while another handle remains active", ({ args, script }) => {
     const result = runEntrypoint(
       script,
       args,
       {
-        AUTHZED_ENDPOINT: "192.0.2.1:50051",
-        AUTHZED_INSECURE: "true",
-        AUTHZED_TOKEN: token,
-        CUBEJS_API_SECRET: "test-cube-secret",
-        CUBEJS_API_URL: "http://192.0.2.1:4000",
-        DATABASE_URL: "postgresql://test:test@192.0.2.1:5432/formbricks",
-        ENCRYPTION_KEY: "test-encryption-key",
-        HUB_API_KEY: "test-hub-key",
-        HUB_API_URL: "http://192.0.2.1:4000",
         NODE_OPTIONS: `--conditions=react-server --import=${keepProcessAliveModule}`,
-        REDIS_URL: "redis://192.0.2.1:6379",
       },
-      8_000
+      2_000
     );
 
     expect(result.error).toBeUndefined();
-    expect(result.status).toBe(1);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).not.toContain(token);
-
-    const outputLines = result.stdout.trimEnd().split("\n");
-    expect(outputLines).toHaveLength(1);
-    expect(JSON.parse(outputLines[0])).toMatchObject({
-      latencyMs: expect.any(Number),
-      retryable: true,
+    expectSingleJsonFailure(result, {
+      code: "authzed_internal",
+      latencyMs: 0,
+      retryable: false,
       status: "unhealthy",
     });
   });

--- a/apps/web/scripts/authzed-health-process.ts
+++ b/apps/web/scripts/authzed-health-process.ts
@@ -1,0 +1,9 @@
+import "server-only";
+
+export const exitAfterStdoutFlush = (exitCode: number | string): void => {
+  process.exitCode = exitCode;
+
+  // Failed grpc-js connections can retain a TCP connect handle after client.close(). Health has
+  // completed its SDK cleanup by this point, so terminate only after its JSON result is flushed.
+  process.stdout.write("", () => process.exit(exitCode));
+};

--- a/apps/web/scripts/authzed-health.ts
+++ b/apps/web/scripts/authzed-health.ts
@@ -1,4 +1,8 @@
 import "server-only";
+import { exitAfterStdoutFlush } from "./authzed-health-process";
+
+// Keep this automation-oriented command to exactly one JSON line, including failed retry paths.
+process.env.LOG_LEVEL = "fatal";
 
 const INVALID_CONFIGURATION_RESULT = {
   code: "authzed_internal",
@@ -27,4 +31,4 @@ const run = async (): Promise<void> => {
   }
 };
 
-void run();
+void run().then(() => exitAfterStdoutFlush(process.exitCode ?? 1));

--- a/apps/web/scripts/docker/authzed-cli.ts
+++ b/apps/web/scripts/docker/authzed-cli.ts
@@ -1,6 +1,11 @@
 import "server-only";
 import { configureCanonicalAuthzedSchemaUrl } from "../../lib/authzed/schema-source";
+import { exitAfterStdoutFlush } from "../authzed-health-process";
 import { INVALID_CONFIGURATION_RESULT, INVALID_REQUEST_RESULT } from "../authzed-schema-results";
+
+// Operator commands have a single-JSON output contract. Suppress application logging before loading
+// runtime modules so retries cannot add diagnostic lines to stdout.
+process.env.LOG_LEVEL = "fatal";
 
 configureCanonicalAuthzedSchemaUrl(import.meta.url, "./schema.zed");
 
@@ -141,4 +146,8 @@ const run = async (): Promise<void> => {
   }
 };
 
-void run();
+void run().then(() => {
+  if (process.argv[2] === "health") {
+    exitAfterStdoutFlush(process.exitCode ?? 1);
+  }
+});


### PR DESCRIPTION
No ticket: this release blocker was found during the Apollo staging outage drill.

## What & why

**Was:** An unreachable SpiceDB returned sanitized JSON after three retries, but the health CLI stayed alive on a pending gRPC TCP handle.

**Now:** Health commands close clients, flush one JSON result, and exit with the documented status within the retry budget.

- Internal retry logs are suppressed for the single-JSON operator contract.
- Explicit termination is limited to health; database-backed commands retain natural cleanup.

## Where to look

- [Health process adapter](https://github.com/formbricks/formbricks/blob/bhagya/fix-authzed-cli-exit-on-unavailable/apps/web/scripts/authzed-health-process.ts) — flush-before-exit boundary
- [Packaged entrypoint](https://github.com/formbricks/formbricks/blob/bhagya/fix-authzed-cli-exit-on-unavailable/apps/web/scripts/docker/authzed-cli.ts) — health-only integration
- [Regression coverage](https://github.com/formbricks/formbricks/blob/bhagya/fix-authzed-cli-exit-on-unavailable/apps/web/scripts/authzed-entrypoints.test.ts) — deterministic active-handle termination

## Breaking changes

- [ ] This PR contains breaking changes

None. It restores the documented internal operator CLI lifecycle and output contract.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run scripts/authzed-entrypoints.test.ts lib/authzed/cli.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Failed development health exits | unit (red on main) | Exit 1 despite an active event-loop handle |
| Failed packaged health exits | unit (red on main) | One sanitized JSON line, then exit 1 |
| Built image reaches blackholed endpoint | integration | Timeout within ten seconds; no token output |

**Open gaps**

- none

**Risks**

- Explicit exit is health-only and runs after client cleanup and stdout flush.

---

> [!NOTE]
> **AI model used** — `gpt-5.6-sol`, reasoning effort `xhigh`.
