### PR TITLE
feat(surveys): report the survey card's rect to native hosts

### DIFF
--- a/apps/web/playwright/survey-modal-non-blocking.spec.ts
+++ b/apps/web/playwright/survey-modal-non-blocking.spec.ts
@@ -272,6 +272,25 @@ test.describe("App survey widget does not block the host page", () => {
     await surveyInput.fill("still works");
     await expect(surveyInput).toHaveValue("still works");
 
+    // Reported again when the viewport changes. Every assertion above is satisfied by a single
+    // report on open, so without this the resize listener could be deleted and nothing would go
+    // red — leaving a host masking touches to where the card used to be after a rotation.
+    const reportsBeforeResize = await page.evaluate(() => window.__cardRects.length);
+    await page.setViewportSize({ width: 900, height: 700 });
+    await expect
+      .poll(() => page.evaluate(() => window.__cardRects.length), { timeout: 30000 })
+      .toBeGreaterThan(reportsBeforeResize);
+
+    // No two consecutive reports are identical. The card animates over 500ms and the rect is
+    // sampled per frame, so without the whole-pixel dedupe a native host takes roughly thirty
+    // bridge hops per open instead of a handful.
+    const hasRepeatedReport = await page.evaluate(() => {
+      const key = (r: (typeof window.__cardRects)[number]) =>
+        r ? [r.x, r.y, r.width, r.height].map(Math.round).join(",") : "none";
+      return window.__cardRects.some((r, i) => i > 0 && key(r) === key(window.__cardRects[i - 1]));
+    });
+    expect(hasRepeatedReport).toBe(false);
+
     // Escape closes the survey when focus is inside it.
     await page.keyboard.press("Escape");
     await expect(dialog).toBeHidden();

--- a/apps/web/playwright/survey-modal-non-blocking.spec.ts
+++ b/apps/web/playwright/survey-modal-non-blocking.spec.ts
@@ -25,6 +25,7 @@ declare global {
     __workspaceId: string;
     __hostEscapeDefaultPrevented: boolean | null;
     __hostChordDefaultPrevented: boolean | null;
+    __cardRects: ({ x: number; y: number; width: number; height: number } | null)[];
   }
 }
 
@@ -59,6 +60,49 @@ const HOST_PAGE = `<!doctype html>
     <script>
       window.__hostEscapeDefaultPrevented = null;
       window.__hostChordDefaultPrevented = null;
+
+      // Stand in for a native SDK. Only the mobile SDKs pass \`onCardRectChange\` — a web host has
+      // no use for it, since CSS pointer-events already keeps a no-overlay survey from swallowing
+      // clicks. So there is no way to observe the contract through the normal widget path, and it
+      // is wrapped here instead. Worth the artificiality: this exact contract silently stopped
+      // firing for the Flutter SDK once (it scraped the DOM for the card, and an a11y fix moved the
+      // attribute it matched on), and nothing failed anywhere until a user reported a dead survey.
+      window.__cardRects = [];
+      // Stand in for a native SDK. Only the mobile SDKs pass \`onCardRectChange\` — a web host has no
+      // use for it, since CSS pointer-events already keeps a no-overlay survey from swallowing
+      // clicks. So the contract cannot be observed through the normal widget path and is wrapped
+      // here instead. Worth the artificiality: this contract silently stopped firing for the
+      // Flutter SDK once (it scraped the DOM for the card, and an a11y fix moved the attribute it
+      // matched on) and nothing failed anywhere until a user reported a dead survey.
+      //
+      // Installed as a setter rather than by polling for the global: js-core resolves its runtime
+      // load and calls renderSurvey in the same microtask chain, so a \`setTimeout\` poll loses the
+      // race and the first — only — render goes unwrapped.
+      (function () {
+        var runtime = null;
+        Object.defineProperty(window, "formbricksSurveys", {
+          configurable: true,
+          get: function () {
+            return runtime;
+          },
+          set: function (value) {
+            if (value && value.renderSurvey && !value.__rectPatched) {
+              value.__rectPatched = true;
+              var original = value.renderSurvey.bind(value);
+              value.renderSurvey = function (props) {
+                return original(
+                  Object.assign({}, props, {
+                    onCardRectChange: function (rect) {
+                      window.__cardRects.push(rect);
+                    },
+                  })
+                );
+              };
+            }
+            runtime = value;
+          },
+        });
+      })();
       // Both reads are deferred to the next task. This listener is registered at page load
       // and the survey's on mount, so on the same target in the same phase they fire in
       // registration order — a synchronous read here always sees \`defaultPrevented === false\`
@@ -138,6 +182,29 @@ test.describe("App survey widget does not block the host page", () => {
     // which point any mount-time focus move has had its chance to land.
     await expect(dialog).toHaveCSS("opacity", "1");
 
+    // The card's rect reaches the host. A native host embeds this renderer in a full-screen WebView
+    // that hit-tests its whole rectangle no matter what CSS says, so without this it cannot tell
+    // which touches belong to the survey and which belong to the app underneath — and it has no way
+    // to work the card's position out for itself.
+    await expect
+      .poll(() => page.evaluate(() => window.__cardRects.filter((r) => r !== null).length), {
+        timeout: 30000,
+      })
+      .toBeGreaterThan(0);
+
+    const reportedRect = await page.evaluate(() => {
+      const rects = window.__cardRects.filter((r) => r !== null);
+      return rects[rects.length - 1];
+    });
+
+    const actualBox = await dialog.boundingBox();
+    expect(actualBox).not.toBeNull();
+    // Reported in whole pixels, so allow a pixel of rounding either way rather than an exact match.
+    expect(Math.abs(reportedRect!.x - actualBox!.x)).toBeLessThanOrEqual(2);
+    expect(Math.abs(reportedRect!.y - actualBox!.y)).toBeLessThanOrEqual(2);
+    expect(Math.abs(reportedRect!.width - actualBox!.width)).toBeLessThanOrEqual(2);
+    expect(Math.abs(reportedRect!.height - actualBox!.height)).toBeLessThanOrEqual(2);
+
     // The survey must not have taken the caret.
     await expect(page.locator("#host-input")).toBeFocused();
     await page.keyboard.type("-AFTER");
@@ -212,6 +279,14 @@ test.describe("App survey widget does not block the host page", () => {
     // Closing clears the announcement: identical text twice is not a change, so without the clear
     // a later open would stay silent.
     await expect(liveRegion).toBeEmpty();
+
+    // And the host is told the card has gone. Without this last report it would keep masking
+    // touches to a rect that is no longer on screen, leaving a dead patch over the app.
+    await expect
+      .poll(() => page.evaluate(() => window.__cardRects[window.__cardRects.length - 1]), {
+        timeout: 30000,
+      })
+      .toBeNull();
   });
 
   test("overlay:dark keeps the modal behaviour", async ({ page, users }) => {

--- a/packages/surveys/src/components/general/render-survey.tsx
+++ b/packages/surveys/src/components/general/render-survey.tsx
@@ -104,6 +104,7 @@ export function RenderSurvey(props: Readonly<SurveyContainerProps>) {
       overlay={props.overlay}
       clickOutside={props.clickOutside}
       onClose={close}
+      onCardRectChange={props.onCardRectChange}
       isOpen={isOpen}
       dir={dir}
       surveyName={getSurveyDisplayName(props.survey.name)}

--- a/packages/surveys/src/components/wrappers/survey-container.tsx
+++ b/packages/surveys/src/components/wrappers/survey-container.tsx
@@ -1,7 +1,8 @@
 import { type ComponentChildren } from "preact";
-import { type MutableRef, useEffect } from "preact/hooks";
+import { type MutableRef, useEffect, useRef } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 import { type TOverlay, type TPlacement } from "@formbricks/types/common";
+import { type TSurveyCardRect } from "@formbricks/types/formbricks-surveys";
 import { ensureLiveRegion } from "@/lib/live-region";
 import { SURVEY_INSTRUCTIONS_ID } from "@/lib/survey-page";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -85,6 +86,106 @@ const useNoOverlayModal = ({
   }, [enabled, announcement]);
 };
 
+// The card animates in over 500ms (`transition-all duration-500`) and changes height with every
+// question, so a rect read once on open is wrong almost immediately. Sample per frame until it holds
+// still for this many frames (~0.65s at 60fps, comfortably past the transition), then stop — the
+// observers restart the loop on any later change, so idling costs nothing.
+const STABLE_FRAMES_BEFORE_IDLE = 40;
+
+type UseCardRectOptions = {
+  /** True only for a modal survey that is open and whose host actually wants the rect. */
+  enabled: boolean;
+  containerRef: MutableRef<HTMLDivElement | null>;
+  onChange?: (rect: TSurveyCardRect | null) => void;
+};
+
+/**
+ * Reports the card's viewport rect to a native host so it can pass touches outside the card through
+ * to the app (see `TSurveyCardRect`).
+ *
+ * It is a prop rather than something the host reads off the DOM itself, and that is the whole point.
+ * Flutter used to scrape `#fbjs [role="dialog"][aria-modal="true"]`; making `aria-modal` conditional
+ * on the overlay — a correct a11y fix — silently matched nothing in the one case the scrape existed
+ * for, and the survey card became untappable in a shipped SDK. Nothing could catch it: the selector
+ * lived in a string, and the renderer is fetched at runtime so there was no version to pin. A typed
+ * prop moves that break to compile time and lets this markup change freely.
+ *
+ * Lives in this file rather than lib/ for the same reason as `useNoOverlayModal` above: one call
+ * site, and its whole behaviour is observers and a frame loop, which per AGENTS.md is Playwright's
+ * job rather than a unit test's.
+ */
+const useCardRect = ({ enabled, containerRef, onChange }: UseCardRectOptions): void => {
+  // Held in a ref so an inline callback from the host does not re-run the effect on every render.
+  // That matters more here than elsewhere: the cleanup reports `null`, so a spurious teardown would
+  // tell the host the card had gone and make it stop accepting touches mid-survey.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const card = containerRef.current;
+    if (!card) return;
+    // Nothing to report to, so do not spin a frame loop for a web host.
+    if (!onChangeRef.current) return;
+
+    let frame: number | null = null;
+    let lastKey = "";
+    let stableFrames = 0;
+
+    const measure = () => {
+      const box = card.getBoundingClientRect();
+      // A zero-area card is not on screen — mid-animation, or already torn down. Report it as
+      // absent rather than as a degenerate rect the host would mask touches against.
+      const rect: TSurveyCardRect | null =
+        box.width > 0 && box.height > 0
+          ? { x: box.left, y: box.top, width: box.width, height: box.height }
+          : null;
+
+      // Compare on whole pixels: sub-pixel jitter during the transition is not a change worth a
+      // bridge hop to native.
+      const key = rect
+        ? `${Math.round(rect.x)},${Math.round(rect.y)},${Math.round(rect.width)},${Math.round(rect.height)}`
+        : "none";
+
+      if (key === lastKey) {
+        stableFrames += 1;
+      } else {
+        lastKey = key;
+        stableFrames = 0;
+        onChangeRef.current?.(rect);
+      }
+
+      frame = stableFrames > STABLE_FRAMES_BEFORE_IDLE ? null : requestAnimationFrame(measure);
+    };
+
+    const restart = () => {
+      if (frame !== null) return;
+      stableFrames = 0;
+      frame = requestAnimationFrame(measure);
+    };
+
+    // ResizeObserver catches the card growing or shrinking with the question; the window listeners
+    // catch it moving without resizing, which rotation and a keyboard-driven viewport change do.
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(restart);
+    observer?.observe(card);
+    window.addEventListener("resize", restart);
+    window.addEventListener("orientationchange", restart);
+    restart();
+
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+      observer?.disconnect();
+      window.removeEventListener("resize", restart);
+      window.removeEventListener("orientationchange", restart);
+      // The card is gone. Without this the host keeps masking touches to a rect that is no longer
+      // on screen, which leaves a dead region over the app after the survey closes.
+      onChangeRef.current?.(null);
+    };
+  }, [enabled, containerRef]);
+};
+
 // Class computations for the modal chrome, at module scope alongside getPlacementStyle. They read
 // nothing but their arguments, and keeping them out of the component body is what actually moves
 // SonarQube's cognitive-complexity number (S3776): it scores each function separately, so a
