### PR TITLE
fix(survey-editor): stop a disabled unit select covering the rule delete button [ENG-3175]

### DIFF
--- a/apps/web/modules/survey/editor/components/validation-rule-field-selector.tsx
+++ b/apps/web/modules/survey/editor/components/validation-rule-field-selector.tsx
@@ -20,14 +20,16 @@ export const ValidationRuleFieldSelector = ({
   value,
   onChange,
   fieldOptions,
-}: ValidationRuleFieldSelectorProps) => {
+}: Readonly<ValidationRuleFieldSelectorProps>) => {
   const { t } = useTranslation();
 
   return (
     <Select
       value={value ?? ""}
       onValueChange={(val) => onChange(val ? (val as TAddressField | TContactInfoField) : undefined)}>
-      <SelectTrigger className="h-9 min-w-[140px] bg-white">
+      {/* w-auto for the same reason as the other row children: Address and Contact Info fields only
+          ever carry string rules, so this never appears on the wrapping date row. */}
+      <SelectTrigger className="h-9 w-auto min-w-0 grow bg-white">
         <SelectValue placeholder={t("workspace.surveys.edit.select_field")} />
       </SelectTrigger>
       <SelectContent>

--- a/apps/web/modules/survey/editor/components/validation-rule-input-type-selector.tsx
+++ b/apps/web/modules/survey/editor/components/validation-rule-input-type-selector.tsx
@@ -21,7 +21,7 @@ export const ValidationRuleInputTypeSelector = ({
   value,
   onChange,
   disabled = false,
-}: ValidationRuleInputTypeSelectorProps) => {
+}: Readonly<ValidationRuleInputTypeSelectorProps>) => {
   const { t } = useTranslation();
 
   return (
@@ -29,8 +29,10 @@ export const ValidationRuleInputTypeSelector = ({
       value={value}
       onValueChange={onChange ? (val) => onChange(val as TSurveyOpenTextElementInputType) : undefined}
       disabled={disabled}>
+      {/* w-auto, not the trigger's default w-full: this only ever sits on a single-line rule row, where
+          a basis of 100% would make the row split into equal thirds and starve the value group. */}
       <SelectTrigger
-        className={cn("h-9 min-w-[120px]", disabled ? "cursor-not-allowed bg-slate-100" : "bg-white")}>
+        className={cn("h-9 w-auto min-w-0 grow", disabled ? "cursor-not-allowed bg-slate-100" : "bg-white")}>
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/apps/web/modules/survey/editor/components/validation-rule-row.tsx
+++ b/apps/web/modules/survey/editor/components/validation-rule-row.tsx
@@ -93,7 +93,18 @@ export const ValidationRuleRow = ({
   // Date rules put up to nine controls on the value side. The operator select soaks up whatever width
   // those controls leave and shrinks first when space is short; at its floor the row wraps, since the
   // toggle's container is overflow-hidden and would otherwise clip the trailing buttons.
+  //
+  // Every other rule stays on one line, so no control on it may carry a pixel min-width: the toggle's
+  // container is overflow-hidden, so a child that refuses to shrink does not scroll into view, it
+  // paints over the delete and add buttons and eats their clicks (ENG-3175). Only the two buttons are
+  // shrink-0; everything else is min-w-0 and truncates.
+  //
+  // The three flexible children are sized `w-auto grow` so each asks for its own content width and
+  // the surplus is shared equally. Left at the SelectTrigger's `w-full`, all three would ask for the
+  // full row and the split would land on exact thirds — which starves the value group, the only one
+  // of the three that holds two controls, down to a value field too narrow to read a number in.
   const isDateRule = Boolean(config.supportsRelative);
+  const flexibleChildClasses = "w-auto grow";
 
   const row = (
     <div className={cn("flex w-full gap-2", isDateRule ? "flex-wrap items-start" : "items-center")}>
@@ -123,7 +134,7 @@ export const ValidationRuleRow = ({
         availableTypes={availableTypesForSelect}
         ruleLabels={ruleLabels}
         needsValue={config.needsValue}
-        className={isDateRule ? "min-w-[140px] flex-[1_1_0%]" : undefined}
+        className={isDateRule ? "min-w-[140px] flex-[1_1_0%]" : flexibleChildClasses}
       />
 
       {/* Value Input (if needed) */}
@@ -131,7 +142,7 @@ export const ValidationRuleRow = ({
         <div
           className={cn(
             "flex min-w-0 gap-2",
-            isDateRule ? "flex-[0_1_auto] items-start" : "w-full items-center"
+            isDateRule ? "flex-[0_1_auto] items-start" : `${flexibleChildClasses} items-center`
           )}>
           <ValidationRuleValueInput
             rule={rule}

--- a/apps/web/modules/survey/editor/components/validation-rule-type-selector.tsx
+++ b/apps/web/modules/survey/editor/components/validation-rule-type-selector.tsx
@@ -31,7 +31,9 @@ export const ValidationRuleTypeSelector = ({
 }: Readonly<ValidationRuleTypeSelectorProps>) => {
   return (
     <Select value={value} onValueChange={(val) => onChange(val as TValidationRuleType)}>
-      <SelectTrigger className={cn("bg-white", needsValue ? "min-w-[200px]" : "flex-1", className)}>
+      {/* min-w-0 rather than a pixel floor: a floor here is what pushed the value group out of the
+          row and under the delete and add buttons at laptop widths (ENG-3175). */}
+      <SelectTrigger className={cn("bg-white", needsValue ? "min-w-0" : "flex-1", className)}>
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/apps/web/modules/survey/editor/components/validation-rule-unit-selector.tsx
+++ b/apps/web/modules/survey/editor/components/validation-rule-unit-selector.tsx
@@ -26,10 +26,21 @@ export const ValidationRuleUnitSelector = ({
   unitOptions,
   ruleLabels,
   disabled = false,
-}: ValidationRuleUnitSelectorProps) => {
+}: Readonly<ValidationRuleUnitSelectorProps>) => {
+  // A single unit is a label, not a choice, so the trigger is inert either way.
+  const isDisabled = disabled || unitOptions.length === 1;
+
   return (
-    <Select value={value} onValueChange={() => {}} disabled={disabled || unitOptions.length === 1}>
-      <SelectTrigger className={cn("h-9 min-w-[180px] flex-1 bg-white", disabled && "cursor-not-allowed")}>
+    <Select value={value} onValueChange={() => {}} disabled={isDisabled}>
+      <SelectTrigger
+        className={cn(
+          // 180px wide where the row has room, but it must give that width back rather than spill out
+          // of the value group and cover the delete and add buttons (ENG-3175).
+          "h-9 w-[180px] min-w-0 bg-white",
+          // A disabled trigger still hit-tests: it swallowed every click aimed at whatever sat under
+          // it without doing anything itself.
+          isDisabled && "pointer-events-none"
+        )}>
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/apps/web/modules/survey/editor/components/validation-rule-value-input.tsx
+++ b/apps/web/modules/survey/editor/components/validation-rule-value-input.tsx
@@ -59,7 +59,7 @@ export const ValidationRuleValueInput = ({
     const optionValue = typeof currentValue === "string" ? currentValue : "";
     return (
       <Select value={optionValue} onValueChange={onChange}>
-        <SelectTrigger className="h-9 min-w-[200px] bg-white">
+        <SelectTrigger className="h-9 min-w-0 bg-white">
           <SelectValue placeholder={t("workspace.surveys.edit.validation.select_option")} />
         </SelectTrigger>
         <SelectContent>
@@ -117,7 +117,11 @@ export const ValidationRuleValueInput = ({
         if (config.valueType === "number" && ["e", "E", "+"].includes(e.key)) e.preventDefault();
       }}
       placeholder={config.valuePlaceholder}
-      className="h-9 min-w-[80px] bg-white"
+      // 5rem is a preference, not a floor. This is the only grower in the value group, so it takes
+      // every pixel the 180px unit selector leaves. When the group is squeezed instead, both shrink
+      // in proportion to their bases, so the unit gives up the larger share (180/260) and this input
+      // the smaller (80/260) — the input is the last to become unreadable, not the first.
+      className="h-9 min-w-0 flex-[1_1_5rem] bg-white"
       min={config.valueType === "number" ? 0 : ""}
     />
   );


### PR DESCRIPTION
Fixes ENG-3175

## What & why

**Was:** On a length validation rule (Text, Email, URL, Phone), the delete button could not be clicked below a ~1570 px viewport. The disabled "Characters" unit select painted on top of it and — being a real `<button disabled>` — still won the hit test, so it swallowed the click without doing anything. A rule added by mistake could not be removed with a mouse on any 1280×720, 1366×768, 1440×900 or 1536×864 screen.

**Now:** The rule row's children shrink instead of overlapping, so the delete and add buttons keep their full 36 px hit area at every width. The inert unit trigger is `pointer-events-none`, so it cannot intercept a click even if the layout regresses again.

- The row sat in an `overflow-hidden` container, so an overflowing child could not be scrolled clear.
- Keyboard and programmatic activation always worked, which is why the Playwright suite did not catch it.

## Where to look

- [`validation-rule-unit-selector.tsx`](https://github.com/formbricks/formbricks/blob/claude/relaxed-ride-l7to7g/apps/web/modules/survey/editor/components/validation-rule-unit-selector.tsx) — 180 px becomes a basis, not a floor
- [`validation-rule-row.tsx`](https://github.com/formbricks/formbricks/blob/claude/relaxed-ride-l7to7g/apps/web/modules/survey/editor/components/validation-rule-row.tsx) — `w-auto grow` on the three flexible children
- Date-rule branch keeps `min-w-[140px] flex-[1_1_0%]`; twMerge resolves it over `min-w-0`

Before
<img width="917" height="154" alt="Screenshot 2026-09-14 at 4 46 45 PM" src="https://github.com/user-attachments/assets/8c4fdcd7-8698-4bd2-817c-b00133e0590d" />


After

<img width="896" height="169" alt="Screenshot 2026-09-14 at 4 46 50 PM" src="https://github.com/user-attachments/assets/4f6b4142-33b2-4b4e-bd1f-b4e80623c87a" />

## Breaking changes

- [ ] This PR contains breaking changes

None — CSS classes on four internal editor components, each imported only by `validation-rule-row.tsx`. Nothing outside this repo reaches them.

## Migrations & env

- none

## How this was tested

Rerun: `pnpm lint && pnpm typecheck && pnpm test`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Delete + add buttons clickable on a length rule at 1115/1282/1508 px | manual | Row sums exactly to its width; both buttons at full 36 px, no overlap |
| Disabled unit trigger no longer hit-tests | manual | `pointer-events-none` reaches Radix's button; no `asChild` indirection |
| Unit select still exactly 180 px above ~1570 px | manual | Unchanged; value input still takes the free space |
| Date-rule branch layout unchanged | manual | Caller's `min-w-[140px] flex-[1_1_0%]` still wins via twMerge |
| No regression across the suite | unit (guard) | 790 files / 10763 tests passed |

<details>
<summary>Worked widths at 1115 px and 1282 px</summary>

Trigger chrome = 2 border + 24 `px-3` + 8 gap + 16 chevron = 50 px. Bases: inputType "Text" ≈ 78, type "At least" ≈ 102, value group = 80 + 8 + 180 = 268. Fixed: two 36 px buttons + 5 × 8 px gaps = 112.

**1115 px viewport, row 605 px** — available 493, bases sum 448, free 45 split three ways:

| | inputType | type | group | Input outer | Input content | unit |
| --- | --- | --- | --- | --- | --- | --- |
| before | 167 | 167 | 167 | ~49 | ~23 | ~159 |
| after | 93 | 117 | 283 | 95 | 69 | 180 |

93 + 117 + 283 + 36 + 36 + 40 = 605 exactly.

**1282 px viewport, row 710 px** (QA's measured row) — 128 / 152 / 318, Input 130 (104 content), unit 180. Totals 710.

</details>

**Open gaps**

- Not verified in a real browser — no dev server in this environment. Widths are derived from the flex algorithm, not measured.
- No before/after screenshots at 1115 px; worth capturing on the delete button and the value field.

**Risks**

- Above ~1570 px the split among the three children changes from exact thirds to content-width plus equal surplus. The unit stays at 180 px and the value input still grows, but the two leading selects carry less dead space than before.
- Dead `disabled:cursor-not-allowed` on the unit trigger: with `pointer-events-none` the cursor now comes from the row beneath. `disabled:opacity-50` still reads as inert.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.