### PR TITLE
chore(api-v3): make the response contract-test exclusions per-operation

### DIFF
--- a/.github/workflows/api-v3-contract-tests.yml
+++ b/.github/workflows/api-v3-contract-tests.yml
@@ -257,13 +257,12 @@ jobs:
         run: python -m pip install schemathesis==4.25.0
         shell: bash
 
-      # `--exclude-path-regex '^/api/v3/responses'` skips the eight response operations. They are
-      # documented (ENG-2868 agreed the contract before implementation, deliberately) but not yet
-      # routed, and `fill-missing` in schemathesis.toml means a documented operation is exercised the
-      # moment it appears — so each one answers Next.js's HTML 404 against a spec that documents
-      # 200/400/401/403/429/500. Remove the flag when the routes land: ENG-2959, which is blocked by
-      # the read, write, delete, batch-delete and validate tickets. Verify by re-running the command
-      # below without the flag and checking the selected-operation count rises.
+      # Which operations are skipped, and why, lives in schemathesis.toml next to the operations it
+      # names — not here. An endpoint's own PR deletes its block there as the route lands, so each
+      # one is contract-checked when it ships rather than all of them at the end (ENG-2959).
+      #
+      # The selected-operation count is the check: it is printed on every run, and it must rise by
+      # exactly the number of operations a PR claims to have implemented.
       - name: Run v3 contract tests
         if: steps.harness.outputs.present == 'true'
         shell: bash
@@ -276,7 +275,6 @@ jobs:
             --url http://localhost:3000 \
             --phases examples \
             --checks not_a_server_error,status_code_conformance,content_type_conformance,response_schema_conformance \
-            --exclude-path-regex '^/api/v3/responses' \
             --generation-database=:memory: \
             --report junit \
             --report-dir schemathesis-report \

--- a/docs/api-v3-reference/contract-tests/schemathesis.toml
+++ b/docs/api-v3-reference/contract-tests/schemathesis.toml
@@ -32,3 +32,44 @@ fill-missing = true
 [[operations]]
 include-tag = "V3 Feedback Records"
 enabled = false
+
+# The v3 response operations are documented but not all routed yet: ENG-2868 agreed the contract
+# before implementation, deliberately. `fill-missing` above means a documented operation is exercised
+# the moment it is selected, so an unrouted one answers Next.js's HTML 404 against a spec documenting
+# 200/400/401/403/429/500 — a red job that says nothing about the contract.
+#
+# One block per operation, keyed by `operationId`, so each endpoint's PR deletes exactly its own and
+# the gate opens as the route lands rather than all at once at the end (ENG-2959). Keyed by operation
+# id rather than path because three of these paths carry both a routed and an unrouted method, which
+# a path filter cannot separate.
+[[operations]]
+include-operation-id = "getResponsesV3"       # ENG-2865
+enabled = false
+
+[[operations]]
+include-operation-id = "countResponsesV3"     # ENG-2865
+enabled = false
+
+[[operations]]
+include-operation-id = "getResponseV3"        # ENG-2865
+enabled = false
+
+[[operations]]
+include-operation-id = "deleteResponseV3"     # ENG-2867
+enabled = false
+
+[[operations]]
+include-operation-id = "batchDeleteResponsesV3"  # ENG-2896
+enabled = false
+
+[[operations]]
+include-operation-id = "createResponseV3"     # ENG-2866
+enabled = false
+
+[[operations]]
+include-operation-id = "updateResponseV3"     # ENG-2866
+enabled = false
+
+[[operations]]
+include-operation-id = "validateResponseV3"   # ENG-2954
+enabled = false


### PR DESCRIPTION
Ref ENG-2959

## What & why

**Was:** one CLI flag, `--exclude-path-regex '^/api/v3/responses'`, skipped all eight response operations. Opening the gate meant one PR at the end turning the whole family on at once.

**Now:** one `[[operations]]` block per operation in `schemathesis.toml`, so each endpoint's PR deletes exactly its own and CI contract-checks that operation as it ships.

- Path filters cannot express this: three of the five response paths carry a routed *and* an unrouted method.
- No net change today — 28 of 44 operations selected before and after.
- The exclusions now sit beside the Feedback Records one, with their reasons and their tickets.

## Where to look

- [schemathesis.toml](https://github.com/formbricks/formbricks/blob/chore/ENG-2959_per-operation-contract-gate/docs/api-v3-reference/contract-tests/schemathesis.toml) — the eight blocks and why they are keyed by `operationId`

## Breaking changes

- [ ] This PR contains breaking changes

None. CI selects exactly the same operations; only where the exclusion is written changes.

## Migrations & env

- none

## How this was tested

Rerun (schemathesis 4.25.0, the version CI installs — the URL is unreachable on purpose, the selection count prints before any request):

```
schemathesis --config-file docs/api-v3-reference/contract-tests/schemathesis.toml \
  run docs/api-v3-reference/openapi.yml --url http://127.0.0.1:59997 --phases examples
```

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Same operations selected as before | manual | 28/44 with the old flag, 28/44 with the blocks |
| One block opens exactly one operation | manual (mutation) | deleting `countResponsesV3` → 29/44 |
| The flag is gone from CI | manual | `grep -c exclude-path-regex` → 0 |

<details>
<summary>Why <code>operationId</code> rather than path or method</summary>

`--exclude-path-regex` is path-level. Three of the five response paths mix implemented and unimplemented methods:

| path | routed | not yet |
| -- | -- | -- |
| `/api/v3/responses` | `GET` (list) | `POST` (create) |
| `/api/v3/responses/{responseId}` | `GET`, `DELETE` | `PATCH` |
| `/api/v3/responses/count` | `GET` | — |
| `/api/v3/responses/batch-delete` | `POST` | — |
| `/api/v3/responses/validate` | — | `POST` |

A path filter cannot enable `GET /api/v3/responses` while leaving `POST` excluded, and `fill-missing = true` means the excluded-but-documented `POST` is exercised the moment it is selected — answering Next's HTML 404 against a spec documenting 201/400/401/403/429/500.

`operationId` is unique per operation and already in the spec, so a block names one thing unambiguously and a PR deleting it cannot widen the gate by accident.

</details>

**Open gaps**

- Nothing automated asserts the block list matches the unrouted set; the selected-operation count is the check, and it prints on every run.
- The blocks are removed by hand, so a PR that implements a route and forgets its block simply stays unverified rather than failing.

**Risks**

- If a future operation is added to the spec with no route and no block, CI goes red on `main` rather than on the PR that documented it.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `xhigh`.