@@ -140,6 +241,9 @@ interface SurveyContainerProps {
   hasInstructions?: boolean;
   /** Language tag of the survey's active language, or null when the survey declares no language. */
   lang?: string | null;
+  /** Notifies a native host where the card is, so it can pass touches outside it through to the
+   *  app. Omitted by web hosts, and then nothing is measured. */
+  onCardRectChange?: (rect: TSurveyCardRect | null) => void;
 }
 
 export function SurveyContainer({
@@ -154,6 +258,7 @@ export function SurveyContainer({
   surveyName,
   hasInstructions = false,
   lang,
+  onCardRectChange,
 }: Readonly<SurveyContainerProps>) {
   const isModal = mode === "modal";
   const { t } = useTranslation();
@@ -197,6 +302,15 @@ export function SurveyContainer({
     containerRef: modalRef,
     onClose,
     announcement: t("common.survey_opened_announcement"),
+  });
+
+  // Measured for any modal survey, not just the no-overlay case: an overlaid survey still needs a
+  // rect so the host can drop its mask the moment the card goes away, and a host that switches
+  // overlay per survey would otherwise get rects for some and not others.
+  useCardRect({
+    enabled: isModal && isOpen,
+    containerRef: modalRef,
+    onChange: onCardRectChange,
   });
 
   if (!isOpen) return null;

--- a/packages/types/formbricks-surveys.ts
+++ b/packages/types/formbricks-surveys.ts
@@ -4,6 +4,21 @@ import type { TUploadFileConfig } from "./storage";
 import type { TSurveyStyling } from "./surveys/types";
 import type { TWorkspaceStyling } from "./workspace";
 
+/**
+ * Viewport rect of the survey card, in CSS pixels, as the renderer measures it.
+ *
+ * Consumed by the native SDKs, which embed the renderer in a full-screen WebView. A platform
+ * WebView hit-tests its whole rectangle and ignores the `pointer-events: none` this renderer puts
+ * outside the card, so a survey with no overlay freezes the host app unless the host masks touches
+ * itself — and the host cannot know where the card is, because CSS decides that inside the page.
+ */
+export interface TSurveyCardRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export interface SurveyBaseProps {
   survey: TJsWorkspaceStateSurvey;
   styling: TSurveyStyling | TWorkspaceStyling;
@@ -74,6 +89,14 @@ export interface SurveyContainerProps extends Omit<SurveyBaseProps, "onFileUploa
   onResponseCreated?: (responseId?: string) => void | Promise<void>;
   onFileUpload?: (file: TJsFileUploadParams["file"], config?: TUploadFileConfig) => Promise<string>;
   onOpenExternalURL?: (url: string) => void | Promise<void>;
+  /** Notifies the host where the survey card is, and `null` once no card is on screen (while it
+   *  animates out, or before the first paint). Exists so a native host can pass touches outside the
+   *  card through to the app — see `TSurveyCardRect` for why it cannot work that out for itself.
+   *
+   *  Modal mode only, and nothing is measured unless a host passes it: web hosts omit it, because
+   *  CSS `pointer-events` already does the job inside a page. Reported on open, on every resize of
+   *  the card (each question changes its height), and on viewport resize or rotation. */
+  onCardRectChange?: (rect: TSurveyCardRect | null) => void;
   mode?: "modal" | "inline";
   containerId?: string;
   overlay?: "none" | "light" | "dark";


### PR DESCRIPTION
<!-- No Linear ticket: this is the prerequisite the iOS/Android/RN passthrough work needs, split out
so the renderer can deploy before any SDK consumes it. ENG-1818 is the first consumer. -->

## What & why

**Was:** the renderer set `pointer-events: none` outside the survey card and left it there. That works inside a web page, but the native SDKs embed the renderer in a full-screen WebView, which hit-tests its whole rectangle and never sees that CSS — so a survey with `overlay: none` froze the host app with nothing painted over it.

**Now:** the renderer reports the card's viewport rect through a new optional `onCardRectChange`, so a native host can mask touches to the card and let the rest reach the app.

- Optional: a host that omits it measures nothing, so web hosts are untouched.
- Reported on open, on each resize as questions change the card's height, on rotation, then `null` once no card is on screen.

## Where to look

- [survey-container.tsx `useCardRect`](packages/surveys/src/components/wrappers/survey-container.tsx) — measuring, dedupe, idle
- [formbricks-surveys.ts](packages/types/formbricks-surveys.ts) — the contract
- [survey-modal-non-blocking.spec.ts](apps/web/playwright/survey-modal-non-blocking.spec.ts) — why the spec wraps the runtime

<details>
<summary>Why a typed prop and not a DOM read</summary>

The Flutter SDK scraped `#fbjs [role="dialog"][aria-modal="true"]` for the card. Making `aria-modal` conditional on the overlay (#8804, a correct a11y fix) matched nothing in the one case the scrape existed for, so the reported rect stayed null, Flutter's pointer mask rejected touches across the whole WebView, and the survey card became untappable in a shipped SDK.

Nothing could catch it. The selector lived in a string, and the renderer is fetched from the server at runtime, so there was no version to pin and no build to fail. A typed prop moves that break to compile time and leaves this markup free to change.
</details>

## Breaking changes

- [ ] This PR contains breaking changes

None — one optional prop added to `packages/surveys`. Existing consumers pass nothing and behave exactly as before; the hook returns before it starts measuring when no callback is given.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm build --filter=@formbricks/surveys --force && npx playwright test apps/web/playwright/survey-modal-non-blocking.spec.ts`

The rebuild is not optional: the spec drives the bundle served from `apps/web/public/js/`, not the source, so a source-only change is invisible to it.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Whole change: revert it and the spec goes red | e2e (mutation) | `git checkout origin/main -- <the 3 source files>` + rebuild → red; restored → 2 pass in 4.0s |
| Reported rect matches the card's real box | e2e | Compared against `dialog.boundingBox()`, 2px tolerance |
| A viewport change produces a fresh report | e2e (mutation) | Red when `survey-container.tsx:~230` drops `addEventListener("resize", restart)` — count stayed at 2. `ResizeObserver` does not cover it |
| Consecutive reports are never identical | e2e (mutation) | Red when `survey-container.tsx:~205` `if (key === lastKey)` is disabled |
| `null` reported once the card closes | e2e | Asserted after Escape, same spec |
| iOS consumes it and passes touches through | manual | Local iOS build on the ENG-1818 branch: host app usable outside the card, survey usable inside |

**Open gaps**

- `.tsx` unit tests are forbidden by AGENTS.md, so the hook has no unit coverage and four quiet guarantees stay unpinned: reporting on a *card* resize as questions change height (distinct from the viewport listener above), the ~0.65s idle, inline mode reporting nothing, and a zero-area card reporting absence. The idle needs a `waitForTimeout`, which AGENTS.md rules out.
- The prop has no web consumer, so the spec wraps `renderSurvey` to stand in for an SDK. Artificial, but the only way to observe the contract from a browser.
- Simulator only for the iOS consumer, no physical device.

**Risks**

- A frame loop runs while the card animates. It idles after ~0.65s stable and only for hosts that pass the prop, so web is untouched — but it is new work on open.
- `getBoundingClientRect` is viewport-relative. A host that insets or scrolls the WebView would need to translate; none do today.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.

