### PR TITLE
fix: terminate AuthZed health CLI after failures (backport #9232 to release/6.0)

### DIFF
--- a/apps/web/scripts/authzed-health-process.ts
+++ b/apps/web/scripts/authzed-health-process.ts
@@ -1,0 +1,9 @@
+import "server-only";
+
+export const exitAfterStdoutFlush = (exitCode: number | string): void => {
+  process.exitCode = exitCode;
+
+  // Failed grpc-js connections can retain a TCP connect handle after client.close(). Health has
+  // completed its SDK cleanup by this point, so terminate only after its JSON result is flushed.
+  process.stdout.write("", () => process.exit(exitCode));
+};

--- a/apps/web/scripts/authzed-health.ts
+++ b/apps/web/scripts/authzed-health.ts
@@ -1,4 +1,8 @@
 import "server-only";
+import { exitAfterStdoutFlush } from "./authzed-health-process";
+
+// Keep this automation-oriented command to exactly one JSON line, including failed retry paths.
+process.env.LOG_LEVEL = "fatal";
 
 const INVALID_CONFIGURATION_RESULT = {
   code: "authzed_internal",
@@ -27,4 +31,4 @@ const run = async (): Promise<void> => {
   }
 };
 
-void run();
+void run().then(() => exitAfterStdoutFlush(process.exitCode ?? 1));

--- a/apps/web/scripts/docker/authzed-cli.ts
+++ b/apps/web/scripts/docker/authzed-cli.ts
@@ -1,6 +1,11 @@
 import "server-only";
 import { configureCanonicalAuthzedSchemaUrl } from "../../lib/authzed/schema-source";
+import { exitAfterStdoutFlush } from "../authzed-health-process";
 import { INVALID_CONFIGURATION_RESULT, INVALID_REQUEST_RESULT } from "../authzed-schema-results";
+
+// Operator commands have a single-JSON output contract. Suppress application logging before loading
+// runtime modules so retries cannot add diagnostic lines to stdout.
+process.env.LOG_LEVEL = "fatal";
 
 configureCanonicalAuthzedSchemaUrl(import.meta.url, "./schema.zed");
 
@@ -141,4 +146,8 @@ const run = async (): Promise<void> => {
   }
 };
 
-void run();
+void run().then(() => {
+  if (process.argv[2] === "health") {
+    exitAfterStdoutFlush(process.exitCode ?? 1);
+  }
+});


### PR DESCRIPTION
Backport of #9232 to `release/6.0`. No ticket — the source PR was a release blocker found during the Apollo staging outage drill.

Minimal, single-fix backport per the backport policy.

## What & why

**Was:** With SpiceDB unreachable, the AuthZed health CLI printed its sanitized JSON but hung on a pending grpc-js TCP handle instead of exiting.

**Now:** Health commands close their client, flush one JSON line, and exit with the documented status inside the retry budget.

- `LOG_LEVEL=fatal` keeps retry logs off the single-JSON operator contract.
- Explicit termination is health-only; database-backed commands keep natural cleanup.

## Where to look

- [apps/web/scripts/authzed-health-process.ts](https://github.com/formbricks/formbricks/blob/backport/9232-to-6.0/apps/web/scripts/authzed-health-process.ts) — flush-before-exit boundary
- [apps/web/scripts/docker/authzed-cli.ts](https://github.com/formbricks/formbricks/blob/backport/9232-to-6.0/apps/web/scripts/docker/authzed-cli.ts) — health-only integration

**Files changed** (3): `apps/web/scripts/authzed-health-process.ts` (new), `apps/web/scripts/authzed-health.ts`, `apps/web/scripts/docker/authzed-cli.ts`.

**Dropped from the original**, per the no-net-new-tests rule: the new `authzed-entrypoints.test.ts` cases (active-handle termination) and the new unreachable-endpoint step in `.github/workflows/docker-build-validation.yml`. No pre-existing test was modified by the source PR, so both files are unchanged here.

## Breaking changes

- [ ] This PR contains breaking changes

None. Internal operator CLI lifecycle only; no API, SDK, env or config surface changes.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run scripts/authzed-entrypoints.test.ts lib/authzed/cli.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Existing entrypoint sanitization still holds on `release/6.0` | unit (guard) | `authzed-entrypoints.test.ts` + `cli.test.ts`: 2 files, 12 tests passed |
| Workspace lint on the cherry-picked branch | manual | `pnpm lint`: 21/21 tasks successful |

**Open gaps**

- The active-handle exit itself has no unit coverage here — its regression tests are net-new and excluded by policy; it is covered on `main` by #9232.

**Risks**

- Exit is health-only and runs after client cleanup and stdout flush; other AuthZed commands are untouched.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.
