### PR TITLE
fix(responses): bound the "Other" response filter instead of permuting every subset

### DIFF
--- a/apps/web/integration/response-filter-other.integration.test.ts
+++ b/apps/web/integration/response-filter-other.integration.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { type TResponseFilterCriteria } from "@formbricks/types/responses";
+import { type TSurvey } from "@formbricks/types/surveys/types";
+import { resetDb } from "@/integration/reset-db";
+import { buildWhereClause } from "@/lib/response/where-clause";
+
+/**
+ * The "Other" response filter against real Postgres (ENG-3161).
+ *
+ * The unit suite mocks `@formbricks/database`, so it can only assert the *shape* of the filter
+ * object — it would pass just as happily with a predicate that selects the wrong rows. Only a real
+ * database shows that the numeric JSON path segments this branch emits actually index into the
+ * stored array, and that the rows the old permutation set existed to handle (a different answer
+ * order, a duplicated label) still come back the same way.
+ *
+ * The fixture is deliberately 12 choices across 2 languages: 24 predefined labels, where the
+ * previous implementation aborted the Node process at 11.
+ */
+
+const LANGUAGES = ["default", "de"] as const;
+const CHOICE_COUNT = 12;
+
+/** Label of choice `index` in `language` — "A0".."A11" in English, "D0".."D11" in German. */
+const label = (language: (typeof LANGUAGES)[number], index: number): string =>
+  `${language === "default" ? "A" : "D"}${index}`;
+
+const MULTI_ID = "qMulti";
+const SINGLE_ID = "qSingle";
+
+const BLOCKS = [
+  {
+    id: "clbk1234567890123456789013",
+    name: "Main Block",
+    elements: [
+      {
+        id: MULTI_ID,
+        type: "multipleChoiceMulti",
+        headline: { default: "Pick many" },
+        required: false,
+        shuffleOption: "none",
+        choices: [
+          ...Array.from({ length: CHOICE_COUNT }, (_unused, index) => ({
+            id: `c${index}`,
+            label: Object.fromEntries(LANGUAGES.map((language) => [language, label(language, index)])),
+          })),
+          { id: "other", label: { default: "Other" } },
+        ],
+      },
+      {
+        id: SINGLE_ID,
+        type: "multipleChoiceSingle",
+        headline: { default: "Pick one" },
+        required: false,
+        shuffleOption: "none",
+        choices: [
+          { id: "s0", label: { default: "S0" } },
+          { id: "s1", label: { default: "S1" } },
+          { id: "other", label: { default: "Other" } },
+        ],
+      },
+    ],
+  },
+];
+
+/** The survey as `buildWhereClause` reads it — it only ever touches `blocks`. */
+const survey = { id: "unused", blocks: BLOCKS } as unknown as TSurvey;
+
+/** Each case seeds one response and is asserted by name, so a failure says which shape broke. */
+const CASES: { name: string; data: Record<string, unknown> }[] = [
+  { name: "one predefined label", data: { [MULTI_ID]: ["A0"] } },
+  { name: "two predefined labels", data: { [MULTI_ID]: ["A0", "A1"] } },
+  { name: "predefined + write-in", data: { [MULTI_ID]: ["A0", "my own answer"] } },
+  { name: "write-in only", data: { [MULTI_ID]: ["my own answer"] } },
+  { name: "empty array", data: { [MULTI_ID]: [] } },
+  { name: "key absent", data: {} },
+  { name: "json null", data: { [MULTI_ID]: null } },
+  { name: "reversed order", data: { [MULTI_ID]: ["A1", "A0"] } },
+  { name: "duplicated label", data: { [MULTI_ID]: ["A0", "A0"] } },
+  { name: "german label + write-in", data: { [MULTI_ID]: ["D0", "my own answer"] } },
+  { name: "german labels only", data: { [MULTI_ID]: ["D0", "D1"] } },
+  { name: "single: predefined", data: { [SINGLE_ID]: "S0" } },
+  { name: "single: write-in", data: { [SINGLE_ID]: "typed" } },
+  { name: "single: empty string", data: { [SINGLE_ID]: "" } },
+];
+
+let surveyId: string;
+/** Response id per case name, so assertions read as sets of names rather than cuids. */
+let idsByName: Map<string, string>;
+
+const seed = async (): Promise<void> => {
+  const organization = await prisma.organization.create({ data: { name: "Filter Org" } });
+  const workspace = await prisma.workspace.create({
+    data: { name: "Filter Workspace", organizationId: organization.id },
+  });
+  const created = await prisma.survey.create({
+    data: {
+      name: "Filter Survey",
+      type: "link",
+      status: "inProgress",
+      workspaceId: workspace.id,
+      blocks: BLOCKS,
+    },
+    select: { id: true },
+  });
+  surveyId = created.id;
+
+  idsByName = new Map();
+  for (const testCase of CASES) {
+    const response = await prisma.response.create({
+      // `json null` stores a JSON null inside the object, which TResponseData does not model.
+      data: { surveyId, finished: true, data: testCase.data as never },
+      select: { id: true },
+    });
+    idsByName.set(testCase.name, response.id);
+  }
+};
+
+/** Names of the responses the filter selects, sorted so assertions are order-independent. */
+const matchingNames = async (filterCriteria: TResponseFilterCriteria): Promise<string[]> => {
+  const where = { surveyId, ...buildWhereClause(survey, filterCriteria) };
+  const rows = await prisma.response.findMany({ where, select: { id: true } });
+
+  // The count path runs the same predicate through a different Prisma call; they must agree.
+  const count = await prisma.response.count({ where });
+  expect(count).toBe(rows.length);
+
+  const nameById = new Map([...idsByName].map(([name, id]) => [id, name]));
+  return rows.map((row) => nameById.get(row.id) ?? row.id).sort((a, b) => a.localeCompare(b));
+};
+
+const otherFilter = (elementId: string, values: string[]): TResponseFilterCriteria => ({
+  data: { [elementId]: { op: "includesOne", value: values } },
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await seed();
+});
+
+describe('multipleChoiceMulti filtered by "Other"', () => {
+  test("selects exactly the responses carrying a value outside the predefined set", async () => {
+    expect(await matchingNames(otherFilter(MULTI_ID, ["Other"]))).toEqual([
+      "german label + write-in",
+      "predefined + write-in",
+      "write-in only",
+    ]);
+  });
+
+  test("a different answer order or a duplicated label is still not an Other", async () => {
+    // These two are the whole reason the old implementation enumerated permutations. Ordering and
+    // duplication must stay invisible to the predicate.
+    const matched = await matchingNames(otherFilter(MULTI_ID, ["Other"]));
+
+    expect(matched).not.toContain("reversed order");
+    expect(matched).not.toContain("duplicated label");
+  });
+
+  test("an unanswered, empty or json-null response does not match", async () => {
+    // Previously these matched: the empty subset was skipped, so `NOT { OR: [...] }` let them
+    // through. Fixing that is a deliberate, user-visible change to filter counts.
+    const matched = await matchingNames(otherFilter(MULTI_ID, ["Other"]));
+
+    expect(matched).not.toContain("empty array");
+    expect(matched).not.toContain("key absent");
+    expect(matched).not.toContain("json null");
+  });
+
+  test("selecting Other alongside a predefined label also returns that label's responses", async () => {
+    // "A0" is now a selected value, so it drops out of predefinedLabels and any entry holding it
+    // counts as "outside the predefined set".
+    expect(await matchingNames(otherFilter(MULTI_ID, ["Other", "A0"]))).toEqual([
+      "duplicated label",
+      "german label + write-in",
+      "one predefined label",
+      "predefined + write-in",
+      "reversed order",
+      "two predefined labels",
+      "write-in only",
+    ]);
+  });
+});
+
+describe('multipleChoiceSingle filtered by "Other"', () => {
+  test("selects the write-in and leaves predefined answers behind", async () => {
+    const matched = await matchingNames(otherFilter(SINGLE_ID, ["Other"]));
+
+    expect(matched).toContain("single: write-in");
+    expect(matched).not.toContain("single: predefined");
+    // An "Other" ticked but left blank stores "", which is not a predefined label and so still
+    // counts as Other — unchanged by ENG-3161, and consistent with how the multi branch treats it.
+    expect(matched).toContain("single: empty string");
+  });
+
+  test("a response that never answered the question does not match", async () => {
+    const matched = await matchingNames(otherFilter(SINGLE_ID, ["Other"]));
+
+    expect(matched).not.toContain("key absent");
+  });
+});

