### PR TITLE
fix(ui): match combobox search against the option label

### DIFF
--- a/apps/web/modules/ui/components/input-combo-box/index.tsx
+++ b/apps/web/modules/ui/components/input-combo-box/index.tsx
@@ -34,6 +34,7 @@ import {
   DropdownMenuTrigger,
 } from "@/modules/ui/components/dropdown-menu";
 import { Input } from "@/modules/ui/components/input";
+import { filterComboboxOption } from "./lib/search";
 
 export interface TComboboxOption {
   icon?: ForwardRefExoticComponent<Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>>;
@@ -80,6 +81,8 @@ function flattenOptions(options?: TComboboxOption[]): TComboboxOption[] {
   return options.flatMap((option) => [option, ...(option.children ? flattenOptions(option.children) : [])]);
 }
 
+// The search terms for an option. `filterComboboxOption` scores these instead of the item's
+// `value`, which is an opaque id the user never sees.
 function getOptionKeywords(option: TComboboxOption): string[] {
   return [option.label];
 }
@@ -386,7 +389,7 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
           align="start"
           className="w-(--radix-dropdown-menu-trigger-width) min-w-52"
           data-testid="dropdown-menu-content">
-          <Command className="flex h-full w-full flex-col overflow-hidden">
+          <Command className="flex h-full w-full flex-col overflow-hidden" filter={filterComboboxOption}>
             {showSearch ? (
               <div className="border-b border-slate-100">
                 <CommandInput

--- a/apps/web/modules/ui/components/input-combo-box/lib/search.test.ts
+++ b/apps/web/modules/ui/components/input-combo-box/lib/search.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+import { filterComboboxOption, scoreComboboxOption } from "./search";
+
+describe("scoreComboboxOption", () => {
+  test("keeps options whose label contains the query", () => {
+    expect(scoreComboboxOption("Asia/Tokyo", "tokyo")).toBeGreaterThan(0);
+    expect(scoreComboboxOption("Asia/Manila", "manila")).toBeGreaterThan(0);
+    expect(scoreComboboxOption("Harsh Bhat", "harsh")).toBeGreaterThan(0);
+  });
+
+  test("drops options that only match as a scattered subsequence", () => {
+    // The reported bug. cmdk's commandScore is a subsequence matcher, so it scores each of these
+    // above zero (0.0029 for Bhagya/harsh, 0.0008 for Monticello/tokyo) and cmdk keeps anything
+    // above zero — which is how a search for "harsh" listed "Bhagya Amarasinghe".
+    expect(scoreComboboxOption("Bhagya Amarasinghe", "harsh")).toBe(0);
+    expect(scoreComboboxOption("America/Kentucky/Monticello", "tokyo")).toBe(0);
+    expect(scoreComboboxOption("Europe/Isle_of_Man", "manila")).toBe(0);
+    expect(scoreComboboxOption("America/Anguilla", "manila")).toBe(0);
+  });
+
+  test("ranks a whole-label match over a prefix, a word prefix and a bare substring", () => {
+    const exact = scoreComboboxOption("Asia/Tokyo", "asia/tokyo");
+    const prefix = scoreComboboxOption("Asia/Tokyo", "asia");
+    const wordPrefix = scoreComboboxOption("Asia/Tokyo", "tok");
+    const contains = scoreComboboxOption("Asia/Tokyo", "okyo");
+
+    expect(exact).toBeGreaterThan(prefix);
+    expect(prefix).toBeGreaterThan(wordPrefix);
+    expect(wordPrefix).toBeGreaterThan(contains);
+    expect(contains).toBeGreaterThan(0);
+  });
+
+  test("matches each term of a multi-word query separately", () => {
+    expect(scoreComboboxOption("America/Los_Angeles", "los angeles")).toBeGreaterThan(0);
+    expect(scoreComboboxOption("Harsh Bhat", "bhat harsh")).toBeGreaterThan(0);
+    // One term missing is still no match.
+    expect(scoreComboboxOption("America/Los_Angeles", "los tokyo")).toBe(0);
+  });
+
+  test("ignores case and accents", () => {
+    expect(scoreComboboxOption("Europe/Zürich", "zurich")).toBeGreaterThan(0);
+    expect(scoreComboboxOption("José Álvarez", "jose")).toBeGreaterThan(0);
+    expect(scoreComboboxOption("Asia/Tokyo", "  TOKYO ")).toBeGreaterThan(0);
+  });
+
+  test("keeps every option while the search box is empty", () => {
+    expect(scoreComboboxOption("Asia/Tokyo", "")).toBeGreaterThan(0);
+    expect(scoreComboboxOption("Asia/Tokyo", "   ")).toBeGreaterThan(0);
+  });
+
+  test("drops an option with no label rather than matching everything", () => {
+    expect(scoreComboboxOption("", "tokyo")).toBe(0);
+  });
+});
+
+describe("filterComboboxOption", () => {
+  test("scores the label and not the option's id", () => {
+    // A member option is `{ label: "Bhagya Amarasinghe", value: <cuid> }`. Before the fix cmdk
+    // searched `value + " " + keywords`, so the cuid's characters could carry the match.
+    expect(filterComboboxOption("cmg8x1k2p0001abcd", "harsh", ["Bhagya Amarasinghe"])).toBe(0);
+    expect(filterComboboxOption("cmg8x1k2p0002efgh", "harsh", ["Harsh Bhat"])).toBeGreaterThan(0);
+  });
+
+  test("does not let a label duplicated into the value match across the two copies", () => {
+    // The timezone picker sets label === value, so cmdk's haystack was the label twice over and a
+    // query could match by straddling the join.
+    expect(
+      filterComboboxOption("America/Kentucky/Monticello", "tokyo", ["America/Kentucky/Monticello"])
+    ).toBe(0);
+  });
+
+  test("falls back to the value when an item carries no keywords", () => {
+    expect(filterComboboxOption("Asia/Tokyo", "tokyo")).toBeGreaterThan(0);
+    expect(filterComboboxOption("Asia/Tokyo", "tokyo", [])).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/modules/ui/components/input-combo-box/lib/search.ts
+++ b/apps/web/modules/ui/components/input-combo-box/lib/search.ts
@@ -1,0 +1,59 @@
+// Descending relevance; cmdk hides any item scored 0 and orders the rest by score.
+const EXACT_MATCH = 1;
+const PREFIX_MATCH = 0.9;
+const WORD_PREFIX_MATCH = 0.8;
+const CONTAINS_MATCH = 0.6;
+const ALL_TERMS_MATCH = 0.4;
+const NO_MATCH = 0;
+
+const WORD_SEPARATOR = /[^\p{L}\p{N}]+/u;
+
+/** Case- and accent-insensitive, so `zurich` finds `Europe/Zürich`. */
+const normalize = (input: string): string =>
+  input
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim();
+
+/**
+ * How well an option's label matches what the user typed, for `InputCombobox`'s `Command` filter.
+ *
+ * cmdk's built-in `commandScore` is a subsequence matcher: every character of the query only has to
+ * appear somewhere in the haystack, in order. That scores `Bhagya Amarasinghe` at 0.0029 for the
+ * query `harsh` — small, but above zero, so the option stays in the list. Worse, cmdk's haystack is
+ * `value + " " + keywords.join(" ")`, and our `value` is the option's id: a member's cuid or a
+ * duplicate of the label, neither of which the user can see. Both turn the picker's search into a
+ * list of options that look unrelated to the query (ENG-2625).
+ *
+ * So this matches on the visible label alone, and only on whole runs of the query — a plain text
+ * search, which is what a picker's search box reads as. Multi-word queries are the one relaxation:
+ * each term may match separately, so `los angeles` still finds `America/Los_Angeles`.
+ */
+export const scoreComboboxOption = (label: string, search: string): number => {
+  const query = normalize(search);
+  // cmdk only calls the filter once something is typed; an empty query keeps every option anyway.
+  if (!query) return EXACT_MATCH;
+
+  const haystack = normalize(label);
+  if (!haystack) return NO_MATCH;
+
+  if (haystack === query) return EXACT_MATCH;
+  if (haystack.startsWith(query)) return PREFIX_MATCH;
+  if (haystack.split(WORD_SEPARATOR).some((word) => word.startsWith(query))) return WORD_PREFIX_MATCH;
+  if (haystack.includes(query)) return CONTAINS_MATCH;
+
+  const terms = query.split(/\s+/);
+  if (terms.length > 1 && terms.every((term) => haystack.includes(term))) return ALL_TERMS_MATCH;
+
+  return NO_MATCH;
+};
+
+/**
+ * cmdk `CommandFilter` for `InputCombobox`: score the label carried in `keywords`, not the `value`.
+ *
+ * The `value` fallback only covers a `CommandItem` rendered without keywords; every option in
+ * `InputCombobox` passes its label.
+ */
+export const filterComboboxOption = (value: string, search: string, keywords?: string[]): number =>
+  scoreComboboxOption(keywords?.length ? keywords.join(" ") : value, search);


### PR DESCRIPTION
Fixes ENG-2625

## What & why

**Was:** Typing in an `InputCombobox` search box left unrelated options in the list — `harsh` listed `Bhagya Amarasinghe`, `tokyo` listed `America/Kentucky/Monticello`.

**Now:** An option stays only if the query appears as a whole run of characters in its visible label.

- cmdk's default filter searched `value + " " + keywords`, and `value` is an id nobody sees: a member's cuid, or the label a second time where `label === value`.
- Its `commandScore` is a subsequence matcher, so scattered characters scored above zero and cmdk keeps anything above zero.
- Multi-word queries still match term by term, so `los angeles` finds `America/Los_Angeles`.

## Where to look

- [`lib/search.ts`](https://github.com/formbricks/formbricks/blob/claude/eng-2625-combobox-search-relevance/apps/web/modules/ui/components/input-combo-box/lib/search.ts) — the ranking, and what now scores 0
- [`index.tsx:392`](https://github.com/formbricks/formbricks/blob/claude/eng-2625-combobox-search-relevance/apps/web/modules/ui/components/input-combo-box/index.tsx#L392) — the one wiring change: `filter` on `Command`

Before:

<img width="550" height="308" alt="Screenshot 2026-09-16 at 3 30 01 PM" src="https://github.com/user-attachments/assets/1ae900eb-0574-46bc-a8b7-99b8f193bc51" />

After:

<img width="539" height="261" alt="Screenshot 2026-09-16 at 3 30 06 PM" src="https://github.com/user-attachments/assets/44fb7b8d-8023-419f-89c4-abff2dcaff32" />





## Breaking changes

- [ ] This PR contains breaking changes

None — internal to a shared web component; nothing outside this repo reaches it.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web test modules/ui/components/input-combo-box/lib/search.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Scattered-subsequence options are dropped | unit (mutation) | 10 passed; revert `search.ts:41-48` to a subsequence match and `drops options that only match as a scattered subsequence` fails |
| The id in `value` can no longer carry a match | unit (mutation) | Passes; drop the `keywords?.length` branch at `search.ts:59` and `scores the label and not the option's id` fails |
| Genuine matches, ranking, accents, empty query | unit (guard) | Passes; `Asia/Tokyo` for `tokyo`, `Europe/Zürich` for `zurich`, exact > prefix > word prefix > substring |
| Nothing else in the app regressed | unit (guard) | `pnpm test` — 791 files, 10773 tests passed |

<details>
<summary>Measured cmdk scores that set the thresholds (cmdk@1.1.1)</summary>

```
commandScore("America/Kentucky/Monticello", "tokyo", [])                             -> 0
commandScore("America/Kentucky/Monticello", "tokyo", ["America/Kentucky/Monticello"]) -> 0.00081
commandScore("Bhagya Amarasinghe", "harsh", [])                                      -> 0.00285
commandScore("cmg8x1k2p0001abcd", "harsh", ["Bhagya Amarasinghe"])                   -> 0.00285
```

The third line is why dropping the duplicated `keywords` alone would not have fixed the member picker: the label on its own still matches `harsh` as a subsequence.

</details>

**Open gaps**

- Not exercised in a browser: no dev database here, so the timezone and member pickers were not clicked through.
- Searching by an option's `value` no longer works where it differs from the label; no consumer surfaces that id.

**Risks**

- Every `showSearch` combobox shares this filter — a query that relied on fuzzy skipping now returns fewer rows.
- Submenu options are still matched by the parent's label only, as before.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018mvnyNFre61Re25zrpUW6D)_