### PR TITLE
fix(charts): resolve option labels from every mapped question [ENG-3140]

### DIFF
--- a/apps/web/modules/ee/analysis/charts/actions.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.ts
@@ -19,7 +19,7 @@ import {
   getCharts,
   updateChart,
 } from "@/modules/ee/analysis/charts/lib/charts";
-import { resolveOptionGrouping } from "@/modules/ee/analysis/charts/lib/option-grouping";
+import { pruneOptionLabels, resolveOptionGrouping } from "@/modules/ee/analysis/charts/lib/option-grouping";
 import { checkFeedbackDirectoryAccess, checkWorkspaceAccess } from "@/modules/ee/analysis/lib/access";
 import {
   type TDimensionValue,
@@ -300,8 +300,9 @@ export const executeQueryAction = authenticatedActionClient
       });
 
       const rows = Array.isArray(rawRows) ? rawRows : [];
+      const usedLabels = pruneOptionLabels(rewrittenQuery, rows, optionLabels);
 
-      return { rows, ...(optionLabels ? { optionLabels } : {}), effectiveQuery: rewrittenQuery };
+      return { rows, ...(usedLabels ? { optionLabels: usedLabels } : {}), effectiveQuery: rewrittenQuery };
     }
   );
 

--- a/apps/web/modules/ee/analysis/charts/lib/option-grouping.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/option-grouping.test.ts
@@ -1,0 +1,349 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { pruneOptionLabels, resolveOptionGrouping } from "./option-grouping";
+
+const mocks = vi.hoisted(() => ({
+  getFeedbackSourcesWithMappings: vi.fn(),
+  getSurvey: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/feedback-source/service", () => ({
+  getFeedbackSourcesWithMappings: mocks.getFeedbackSourcesWithMappings,
+}));
+
+vi.mock("@/lib/survey/service", () => ({
+  getSurvey: mocks.getSurvey,
+}));
+
+/** A survey carrying a single element, shaped the way getElementsFromBlocks reads it. */
+const surveyWith = (id: string, element: Record<string, unknown>) => ({
+  id,
+  blocks: [{ id: `block-${id}`, elements: [element] }],
+});
+
+const singleSelect = (id: string, headline: string, choices: { id: string; label: string }[]) => ({
+  id,
+  type: "multipleChoiceSingle",
+  headline: { default: headline },
+  choices: choices.map((c) => ({ id: c.id, label: { default: c.label } })),
+});
+
+const multiSelect = (id: string, headline: string, choices: { id: string; label: string }[]) => ({
+  ...singleSelect(id, headline, choices),
+  type: "multipleChoiceMulti",
+});
+
+/** Wire the workspace's mappings and the surveys they point at. */
+const givenWorkspace = (
+  entries: { mapping: Record<string, unknown>; survey: ReturnType<typeof surveyWith> }[]
+) => {
+  mocks.getFeedbackSourcesWithMappings.mockResolvedValue([
+    { formbricksMappings: entries.map((e) => e.mapping) },
+  ]);
+  mocks.getSurvey.mockImplementation(
+    async (surveyId: string) => entries.find((e) => e.survey.id === surveyId)?.survey
+  );
+};
+
+const groupByValueId = (filters: unknown[] = []) => ({
+  measures: ["FeedbackRecords.count"],
+  dimensions: ["FeedbackRecords.valueId"],
+  filters,
+});
+
+const fieldIdFilter = (value: string) => ({
+  member: "FeedbackRecords.fieldId",
+  operator: "equals",
+  values: [value],
+});
+
+const fieldLabelFilter = (value: string) => ({
+  member: "FeedbackRecords.fieldLabel",
+  operator: "equals",
+  values: [value],
+});
+
+describe("resolveOptionGrouping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("leaves a query that groups by neither value dimension untouched", async () => {
+    const query = {
+      measures: ["FeedbackRecords.count"],
+      dimensions: ["FeedbackRecords.fieldLabel"],
+      filters: [],
+    };
+
+    const result = await resolveOptionGrouping(query as never, "workspace-1");
+
+    expect(result.optionLabels).toBeUndefined();
+    expect(result.rewrittenQuery).toBe(query);
+    expect(mocks.getFeedbackSourcesWithMappings).not.toHaveBeenCalled();
+  });
+
+  test("labels a single-select pinned by an exact fieldId filter", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-single", surveyId: "survey-1", customFieldLabel: null },
+        survey: surveyWith(
+          "survey-1",
+          singleSelect("el-single", "Nationality", [
+            { id: "c-in", label: "India" },
+            { id: "c-nl", label: "Netherlands" },
+          ])
+        ),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(
+      groupByValueId([fieldIdFilter("el-single")]) as never,
+      "workspace-1"
+    );
+
+    expect(result.optionLabels).toEqual({ "c-in": "India", "c-nl": "Netherlands" });
+  });
+
+  // ENG-3140: multi-select and matrix records store field_id as `${elementId}__${optionId}`, so a
+  // Field ID filter never equalled the mapping's elementId and the whole map was dropped.
+  test("labels a multi-select pinned by a per-option fieldId (elementId__optionId)", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-multi", surveyId: "survey-1", customFieldLabel: null },
+        survey: surveyWith(
+          "survey-1",
+          multiSelect("el-multi", "Sports followed", [
+            { id: "c-cricket", label: "Cricket" },
+            { id: "c-hockey", label: "Hockey" },
+          ])
+        ),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(
+      groupByValueId([fieldIdFilter("el-multi__c-cricket")]) as never,
+      "workspace-1"
+    );
+
+    expect(result.optionLabels).toEqual({ "c-cricket": "Cricket", "c-hockey": "Hockey" });
+  });
+
+  // ENG-3140: the old ambiguity guard returned undefined when 2+ mappings shared a field label,
+  // which is exactly the Asia Cup shape — the same question asked across several surveys.
+  test("merges labels from every mapping sharing the filtered field label", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-a", surveyId: "survey-a", customFieldLabel: null },
+        survey: surveyWith("survey-a", singleSelect("el-a", "Nationality", [{ id: "c-in", label: "India" }])),
+      },
+      {
+        mapping: { elementId: "el-b", surveyId: "survey-b", customFieldLabel: null },
+        survey: surveyWith(
+          "survey-b",
+          singleSelect("el-b", "Nationality", [{ id: "c-pk", label: "Pakistan" }])
+        ),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(
+      groupByValueId([fieldLabelFilter("Nationality")]) as never,
+      "workspace-1"
+    );
+
+    expect(result.optionLabels).toEqual({ "c-in": "India", "c-pk": "Pakistan" });
+  });
+
+  // ENG-3140: free-text "other" answers are ingested under the stable "other" value_id. Editor-built
+  // surveys carry a choice with that id, but an element that only sets otherOptionPlaceholder does
+  // not — and that bucket used to render the bare id.
+  test("labels the free-text other bucket when the element carries no explicit other choice", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-single", surveyId: "survey-1", customFieldLabel: null },
+        survey: surveyWith("survey-1", {
+          ...singleSelect("el-single", "Nationality", [{ id: "c-in", label: "India" }]),
+          otherOptionPlaceholder: { default: "Please specify" },
+        }),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(
+      groupByValueId([fieldIdFilter("el-single")]) as never,
+      "workspace-1"
+    );
+
+    expect(result.optionLabels).toEqual({ "c-in": "India", other: "Other" });
+  });
+
+  test("prefers the survey's own other-choice label over the fallback", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-single", surveyId: "survey-1", customFieldLabel: null },
+        survey: surveyWith(
+          "survey-1",
+          singleSelect("el-single", "Nationality", [
+            { id: "c-in", label: "India" },
+            { id: "other", label: "Somewhere else" },
+          ])
+        ),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(
+      groupByValueId([fieldIdFilter("el-single")]) as never,
+      "workspace-1"
+    );
+
+    expect(result.optionLabels).toEqual({ "c-in": "India", other: "Somewhere else" });
+  });
+
+  // ENG-3140: matrix records store the matched *column* id in value_id.
+  test("labels a matrix by its column ids", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-matrix", surveyId: "survey-1", customFieldLabel: null },
+        survey: surveyWith("survey-1", {
+          id: "el-matrix",
+          type: "matrix",
+          headline: { default: "Rate each area" },
+          rows: [{ id: "r-1", label: { default: "Support" } }],
+          columns: [
+            { id: "col-good", label: { default: "Good" } },
+            { id: "col-bad", label: { default: "Bad" } },
+          ],
+        }),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(
+      groupByValueId([fieldIdFilter("el-matrix__r-1")]) as never,
+      "workspace-1"
+    );
+
+    expect(result.optionLabels).toEqual({ "col-good": "Good", "col-bad": "Bad" });
+  });
+
+  // ENG-3140: with no field filter at all the resolver used to give up, which is the reported
+  // dashboard's shape. Ids are cuids, so labelling from the whole workspace cannot mislabel.
+  test("falls back to the whole workspace when a valueId grouping pins no mapping", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-a", surveyId: "survey-a", customFieldLabel: null },
+        survey: surveyWith("survey-a", singleSelect("el-a", "Nationality", [{ id: "c-in", label: "India" }])),
+      },
+      {
+        mapping: { elementId: "el-b", surveyId: "survey-b", customFieldLabel: null },
+        survey: surveyWith(
+          "survey-b",
+          multiSelect("el-b", "Sports followed", [{ id: "c-cricket", label: "Cricket" }])
+        ),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(groupByValueId() as never, "workspace-1");
+
+    expect(result.optionLabels).toEqual({ "c-in": "India", "c-cricket": "Cricket" });
+  });
+
+  test("does not widen to the whole workspace for a valueText grouping", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-a", surveyId: "survey-a", customFieldLabel: null },
+        survey: surveyWith("survey-a", singleSelect("el-a", "Nationality", [{ id: "c-in", label: "India" }])),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(
+      {
+        measures: ["FeedbackRecords.count"],
+        dimensions: ["FeedbackRecords.valueText"],
+        filters: [],
+      } as never,
+      "workspace-1"
+    );
+
+    expect(result.optionLabels).toBeUndefined();
+    expect(mocks.getSurvey).not.toHaveBeenCalled();
+  });
+
+  test("omits optionLabels when the pinned element carries no option ids", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-open", surveyId: "survey-1", customFieldLabel: null },
+        survey: surveyWith("survey-1", {
+          id: "el-open",
+          type: "openText",
+          headline: { default: "Anything else?" },
+        }),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(
+      groupByValueId([fieldIdFilter("el-open")]) as never,
+      "workspace-1"
+    );
+
+    expect(result.optionLabels).toBeUndefined();
+  });
+
+  // Ranking stores the rank in value_number and picture selection falls through the generic path,
+  // so neither writes a value_id — there is no bucket for this resolver to label.
+  test("omits optionLabels for a ranking element, which stores no value_id", async () => {
+    givenWorkspace([
+      {
+        mapping: { elementId: "el-rank", surveyId: "survey-1", customFieldLabel: null },
+        survey: surveyWith("survey-1", {
+          id: "el-rank",
+          type: "ranking",
+          headline: { default: "Rank these" },
+          choices: [
+            { id: "c-1", label: { default: "First" } },
+            { id: "c-2", label: { default: "Second" } },
+          ],
+        }),
+      },
+    ]);
+
+    const result = await resolveOptionGrouping(
+      groupByValueId([fieldIdFilter("el-rank__c-1")]) as never,
+      "workspace-1"
+    );
+
+    expect(result.optionLabels).toBeUndefined();
+  });
+});
+
+describe("pruneOptionLabels", () => {
+  const labels = { "c-in": "India", "c-pk": "Pakistan", "c-unrelated": "From another survey" };
+
+  test("keeps only the labels the returned rows actually render", () => {
+    const rows = [
+      { "FeedbackRecords.valueId": "c-in", "FeedbackRecords.count": 12 },
+      { "FeedbackRecords.valueId": "c-pk", "FeedbackRecords.count": 7 },
+    ];
+
+    expect(pruneOptionLabels(groupByValueId() as never, rows, labels)).toEqual({
+      "c-in": "India",
+      "c-pk": "Pakistan",
+    });
+  });
+
+  test("passes the map through untouched for a grouping that carries no value_id", () => {
+    const query = {
+      measures: ["FeedbackRecords.count"],
+      dimensions: ["FeedbackRecords.valueText"],
+      filters: [],
+    };
+
+    expect(pruneOptionLabels(query as never, [{ "FeedbackRecords.valueText": "India" }], labels)).toBe(
+      labels
+    );
+  });
+
+  test("drops the map entirely when no row matches it", () => {
+    const rows = [{ "FeedbackRecords.valueId": "c-gone", "FeedbackRecords.count": 1 }];
+
+    expect(pruneOptionLabels(groupByValueId() as never, rows, labels)).toBeUndefined();
+  });
+});