--- a/apps/web/lib/response/utils.test.ts
+++ b/apps/web/lib/response/utils.test.ts
@@ -613,6 +613,18 @@ describe("Response Utils", () => {
         expect(() => buildWhereClause(manySurvey, otherFilter(manyIds))).toThrow(InvalidInputError);
       });
 
+      // Tags are the other client-supplied list that expands one clause per entry — a relation
+      // subquery each — so they are charged against the same budget rather than a separate cap.
+      test("applied tags are charged against the budget too", () => {
+        const survey = buildChoiceSurvey(TSurveyElementTypeEnum.MultipleChoiceMulti, 2);
+        const tags = (count: number): TResponseFilterCriteria => ({
+          tags: { applied: Array.from({ length: count }, (_unused, index) => `tag-${index}`) },
+        });
+
+        expect(() => buildWhereClause(survey, tags(10_000))).not.toThrow();
+        expect(() => buildWhereClause(survey, tags(10_001))).toThrow(InvalidInputError);
+      });
+
       // Every language variant of every label is a separate clause, which is how a modest-looking
       // survey reached the old factorial blow-up at 11 labels.
       test("extra languages count against the budget", () => {

--- a/apps/web/lib/response/utils.test.ts
+++ b/apps/web/lib/response/utils.test.ts
@@ -4,14 +4,14 @@ import {
   type TEmbeddedValueResponse,
   deriveLegacyEmbeddedData,
 } from "@formbricks/types/embedded-data-resolver";
-import { TResponse } from "@formbricks/types/responses";
+import { InvalidInputError } from "@formbricks/types/errors";
+import { TResponse, TResponseFilterCriteria } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import {
   calculateTtcTotal,
   extractChoiceIdsFromResponse,
   extractSurveyDetails,
-  generateAllPermutationsOfSubsets,
   getReservedFilterEntries,
   getResponseContactAttributes,
   getResponseHiddenFields,
@@ -439,16 +439,20 @@ describe("Response Utils", () => {
         data: { qMulti: { op: "includesOne", value: ["Other"] } },
       });
 
+      // One probe per array position (choices.length), each asserting the entry exists and is
+      // none of the predefined labels. Exact toEqual, not arrayContaining: the old weak matcher is
+      // what let an unbounded clause set pass as "correct" (ENG-3161).
       expect(result.AND).toEqual([
         {
           AND: [
             {
-              NOT: {
-                OR: expect.arrayContaining([
-                  { data: { path: ["qMulti"], equals: ["A"] } },
-                  { data: { path: ["qMulti"], equals: ["B"] } },
-                ]),
-              },
+              OR: [0, 1, 2].map((index) => ({
+                AND: [
+                  { data: { path: ["qMulti", String(index)], not: Prisma.DbNull } },
+                  { data: { path: ["qMulti", String(index)], not: "A" } },
+                  { data: { path: ["qMulti", String(index)], not: "B" } },
+                ],
+              })),
             },
           ],
         },
@@ -506,6 +510,122 @@ describe("Response Utils", () => {
           ],
         },
       ]);
+    });
+
+    describe("includesOne: 'Other' clause budget (ENG-3161)", () => {
+      /**
+       * One choice element per id in `elementIds`, each carrying `choiceCount` predefined choices
+       * (localized into every entry of `languages`) plus the "Other" choice.
+       */
+      const buildChoiceSurvey = (
+        elementType: TSurveyElementTypeEnum.MultipleChoiceMulti | TSurveyElementTypeEnum.MultipleChoiceSingle,
+        choiceCount: number,
+        languages: string[] = ["default"],
+        elementIds: string[] = ["q0"]
+      ): TSurvey =>
+        ({
+          id: "sBudget",
+          name: "BudgetSurvey",
+          blocks: [
+            {
+              id: "block1",
+              name: "Block 1",
+              elements: elementIds.map((elementId) => ({
+                id: elementId,
+                type: elementType,
+                headline: { default: "Pick" },
+                required: false,
+                choices: [
+                  ...Array.from({ length: choiceCount }, (_unused, index) => ({
+                    id: `c${index}`,
+                    label: Object.fromEntries(
+                      languages.map((language) => [language, `${language}-label-${index}`])
+                    ),
+                  })),
+                  { id: "other", label: { default: "Other" } },
+                ],
+                shuffleOption: "none",
+                isDraft: false,
+              })),
+            },
+          ],
+          questions: [],
+          type: "app",
+          hiddenFields: { enabled: false, fieldIds: [] },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          workspaceId: "eBudget",
+          createdBy: "uBudget",
+          status: "inProgress",
+        }) as unknown as TSurvey;
+
+      const otherFilter = (elementIds: string[]): TResponseFilterCriteria => ({
+        data: Object.fromEntries(
+          elementIds.map((elementId) => [elementId, { op: "includesOne" as const, value: ["Other"] }])
+        ),
+      });
+
+      // The multi branch emits (choices + 1) probes x (labels + 1) clauses, so a monolingual
+      // element sits at (c + 1)^2 -- exactly the budget at c = 99.
+      test("multi: a survey just inside the budget still builds", () => {
+        const survey = buildChoiceSurvey(TSurveyElementTypeEnum.MultipleChoiceMulti, 99);
+
+        const result = buildWhereClause(survey, otherFilter(["q0"]));
+
+        expect(result.AND).toHaveLength(1);
+      });
+
+      test("multi: a survey just past the budget is refused", () => {
+        const survey = buildChoiceSurvey(TSurveyElementTypeEnum.MultipleChoiceMulti, 100);
+
+        expect(() => buildWhereClause(survey, otherFilter(["q0"]))).toThrow(InvalidInputError);
+      });
+
+      test("single: the label-count budget is enforced too", () => {
+        const withinBudget = buildChoiceSurvey(TSurveyElementTypeEnum.MultipleChoiceSingle, 10_000);
+        expect(() => buildWhereClause(withinBudget, otherFilter(["q0"]))).not.toThrow();
+
+        const pastBudget = buildChoiceSurvey(TSurveyElementTypeEnum.MultipleChoiceSingle, 10_001);
+        expect(() => buildWhereClause(pastBudget, otherFilter(["q0"]))).toThrow(InvalidInputError);
+      });
+
+      // The budget is per call, not per branch: filterCriteria.data is a record and every key is
+      // expanded. This is the test that fails if the budget is ever made per-branch again.
+      test("many individually-cheap filter keys still exhaust the budget", () => {
+        const cheapIds = Array.from({ length: 5 }, (_unused, index) => `q${index}`);
+        const cheapSurvey = buildChoiceSurvey(
+          TSurveyElementTypeEnum.MultipleChoiceMulti,
+          40,
+          ["default"],
+          cheapIds
+        );
+        // 5 x (41 x 41) = 8405, inside the budget.
+        expect(() => buildWhereClause(cheapSurvey, otherFilter(cheapIds))).not.toThrow();
+
+        const manyIds = Array.from({ length: 10 }, (_unused, index) => `q${index}`);
+        const manySurvey = buildChoiceSurvey(
+          TSurveyElementTypeEnum.MultipleChoiceMulti,
+          40,
+          ["default"],
+          manyIds
+        );
+        // 10 x (41 x 41) = 16810, past the budget, though each key alone is far inside it.
+        expect(() => buildWhereClause(manySurvey, otherFilter(manyIds))).toThrow(InvalidInputError);
+      });
+
+      // Every language variant of every label is a separate clause, which is how a modest-looking
+      // survey reached the old factorial blow-up at 11 labels.
+      test("extra languages count against the budget", () => {
+        const monolingual = buildChoiceSurvey(TSurveyElementTypeEnum.MultipleChoiceMulti, 60);
+        expect(() => buildWhereClause(monolingual, otherFilter(["q0"]))).not.toThrow();
+
+        const trilingual = buildChoiceSurvey(TSurveyElementTypeEnum.MultipleChoiceMulti, 60, [
+          "default",
+          "de",
+          "fr",
+        ]);
+        expect(() => buildWhereClause(trilingual, otherFilter(["q0"]))).toThrow(InvalidInputError);
+      });
     });
 
     test("includesOne: regular choice match", () => {
@@ -1597,18 +1717,6 @@ describe("Response Utils", () => {
         hidden1: [],
         hidden2: [],
       });
-    });
-  });
-
-  describe("generateAllPermutationsOfSubsets", () => {
-    test("with empty array returns empty", () => {
-      expect(generateAllPermutationsOfSubsets([])).toEqual([]);
-    });
-
-    test("with two elements returns 4 permutations", () => {
-      const out = generateAllPermutationsOfSubsets(["x", "y"]);
-      expect(out).toEqual(expect.arrayContaining([["x"], ["y"], ["x", "y"], ["y", "x"]]));
-      expect(out).toHaveLength(4);
     });
   });
 });

