### PR TITLE
docs(review): make performance an explicit review dimension (ENG-3179)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -180,6 +180,24 @@ reviews:
         - Caching uses `cache.withCache()` with a key from `createCacheKey.*`. Next.js
           `unstable_cache()` is banned, and cache keys are never built by string concatenation.
 
+    - path: "{apps/web,packages}/**/*.ts"
+      instructions: |
+        Performance is an explicit review dimension in this repo (AGENTS.md "Performance in Review"):
+        the patterns below reach `main` when nobody looks for them. Raise one where the diff
+        introduces it:
+        - N+1 work: a query, AI call or cross-service fetch issued inside a `for`/`map`/`Promise.all`
+          over rows. Ask for one `findMany` with an `in` filter, an `include`, or a single grouped
+          query.
+        - Unbounded work: a `findMany` with no `take`, a pagination or retry loop with no ceiling, or
+          a whole table pulled into memory and filtered in JS.
+        - A new `where`/`orderBy` combination with no index that serves it.
+        - Expensive calls repeated per request or per row — embeddings, AI calls, cross-service
+          fetches — that are not behind `cache.withCache()`, batched, or moved into a job.
+        - Independent queries awaited sequentially instead of `Promise.all`.
+        Quantify the cost against the data ("one query per response, ~5k on a 5k-response survey").
+        If you cannot, ask the author for numbers instead of speculating. Do not raise these on
+        `*.test.ts`, `__mocks__`, or seed scripts, where looping over fixtures is expected.
+
     - path: "packages/database/schema/*.prisma"
       instructions: |
         - Every tenant-owned model needs a workspace/organization scope column, and cross-model

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,30 @@ Always mark React component props as `Readonly<>` (e.g., `({ children }: Readonl
 - Prefer cursor pagination for large datasets.
 - When filtering by `createdAt`, include indexed fields (e.g., `surveyId` + `createdAt`).
 
+## Performance in Review
+
+Performance is an explicit review dimension, not something to discover in production. The bottlenecks that
+have reached `main` — N+1 queries, embedding work that never finishes — were all visible in the diff that
+introduced them, so every review of data access, of a loop over tenant data, or of an AI/embedding path looks
+for them deliberately.
+
+What to look for:
+
+- **N+1 queries** — a query, AI call, or cross-service fetch issued inside a `for`/`map`/`Promise.all` over
+  rows. One `findMany` with an `in` filter, an `include`, or a single grouped query replaces it.
+- **Unbounded work** — a `findMany` with no `take`, a pagination or retry loop with no ceiling, or a whole
+  table pulled into memory and filtered in JS. Bound it and push the filter into the query.
+- **Missing indexes** — a new `where`/`orderBy` combination needs an index that serves it; see "Database &
+  Prisma Performance" for the `createdAt` rule.
+- **Uncached expensive calls** — embeddings, AI calls, and cross-service fetches repeated per request or per
+  row belong behind `cache.withCache()` (see "Caching"), batched, or moved into a job.
+- **Sequential awaits** — independent queries awaited one after another instead of `Promise.all`.
+
+State the cost in terms of the data: "one query per response, so ~5k queries on a 5k-response survey" is
+reviewable, "this might be slow" is not. Where the answer is genuinely unclear, ask the author for numbers
+rather than guessing. `.coderabbit.yaml` carries the same checks as path instructions, so the automated review
+raises them too — but that is a second pair of eyes, and its silence is not a pass.
+
 ## Testing Guidelines
 
 Principles:


### PR DESCRIPTION
Fixes ENG-3179

## What & why

**Was:** Nothing in the review guidance asked anyone to look at performance, so N+1 queries, unbounded reads and uncached embedding work reached `main` unremarked.

**Now:** Performance is a named review dimension. `AGENTS.md` gains a "Performance in Review" section with the five patterns a reviewer checks and how to state the cost; `.coderabbit.yaml` carries the same checks as a path instruction over TypeScript in `apps/web` and `packages`, so the automated review raises them on every PR too.

- Patterns: N+1 work, unbounded work, missing indexes, uncached expensive calls, sequential awaits.
- The instruction asks for a cost stated against the data, or a question to the author — not speculation.

## Where to look

- [`.coderabbit.yaml` L183-L199](https://github.com/formbricks/formbricks/blob/8d2f8601d658aeb8e196309d11334875261e51a5/.coderabbit.yaml#L183-L199) — new path instruction and its glob
- [`AGENTS.md` L187-L209](https://github.com/formbricks/formbricks/blob/8d2f8601d658aeb8e196309d11334875261e51a5/AGENTS.md#L187-L209) — the reviewer-facing list

## Breaking changes

- [ ] This PR contains breaking changes

None. Guidance and reviewer configuration only — no runtime code, no API or SDK shape, no env var or config key a consumer reaches.

## Migrations & env

- none

## How this was tested

Rerun: `python3 -c "import yaml; yaml.safe_load(open('.coderabbit.yaml'))"`

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Config still parses and `path_filters` stay exclusion-only | manual | Ran the `coderabbit-config-validation` inline check: 4 filters, all exclusions, 20 path instructions |
| New glob reaches the code the patterns live in | manual | `{apps/web,packages}/**/*.ts` covers services, routes and packages; tests, `__mocks__` and seeds carved out in the instruction text |

**Open gaps**

- Schema validation could not run here: `cli.coderabbit.ai` is blocked by this sandbox's egress policy. The `Validate CodeRabbit config` job covers it.
- Whether reviews actually surface these patterns only shows over the next few PRs.

**Risks**

- The glob matches broadly. If reviews turn noisy on `.ts` files, narrow the path rather than dropping the checks.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Xh8WH8mWzdd7yMkHQFnmC)_