### PR TITLE
fix(api-v3): drop an unresolved reason nothing can honestly emit

### DIFF
--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -7055,7 +7055,8 @@ components:
       description: |
         Stored data that nothing in the current survey definition can account for. Deleting an element, a hidden field or a variable leaves its values behind on already-collected responses and nothing cleans them up, so the payload reports them here instead of dropping them silently or faking them into `answers[]` without a type or a label. Consumers doing analysis can ignore this array; consumers doing export or migration should not.
 
-        **One case is deliberately not reported**, and it is stated here because this collection otherwise reads as exhaustive: a `locked` Embedded Data field, with no `defaultValue`, with a scalar stored under its key. A locked field ignores whatever a response supplies, so the value was never the field's to hold — it is absent from `embeddedData[]` for that reason, withheld from `data` because that map carries element answers only, and not reported here because its *shape* is not the problem. Non-scalar values under a locked field are reported, as `valueShapeMismatch`. If that gap proves to matter, a reason code can be added without breaking anyone; removing one could not, which is why it is written down rather than guessed at now.
+        **A declared field's `defaultValue` takes precedence over anything unreadable stored under its key**, and that is worth stating because this collection otherwise reads as exhaustive. Resolution falls back to the default before a value is ever judged unreadable, so a field that declares one always resolves — and the stored bytes, whatever their shape, are reported nowhere. Only a field with **no** `defaultValue` can reach `valueShapeMismatch`.
+        A `locked` field narrows that further: it ignores whatever a response supplies, so a *scalar* under its key is not reported either — the shape is not the problem, the lock is — while a non-scalar under a lockless, defaultless field is. Neither case is a silent drop by accident; both are consequences of resolution order, and they are written down so a consumer does not read `unresolved[]` as a guarantee that nothing was left behind. If either proves to matter in practice a reason code can be added without breaking anyone, whereas removing one could not — which is why this is documentation rather than a guess at a fifth enum member.
       required:
         - key
         - rawValue
@@ -7063,7 +7064,7 @@ components:
       properties:
         key:
           type: string
-          description: 'The key as stored on the response: a former element id or hidden-field name for the two `elementNotInSurvey` cases, and a variable''s cuid for `variableNotInSurvey` — that map is keyed by id rather than by name.'
+          description: The key as stored on the response. For `elementNotInSurvey` it is a former element id or hidden-field name; for `variableNotInSurvey` a variable's cuid, since that map is keyed by id rather than by name; and for `valueShapeMismatch` the id or name of the element or declared field that *does* still exist — that reason means the key resolved and the value did not.
         rawValue:
           description: The stored value, returned verbatim and untyped because nothing describes it any more.
           oneOf:
@@ -7085,9 +7086,9 @@ components:
             Why the entry could not be resolved:
 
             - `elementNotInSurvey` — nothing in the current definition claims this key. It covers a deleted
-              element **and** a deleted hidden field, because the two cannot be told apart: both are stored
-              under their own name in one map, and storage keeps no record of which kind a vanished key
-              used to be.
+              element **and** a deleted hidden field, because the two cannot be told apart: an answer is
+              stored under its element id and a hidden field under its name, in one shared map, and storage
+              keeps no record of which kind a vanished key used to be.
 
             - `variableNotInSurvey` — no variable with this id exists in the current definition. Variables
               *are* distinguishable, because they live in their own map keyed by cuid rather than sharing

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -7053,7 +7053,9 @@ components:
     ResponseUnresolvedEntry:
       type: object
       description: |
-        Stored data whose element no longer exists in the survey definition. Deleting an element leaves its answers behind on already-collected responses and nothing cleans them up, so the payload reports them here instead of dropping them silently or faking them into `answers[]` without a type or a label. Consumers doing analysis can ignore this array; consumers doing export or migration should not.
+        Stored data that nothing in the current survey definition can account for. Deleting an element, a hidden field or a variable leaves its values behind on already-collected responses and nothing cleans them up, so the payload reports them here instead of dropping them silently or faking them into `answers[]` without a type or a label. Consumers doing analysis can ignore this array; consumers doing export or migration should not.
+
+        **One case is deliberately not reported**, and it is stated here because this collection otherwise reads as exhaustive: a `locked` Embedded Data field, with no `defaultValue`, with a scalar stored under its key. A locked field ignores whatever a response supplies, so the value was never the field's to hold — it is absent from `embeddedData[]` for that reason, withheld from `data` because that map carries element answers only, and not reported here because its *shape* is not the problem. Non-scalar values under a locked field are reported, as `valueShapeMismatch`. If that gap proves to matter, a reason code can be added without breaking anyone; removing one could not, which is why it is written down rather than guessed at now.
       required:
         - key
         - rawValue
@@ -7061,7 +7063,7 @@ components:
       properties:
         key:
           type: string
-          description: The key as stored on the response — usually a former element id or hidden-field key.
+          description: 'The key as stored on the response: a former element id or hidden-field name for the two `elementNotInSurvey` cases, and a variable''s cuid for `variableNotInSurvey` — that map is keyed by id rather than by name.'
         rawValue:
           description: The stored value, returned verbatim and untyped because nothing describes it any more.
           oneOf:
