### PR TITLE
fix(survey-link): stop a mounted gate fighting the language picker [ENG-3160]

### DIFF
--- a/apps/web/modules/survey/link/hooks/use-app-locale.test.ts
+++ b/apps/web/modules/survey/link/hooks/use-app-locale.test.ts
@@ -1,7 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useSyncExternalStore } from "react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { useAppLocale } from "./use-app-locale";
 
@@ -10,19 +11,55 @@ const i18n = {
   changeLanguage: vi.fn(),
 };
 
+/**
+ * The two things about `useTranslation` this hook actually depends on, modelled rather than stubbed
+ * away: every consumer re-renders when the language changes, and each one is handed a NEW `i18n`
+ * wrapper object when it does (react-i18next's own `createI18nWrapper`, keyed on `language`). The
+ * identity a caller sees is language-scoped, not stable — which is what ENG-3160 turned on.
+ */
+const languageListeners = new Set<() => void>();
+let i18nWrapper: typeof i18n = i18n;
+let wrapperLanguage = i18n.language;
+
+const currentI18n = (): typeof i18n => {
+  if (wrapperLanguage !== i18n.language) {
+    wrapperLanguage = i18n.language;
+    i18nWrapper = Object.create(Object.getPrototypeOf(i18n), Object.getOwnPropertyDescriptors(i18n));
+  }
+  return i18nWrapper;
+};
+
+const setLanguage = (next: string) => {
+  i18n.language = next;
+  for (const notify of languageListeners) notify();
+};
+
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ i18n }),
+  useTranslation: () => {
+    useSyncExternalStore(
+      (notify: () => void) => {
+        languageListeners.add(notify);
+        return () => languageListeners.delete(notify);
+      },
+      () => i18n.language,
+      () => i18n.language
+    );
+    return { i18n: currentI18n() };
+  },
 }));
 
 /** Resolves like i18next does: the language is live only once the promise settles. */
 const changeLanguageSucceeds = () => {
   i18n.changeLanguage.mockImplementation(async (next: string) => {
-    i18n.language = next;
+    setLanguage(next);
   });
 };
 
 beforeEach(() => {
   i18n.language = "en-US";
+  wrapperLanguage = "en-US";
+  i18nWrapper = i18n;
+  languageListeners.clear();
   i18n.changeLanguage.mockReset();
   changeLanguageSucceeds();
 });