--- a/apps/web/lib/response/utils.ts
+++ b/apps/web/lib/response/utils.ts
@@ -523,53 +523,6 @@ export const getResponseHiddenFields = (
   }
 };
 
-export const generateAllPermutationsOfSubsets = (array: string[]): string[][] => {
-  const subsets: string[][] = [];
-
-  // Helper function to generate permutations of an array
-  const generatePermutations = (arr: string[]): string[][] => {
-    const permutations: string[][] = [];
-
-    // Recursive function to generate permutations
-    const permute = (current: string[], remaining: string[]): void => {
-      if (remaining.length === 0) {
-        permutations.push(current.slice()); // Make a copy of the current permutation
-        return;
-      }
-
-      for (let i = 0; i < remaining.length; i++) {
-        current.push(remaining[i]);
-        permute(current, remaining.slice(0, i).concat(remaining.slice(i + 1)));
-        current.pop();
-      }
-    };
-
-    permute([], arr);
-    return permutations;
-  };
-
-  // Recursive function to generate subsets
-  const findSubsets = (currentIndex: number, currentSubset: string[]): void => {
-    if (currentIndex === array.length) {
-      if (currentSubset.length > 0) {
-        // Skip empty subset if not needed
-        const allPermutations = generatePermutations(currentSubset);
-        subsets.push(...allPermutations); // Spread operator to add all permutations individually
-      }
-      return;
-    }
-
-    // Include the current element
-    findSubsets(currentIndex + 1, currentSubset.concat(array[currentIndex]));
-
-    // Exclude the current element
-    findSubsets(currentIndex + 1, currentSubset);
-  };
-
-  findSubsets(0, []);
-  return subsets;
-};
-
 /**
  * Canonicalize a response's language code on write (ENG-1067). SDK clients — especially stale or
  * anonymous caches — can submit a legacy code (e.g. "hi") at any point; storing its canonical BCP-47

--- a/apps/web/lib/response/where-clause.ts
+++ b/apps/web/lib/response/where-clause.ts
@@ -282,18 +282,26 @@ const createFilterTags = (tags: TResponseFilterCriteria["tags"]) => {
  */
 const MAX_FILTER_CLAUSES = 10_000;
 