@@ -7077,15 +7079,20 @@ components:
           type: string
           enum:
             - elementNotInSurvey
-            - hiddenFieldNotInSurvey
             - variableNotInSurvey
             - valueShapeMismatch
           description: |
             Why the entry could not be resolved:
 
-            - `elementNotInSurvey` — no element with this id exists in the current definition.
-            - `hiddenFieldNotInSurvey` — the key is not among the survey's declared hidden fields.
-            - `variableNotInSurvey` — no variable with this id exists in the current definition.
+            - `elementNotInSurvey` — nothing in the current definition claims this key. It covers a deleted
+              element **and** a deleted hidden field, because the two cannot be told apart: both are stored
+              under their own name in one map, and storage keeps no record of which kind a vanished key
+              used to be.
+
+            - `variableNotInSurvey` — no variable with this id exists in the current definition. Variables
+              *are* distinguishable, because they live in their own map keyed by cuid rather than sharing
+              the answer map.
+
             - `valueShapeMismatch` — the key resolves to a current element **or a declared Embedded Data
               field**, but the stored value's shape cannot be read as an
               answer of that element's type (for example a string where the element expects a selection

--- a/docs/api-v3-reference/src/components/schemas/ResponseUnresolvedEntry.yml
+++ b/docs/api-v3-reference/src/components/schemas/ResponseUnresolvedEntry.yml
@@ -7,14 +7,19 @@ description: >
   consumers doing export or migration should not.
 
 
-  **One case is deliberately not reported**, and it is stated here because this collection otherwise
-  reads as exhaustive: a `locked` Embedded Data field, with no `defaultValue`, with a scalar stored
-  under its key. A locked field ignores whatever a response supplies, so the value was never the
-  field's to hold — it is absent from `embeddedData[]` for that reason, withheld from `data` because
-  that map carries element answers only, and not reported here because its *shape* is not the
-  problem. Non-scalar values under a locked field are reported, as `valueShapeMismatch`. If that gap
-  proves to matter, a reason code can be added without breaking anyone; removing one could not, which
-  is why it is written down rather than guessed at now.
+  **A declared field's `defaultValue` takes precedence over anything unreadable stored under its
+  key**, and that is worth stating because this collection otherwise reads as exhaustive. Resolution
+  falls back to the default before a value is ever judged unreadable, so a field that declares one
+  always resolves — and the stored bytes, whatever their shape, are reported nowhere. Only a field
+  with **no** `defaultValue` can reach `valueShapeMismatch`.
+
+  A `locked` field narrows that further: it ignores whatever a response supplies, so a *scalar* under
+  its key is not reported either — the shape is not the problem, the lock is — while a non-scalar
+  under a lockless, defaultless field is. Neither case is a silent drop by accident; both are
+  consequences of resolution order, and they are written down so a consumer does not read
+  `unresolved[]` as a guarantee that nothing was left behind. If either proves to matter in practice a
+  reason code can be added without breaking anyone, whereas removing one could not — which is why
+  this is documentation rather than a guess at a fifth enum member.
 required:
   - key
   - rawValue
@@ -23,9 +28,10 @@ properties:
   key:
     type: string
     description: >-
-      The key as stored on the response: a former element id or hidden-field name for the two
-      `elementNotInSurvey` cases, and a variable's cuid for `variableNotInSurvey` — that map is keyed
-      by id rather than by name.
+      The key as stored on the response. For `elementNotInSurvey` it is a former element id or
+      hidden-field name; for `variableNotInSurvey` a variable's cuid, since that map is keyed by id
+      rather than by name; and for `valueShapeMismatch` the id or name of the element or declared
+      field that *does* still exist — that reason means the key resolved and the value did not.
   rawValue:
     description: The stored value, returned verbatim and untyped because nothing describes it any more.
     oneOf:
@@ -48,9 +54,9 @@ properties:
 
 
       - `elementNotInSurvey` — nothing in the current definition claims this key. It covers a deleted
-        element **and** a deleted hidden field, because the two cannot be told apart: both are stored
-        under their own name in one map, and storage keeps no record of which kind a vanished key
-        used to be.
+        element **and** a deleted hidden field, because the two cannot be told apart: an answer is
+        stored under its element id and a hidden field under its name, in one shared map, and storage
+        keeps no record of which kind a vanished key used to be.
 
       - `variableNotInSurvey` — no variable with this id exists in the current definition. Variables
         *are* distinguishable, because they live in their own map keyed by cuid rather than sharing

--- a/docs/api-v3-reference/src/components/schemas/ResponseUnresolvedEntry.yml
+++ b/docs/api-v3-reference/src/components/schemas/ResponseUnresolvedEntry.yml
@@ -1,10 +1,20 @@
 type: object
 description: >