@@ -34,7 +71,7 @@ describe("useAppLocale", () => {
       (next: string) =>
         new Promise<void>((resolve) => {
           applyLocale = () => {
-            i18n.language = next;
+            setLanguage(next);
             resolve();
           };
         })
@@ -63,7 +100,7 @@ describe("useAppLocale", () => {
   test("reports ready after falling back, so a waiting caller is never left blank", async () => {
     i18n.changeLanguage.mockImplementation(async (next: string) => {
       if (next === "he") throw new Error("no bundle for he");
-      i18n.language = next;
+      setLanguage(next);
     });
 
     const { result } = renderHook(() => useAppLocale("he"));
@@ -87,5 +124,73 @@ describe("useAppLocale", () => {
     await waitFor(() => {
       expect(i18n.changeLanguage).toHaveBeenCalledWith("fr-FR");
     });
+  });
+
+  test("a gate still mounted behind the survey does not fight the in-survey language switch", async () => {
+    // A PIN-protected survey keeps both alive at once: PinScreen holds the locale its gate was
+    // resolved in, and renders SurveyClientWrapper — which follows the language picker — beneath it.
+    // Each switch used to make the gate re-apply its own locale, the survey re-apply its new one, and
+    // so on until React aborted the render tree onto the app's error boundary (ENG-3160).
+    //
+    // Capped so a regression starves instead of hanging the suite; the assertion is on the calls.
+    i18n.changeLanguage.mockImplementation(async (next: string) => {
+      if (i18n.changeLanguage.mock.calls.length > 10) return;
+      setLanguage(next);
+    });
+
+    const { rerender } = renderHook(
+      ({ surveyLocale }: { surveyLocale: string }) => {
+        useAppLocale("en-US");
+        useAppLocale(surveyLocale);
+      },
+      { initialProps: { surveyLocale: "en-US" } }
+    );
+
+    expect(i18n.changeLanguage).not.toHaveBeenCalled();
+
+    rerender({ surveyLocale: "de-DE" });
+
+    await waitFor(() => {
+      expect(i18n.changeLanguage).toHaveBeenCalledWith("de-DE");
+    });
+    // Drain any further effect pass before asserting that none fired. Each act() flushes the
+    // microtask queue the mock settles on, so a ping-pong round cannot slip through the way it could
+    // hide behind a fixed wall-clock margin on a loaded runner.
+    await act(async () => {});
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(i18n.changeLanguage).toHaveBeenCalledExactlyOnceWith("de-DE");
+    expect(i18n.language).toBe("de-DE");
+  });
+
+  test("a survey mounting behind a settled gate wins once, and the gate does not answer back", async () => {
+    // The order the reported crash actually takes, which the test above does not cover: the gate
+    // resolves first and settles on its own locale (with no ?lang= that is the Accept-Language one),
+    // and SurveyClientWrapper mounts later on the survey's default language. They differ routinely.
+    // The later mount must win exactly once, and the settled gate must not re-assert its own locale.
+    i18n.changeLanguage.mockImplementation(async (next: string) => {
+      if (i18n.changeLanguage.mock.calls.length > 10) return;
+      setLanguage(next);
+    });
+    setLanguage("fr-FR");
+
+    const gate = renderHook(() => useAppLocale("fr-FR"));
+
+    await waitFor(() => {
+      expect(gate.result.current).toBe(true);
+    });
+    expect(i18n.changeLanguage).not.toHaveBeenCalled();
+
+    const survey = renderHook(() => useAppLocale("en-US"));
+
+    await waitFor(() => {
+      expect(survey.result.current).toBe(true);
+    });
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(i18n.changeLanguage).toHaveBeenCalledExactlyOnceWith("en-US");
+    expect(i18n.language).toBe("en-US");
   });
 });

--- a/apps/web/modules/survey/link/hooks/use-app-locale.ts
+++ b/apps/web/modules/survey/link/hooks/use-app-locale.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 /**
@@ -24,10 +24,27 @@ import { useTranslation } from "react-i18next";
  */
 export const useAppLocale = (locale: string): boolean => {
   const { i18n } = useTranslation();
+
+  // The effect below applies the locale THIS caller asked for, so it is keyed on that request alone.
+  // `i18n` cannot be a dependency: react-i18next hands back a fresh wrapper object on every language
+  // change, so an effect keyed on it re-fires on switches this caller never asked for and re-applies
+  // its own (by then stale) locale. Two callers alive at once — a PIN gate holding its server-resolved
+  // gate locale, and the survey behind it following the in-survey language picker — then overwrite each
+  // other's language forever, until React gives up with "Maximum update depth exceeded" and the
+  // respondent lands on the app's error boundary (ENG-3160). The instance itself is the singleton the
+  // root layout initialised; only its identity churns, so it is kept in a ref instead. Declared above
+  // the effect that reads it, so a commit that changes both lands the new instance first.
+  const i18nRef = useRef(i18n);
+  useEffect(() => {
+    i18nRef.current = i18n;
+  }, [i18n]);
+
   const [isLocaleReady, setIsLocaleReady] = useState(() => i18n.language === locale);
 
   useEffect(() => {
-    if (i18n.language === locale) {
+    const i18nInstance = i18nRef.current;
+
+    if (i18nInstance.language === locale) {
       setIsLocaleReady(true);
       return;
     }
@@ -35,10 +52,10 @@ export const useAppLocale = (locale: string): boolean => {
     let isCurrent = true;
     const applyLocale = async () => {
       try {
-        await i18n.changeLanguage(locale);
+        await i18nInstance.changeLanguage(locale);
       } catch {
         // A locale with no bundle would otherwise leave the UI on the previous language mid-render.
-        await i18n.changeLanguage("en-US").catch(() => undefined);
+        await i18nInstance.changeLanguage("en-US").catch(() => undefined);
       } finally {
         // Settled either way: a caller waiting on this must not be left with nothing to paint.
         if (isCurrent) setIsLocaleReady(true);
@@ -50,7 +67,7 @@ export const useAppLocale = (locale: string): boolean => {
     return () => {
       isCurrent = false;
     };
-  }, [locale, i18n]);
+  }, [locale]);
 
   return isLocaleReady;
 };


### PR DESCRIPTION
Fixes ENG-3160

## What & why

**Was:** On a PIN-protected link survey, picking a language in the in-survey picker replaced the survey with the app's root error boundary — an anonymous respondent got "Error loading resources" and an internal "Go to Dashboard" button, and the survey could not be completed in any other language.

**Now:** The picker switches language and the survey re-renders in it. The PIN and email-verification gates are untouched.

`useAppLocale` keyed its effect on the `i18n` object. react-i18next mints a new wrapper per language ([`createI18nWrapper`](https://github.com/i18next/react-i18next/pull/1884), deliberate since 16.3.0), so every consumer's effect re-fired on every switch and re-applied its own, by then stale, locale. Behind a PIN two consumers are alive at once — the gate and the `SurveyClientWrapper` it renders — so each switch made them overwrite each other until React aborted with "Maximum update depth exceeded".

- PIN alone reproduces it; email verification is not required.
- The second consumer arrived in #9155, which is what made the re-fire stop being idempotent.

## Where to look

- [`use-app-locale.ts:70`](apps/web/modules/survey/link/hooks/use-app-locale.ts#L70) — effect keyed on `[locale]` alone
- [`use-app-locale.ts:37-40`](apps/web/modules/survey/link/hooks/use-app-locale.ts#L37-L40) — instance read via a ref, synced in an effect declared first

Before:


https://github.com/user-attachments/assets/1677bc08-dc58-4ef0-9355-eb8f1287bcd8


After:

https://github.com/user-attachments/assets/5a2e7bf3-34f0-45e5-a314-aced5fc3a14b

## Breaking changes

- [ ] This PR contains breaking changes

None — an internal hook in `apps/web`, reached by no external consumer. No signature change and no caller changes.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm --filter @formbricks/web exec vitest run modules/survey/link/hooks/use-app-locale.test.ts`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Switching language with a gate still mounted | unit (red on main) | one `changeLanguage("de-DE")`; pre-fix 11 alternating calls |
| Survey mounting behind a gate already on another locale | unit (red on main) | later mount wins once; gate does not answer back |
| Locale resolution, `en-US` fallback, re-request | unit (guard) | 4 pre-existing tests unchanged and passing |
| PIN-gated 2-language survey, picker → Deutsch → back | manual | `html lang: de-DE`, German copy, 0 console errors; pre-fix crashed |

<details>
<summary>Red-on-main and manual run detail</summary>

Red on main — restore the pre-fix hook, keep the test file, then use the `Rerun:` command:

```
git checkout HEAD~1 -- apps/web/modules/survey/link/hooks/use-app-locale.ts
```

Both regression tests fail; the first with the ping-pong itself:

```
- ["de-DE"]
+ ["de-DE","en-US","de-DE","en-US","de-DE","en-US","de-DE","en-US","de-DE","en-US","de-DE"]
```

Manual: local Postgres + Redis + `next dev`, seeded 2-language link survey with PIN and email verification, opened from the emailed `?verify=` link with the PIN entered. Before: `Maximum update depth exceeded`, `html lang` stuck at `en-US`. After: `html lang: de-DE`, "Willkommen / Weiter", and switching back to English works.

</details>

**Open gaps**

- A switch superseded before its locale chunk resolves can leave the app locale on the abandoned language; the old dep array healed that by accident. Follow-up: ENG-3170.
- No e2e — AGENTS.md lists a language selector as do-not-E2E, and `survey.spec.ts:663` stops at copying the `lang=de` link.

**Risks**

- A consumer now ignores language changes it did not request. All three call sites pass a locale they own, so none relied on that re-fire.
- The respondent-facing route still has no `error.tsx` of its own, so any other throw there falls to the internal one. Follow-up: ENG-3171.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.