-export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilterCriteria) => {
-  const whereClause: Prisma.ResponseWhereInput["AND"] = [];
+/**
+ * One call's clause allowance. The returned `spend` charges against it and refuses the filter once
+ * it is exhausted. Kept out of buildWhereClause so the budget is a self-contained concern rather
+ * than more branching inside an already-large builder.
+ */
+const createClauseBudget = (): ((count: number) => void) => {
+  let remaining = MAX_FILTER_CLAUSES;
 
-  let clauseBudget = MAX_FILTER_CLAUSES;
-
-  /** Charge `count` clauses against this call's budget, refusing the filter once it is exhausted. */
-  const spend = (count: number): void => {
-    clauseBudget -= count;
-    if (clauseBudget < 0) {
+  return (count: number): void => {
+    remaining -= count;
+    if (remaining < 0) {
       throw new InvalidInputError("This response filter is too large to evaluate");
     }
   };
+};
+
+export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilterCriteria) => {
+  const whereClause: Prisma.ResponseWhereInput["AND"] = [];
+
+  const spend = createClauseBudget();
 
   if (filterCriteria?.finished !== undefined) {
     whereClause.push({

--- a/apps/web/lib/response/where-clause.ts
+++ b/apps/web/lib/response/where-clause.ts
@@ -324,10 +324,10 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
   }
 
   if (filterCriteria?.tags) {
-    // `applied` expands to one relation subquery per tag; `notApplied` is a single `notIn`.
-    spend((filterCriteria.tags.applied?.length ?? 0) + (filterCriteria.tags.notApplied ? 1 : 0));
-
+    // `applied` expands to one relation subquery per tag, so charge what was actually emitted.
     const tagFilters = createFilterTags(filterCriteria.tags);
+    spend(tagFilters.length);
+
     whereClause.push({
       AND: tagFilters,
     });

--- a/apps/web/lib/response/where-clause.ts
+++ b/apps/web/lib/response/where-clause.ts
@@ -7,10 +7,10 @@ import {
   getSurveyEmbeddedFields,
   listShadowingNames,
 } from "@formbricks/types/embedded-data-resolver";
+import { InvalidInputError } from "@formbricks/types/errors";
 import { TResponseFilterCriteria } from "@formbricks/types/responses";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
-import { generateAllPermutationsOfSubsets } from "./utils";
 
 type TTypedFieldFilterCondition = NonNullable<TResponseFilterCriteria["reserved"]>[string];
 
@@ -266,8 +266,34 @@ const createFilterTags = (tags: TResponseFilterCriteria["tags"]) => {
   return filterTags.flat();
 };
 
+/**
+ * Upper bound on the filter clauses a single buildWhereClause call may emit.
+ *
+ * The "Other" branches below scale with the element's choice count, which has no maximum
+ * (ZSurveyElementChoice is `.min(2)` only), so an unbounded predicate is a denial-of-service
+ * vector — a low-privilege request could allocate until the process died (ENG-3161).
+ *
+ * The budget is per CALL, not per branch: `filterCriteria.data` is a record whose keys are each
+ * iterated below, so a per-branch cap would simply be multiplied by the key count.
+ *
+ * 10k clauses is ~30k bind parameters (each probe binds key + index + label), comfortably under
+ * PostgreSQL's 65535 ceiling, and allows ~99 monolingual choices on a single element — far past
+ * any real survey.
+ */
+const MAX_FILTER_CLAUSES = 10_000;
+
 export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilterCriteria) => {
   const whereClause: Prisma.ResponseWhereInput["AND"] = [];
+
+  let clauseBudget = MAX_FILTER_CLAUSES;
+
+  /** Charge `count` clauses against this call's budget, refusing the filter once it is exhausted. */
+  const spend = (count: number): void => {
+    clauseBudget -= count;
+    if (clauseBudget < 0) {
+      throw new InvalidInputError("This response filter is too large to evaluate");
+    }
+  };
 
   if (filterCriteria?.finished !== undefined) {
     whereClause.push({
@@ -579,17 +605,31 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
               });
             });
 
-            const subsets = generateAllPermutationsOfSubsets(predefinedLabels);
             if (element.type === "multipleChoiceMulti") {
-              const subsetConditions = subsets.map((subset) => ({
-                data: { path: [key], equals: subset },
-              }));
+              // A multi answer is a string[] of the chosen labels, with the "Other" write-in stored
+              // as the raw typed text. "Other was chosen" therefore means: at least one entry is
+              // not a predefined label. Prisma's JSON filters have no subset operator, so each
+              // array position is probed by numeric path segment. An answer holds at most one entry
+              // per choice, so choices.length positions cover it; positions past the end extract to
+              // SQL NULL, so unanswered and empty ([]) responses correctly do not match.
+              const positions = element.choices.length;
+              spend(positions * (predefinedLabels.length + 1));
+
               data.push({
-                NOT: {
-                  OR: subsetConditions,
-                },
+                OR: Array.from({ length: positions }, (_unused, index) => ({
+                  AND: [
+                    { data: { path: [key, String(index)], not: Prisma.DbNull } },
+                    ...predefinedLabels.map((label) => ({
+                      data: { path: [key, String(index)], not: label },
+                    })),
+                  ],
+                })),
               });
             } else {
+              // A single answer is a scalar string, so "not any predefined label" is directly
+              // expressible and stays linear in the label count.
+              spend(predefinedLabels.length);
+
               data.push({
                 AND: predefinedLabels.map((label) => ({
                   NOT: {
@@ -602,6 +642,9 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
               });
             }
           } else {
+            // Two clauses per selected value: the array shape and the scalar shape.
+            spend(val.value.length * 2);
+
             data.push({
               OR: val.value.map((value: string | number) => ({
                 OR: [

--- a/apps/web/lib/response/where-clause.ts
+++ b/apps/web/lib/response/where-clause.ts
@@ -316,6 +316,9 @@ export const buildWhereClause = (survey: TSurvey, filterCriteria?: TResponseFilt
   }
 
   if (filterCriteria?.tags) {
+    // `applied` expands to one relation subquery per tag; `notApplied` is a single `notIn`.
+    spend((filterCriteria.tags.applied?.length ?? 0) + (filterCriteria.tags.notApplied ? 1 : 0));
+
     const tagFilters = createFilterTags(filterCriteria.tags);
     whereClause.push({
       AND: tagFilters,

--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -328,8 +328,10 @@ const ZResponseFilterCriteriaFields = z.object({
 
   tags: z
     .object({
-      applied: z.array(z.string()).optional(),
-      notApplied: z.array(z.string()).optional(),
+      // `applied` expands to one relation subquery per tag in createFilterTags, so it carries the
+      // same clause-expansion risk as the data filters above.
+      applied: z.array(z.string()).max(MAX_FILTER_VALUES).optional(),
+      notApplied: z.array(z.string()).max(MAX_FILTER_VALUES).optional(),
     })
     .optional(),
 

--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -106,14 +106,23 @@ const ZResponseFilterCriteriaDataGreaterThan = z.object({
   value: z.union([z.number(), z.string()]),
 });
 
+/**
+ * Response filters are client-supplied and every entry below is expanded into Prisma filter clauses
+ * by buildWhereClause, so unbounded arrays and records are a denial-of-service vector (ENG-3161).
+ * These caps are defence in depth behind that builder's own clause budget — deliberately far above
+ * any real survey, since the budget is what makes the cost provably finite.
+ */
+const MAX_FILTER_VALUES = 1_000;
+const MAX_FILTER_KEYS = 500;
+
 const ZResponseFilterCriteriaDataIncludesOne = z.object({
   op: z.literal(ZResponseFilterCondition.enum.includesOne),
-  value: z.union([z.array(z.string()), z.array(z.number())]),
+  value: z.union([z.array(z.string()).max(MAX_FILTER_VALUES), z.array(z.number()).max(MAX_FILTER_VALUES)]),
 });
 
 const ZResponseFilterCriteriaDataIncludesAll = z.object({
   op: z.literal(ZResponseFilterCondition.enum.includesAll),
-  value: z.array(z.string()),
+  value: z.array(z.string()).max(MAX_FILTER_VALUES),
 });
 
 // Booleans belong to boolean-typed Embedded Data fields, whose stored values are real jsonb
@@ -251,7 +260,7 @@ const ZQuotasFilterCriteriaScreenedOutNotInQuota = z.object({
   op: z.literal("screenedOutNotInQuota"),
 });
 
-export const ZResponseFilterCriteria = z.object({
+const ZResponseFilterCriteriaFields = z.object({
   finished: z.boolean().optional(),
   responseIds: z.array(ZId).optional(),
   createdAt: z
@@ -361,6 +370,24 @@ export const ZResponseFilterCriteria = z.object({
     )
     .optional(),
 });
+
+/**
+ * Every record field above is iterated per key by buildWhereClause, so an unbounded key count
+ * multiplies the filter clauses it emits. z.record carries no size check in Zod 4, hence the
+ * refinement — kept separate from the shape so the object literal stays untouched.
+ */
+export const ZResponseFilterCriteria = ZResponseFilterCriteriaFields.refine(
+  (criteria) =>
+    [
+      criteria.contactAttributes,
+      criteria.data,
+      criteria.reserved,
+      criteria.others,
+      criteria.meta,
+      criteria.quotas,
+    ].every((record) => !record || Object.keys(record).length <= MAX_FILTER_KEYS),
+  { error: `A response filter may not carry more than ${MAX_FILTER_KEYS} conditions per field` }
+);
 
 export const ZResponseContact = z.object({
   id: ZId,


### PR DESCRIPTION
Ref ENG-3161

## What & why

**Was:** filtering responses by a multiple-choice question's "Other" option built every permutation of every subset of the remaining labels. At 11 labels that aborted the Node process with an uncatchable OOM, taking every tenant on the instance down with it.

**Now:** the filter asks the question directly — probe each answer position, assert it is none of the predefined labels — under a per-call clause budget.

- Reported to security@formbricks.com by Arthur Chan (Ada Logics). Credit is owed to **Google** and **Ada Logics** in any advisory.
- Reachable by any member with `workspace.read`, via one crafted server-action payload.
- `n` is (choices × languages) − selected labels, so a bilingual 6-choice question reaches 11.

## Where to look

- [where-clause.ts#L626](https://github.com/formbricks/formbricks/blob/fix/ENG-3161_response-filter-other-permutations/apps/web/lib/response/where-clause.ts#L626) — the replacement predicate
- [where-clause.ts#L283](https://github.com/formbricks/formbricks/blob/fix/ENG-3161_response-filter-other-permutations/apps/web/lib/response/where-clause.ts#L283) — why the budget is per call, not per branch
- [responses.ts](https://github.com/formbricks/formbricks/blob/fix/ENG-3161_response-filter-other-permutations/packages/types/responses.ts#L109) — schema caps behind it

## Breaking changes

- [ ] This PR contains breaking changes

None. The filter is reached from server actions and one internal route; no public API request or response shape, endpoint, env var or SDK signature changes.

## Migrations & env

- none

## How this was tested

Rerun: `cd apps/web && pnpm test lib/response/utils.test.ts && pnpm test:integration`

### Same actions, `main` vs this branch

Identical seeded responses, identical filter (`includesOne: ["Other"]`), same database, `--max-old-space-size=4096`.

| Survey | `main` | this branch |
| --- | --- | --- |
| 3 choices, 1 language (3 labels) | 5 rows, 42 ms | **2 rows**, 48 ms |
| 6 choices, 2 languages (12 labels) | **process aborted** — `FATAL ERROR: Ineffective mark-compacts near heap limit`, 68 s, no result | **2 rows**, 41 ms, 3 MB heap |

The small survey is the interesting one: `main` returns three rows that are not "Other" answers at all — `empty-array`, `json-null` and `duplicate-label` (`["A0","A0"]`, which matches no permutation, so the old `NOT` let it through). Both agree on every other row, including `reversed-order`, which is the case the permutation set existed for.

**Coverage**

| Behaviour | How | Outcome |
| --- | --- | --- |
| Other filter selects exactly the write-in responses | unit (red on main) | 6/6 green; against old code the worker dies with `Ineffective mark-compacts near heap limit` |
| Reversed order and duplicated labels stay excluded | unit (red on main) | Both excluded; `main` wrongly matched the duplicate |
| Empty, absent and json-null stop matching | unit (red on main) | No longer returned; `main` returned all three |
| Budget refuses oversized filters, tags included | unit (mutation) | All 6 budget tests red when `where-clause.ts:295` is forced false |
| Every record filter field caps its key count | unit (mutation) | Each field's case red when it is dropped from the refinement in `responses.ts` |
| Reporter's PoC | manual | Its `awk` extraction is now empty, so the PoC image fails to build |

<details>
<summary>Local run notes</summary>

The integration harness clones its schema from the dev DB and defaults to `localhost:5432`. If that port is another stack, or the dev DB is behind your branch, build an isolated source with `prisma db push --config ./prisma.config.ts --url <url>` and point `TEST_DB_SOURCE` / `TEST_DB_NAME` / `TEST_DATABASE_URL` at it.

At 1,000 and 4,000 choices the predicate now throws in single-digit ms with <50 MB heap delta, where the un-budgeted version allocated 2,330 MB.
</details>

**Open gaps**

- No E2E: the multi-choice filter UI strips "Other" from its dropdown, so this branch has no browser path.
- **A legitimate survey can exceed the clause budget.** Not "~99 choices" as first written — that holds only monolingual and only with the whole allowance. The cost falls as `10000 / (L x c)`, so a 45-option country list in five languages does not fit, and `tags` or a second `data` key takes from the same budget. Those questions cannot be filtered by Other at all.
- The internal attachments route surfaces an over-budget filter as a 500 rather than a 400 — reached by the survey above rather than only by an extreme payload.
- `OTHER_WRITE_IN_PROBE_SLACK` mitigates rather than closes the unbounded-array case: a positional probe cannot bound an array with no cap. Bounding `ZResponseDataValue` on write is the real fix and wants its own ticket.

**Review fixes**

- CodeRabbit caught `variables` missing from the key-count refinement — the one record field I'd left out. Added, with tests that bind every field's cap.
- Sonar flagged `buildWhereClause` at cognitive complexity 17; the budget is now a module-level factory and the tags guard drops its ternary.
- **Review (Dhruwang):** the probe window stopped at `choices.length`, so a write-in in a longer stored array was silently dropped — a narrowing the old predicate did not have. Fixed with a probe slack, proven by mutation against real Postgres. His second route to it (choices deleted from a running survey) turns out not to narrow, and the suite now pins why.
- **Review (Dhruwang):** every language variant of a label was charged separately, so an untranslated choice spent budget on the same clause repeated. Deduplicated.

**Risks**

- Filter counts change for empty, absent, json-null and duplicate-label answers — all four were wrong before, and all four are user-visible on `release/5.4`.
- `responseIds` stays uncapped by design: it emits one `in` clause rather than expanding, and is populated from row selection.
- Backports to `release/6.0` and `release/5.4` follow.

---

> [!NOTE]
> **AI model used** — `claude-opus-5`, reasoning effort `unknown`.




