### PR TITLE
fix(ui): cap combobox option list inside its popover [ENG-3158]

### DIFF
--- a/apps/web/modules/ui/components/input-combo-box/index.tsx
+++ b/apps/web/modules/ui/components/input-combo-box/index.tsx
@@ -35,6 +35,25 @@ import {
 } from "@/modules/ui/components/dropdown-menu";
 import { Input } from "@/modules/ui/components/input";
 
+/**
+ * The height `DropdownMenuContent` caps itself at — mirrors the `max-h` on that component, which
+ * is what keeps a long menu inside the viewport.
+ */
+const POPOVER_MAX_HEIGHT = "min(20rem, var(--radix-dropdown-menu-content-available-height, 20rem))";
+/** The popover's own `p-1`, top and bottom. */
+const POPOVER_PADDING = "0.5rem";
+
+/**
+ * Cap the option list at the popover's height minus its chrome, so the list is the only thing that
+ * can scroll. Sized any taller — it used to be a flat `400px` against a 320px popover — the list
+ * scrolls internally *and* overflows the popover, which then scrolls too, and the dropdown renders
+ * two nested scrollbars. The search row is `h-8` plus its 1px bottom border.
+ */
+const getOptionListMaxHeight = (showSearch: boolean): string =>
+  showSearch
+    ? `calc(${POPOVER_MAX_HEIGHT} - ${POPOVER_PADDING} - 2rem - 1px)`
+    : `calc(${POPOVER_MAX_HEIGHT} - ${POPOVER_PADDING})`;
+
 export interface TComboboxOption {
   icon?: ForwardRefExoticComponent<Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>>;
   imgSrc?: string;
@@ -384,7 +403,7 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
         <DropdownMenuContent
           side="bottom"
           align="start"
-          className="w-(--radix-dropdown-menu-trigger-width) min-w-52"
+          className="w-(--radix-dropdown-menu-trigger-width) min-w-52 overflow-y-hidden"
           data-testid="dropdown-menu-content">
           <Command className="flex h-full w-full flex-col overflow-hidden">
             {showSearch ? (
@@ -401,7 +420,10 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
               <button autoFocus className="sr-only" aria-hidden type="button" />
             )}
 
-            <CommandList ref={listRef} className="max-h-[400px] overflow-y-auto border-0 p-1">
+            <CommandList
+              ref={listRef}
+              className="max-h-none overflow-y-auto border-0 p-1"
+              style={{ maxHeight: getOptionListMaxHeight(showSearch) }}>
               <CommandEmpty className="mx-2 my-0 text-xs font-semibold text-slate-500">
                 {emptyDropdownText ?? t("workspace.surveys.edit.no_option_found")}
               </CommandEmpty>


### PR DESCRIPTION
Fixes ENG-3158

## What & why

**Was:** Every `InputCombobox` dropdown showed two vertical scrollbars side by side.

**Now:** One scrollbar, on the option list.

- The list was capped at a flat `400px` inside a popover that caps itself at `320px`, so it scrolled internally *and* overflowed the popover, which scrolled too.
- It is now capped at the popover's own height minus its chrome (padding, and the search row when shown), so it cannot overflow at any viewport height.
- The popover no longer scrolls, leaving the list as the single scroll container — which is also what `resetListScroll` scrolls when the search query changes.

## Where to look

- [`index.tsx:49` `getOptionListMaxHeight`](https://github.com/formbricks/formbricks/blob/d38ca1f/apps/web/modules/ui/components/input-combo-box/index.tsx#L49) — the cap, mirroring `DropdownMenuContent`'s `max-h`
- [`index.tsx:423` `CommandList`](https://github.com/formbricks/formbricks/blob/d38ca1f/apps/web/modules/ui/components/input-combo-box/index.tsx#L423) — `max-h-none` clears the `max-h-[300px]` the shared `CommandList` sets, so the inline cap is the only one

Before:

<img width="311" height="403" alt="Screenshot 2026-09-14 at 5 16 08 PM" src="https://github.com/user-attachments/assets/bc1624b1-82c3-4e8c-8f52-d83063210473" />


After:

<img width="386" height="422" alt="Screenshot 2026-09-14 at 5 15 49 PM" src="https://github.com/user-attachments/assets/0d46ffb9-af84-4ea1-9d1e-17b615696153" />


## Breaking changes

- [ ] This PR contains breaking changes

None — styling internal to one shared component. No API, SDK, env or config surface.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm lint --filter=@formbricks/web`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| List + chrome fits the popover exactly | manual | 279+41 and 312+8 both = 320px; was 441 vs 320 |
| Cap tracks a short viewport | manual | Both branches derive from the popover's `available-height` var |
| Search-row arithmetic | manual | Subtracts `2rem + 1px`; each term subtracted separately |
| Fix reaches all 9 importing surfaces | manual | Both classNames are internal — no caller override path |
| Lint / typecheck | manual | 21/21 tasks, 0 errors; `tsc --noEmit` silent |

**Open gaps**

- **Not verified in a browser** — no browser in the automation environment. Worth a QA glance at the Conditional Logic operand dropdown from the ticket's repro, at a normal and a short viewport.
- No test added: this is a UI detail in a component, where AGENTS.md rules out a `.tsx` unit test and does not want an E2E.

**Risks**

- If the search row's height changes, the constant needs changing with it; it is commented at the definition.
- The popover can no longer scroll, so a future child taller than the list would be clipped rather than scrollable.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJMKNhxD2vLbdZTwXsA8kW)_