-  Stored data whose element no longer exists in the survey definition. Deleting an element leaves its
-  answers behind on already-collected responses and nothing cleans them up, so the payload reports
-  them here instead of dropping them silently or faking them into `answers[]` without a type or a
-  label. Consumers doing analysis can ignore this array; consumers doing export or migration should
-  not.
+  Stored data that nothing in the current survey definition can account for. Deleting an element, a
+  hidden field or a variable leaves its values behind on already-collected responses and nothing
+  cleans them up, so the payload reports them here instead of dropping them silently or faking them
+  into `answers[]` without a type or a label. Consumers doing analysis can ignore this array;
+  consumers doing export or migration should not.
+
+
+  **One case is deliberately not reported**, and it is stated here because this collection otherwise
+  reads as exhaustive: a `locked` Embedded Data field, with no `defaultValue`, with a scalar stored
+  under its key. A locked field ignores whatever a response supplies, so the value was never the
+  field's to hold — it is absent from `embeddedData[]` for that reason, withheld from `data` because
+  that map carries element answers only, and not reported here because its *shape* is not the
+  problem. Non-scalar values under a locked field are reported, as `valueShapeMismatch`. If that gap
+  proves to matter, a reason code can be added without breaking anyone; removing one could not, which
+  is why it is written down rather than guessed at now.
 required:
   - key
   - rawValue
@@ -12,7 +22,10 @@ required:
 properties:
   key:
     type: string
-    description: The key as stored on the response — usually a former element id or hidden-field key.
+    description: >-
+      The key as stored on the response: a former element id or hidden-field name for the two
+      `elementNotInSurvey` cases, and a variable's cuid for `variableNotInSurvey` — that map is keyed
+      by id rather than by name.
   rawValue:
     description: The stored value, returned verbatim and untyped because nothing describes it any more.
     oneOf:
@@ -28,18 +41,20 @@ properties:
     type: string
     enum:
       - elementNotInSurvey
-      - hiddenFieldNotInSurvey
       - variableNotInSurvey
       - valueShapeMismatch
     description: >
       Why the entry could not be resolved:
 
 
-      - `elementNotInSurvey` — no element with this id exists in the current definition.
+      - `elementNotInSurvey` — nothing in the current definition claims this key. It covers a deleted
+        element **and** a deleted hidden field, because the two cannot be told apart: both are stored
+        under their own name in one map, and storage keeps no record of which kind a vanished key
+        used to be.
 
-      - `hiddenFieldNotInSurvey` — the key is not among the survey's declared hidden fields.
-
-      - `variableNotInSurvey` — no variable with this id exists in the current definition.
+      - `variableNotInSurvey` — no variable with this id exists in the current definition. Variables
+        *are* distinguishable, because they live in their own map keyed by cuid rather than sharing
+        the answer map.
 
       - `valueShapeMismatch` — the key resolves to a current element **or a declared Embedded Data
         field**, but the stored value's shape cannot be read as an


### PR DESCRIPTION
Fixes ENG-3172

## What & why

**Was:** `unresolved[]` published four reasons, one of which nothing could emit. A consumer switching on it would handle a branch that never arrives and infer a distinction that does not exist.

**Now:** three reasons, each with a producer, and the one case the collection deliberately does not report is written down.

- `elementNotInSurvey` covers a deleted element **and** a deleted hidden field, because nothing can tell them apart.
- `variableNotInSurvey` stays — variables are keyed by cuid in their own map, so an orphan there is distinguishable.
- A locked field with no default and a scalar value is named as the known exception.

## Where to look

- [ResponseUnresolvedEntry.yml](https://github.com/formbricks/formbricks/blob/fix/ENG-3172_unresolved-reason-corrections/docs/api-v3-reference/src/components/schemas/ResponseUnresolvedEntry.yml) — the whole change

## Breaking changes

- [ ] This PR contains breaking changes

Removing an enum member from a published response schema would normally be breaking. It is not here: the operations that would return it are documented but **not implemented** — `/api/v3/responses` has no routes yet and is excluded from the contract job (ENG-2959) — so no deployed endpoint has ever emitted this value, and no client can have branched on it. The spec has been on `main` for hours, not releases.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm api:v3:lint && pnpm api:v3:check`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Spec stays valid and the bundle is regenerated | unit (guard) | 0 lint errors; `--check` in sync |
| The freshness gate actually catches a stale bundle | manual | edited the bundle by hand → `--check` exits 1 |
| No reference to the removed member survives | manual | `grep` across `docs/` returns nothing |

<details>
<summary>Why a producer could not simply be written instead</summary>

A key in `response.data` that matches nothing in the current definition could be a deleted element or a deleted hidden field. Both are stored under their own name in the same map — that sharing is the premise of the Embedded Data read seam, and it is what makes a hidden field's value indistinguishable from an answer once the declaration is gone. Nothing recorded which kind the key used to be, so a producer for `hiddenFieldNotInSurvey` would have to guess, and a guess published as a typed reason is worse than one honest reason covering both.

Variables are the opposite case and stay: they live in `response.variables` keyed by cuid, never in the answer map, so a stored key with no surviving declaration is unambiguously an orphaned variable.

</details>

**Open gaps**

- The mirror in `resources.ts` and its drift guard are on ENG-2863's branch, not on `main`; they follow there.
- The locked-field case is documented, not fixed — deliberately, and the ticket records the reasoning.

**Risks**

- None to running code: nothing implements these operations yet, so the schema has no emitter to fall out of step with.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `xhigh`.