--- a/apps/web/modules/ee/analysis/charts/lib/option-grouping.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/option-grouping.ts
@@ -8,7 +8,9 @@ import { getLocalizedValue } from "@/lib/i18n/utils";
 import { getSurvey } from "@/lib/survey/service";
 import { getElementsFromBlocks } from "@/lib/survey/utils";
 
-// ── Single-select option-id resolution helpers ────────────────────────────────
+const VALUE_ID_DIMENSION = "FeedbackRecords.valueId";
+
+// ── Option-id resolution helpers ──────────────────────────────────────────────
 
 /** Extract the first `equals` value for a member filter by member name, searching top-level filters only. */
 function extractMemberEqualsValue(filters: TCubeFilter[], member: string): string | undefined {
@@ -28,29 +30,48 @@ function extractMemberEqualsValue(filters: TCubeFilter[], member: string): strin
 const getChoiceLabelDefault = (choice: { label: TSurveyElementChoice["label"] }): string =>
   getTextContent(getLocalizedValue(choice.label, "default"));
 
-interface TResolvedElement {
+interface TMappingRef {
   elementId: string;
   surveyId: string;
+  customFieldLabel?: string | null;
 }
+
+type TSurveyLoader = (surveyId: string) => Promise<Awaited<ReturnType<typeof getSurvey>> | undefined>;
 
 export interface TOptionGroupingResult {
   rewrittenQuery: TChartQuery;
   optionLabels?: Record<string, string>;
 }
 
-/** Find the mapping that owns this elementId and return its element/survey pair. */
-const resolveElementByFieldId = async (
-  fieldId: string,
-  workspaceId: string
-): Promise<TResolvedElement | undefined> => {
-  const feedbackSources = await getFeedbackSourcesWithMappings(workspaceId);
-  for (const source of feedbackSources) {
-    const mapping = source.formbricksMappings.find((m) => m.elementId === fieldId);
-    if (mapping) {
-      return { elementId: fieldId, surveyId: mapping.surveyId };
+/** Dedupe survey loads so we only call getSurvey once per distinct surveyId within one resolve. */
+const createSurveyLoader = (): TSurveyLoader => {
+  const cache = new Map<string, Awaited<ReturnType<typeof getSurvey>>>();
+  return async (surveyId: string) => {
+    if (!cache.has(surveyId)) {
+      cache.set(surveyId, await getSurvey(surveyId));
     }
-  }
-  return undefined;
+    return cache.get(surveyId);
+  };
+};
+
+/** Every mapping in the workspace, flattened across feedback sources. */
+const getWorkspaceMappings = async (workspaceId: string): Promise<TMappingRef[]> => {
+  const feedbackSources = await getFeedbackSourcesWithMappings(workspaceId);
+  return feedbackSources.flatMap((source) => source.formbricksMappings);
+};
+
+/**
+ * Match mappings by the `field_id` a record carries. Elements that expand into one record per
+ * option store `field_id = ${elementId}__${optionId}` (multi-select and matrix, see transform.ts),
+ * so an exact match on the mapping's elementId misses them — strip the `__` suffix and retry.
+ * Element ids are cuids (alphanumeric), so the first `__` is always the separator.
+ */
+const resolveMappingsByFieldId = (fieldId: string, mappings: TMappingRef[]): TMappingRef[] => {
+  const exact = mappings.filter((m) => m.elementId === fieldId);
+  if (exact.length > 0) return exact;
+
+  const [elementId] = fieldId.split("__");
+  return elementId === fieldId ? [] : mappings.filter((m) => m.elementId === elementId);
 };
 
 /**
@@ -58,8 +79,8 @@ const resolveElementByFieldId = async (
  * default-language headline (mirroring how transform.ts computes field_label on ingest).
  */
 const getMappingEffectiveLabel = async (
-  mapping: { elementId: string; surveyId: string; customFieldLabel?: string | null },
-  loadSurvey: (surveyId: string) => Promise<Awaited<ReturnType<typeof getSurvey>> | undefined>
+  mapping: TMappingRef,
+  loadSurvey: TSurveyLoader
 ): Promise<string | undefined> => {
   // Fast path: customFieldLabel is already stored on the mapping. Even if it doesn't match,
   // skip the survey load because the effective label is the custom one, not the headline.
@@ -77,73 +98,134 @@ const getMappingEffectiveLabel = async (
 
 /**
  * Users filter by "Field Label" (fieldLabel) rather than the internal fieldId, so we resolve the
- * label → elementId by matching each mapping's effective label. If zero or multiple mappings
- * share the same label (ambiguous), returns undefined rather than guessing.
+ * label → mappings by matching each mapping's effective label. Several mapped questions can share
+ * one label (the same question asked across surveys); all of them are returned and their labels
+ * merged, rather than dropping the map because the match was not unique.
  */
-const resolveElementByFieldLabel = async (
+const resolveMappingsByFieldLabel = async (
   fieldLabelFilter: string,
-  workspaceId: string
-): Promise<TResolvedElement | undefined> => {
-  const feedbackSources = await getFeedbackSourcesWithMappings(workspaceId);
-
-  // Dedupe survey loads so we only call getSurvey once per distinct surveyId.
-  const surveyCache = new Map<string, Awaited<ReturnType<typeof getSurvey>>>();
-  const loadSurvey = async (surveyId: string) => {
-    if (!surveyCache.has(surveyId)) {
-      surveyCache.set(surveyId, await getSurvey(surveyId));
-    }
-    return surveyCache.get(surveyId);
-  };
-
-  // Collect candidates: mappings whose effective label exactly matches the filter value.
-  const candidates: TResolvedElement[] = [];
-  for (const source of feedbackSources) {
-    for (const mapping of source.formbricksMappings) {
-      const effectiveLabel = await getMappingEffectiveLabel(mapping, loadSurvey);
-      if (effectiveLabel === fieldLabelFilter) {
-        candidates.push({ elementId: mapping.elementId, surveyId: mapping.surveyId });
-      }
+  mappings: TMappingRef[],
+  loadSurvey: TSurveyLoader
+): Promise<TMappingRef[]> => {
+  const candidates: TMappingRef[] = [];
+  for (const mapping of mappings) {
+    const effectiveLabel = await getMappingEffectiveLabel(mapping, loadSurvey);
+    if (effectiveLabel === fieldLabelFilter) {
+      candidates.push(mapping);
     }
   }
-
-  // Ambiguity guard: if zero or multiple mappings share this label, do not guess.
-  return candidates.length === 1 ? candidates[0] : undefined;
+  return candidates;
 };
 
 /**
- * Choice questions (single- AND multi-select) store one record per selected option with a stable
- * value_id (see transform.ts), so both are handled identically: respect the dimension the user
- * picked — grouping by Value (Text) stays valueText, grouping by Value (Option) stays valueId — and
- * only build the choice-id → default-language label map so the renderer can show human labels when
- * the user groups by valueId (the map is harmlessly unused otherwise). No dimension is rewritten.
+ * Add an element's `value_id` → default-language label pairs to `into`.
+ *
+ * Which ids an element can produce follows what transform.ts writes on ingest:
+ * - single- and multi-select store the matched choice id, plus the stable `"other"` id for
+ *   free-text answers when the element offers an other option;
+ * - matrix stores the matched *column* id (the row goes into field_id/field_label);
+ * - ranking stores the rank as `value_number` and picture selection falls through the generic
+ *   path, so neither carries a `value_id` — there is no bucket to label.
+ *
+ * Existing entries are never overwritten: ids are cuids and cannot collide across elements, but
+ * the shared `"other"` id can, and the first mapped element's wording is as good as any.
  */
-const buildChoiceLabels = (element: {
-  choices: { id: string; label: TSurveyElementChoice["label"] }[];
-}): Record<string, string> => {
+const collectOptionLabels = (
+  element: { type: string; choices?: unknown; columns?: unknown; otherOptionPlaceholder?: unknown },
+  into: Record<string, string>
+): void => {
+  const addAll = (options: unknown): void => {
+    if (!Array.isArray(options)) return;
+    for (const option of options as { id: string; label: TSurveyElementChoice["label"] }[]) {
+      into[option.id] ??= getChoiceLabelDefault(option);
+    }
+  };
+
+  if (
+    element.type === TSurveyElementTypeEnum.MultipleChoiceSingle ||
+    element.type === TSurveyElementTypeEnum.MultipleChoiceMulti
+  ) {
+    addAll(element.choices);
+
+    // Free-text "other" answers are stored under the stable "other" id (transform.ts). Surveys
+    // built in the editor carry an explicit choice with that id, so `addAll` already labelled it;
+    // an element that only sets otherOptionPlaceholder still produces the bucket and would
+    // otherwise render the bare id. Like every other label in this map, the fallback is
+    // default-language text, not the viewer's locale.
+    const choices = Array.isArray(element.choices) ? (element.choices as { id: string }[]) : [];
+    if (element.otherOptionPlaceholder !== undefined || choices.some((choice) => choice.id === "other")) {
+      into.other ??= "Other";
+    }
+    return;
+  }
+
+  if (element.type === TSurveyElementTypeEnum.Matrix) {
+    addAll(element.columns);
+  }
+};
+
+/** Resolve each mapping to its element and merge every option label it can produce. */
+const buildOptionLabels = async (
+  mappings: TMappingRef[],
+  loadSurvey: TSurveyLoader
+): Promise<Record<string, string>> => {
   const optionLabels: Record<string, string> = {};
-  for (const choice of element.choices) {
-    optionLabels[choice.id] = getChoiceLabelDefault(choice);
+  for (const mapping of mappings) {
+    const survey = await loadSurvey(mapping.surveyId);
+    if (!survey) continue;
+    const element = getElementsFromBlocks(survey.blocks).find((el) => el.id === mapping.elementId);
+    if (!element) continue;
+    collectOptionLabels(element, optionLabels);
   }
   return optionLabels;
 };
 
 /**
- * When a query groups by either `FeedbackRecords.valueText` or `FeedbackRecords.valueId`, and a
- * `FeedbackRecords.fieldId equals <id>` or `FeedbackRecords.fieldLabel equals <label>` filter is
- * present, resolve the element and — for a single- or multi-select choice question — attach a
- * `{ [value_id]: defaultLabel }` map so the renderer can show human-readable option labels when
- * the user groups by valueId. The dimension the user picked is never rewritten: both select types
- * store one record per option with its own value_id (see transform.ts), so valueText and valueId
- * both group correctly on their own.
+ * Ship only the labels a `Value (Option)` grouping actually renders. The map behind it can be
+ * built from every mapping in the workspace (see below), and the caller has already narrowed the
+ * rows to the feedback directory the viewer may read — so pruning against those rows keeps
+ * unrelated surveys' option labels out of the response and off the wire. Groupings that do not
+ * carry a value_id pass through untouched; the renderer never consults the map for them.
+ */
+export const pruneOptionLabels = (
+  query: TChartQuery,
+  rows: Record<string, unknown>[],
+  optionLabels: Record<string, string> | undefined
+): Record<string, string> | undefined => {
+  if (!optionLabels || !(query.dimensions ?? []).includes(VALUE_ID_DIMENSION)) {
+    return optionLabels;
+  }
+
+  const used: Record<string, string> = {};
+  for (const row of rows) {
+    const valueId = row[VALUE_ID_DIMENSION];
+    if (typeof valueId === "string" && optionLabels[valueId] !== undefined) {
+      used[valueId] = optionLabels[valueId];
+    }
+  }
+  return Object.keys(used).length > 0 ? used : undefined;
+};
+
+/**
+ * When a query groups by either `FeedbackRecords.valueText` or `FeedbackRecords.valueId`, attach a
+ * `{ [value_id]: defaultLabel }` map so the renderer can show human-readable option labels instead
+ * of the raw choice ids stored in `value_id`. The dimension the user picked is never rewritten:
+ * choice records store one row per option with its own value_id (see transform.ts), so valueText
+ * and valueId both group correctly on their own.
  *
- * If no `fieldId` filter is present, falls back to a `FeedbackRecords.fieldLabel equals <label>`
- * filter: loads all source mappings, computes each mapping's effective label
- * (customFieldLabel if set, else the element's default-language headline — same logic as
- * transform.ts), and resolves exactly one match. If zero or multiple mappings share the same
- * label (ambiguous), the query is returned unchanged rather than guessing.
+ * Which mappings contribute labels:
+ * - a `FeedbackRecords.fieldId equals <id>` filter pins the mapping directly (matching the
+ *   `${elementId}__${optionId}` form multi-select and matrix records use as well);
+ * - otherwise a `FeedbackRecords.fieldLabel equals <label>` filter matches every mapping whose
+ *   effective label is that string — several surveys may ask the same question, and all of them
+ *   contribute;
+ * - when the filters pin nothing and the chart groups by valueId, every mapping in the workspace
+ *   contributes. Grouping by valueId with no resolvable label map is exactly the case that renders
+ *   bare cuids (ENG-3140), and option ids are cuids, so a wider map cannot mislabel a bucket.
+ *   A valueText grouping is readable on its own and does not pay for that widening.
  *
  * Returns `{ rewrittenQuery, optionLabels }`. `rewrittenQuery` is always the original query
- * (kept for caller symmetry); `optionLabels` is set only for resolved choice questions.
+ * (kept for caller symmetry); `optionLabels` is omitted when no mapped element carries option ids.
  */
 export async function resolveOptionGrouping(
   query: TChartQuery,
@@ -151,49 +233,39 @@ export async function resolveOptionGrouping(
 ): Promise<TOptionGroupingResult> {
   const dimensions = query.dimensions ?? [];
   const hasValueText = dimensions.includes("FeedbackRecords.valueText");
-  const hasValueId = dimensions.includes("FeedbackRecords.valueId");
+  const hasValueId = dimensions.includes(VALUE_ID_DIMENSION);
   if (!hasValueText && !hasValueId) {
     return { rewrittenQuery: query };
   }
 
-  // ── Resolve element via fieldId (preferred) or fieldLabel (fallback) ──────
   const fieldId = extractMemberEqualsValue(query.filters ?? [], "FeedbackRecords.fieldId");
   const fieldLabelFilter = fieldId
     ? undefined
     : extractMemberEqualsValue(query.filters ?? [], "FeedbackRecords.fieldLabel");
 
-  let resolved: TResolvedElement | undefined;
+  const workspaceMappings = await getWorkspaceMappings(workspaceId);
+  const loadSurvey = createSurveyLoader();
+
+  let mappings: TMappingRef[] = [];
   if (fieldId) {
-    resolved = await resolveElementByFieldId(fieldId, workspaceId);
+    mappings = resolveMappingsByFieldId(fieldId, workspaceMappings);
   } else if (fieldLabelFilter) {
-    resolved = await resolveElementByFieldLabel(fieldLabelFilter, workspaceId);
-  }
-  if (!resolved) {
-    return { rewrittenQuery: query };
-  }
-  const { elementId, surveyId } = resolved;
-
-  const survey = await getSurvey(surveyId);
-  if (!survey) {
-    return { rewrittenQuery: query };
+    mappings = await resolveMappingsByFieldLabel(fieldLabelFilter, workspaceMappings, loadSurvey);
   }
 
-  const elements = getElementsFromBlocks(survey.blocks);
-  const element = elements.find((el) => el.id === elementId);
-  if (!element) {
+  // Nothing pinned down, but the chart is grouping by the raw option id: label from the whole
+  // workspace rather than leaving the ids bare.
+  if (mappings.length === 0 && hasValueId) {
+    mappings = workspaceMappings;
+  }
+  if (mappings.length === 0) {
     return { rewrittenQuery: query };
   }
 
-  if (
-    element.type === TSurveyElementTypeEnum.MultipleChoiceSingle ||
-    element.type === TSurveyElementTypeEnum.MultipleChoiceMulti
-  ) {
-    // Keep the user's chosen dimension; just attach labels so a valueId grouping reads nicely.
-    const optionLabels = buildChoiceLabels(
-      element as { choices: { id: string; label: TSurveyElementChoice["label"] }[] }
-    );
-    return { rewrittenQuery: query, optionLabels };
+  const optionLabels = await buildOptionLabels(mappings, loadSurvey);
+  if (Object.keys(optionLabels).length === 0) {
+    return { rewrittenQuery: query };
   }
 
-  return { rewrittenQuery: query };
+  return { rewrittenQuery: query, optionLabels };
 }

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
@@ -9,7 +9,7 @@ import { getTranslate } from "@/lingodotdev/server";
 import { executeTenantScopedQuery } from "@/modules/ee/analysis/api/lib/cube-client";
 import { prepareQueryForChartType } from "@/modules/ee/analysis/charts/lib/big-number";
 import { resolveChartType } from "@/modules/ee/analysis/charts/lib/chart-utils";
-import { resolveOptionGrouping } from "@/modules/ee/analysis/charts/lib/option-grouping";
+import { pruneOptionLabels, resolveOptionGrouping } from "@/modules/ee/analysis/charts/lib/option-grouping";
 import { AnalysisPageLayout } from "@/modules/ee/analysis/components/analysis-page-layout";
 import { checkFeedbackDirectoryAccess } from "@/modules/ee/analysis/lib/access";
 import type { TChartDataRow } from "@/modules/ee/analysis/types/analysis";
@@ -66,10 +66,13 @@ async function executeWidgetQuery(
       source: "dashboards.widget",
     });
 
+    const rows = Array.isArray(data) ? data : [];
+    const usedLabels = pruneOptionLabels(rewrittenQuery, rows, optionLabels);
+
     return {
-      data: Array.isArray(data) ? data : [],
+      data: rows,
       query: rewrittenQuery,
-      ...(optionLabels ? { optionLabels } : {}),
+      ...(usedLabels ? { optionLabels: usedLabels } : {}),
     };
   } catch (error) {
     logger.error(error, "Failed to load dashboard widget data");


### PR DESCRIPTION
Fixes ENG-3140

## What & why

**Was:** A chart grouped by `Value (Option)` printed raw choice cuids (`lca104azbjkuiscxztkh2yp`) whenever the server could not pin the query to exactly one mapped question.

**Now:** It shows the option labels, including a readable `Other` bucket.

- Several surveys sharing a field label used to drop the whole map; all of them now contribute.
- A `Field ID` filter now matches multi-select and matrix records, stored as `elementId__optionId`.
- Matrix columns resolve too. Ranking and picture selection write no `value_id` at ingest.

## Where to look

- [`resolveOptionGrouping:258`](https://github.com/formbricks/formbricks/blob/claude/eng-3140-option-labels/apps/web/modules/ee/analysis/charts/lib/option-grouping.ts#L255-L262) — workspace-wide fallback, valueId only
- [`pruneOptionLabels:190`](https://github.com/formbricks/formbricks/blob/claude/eng-3140-option-labels/apps/web/modules/ee/analysis/charts/lib/option-grouping.ts#L184-L208) — keeps other surveys' labels off the wire
- [`resolveMappingsByFieldId:69`](https://github.com/formbricks/formbricks/blob/claude/eng-3140-option-labels/apps/web/modules/ee/analysis/charts/lib/option-grouping.ts#L63-L76) — the `__` suffix match

Before:

<img width="974" height="534" alt="Screenshot 2026-09-15 at 11 13 25 AM" src="https://github.com/user-attachments/assets/83fbcd22-d2a2-417c-bf28-8929a944174d" />


After:

<img width="1467" height="727" alt="Screenshot 2026-09-15 at 11 20 05 AM" src="https://github.com/user-attachments/assets/5d248f27-abed-4f55-9e92-5787dfd70374" />

## Breaking changes

- [ ] This PR contains breaking changes

None. Internal to this repo — no API, SDK or config surface changes.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter=@formbricks/web test modules/ee/analysis`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Two mapped questions share a field label | unit (red on main) | Labels merge from both mappings instead of vanishing |
| Multi-select pinned by `Field ID` (`el__opt`) | unit (red on main) | Choice labels resolve; suffix no longer defeats the match |
| No field filter, grouped by valueId | unit (red on main) | Labels come from the whole workspace |
| Free-text `other` with no explicit choice | unit (red on main) | Buckets under `Other` |
| Matrix grouped by valueId | unit (red on main) | Column labels resolve |
| Response carries only the labels its rows use | unit (mutation) | Unrelated surveys' labels pruned out; mutate `option-grouping.ts:203` |

<details>
<summary>Verification output</summary>

Checking out main's `option-grouping.ts` and rerunning the new spec against it gives
**8 failed | 6 passed (14)**: the five `red on main` rows above, plus the three `pruneOptionLabels`
cases, which fail as `pruneOptionLabels is not a function` because that export is new — hence the
`mutation` row rather than a sixth `red on main`. With the fix applied the spec is green.

```
$ pnpm --filter=@formbricks/web test modules/ee/analysis
 Test Files  36 passed (36)
      Tests  606 passed (606)

$ pnpm test
 Test Files  791 passed (791)
      Tests  10774 passed (10774)

$ pnpm format:check
All matched files use Prettier code style!

$ pnpm typecheck --filter=@formbricks/web
 Tasks:    12 successful, 12 total

$ npx eslint <the four changed files>
(no output — 0 errors, 0 warnings)
```

</details>

**Open gaps**

- Not reproduced against the Asia Cup dashboard; covers the ticket's four candidate causes.
- The backport the ticket asks for is not done here.
- ~613 changed lines, over the ~500 an unattended run should stay under.

**Risks**

- The valueId fallback loads every mapped survey. The `fieldLabel` path already did; `getSurvey` is request-cached.
- Two surveys with differently-worded `other` choices share whichever label is read first.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeiBLtJz742c3tgv8i3vMW)_